### PR TITLE
Fix: Add claudex-sandbox-net network to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,9 @@ services:
       - SECRET_KEY=${SECRET_KEY:-claudex_default_secret_key_for_development_only}
       - PYTHONUNBUFFERED=1
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
+    networks:
+      - default
+      - claudex-sandbox-net
 
   celery-worker:
     build:
@@ -139,3 +142,8 @@ volumes:
     driver: local
   redis_data:
     driver: local
+
+networks:
+  claudex-sandbox-net:
+    name: claudex-sandbox-net
+    driver: bridge


### PR DESCRIPTION
Docker sandbox containers are created on the claudex-sandbox-net network, but this network wasn't defined in docker-compose.yml. This caused a "network not found" error when trying to start a sandbox on fresh installs.

Changes:
- Define claudex-sandbox-net network in docker-compose.yml
- Add API service to both default and sandbox networks
- Use explicit name to avoid project prefix on network name