### PR TITLE
feat: add plugin marketplace UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Your own Claude Code UI. Open source, self-hosted, runs entirely on your machine
 [![Python 3.13](https://img.shields.io/badge/python-3.13-blue.svg)](https://www.python.org/)
 [![React 19](https://img.shields.io/badge/React-19-61DAFB.svg)](https://reactjs.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-009688.svg)](https://fastapi.tiangolo.com/)
-[![Discord](https://img.shields.io/badge/Discord-Join%20Us-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/5PKRqG7K)
 
 ## Why Claudex?
 
@@ -143,12 +142,6 @@ docker compose logs -f    # Logs
 - **Admin Panel:** http://localhost:8080/admin
 
 Default admin: `admin@example.com` / `admin123`
-
-## Community
-
-Join our Discord server to get help, share feedback, and connect with other users:
-
-[![Discord](https://img.shields.io/badge/Discord-Join%20Us-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/5PKRqG7K)
 
 ## Contributing
 

--- a/backend/app/api/endpoints/agents.py
+++ b/backend/app/api/endpoints/agents.py
@@ -170,6 +170,9 @@ async def delete_agent(
     user_settings.custom_agents = current_agents
     flag_modified(user_settings, "custom_agents")
 
+    if user_service.remove_installed_component(user_settings, f"agent:{agent_name}"):
+        flag_modified(user_settings, "installed_plugins")
+
     await user_service.commit_settings_and_invalidate_cache(
         user_settings, db, current_user.id
     )

--- a/backend/app/api/endpoints/commands.py
+++ b/backend/app/api/endpoints/commands.py
@@ -178,6 +178,11 @@ async def delete_command(
     user_settings.custom_slash_commands = current_commands
     flag_modified(user_settings, "custom_slash_commands")
 
+    if user_service.remove_installed_component(
+        user_settings, f"command:{command_name}"
+    ):
+        flag_modified(user_settings, "installed_plugins")
+
     await user_service.commit_settings_and_invalidate_cache(
         user_settings, db, current_user.id
     )

--- a/backend/app/api/endpoints/marketplace.py
+++ b/backend/app/api/endpoints/marketplace.py
@@ -1,0 +1,386 @@
+from typing import Any, cast
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
+
+from app.core.deps import (
+    get_agent_service,
+    get_command_service,
+    get_db,
+    get_marketplace_service,
+    get_plugin_installer_service,
+    get_skill_service,
+    get_user_service,
+)
+from app.services.agent import AgentService
+from app.services.command import CommandService
+from app.services.skill import SkillService
+from app.core.security import get_current_user
+from app.models.db_models import User, UserSettings
+from app.models.schemas.marketplace import (
+    InstallComponentRequest,
+    InstallComponentResult,
+    InstallResponse,
+    InstalledPlugin,
+    MarketplacePlugin,
+    PluginDetails,
+    UninstallComponentsRequest,
+    UninstallResponse,
+)
+from app.models.types import (
+    CustomAgentDict,
+    CustomMcpDict,
+    CustomSkillDict,
+    CustomSlashCommandDict,
+    InstalledPluginDict,
+)
+from app.services.exceptions import MarketplaceException, UserException
+from app.services.marketplace import MarketplaceService
+from app.services.plugin_installer import PluginInstallerService
+from app.services.user import UserService
+
+router = APIRouter()
+
+
+def _append_if_not_exists(
+    items: list[Any],
+    new_item: Any,
+) -> None:
+    if not any(item.get("name") == new_item.get("name") for item in items):
+        items.append(new_item)
+
+
+@router.get("/catalog", response_model=list[MarketplacePlugin])
+async def get_catalog(
+    force_refresh: bool = Query(False, description="Force refresh catalog cache"),
+    marketplace_service: MarketplaceService = Depends(get_marketplace_service),
+) -> list[MarketplacePlugin]:
+    try:
+        plugins = await marketplace_service.fetch_catalog(force_refresh=force_refresh)
+        return [MarketplacePlugin(**p) for p in plugins]
+    except MarketplaceException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+
+
+@router.get("/catalog/{plugin_name}", response_model=PluginDetails)
+async def get_plugin_details(
+    plugin_name: str,
+    marketplace_service: MarketplaceService = Depends(get_marketplace_service),
+) -> PluginDetails:
+    try:
+        details = await marketplace_service.get_plugin_details(plugin_name)
+        return PluginDetails(**details)
+    except MarketplaceException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+
+
+@router.post("/install", response_model=InstallResponse)
+async def install_plugin_components(
+    request: InstallComponentRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    marketplace_service: MarketplaceService = Depends(get_marketplace_service),
+    installer_service: PluginInstallerService = Depends(get_plugin_installer_service),
+    user_service: UserService = Depends(get_user_service),
+) -> InstallResponse:
+    # 3-phase install to minimize DB lock time:
+    # 1. read settings without lock, 2. network IO, 3. short write lock
+    try:
+        user_settings_readonly = await user_service.get_user_settings(
+            current_user.id, db=db, for_update=False
+        )
+    except UserException as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+    current_agents: list[CustomAgentDict] = list(
+        user_settings_readonly.custom_agents or []
+    )
+    current_commands: list[CustomSlashCommandDict] = list(
+        user_settings_readonly.custom_slash_commands or []
+    )
+    current_skills: list[CustomSkillDict] = list(
+        user_settings_readonly.custom_skills or []
+    )
+    current_mcps: list[CustomMcpDict] = list(user_settings_readonly.custom_mcps or [])
+
+    try:
+        details = await marketplace_service.get_plugin_details(request.plugin_name)
+    except MarketplaceException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+
+    try:
+        result = await installer_service.install_components(
+            user_id=str(current_user.id),
+            plugin_name=request.plugin_name,
+            components=request.components,
+            current_agents=current_agents,
+            current_commands=current_commands,
+            current_skills=current_skills,
+            current_mcps=current_mcps,
+        )
+    except MarketplaceException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e))
+
+    if result.installed:
+        try:
+            user_settings = cast(
+                UserSettings,
+                await user_service.get_user_settings(
+                    current_user.id, db=db, for_update=True
+                ),
+            )
+        except UserException as e:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+        if user_settings.custom_agents is None:
+            user_settings.custom_agents = []
+        for agent in result.new_agents:
+            _append_if_not_exists(user_settings.custom_agents, agent)
+
+        if user_settings.custom_slash_commands is None:
+            user_settings.custom_slash_commands = []
+        for cmd in result.new_commands:
+            _append_if_not_exists(user_settings.custom_slash_commands, cmd)
+
+        if user_settings.custom_skills is None:
+            user_settings.custom_skills = []
+        for skill in result.new_skills:
+            _append_if_not_exists(user_settings.custom_skills, skill)
+
+        if user_settings.custom_mcps is None:
+            user_settings.custom_mcps = []
+        for mcp in result.new_mcps:
+            _append_if_not_exists(user_settings.custom_mcps, mcp)
+
+        installed_plugins: list[InstalledPluginDict] = list(
+            user_settings.installed_plugins or []
+        )
+        existing_idx = next(
+            (
+                i
+                for i, p in enumerate(installed_plugins)
+                if p["name"] == request.plugin_name
+            ),
+            None,
+        )
+        record = installer_service.create_installed_record(
+            request.plugin_name,
+            details.get("version"),
+            result.installed,
+        )
+        if existing_idx is not None:
+            existing_comps = set(installed_plugins[existing_idx].get("components", []))
+            existing_comps.update(result.installed)
+            record["components"] = list(existing_comps)
+            installed_plugins[existing_idx] = record
+        else:
+            installed_plugins.append(record)
+        user_settings.installed_plugins = installed_plugins
+
+        flag_modified(user_settings, "custom_agents")
+        flag_modified(user_settings, "custom_slash_commands")
+        flag_modified(user_settings, "custom_skills")
+        flag_modified(user_settings, "custom_mcps")
+        flag_modified(user_settings, "installed_plugins")
+
+        await user_service.commit_settings_and_invalidate_cache(
+            user_settings, db, current_user.id
+        )
+
+    return InstallResponse(
+        plugin_name=request.plugin_name,
+        version=details.get("version"),
+        installed=result.installed,
+        failed=result.failed,
+    )
+
+
+@router.get("/installed", response_model=list[InstalledPlugin])
+async def get_installed_plugins(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    user_service: UserService = Depends(get_user_service),
+) -> list[InstalledPlugin]:
+    try:
+        user_settings = await user_service.get_user_settings(current_user.id, db=db)
+    except UserException as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+    installed: list[InstalledPluginDict] = cast(
+        list[InstalledPluginDict], user_settings.installed_plugins or []
+    )
+    return [InstalledPlugin(**p) for p in installed]
+
+
+@router.post("/uninstall", response_model=UninstallResponse)
+async def uninstall_plugin_components(
+    request: UninstallComponentsRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    user_service: UserService = Depends(get_user_service),
+    agent_service: AgentService = Depends(get_agent_service),
+    command_service: CommandService = Depends(get_command_service),
+    skill_service: SkillService = Depends(get_skill_service),
+) -> UninstallResponse:
+    try:
+        user_settings = cast(
+            UserSettings,
+            await user_service.get_user_settings(
+                current_user.id, db=db, for_update=True
+            ),
+        )
+    except UserException as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+    uninstalled: list[str] = []
+    failed: list[InstallComponentResult] = []
+    user_id = str(current_user.id)
+
+    for component_id in request.components:
+        if ":" not in component_id:
+            failed.append(
+                InstallComponentResult(
+                    component=component_id,
+                    success=False,
+                    error="Invalid component format",
+                )
+            )
+            continue
+
+        comp_type, comp_name = component_id.split(":", 1)
+
+        try:
+            if comp_type == "agent":
+                agents = list(user_settings.custom_agents or [])
+                idx = next(
+                    (i for i, a in enumerate(agents) if a.get("name") == comp_name),
+                    None,
+                )
+                if idx is not None:
+                    await agent_service.delete(user_id, comp_name)
+                    agents.pop(idx)
+                    user_settings.custom_agents = agents if agents else None
+                    uninstalled.append(component_id)
+                else:
+                    failed.append(
+                        InstallComponentResult(
+                            component=component_id,
+                            success=False,
+                            error="Agent not found",
+                        )
+                    )
+
+            elif comp_type == "command":
+                commands = list(user_settings.custom_slash_commands or [])
+                idx = next(
+                    (i for i, c in enumerate(commands) if c.get("name") == comp_name),
+                    None,
+                )
+                if idx is not None:
+                    await command_service.delete(user_id, comp_name)
+                    commands.pop(idx)
+                    user_settings.custom_slash_commands = commands if commands else None
+                    uninstalled.append(component_id)
+                else:
+                    failed.append(
+                        InstallComponentResult(
+                            component=component_id,
+                            success=False,
+                            error="Command not found",
+                        )
+                    )
+
+            elif comp_type == "skill":
+                skills = list(user_settings.custom_skills or [])
+                idx = next(
+                    (i for i, s in enumerate(skills) if s.get("name") == comp_name),
+                    None,
+                )
+                if idx is not None:
+                    await skill_service.delete(user_id, comp_name)
+                    skills.pop(idx)
+                    user_settings.custom_skills = skills if skills else None
+                    uninstalled.append(component_id)
+                else:
+                    failed.append(
+                        InstallComponentResult(
+                            component=component_id,
+                            success=False,
+                            error="Skill not found",
+                        )
+                    )
+
+            elif comp_type == "mcp":
+                mcps = list(user_settings.custom_mcps or [])
+                idx = next(
+                    (i for i, m in enumerate(mcps) if m.get("name") == comp_name), None
+                )
+                if idx is not None:
+                    mcps.pop(idx)
+                    user_settings.custom_mcps = mcps if mcps else None
+                    uninstalled.append(component_id)
+                else:
+                    failed.append(
+                        InstallComponentResult(
+                            component=component_id, success=False, error="MCP not found"
+                        )
+                    )
+
+            else:
+                failed.append(
+                    InstallComponentResult(
+                        component=component_id,
+                        success=False,
+                        error=f"Unknown component type: {comp_type}",
+                    )
+                )
+
+        except Exception as e:
+            failed.append(
+                InstallComponentResult(
+                    component=component_id, success=False, error=str(e)
+                )
+            )
+
+    if uninstalled:
+        # Update installed_plugins to remove uninstalled components
+        installed_plugins: list[InstalledPluginDict] = list(
+            user_settings.installed_plugins or []
+        )
+        plugin_idx = next(
+            (
+                i
+                for i, p in enumerate(installed_plugins)
+                if p["name"] == request.plugin_name
+            ),
+            None,
+        )
+        if plugin_idx is not None:
+            plugin = installed_plugins[plugin_idx]
+            remaining = [
+                c for c in plugin.get("components", []) if c not in uninstalled
+            ]
+            if remaining:
+                plugin["components"] = remaining
+            else:
+                installed_plugins.pop(plugin_idx)
+            user_settings.installed_plugins = (
+                installed_plugins if installed_plugins else None
+            )
+
+        flag_modified(user_settings, "custom_agents")
+        flag_modified(user_settings, "custom_slash_commands")
+        flag_modified(user_settings, "custom_skills")
+        flag_modified(user_settings, "custom_mcps")
+        flag_modified(user_settings, "installed_plugins")
+
+        await user_service.commit_settings_and_invalidate_cache(
+            user_settings, db, current_user.id
+        )
+
+    return UninstallResponse(
+        plugin_name=request.plugin_name,
+        uninstalled=uninstalled,
+        failed=failed,
+    )

--- a/backend/app/api/endpoints/mcps.py
+++ b/backend/app/api/endpoints/mcps.py
@@ -1,0 +1,176 @@
+import re
+
+from typing import cast
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
+
+from app.core.deps import get_db, get_user_service
+from app.core.security import get_current_user
+from app.models.db_models import User
+from app.models.schemas import (
+    McpCreateRequest,
+    McpDeleteResponse,
+    McpResponse,
+    McpUpdateRequest,
+)
+from app.models.types import CustomMcpDict
+from app.services.exceptions import UserException
+from app.services.user import UserService
+
+router = APIRouter()
+
+SAFE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
+MAX_MCPS_PER_USER = 20
+
+
+@router.post("/", response_model=McpResponse, status_code=status.HTTP_201_CREATED)
+async def create_mcp(
+    request: McpCreateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    user_service: UserService = Depends(get_user_service),
+) -> CustomMcpDict:
+    if not SAFE_NAME_PATTERN.match(request.name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid MCP name format",
+        )
+
+    try:
+        user_settings = await user_service.get_user_settings(
+            current_user.id, db=db, for_update=True
+        )
+    except UserException as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+    current_mcps: list[CustomMcpDict] = cast(
+        list[CustomMcpDict], user_settings.custom_mcps or []
+    )
+
+    if len(current_mcps) >= MAX_MCPS_PER_USER:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Maximum {MAX_MCPS_PER_USER} MCPs per user",
+        )
+
+    if any(m.get("name") == request.name for m in current_mcps):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"MCP '{request.name}' already exists",
+        )
+
+    mcp_data: CustomMcpDict = {
+        "name": request.name,
+        "description": request.description,
+        "command_type": request.command_type,
+        "package": request.package,
+        "url": request.url,
+        "env_vars": request.env_vars,
+        "args": request.args,
+        "enabled": request.enabled,
+    }
+
+    current_mcps.append(mcp_data)
+    user_settings.custom_mcps = current_mcps
+    flag_modified(user_settings, "custom_mcps")
+
+    await user_service.commit_settings_and_invalidate_cache(
+        user_settings, db, current_user.id
+    )
+
+    return mcp_data
+
+
+@router.put("/{mcp_name}", response_model=McpResponse)
+async def update_mcp(
+    mcp_name: str,
+    request: McpUpdateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    user_service: UserService = Depends(get_user_service),
+) -> CustomMcpDict:
+    if not SAFE_NAME_PATTERN.match(mcp_name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid MCP name format",
+        )
+
+    try:
+        user_settings = await user_service.get_user_settings(
+            current_user.id, db=db, for_update=True
+        )
+    except UserException as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+    current_mcps: list[CustomMcpDict] = cast(
+        list[CustomMcpDict], user_settings.custom_mcps or []
+    )
+    mcp_index = next(
+        (i for i, m in enumerate(current_mcps) if m.get("name") == mcp_name),
+        None,
+    )
+
+    if mcp_index is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"MCP '{mcp_name}' not found",
+        )
+
+    mcp = current_mcps[mcp_index]
+    update_data = request.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        mcp[key] = value  # type: ignore[literal-required]
+
+    user_settings.custom_mcps = current_mcps
+    flag_modified(user_settings, "custom_mcps")
+
+    await user_service.commit_settings_and_invalidate_cache(
+        user_settings, db, current_user.id
+    )
+
+    return mcp
+
+
+@router.delete("/{mcp_name}", response_model=McpDeleteResponse)
+async def delete_mcp(
+    mcp_name: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    user_service: UserService = Depends(get_user_service),
+) -> McpDeleteResponse:
+    if not SAFE_NAME_PATTERN.match(mcp_name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid MCP name format",
+        )
+
+    try:
+        user_settings = await user_service.get_user_settings(
+            current_user.id, db=db, for_update=True
+        )
+    except UserException as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+    current_mcps = user_settings.custom_mcps or []
+    mcp_index = next(
+        (i for i, m in enumerate(current_mcps) if m.get("name") == mcp_name),
+        None,
+    )
+
+    if mcp_index is None:
+        return McpDeleteResponse(status="not_found")
+
+    current_mcps.pop(mcp_index)
+    user_settings.custom_mcps = current_mcps
+    flag_modified(user_settings, "custom_mcps")
+
+    if user_service.remove_installed_component(user_settings, f"mcp:{mcp_name}"):
+        flag_modified(user_settings, "installed_plugins")
+
+    await user_service.commit_settings_and_invalidate_cache(
+        user_settings, db, current_user.id
+    )
+
+    return McpDeleteResponse(status="deleted")

--- a/backend/app/api/endpoints/skills.py
+++ b/backend/app/api/endpoints/skills.py
@@ -103,6 +103,9 @@ async def delete_skill(
     user_settings.custom_skills = current_skills
     flag_modified(user_settings, "custom_skills")
 
+    if user_service.remove_installed_component(user_settings, f"skill:{skill_name}"):
+        flag_modified(user_settings, "installed_plugins")
+
     await user_service.commit_settings_and_invalidate_cache(
         user_settings, db, current_user.id
     )

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -23,6 +23,8 @@ from app.services.sandbox_providers import (
     create_sandbox_provider,
 )
 from app.services.scheduler import SchedulerService
+from app.services.marketplace import MarketplaceService
+from app.services.plugin_installer import PluginInstallerService
 from app.services.skill import SkillService
 from app.services.storage import StorageService
 from app.services.user import UserService
@@ -56,6 +58,14 @@ def get_command_service() -> CommandService:
 
 def get_agent_service() -> AgentService:
     return AgentService()
+
+
+def get_marketplace_service() -> MarketplaceService:
+    return MarketplaceService()
+
+
+def get_plugin_installer_service() -> PluginInstallerService:
+    return PluginInstallerService()
 
 
 def get_scheduler_service() -> SchedulerService:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,8 @@ from app.api.endpoints import (
     skills,
     commands,
     agents,
+    mcps,
+    marketplace,
 )
 from app.api.endpoints import settings as settings_router
 from app.core.config import get_settings
@@ -110,6 +112,11 @@ def create_application() -> FastAPI:
         tags=["Agents"],
     )
     application.include_router(
+        mcps.router,
+        prefix=f"{settings.API_V1_STR}/mcps",
+        tags=["MCPs"],
+    )
+    application.include_router(
         attachments.router,
         prefix=f"{settings.API_V1_STR}",
         tags=["Attachments"],
@@ -128,6 +135,11 @@ def create_application() -> FastAPI:
         ai_models.router,
         prefix=f"{settings.API_V1_STR}/models",
         tags=["Models"],
+    )
+    application.include_router(
+        marketplace.router,
+        prefix=f"{settings.API_V1_STR}/marketplace",
+        tags=["Marketplace"],
     )
 
     application.openapi = lambda: custom_openapi(application)

--- a/backend/app/models/db_models/user.py
+++ b/backend/app/models/db_models/user.py
@@ -13,6 +13,7 @@ from app.models.types import (
     CustomPromptDict,
     CustomSkillDict,
     CustomSlashCommandDict,
+    InstalledPluginDict,
 )
 
 from app.db.base_class import Base
@@ -100,5 +101,8 @@ class UserSettings(Base):
     )
     auto_compact_disabled: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false", nullable=False
+    )
+    installed_plugins: Mapped[list[InstalledPluginDict] | None] = mapped_column(
+        JSON, nullable=True
     )
     user = relationship("User", back_populates="settings")

--- a/backend/app/models/schemas/__init__.py
+++ b/backend/app/models/schemas/__init__.py
@@ -80,6 +80,7 @@ from .settings import (
 from .skills import SkillDeleteResponse, SkillResponse
 from .commands import CommandDeleteResponse, CommandResponse, CommandUpdateRequest
 from .agents import AgentDeleteResponse, AgentResponse, AgentUpdateRequest
+from .mcps import McpCreateRequest, McpDeleteResponse, McpResponse, McpUpdateRequest
 from .ai_model import AIModelResponse
 from .errors import HTTPErrorResponse
 
@@ -173,6 +174,11 @@ __all__ = [
     "AgentResponse",
     "AgentDeleteResponse",
     "AgentUpdateRequest",
+    # mcps
+    "McpCreateRequest",
+    "McpDeleteResponse",
+    "McpResponse",
+    "McpUpdateRequest",
     # ai_model
     "AIModelResponse",
     # errors

--- a/backend/app/models/schemas/marketplace.py
+++ b/backend/app/models/schemas/marketplace.py
@@ -1,0 +1,71 @@
+from pydantic import BaseModel, Field
+
+
+class MarketplaceAuthor(BaseModel):
+    name: str
+    email: str | None = None
+    url: str | None = None
+
+
+class MarketplacePlugin(BaseModel):
+    name: str = Field(..., description="Plugin identifier")
+    description: str = Field(..., description="What the plugin does")
+    category: str = Field(..., description="Plugin category")
+    source: str = Field(..., description="Source path in repository")
+    version: str | None = Field(None, description="Plugin version")
+    author: MarketplaceAuthor | None = None
+    homepage: str | None = None
+
+
+class PluginComponents(BaseModel):
+    agents: list[str] = Field(default_factory=list)
+    commands: list[str] = Field(default_factory=list)
+    skills: list[str] = Field(default_factory=list)
+    mcp_servers: list[str] = Field(default_factory=list)
+
+
+class PluginDetails(MarketplacePlugin):
+    readme: str | None = None
+    components: PluginComponents = Field(default_factory=PluginComponents)
+
+
+class InstallComponentRequest(BaseModel):
+    plugin_name: str = Field(..., description="Name of the plugin to install from")
+    components: list[str] = Field(
+        ...,
+        description="Components to install (e.g., 'agent:name', 'command:name', 'skill:name', 'mcp:name')",
+    )
+
+
+class InstallComponentResult(BaseModel):
+    component: str
+    success: bool
+    error: str | None = None
+
+
+class InstallResponse(BaseModel):
+    plugin_name: str
+    version: str | None
+    installed: list[str]
+    failed: list[InstallComponentResult]
+
+
+class InstalledPlugin(BaseModel):
+    name: str
+    version: str | None = None
+    installed_at: str
+    components: list[str]
+
+
+class UninstallComponentsRequest(BaseModel):
+    plugin_name: str = Field(..., description="Name of the plugin to uninstall from")
+    components: list[str] = Field(
+        ...,
+        description="Components to uninstall (e.g., 'agent:name', 'command:name')",
+    )
+
+
+class UninstallResponse(BaseModel):
+    plugin_name: str
+    uninstalled: list[str]
+    failed: list[InstallComponentResult]

--- a/backend/app/models/schemas/mcps.py
+++ b/backend/app/models/schemas/mcps.py
@@ -1,0 +1,39 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class McpCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=50)
+    description: str = Field(..., min_length=1, max_length=500)
+    command_type: Literal["npx", "bunx", "uvx", "http"]
+    package: str | None = None
+    url: str | None = None
+    env_vars: dict[str, str] | None = None
+    args: list[str] | None = None
+    enabled: bool = True
+
+
+class McpUpdateRequest(BaseModel):
+    description: str | None = Field(None, min_length=1, max_length=500)
+    command_type: Literal["npx", "bunx", "uvx", "http"] | None = None
+    package: str | None = None
+    url: str | None = None
+    env_vars: dict[str, str] | None = None
+    args: list[str] | None = None
+    enabled: bool | None = None
+
+
+class McpResponse(BaseModel):
+    name: str
+    description: str
+    command_type: Literal["npx", "bunx", "uvx", "http"]
+    package: str | None = None
+    url: str | None = None
+    env_vars: dict[str, str] | None = None
+    args: list[str] | None = None
+    enabled: bool = True
+
+
+class McpDeleteResponse(BaseModel):
+    status: Literal["deleted", "not_found"]

--- a/backend/app/models/schemas/settings.py
+++ b/backend/app/models/schemas/settings.py
@@ -74,6 +74,15 @@ class CustomPrompt(BaseModel):
     content: str = Field(..., description="The system prompt content")
 
 
+class InstalledPluginSchema(BaseModel):
+    name: str = Field(..., description="Plugin name")
+    version: str | None = None
+    installed_at: str = Field(..., description="ISO timestamp when installed")
+    components: list[str] = Field(
+        default_factory=list, description="Installed components (type:name)"
+    )
+
+
 class UserSettingsBase(BaseModel):
     github_personal_access_token: str | None = None
     e2b_api_key: str | None = None
@@ -88,6 +97,7 @@ class UserSettingsBase(BaseModel):
     custom_skills: list[CustomSkill] | None = None
     custom_slash_commands: list[CustomSlashCommand] | None = None
     custom_prompts: list[CustomPrompt] | None = None
+    installed_plugins: list[InstalledPluginSchema] | None = None
     notification_sound_enabled: bool = True
     sandbox_provider: Literal["e2b", "docker"] = "docker"
     auto_compact_disabled: bool = False
@@ -99,6 +109,7 @@ class UserSettingsBase(BaseModel):
         "custom_skills",
         "custom_slash_commands",
         "custom_prompts",
+        "installed_plugins",
         mode="before",
     )
     @classmethod

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -109,3 +109,46 @@ type JSONValue = (
 )
 type JSONDict = dict[str, JSONValue]
 type JSONList = list[JSONValue]
+
+
+class MarketplaceAuthorDict(TypedDict, total=False):
+    name: str
+    email: str | None
+    url: str | None
+
+
+class MarketplacePluginDict(TypedDict, total=False):
+    name: str
+    description: str
+    category: str
+    source: str
+    version: str | None
+    author: MarketplaceAuthorDict | None
+    homepage: str | None
+    has_lsp_only: bool
+
+
+class PluginComponentsDict(TypedDict, total=False):
+    agents: list[str]
+    commands: list[str]
+    skills: list[str]
+    mcp_servers: list[str]
+
+
+class PluginDetailsDict(TypedDict, total=False):
+    name: str
+    description: str
+    category: str
+    source: str
+    version: str | None
+    author: MarketplaceAuthorDict | None
+    homepage: str | None
+    readme: str | None
+    components: PluginComponentsDict
+
+
+class InstalledPluginDict(TypedDict, total=False):
+    name: str
+    version: str | None
+    installed_at: str
+    components: list[str]

--- a/backend/app/services/exceptions.py
+++ b/backend/app/services/exceptions.py
@@ -62,6 +62,10 @@ class ErrorCode(str, Enum):
     AGENT_INVALID = "AGENT_INVALID"
     AGENT_UPLOAD_FAILED = "AGENT_UPLOAD_FAILED"
 
+    MARKETPLACE_FETCH_FAILED = "MARKETPLACE_FETCH_FAILED"
+    MARKETPLACE_PLUGIN_NOT_FOUND = "MARKETPLACE_PLUGIN_NOT_FOUND"
+    MARKETPLACE_INSTALL_FAILED = "MARKETPLACE_INSTALL_FAILED"
+
     VALIDATION_ERROR = "VALIDATION_ERROR"
     RATE_LIMIT_EXCEEDED = "RATE_LIMIT_EXCEEDED"
     EXTERNAL_SERVICE_ERROR = "EXTERNAL_SERVICE_ERROR"
@@ -231,5 +235,16 @@ class AuthException(ServiceException):
         error_code: ErrorCode = ErrorCode.AUTH_INVALID_TOKEN,
         details: ExceptionDetails | None = None,
         status_code: int = 401,
+    ):
+        super().__init__(message, error_code, details, status_code)
+
+
+class MarketplaceException(ServiceException):
+    def __init__(
+        self,
+        message: str,
+        error_code: ErrorCode = ErrorCode.MARKETPLACE_FETCH_FAILED,
+        details: ExceptionDetails | None = None,
+        status_code: int = 400,
     ):
         super().__init__(message, error_code, details, status_code)

--- a/backend/app/services/marketplace.py
+++ b/backend/app/services/marketplace.py
@@ -1,0 +1,430 @@
+import io
+import json
+import logging
+import re
+import zipfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+
+from app.core.config import get_settings
+from app.models.types import (
+    MarketplaceAuthorDict,
+    MarketplacePluginDict,
+    PluginComponentsDict,
+    PluginDetailsDict,
+)
+from app.services.exceptions import ErrorCode, MarketplaceException
+
+settings = get_settings()
+logger = logging.getLogger(__name__)
+
+CATALOG_URL = "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/.claude-plugin/marketplace.json"
+REPO_RAW_BASE = (
+    "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main"
+)
+GITHUB_API_BASE = (
+    "https://api.github.com/repos/anthropics/claude-plugins-official/contents"
+)
+CACHE_TTL_SECONDS = 3600
+MAX_RECURSION_DEPTH = 5
+MAX_SKILL_FILES = 50
+
+_catalog_cache: list[MarketplacePluginDict] | None = None
+_catalog_cached_at: datetime | None = None
+SAFE_PATH_SEGMENT = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
+
+
+def _validate_path_segment(segment: str) -> bool:
+    if not segment:
+        return False
+    if segment in (".", ".."):
+        return False
+    if not SAFE_PATH_SEGMENT.match(segment):
+        return False
+    return True
+
+
+def _validate_source_path(source: str) -> str:
+    if source.startswith("./"):
+        source = source[2:]
+    if source.startswith("/"):
+        raise MarketplaceException(
+            "Invalid source path: absolute paths not allowed",
+            error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
+        )
+    segments = source.split("/")
+    for seg in segments:
+        if seg and not _validate_path_segment(seg):
+            raise MarketplaceException(
+                f"Invalid path segment: {seg}",
+                error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
+            )
+    return source
+
+
+def _validate_component_name(name: str) -> str:
+    if not _validate_path_segment(name):
+        raise MarketplaceException(
+            f"Invalid component name: {name}",
+            error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
+        )
+    return name
+
+
+class MarketplaceService:
+    def __init__(self) -> None:
+        self.cache_path = Path(settings.STORAGE_PATH) / "marketplace_cache"
+        self.cache_path.mkdir(parents=True, exist_ok=True)
+        self._cache_file = self.cache_path / "catalog.json"
+
+    async def fetch_catalog(
+        self, force_refresh: bool = False
+    ) -> list[MarketplacePluginDict]:
+        global _catalog_cache, _catalog_cached_at
+
+        if not force_refresh and self._is_cache_valid():
+            return _catalog_cache or []
+
+        if not force_refresh and self._load_disk_cache():
+            return _catalog_cache or []
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            try:
+                response = await client.get(CATALOG_URL)
+                response.raise_for_status()
+                data = response.json()
+            except httpx.HTTPError as e:
+                logger.error(f"Failed to fetch marketplace catalog: {e}")
+                raise MarketplaceException(
+                    f"Failed to fetch marketplace catalog: {e}",
+                    error_code=ErrorCode.MARKETPLACE_FETCH_FAILED,
+                )
+
+        all_plugins: list[MarketplacePluginDict] = []
+        for plugin in data.get("plugins", []):
+            all_plugins.append(self._normalize_plugin(plugin))
+
+        plugins = [
+            p
+            for p in all_plugins
+            if not p["source"].startswith("external:")
+            and not p.get("has_lsp_only", False)
+        ]
+
+        _catalog_cache = plugins
+        _catalog_cached_at = datetime.now(timezone.utc)
+        self._save_disk_cache(plugins)
+        return plugins
+
+    def _is_cache_valid(self) -> bool:
+        global _catalog_cache, _catalog_cached_at
+        if _catalog_cache is None or _catalog_cached_at is None:
+            return False
+        expiry = _catalog_cached_at + timedelta(seconds=CACHE_TTL_SECONDS)
+        return datetime.now(timezone.utc) < expiry
+
+    def _load_disk_cache(self) -> bool:
+        global _catalog_cache, _catalog_cached_at
+        try:
+            if not self._cache_file.exists():
+                return False
+            stat = self._cache_file.stat()
+            cache_age = datetime.now(timezone.utc) - datetime.fromtimestamp(
+                stat.st_mtime, tz=timezone.utc
+            )
+            if cache_age.total_seconds() > CACHE_TTL_SECONDS:
+                return False
+            with open(self._cache_file, "r") as f:
+                _catalog_cache = json.load(f)
+            _catalog_cached_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to load disk cache: {e}")
+            return False
+
+    def _save_disk_cache(self, plugins: list[MarketplacePluginDict]) -> None:
+        try:
+            with open(self._cache_file, "w") as f:
+                json.dump(plugins, f)
+        except Exception as e:
+            logger.warning(f"Failed to save disk cache: {e}")
+
+    def _normalize_plugin(self, raw: dict[str, Any]) -> MarketplacePluginDict:
+        author_raw = raw.get("author") or raw.get("owner")
+        author: MarketplaceAuthorDict | None = None
+        if isinstance(author_raw, str):
+            author = {"name": author_raw}
+        elif isinstance(author_raw, dict):
+            author = cast(MarketplaceAuthorDict, author_raw)
+
+        source_raw = raw.get("source", "")
+        if isinstance(source_raw, dict):
+            # external plugins have source as {"source": "url", "url": "..."} - prefix with "external:"
+            source = f"external:{source_raw.get('url', '')}"
+        else:
+            source = source_raw
+
+        has_lsp_only = bool(raw.get("lspServers")) and not any(
+            [
+                raw.get("agents"),
+                raw.get("commands"),
+                raw.get("skills"),
+                raw.get("mcpServers"),
+            ]
+        )
+
+        return {
+            "name": raw.get("name", ""),
+            "description": raw.get("description", ""),
+            "category": raw.get("category", "other"),
+            "source": source,
+            "version": raw.get("version"),
+            "author": author,
+            "homepage": raw.get("homepage"),
+            "has_lsp_only": has_lsp_only,
+        }
+
+    async def get_plugin_details(self, plugin_name: str) -> PluginDetailsDict:
+        catalog = await self.fetch_catalog()
+
+        plugin = next((p for p in catalog if p["name"] == plugin_name), None)
+        if not plugin:
+            raise MarketplaceException(
+                f"Plugin '{plugin_name}' not found",
+                error_code=ErrorCode.MARKETPLACE_PLUGIN_NOT_FOUND,
+                status_code=404,
+            )
+
+        source = plugin.get("source", "")
+        if source.startswith("external:"):
+            return {
+                "name": plugin["name"],
+                "description": plugin.get("description", ""),
+                "category": plugin.get("category", "other"),
+                "source": source,
+                "version": plugin.get("version"),
+                "author": plugin.get("author"),
+                "homepage": plugin.get("homepage"),
+                "readme": None,
+                "components": {
+                    "agents": [],
+                    "commands": [],
+                    "skills": [],
+                    "mcp_servers": [],
+                },
+            }
+
+        source = _validate_source_path(source)
+        readme = await self._fetch_readme(source)
+        components = await self._discover_components(source)
+
+        return {
+            "name": plugin["name"],
+            "description": plugin.get("description", ""),
+            "category": plugin.get("category", "other"),
+            "source": plugin.get("source", ""),
+            "version": plugin.get("version"),
+            "author": plugin.get("author"),
+            "homepage": plugin.get("homepage"),
+            "readme": readme,
+            "components": components,
+        }
+
+    async def _fetch_readme(self, source: str) -> str | None:
+        url = f"{REPO_RAW_BASE}/{source}/README.md"
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            try:
+                response = await client.get(url)
+                if response.status_code == 200:
+                    return str(response.text)
+            except httpx.HTTPError:
+                pass
+        return None
+
+    async def _discover_components(self, source: str) -> PluginComponentsDict:
+        components: PluginComponentsDict = {
+            "agents": [],
+            "commands": [],
+            "skills": [],
+            "mcp_servers": [],
+        }
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            agents = await self._list_directory(client, f"{source}/agents")
+            components["agents"] = [
+                f.replace(".md", "") for f in agents if f.endswith(".md")
+            ]
+
+            commands = await self._list_directory(client, f"{source}/commands")
+            components["commands"] = [
+                f.replace(".md", "") for f in commands if f.endswith(".md")
+            ]
+
+            skills_dirs = await self._list_directory(client, f"{source}/skills")
+            components["skills"] = [
+                d
+                for d in skills_dirs
+                if not d.startswith(".") and _validate_path_segment(d)
+            ]
+
+            mcp_servers = await self._fetch_mcp_config(client, source)
+            components["mcp_servers"] = mcp_servers
+
+        return components
+
+    async def _list_directory(self, client: httpx.AsyncClient, path: str) -> list[str]:
+        url = f"{GITHUB_API_BASE}/{path}"
+        try:
+            response = await client.get(
+                url, headers={"Accept": "application/vnd.github.v3+json"}
+            )
+            if response.status_code != 200:
+                return []
+            data = response.json()
+            if isinstance(data, list):
+                return [
+                    item["name"]
+                    for item in data
+                    if _validate_path_segment(item.get("name", ""))
+                ]
+        except httpx.HTTPError:
+            pass
+        return []
+
+    async def _fetch_mcp_config(
+        self, client: httpx.AsyncClient, source: str
+    ) -> list[str]:
+        url = f"{REPO_RAW_BASE}/{source}/.mcp.json"
+        try:
+            response = await client.get(url)
+            if response.status_code != 200:
+                return []
+            data = response.json()
+            if not isinstance(data, dict):
+                return []
+            servers = data.get("mcpServers") or data
+            return [
+                k
+                for k in servers.keys()
+                if _validate_path_segment(k) and isinstance(servers[k], dict)
+            ]
+        except (httpx.HTTPError, ValueError):
+            pass
+        return []
+
+    async def download_agent(self, source: str, agent_name: str) -> bytes:
+        source = _validate_source_path(source)
+        agent_name = _validate_component_name(agent_name)
+        return await self._download_file(f"{source}/agents/{agent_name}.md")
+
+    async def download_command(self, source: str, command_name: str) -> bytes:
+        source = _validate_source_path(source)
+        command_name = _validate_component_name(command_name)
+        return await self._download_file(f"{source}/commands/{command_name}.md")
+
+    async def download_skill_as_zip(self, source: str, skill_name: str) -> bytes:
+        source = _validate_source_path(source)
+        skill_name = _validate_component_name(skill_name)
+
+        skill_path = f"{source}/skills/{skill_name}"
+        zip_buffer = io.BytesIO()
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            files = await self._collect_files_recursive(client, skill_path, depth=0)
+
+            if not files:
+                raise MarketplaceException(
+                    f"Skill '{skill_name}' has no files",
+                    error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
+                )
+
+            with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+                for file_path in files:
+                    url = f"{REPO_RAW_BASE}/{file_path}"
+                    try:
+                        response = await client.get(url)
+                        response.raise_for_status()
+                        relative = file_path.replace(f"{skill_path}/", "")
+                        zf.writestr(relative, response.content)
+                    except httpx.HTTPError as e:
+                        logger.warning(f"Failed to download {file_path}: {e}")
+
+        zip_buffer.seek(0)
+        return zip_buffer.read()
+
+    async def _collect_files_recursive(
+        self,
+        client: httpx.AsyncClient,
+        path: str,
+        depth: int,
+        total_count: list[int] | None = None,
+    ) -> list[str]:
+        # mutable list used to share file count state across recursive calls
+        # (integers are immutable in Python so a list wrapper is needed)
+        if total_count is None:
+            total_count = [0]
+
+        if depth > MAX_RECURSION_DEPTH:
+            logger.warning(f"Max recursion depth reached for {path}")
+            return []
+
+        if total_count[0] >= MAX_SKILL_FILES:
+            return []
+
+        files: list[str] = []
+        url = f"{GITHUB_API_BASE}/{path}"
+        try:
+            response = await client.get(
+                url, headers={"Accept": "application/vnd.github.v3+json"}
+            )
+            if response.status_code != 200:
+                return []
+            data = response.json()
+            if not isinstance(data, list):
+                return []
+            for item in data:
+                if total_count[0] >= MAX_SKILL_FILES:
+                    logger.warning(f"Max total file count ({MAX_SKILL_FILES}) reached")
+                    break
+                name = item.get("name", "")
+                if not _validate_path_segment(name):
+                    continue
+                if item["type"] == "file":
+                    files.append(item["path"])
+                    total_count[0] += 1
+                elif item["type"] == "dir":
+                    sub_files = await self._collect_files_recursive(
+                        client, item["path"], depth + 1, total_count
+                    )
+                    files.extend(sub_files)
+        except httpx.HTTPError:
+            pass
+        return files
+
+    async def download_mcp_config(self, source: str) -> dict[str, Any] | None:
+        source = _validate_source_path(source)
+        url = f"{REPO_RAW_BASE}/{source}/.mcp.json"
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            try:
+                response = await client.get(url)
+                if response.status_code == 200:
+                    return cast(dict[str, Any], response.json())
+            except (httpx.HTTPError, ValueError):
+                pass
+        return None
+
+    async def _download_file(self, path: str) -> bytes:
+        url = f"{REPO_RAW_BASE}/{path}"
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            try:
+                response = await client.get(url)
+                response.raise_for_status()
+                return bytes(response.content)
+            except httpx.HTTPError as e:
+                raise MarketplaceException(
+                    f"Failed to download {path}: {e}",
+                    error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
+                )

--- a/backend/app/services/plugin_installer.py
+++ b/backend/app/services/plugin_installer.py
@@ -1,0 +1,280 @@
+import io
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal, cast
+
+from fastapi import UploadFile
+
+from app.models.schemas.marketplace import InstallComponentResult
+from app.models.types import (
+    CustomAgentDict,
+    CustomMcpDict,
+    CustomSkillDict,
+    CustomSlashCommandDict,
+    InstalledPluginDict,
+    PluginComponentsDict,
+)
+from app.services.agent import AgentService
+from app.services.command import CommandService
+from app.services.marketplace import MarketplaceService
+from app.services.skill import SkillService
+
+logger = logging.getLogger(__name__)
+
+McpCommandType = Literal["npx", "bunx", "uvx"]
+SUPPORTED_MCP_COMMANDS: set[McpCommandType] = {"npx", "bunx", "uvx"}
+
+
+@dataclass
+class InstallResult:
+    installed: list[str]
+    failed: list[InstallComponentResult]
+    new_agents: list[CustomAgentDict]
+    new_commands: list[CustomSlashCommandDict]
+    new_skills: list[CustomSkillDict]
+    new_mcps: list[CustomMcpDict]
+
+
+class PluginInstallerService:
+    def __init__(self) -> None:
+        self.marketplace = MarketplaceService()
+        self.skill_service = SkillService()
+        self.agent_service = AgentService()
+        self.command_service = CommandService()
+
+    async def install_components(
+        self,
+        user_id: str,
+        plugin_name: str,
+        components: list[str],
+        current_agents: list[CustomAgentDict],
+        current_commands: list[CustomSlashCommandDict],
+        current_skills: list[CustomSkillDict],
+        current_mcps: list[CustomMcpDict],
+    ) -> InstallResult:
+        details = await self.marketplace.get_plugin_details(plugin_name)
+        source = details.get("source", "")
+        available_components = details.get("components", {})
+
+        installed: list[str] = []
+        failed: list[InstallComponentResult] = []
+        new_agents: list[CustomAgentDict] = []
+        new_commands: list[CustomSlashCommandDict] = []
+        new_skills: list[CustomSkillDict] = []
+        new_mcps: list[CustomMcpDict] = []
+
+        for component in components:
+            if ":" not in component:
+                failed.append(
+                    InstallComponentResult(
+                        component=component,
+                        success=False,
+                        error="Invalid component format (expected 'type:name')",
+                    )
+                )
+                continue
+
+            comp_type, comp_name = component.split(":", 1)
+
+            validation_error = self._validate_component(
+                comp_type, comp_name, available_components
+            )
+            if validation_error:
+                failed.append(
+                    InstallComponentResult(
+                        component=component,
+                        success=False,
+                        error=validation_error,
+                    )
+                )
+                continue
+
+            try:
+                if comp_type == "agent":
+                    agent = await self._install_agent(
+                        user_id, source, comp_name, current_agents
+                    )
+                    new_agents.append(agent)
+                    installed.append(component)
+                elif comp_type == "command":
+                    cmd = await self._install_command(
+                        user_id, source, comp_name, current_commands
+                    )
+                    new_commands.append(cmd)
+                    installed.append(component)
+                elif comp_type == "skill":
+                    skill = await self._install_skill(
+                        user_id, source, comp_name, current_skills
+                    )
+                    new_skills.append(skill)
+                    installed.append(component)
+                elif comp_type == "mcp":
+                    mcp = await self._install_mcp(source, comp_name, current_mcps)
+                    if mcp:
+                        new_mcps.append(mcp)
+                        installed.append(component)
+                    else:
+                        failed.append(
+                            InstallComponentResult(
+                                component=component,
+                                success=False,
+                                error="MCP server uses unsupported command type",
+                            )
+                        )
+                else:
+                    failed.append(
+                        InstallComponentResult(
+                            component=component,
+                            success=False,
+                            error=f"Unknown component type: {comp_type}",
+                        )
+                    )
+            except Exception as e:
+                logger.error(f"Failed to install {component}: {e}")
+                failed.append(
+                    InstallComponentResult(
+                        component=component, success=False, error=str(e)
+                    )
+                )
+
+        return InstallResult(
+            installed=installed,
+            failed=failed,
+            new_agents=new_agents,
+            new_commands=new_commands,
+            new_skills=new_skills,
+            new_mcps=new_mcps,
+        )
+
+    def _validate_component(
+        self,
+        comp_type: str,
+        comp_name: str,
+        available: PluginComponentsDict,
+    ) -> str | None:
+        if comp_type == "agent":
+            if comp_name not in available.get("agents", []):
+                return f"Agent '{comp_name}' not found in plugin"
+        elif comp_type == "command":
+            if comp_name not in available.get("commands", []):
+                return f"Command '{comp_name}' not found in plugin"
+        elif comp_type == "skill":
+            if comp_name not in available.get("skills", []):
+                return f"Skill '{comp_name}' not found in plugin"
+        elif comp_type == "mcp":
+            if comp_name not in available.get("mcp_servers", []):
+                return f"MCP server '{comp_name}' not found in plugin"
+        elif comp_type not in ("agent", "command", "skill", "mcp"):
+            return f"Unknown component type: {comp_type}"
+        return None
+
+    async def _install_agent(
+        self,
+        user_id: str,
+        source: str,
+        agent_name: str,
+        current_agents: list[CustomAgentDict],
+    ) -> CustomAgentDict:
+        content = await self.marketplace.download_agent(source, agent_name)
+        file = self._create_upload_file(f"{agent_name}.md", content)
+        return await self.agent_service.upload(user_id, file, current_agents)
+
+    async def _install_command(
+        self,
+        user_id: str,
+        source: str,
+        command_name: str,
+        current_commands: list[CustomSlashCommandDict],
+    ) -> CustomSlashCommandDict:
+        content = await self.marketplace.download_command(source, command_name)
+        file = self._create_upload_file(f"{command_name}.md", content)
+        return await self.command_service.upload(user_id, file, current_commands)
+
+    async def _install_skill(
+        self,
+        user_id: str,
+        source: str,
+        skill_name: str,
+        current_skills: list[CustomSkillDict],
+    ) -> CustomSkillDict:
+        zip_content = await self.marketplace.download_skill_as_zip(source, skill_name)
+        file = self._create_upload_file(f"{skill_name}.zip", zip_content)
+        return await self.skill_service.upload(user_id, file, current_skills)
+
+    async def _install_mcp(
+        self,
+        source: str,
+        mcp_name: str,
+        current_mcps: list[CustomMcpDict],
+    ) -> CustomMcpDict | None:
+        config = await self.marketplace.download_mcp_config(source)
+        if not config:
+            return None
+
+        servers = config.get("mcpServers") or config
+        server_config = servers.get(mcp_name)
+        if not server_config:
+            return None
+
+        if any(m.get("name") == mcp_name for m in current_mcps):
+            raise Exception(f"MCP server '{mcp_name}' already exists")
+
+        return self._convert_mcp_config(mcp_name, server_config)
+
+    def _convert_mcp_config(
+        self, name: str, config: dict[str, Any]
+    ) -> CustomMcpDict | None:
+        command = config.get("command", "")
+        args = config.get("args", [])
+
+        if command not in SUPPORTED_MCP_COMMANDS:
+            logger.warning(f"MCP server '{name}' uses unsupported command: {command}")
+            return None
+
+        command_type = cast(McpCommandType, command)
+        package: str | None = None
+        filtered_args: list[str] = []
+
+        # parse npx/bunx/uvx args: extract package name from "-y <pkg>" or first non-flag arg
+        skip_next = False
+        for i, arg in enumerate(args):
+            if skip_next:
+                skip_next = False
+                continue
+            if arg == "-y":
+                skip_next = True
+                if i + 1 < len(args):
+                    package = args[i + 1]
+            elif arg.startswith("@") or (not arg.startswith("-") and not package):
+                package = arg
+            else:
+                filtered_args.append(arg)
+
+        return {
+            "name": name,
+            "description": f"MCP server from marketplace: {name}",
+            "command_type": command_type,
+            "package": package,
+            "url": None,
+            "env_vars": config.get("env"),
+            "args": filtered_args if filtered_args else None,
+            "enabled": True,
+        }
+
+    def _create_upload_file(self, filename: str, content: bytes) -> UploadFile:
+        file_obj = io.BytesIO(content)
+        return UploadFile(file=file_obj, filename=filename)
+
+    def create_installed_record(
+        self,
+        plugin_name: str,
+        version: str | None,
+        components: list[str],
+    ) -> InstalledPluginDict:
+        return {
+            "name": plugin_name,
+            "version": version,
+            "installed_at": datetime.now(timezone.utc).isoformat(),
+            "components": components,
+        }

--- a/backend/migrations/versions/e5f6g7h8i9j0_add_installed_plugins.py
+++ b/backend/migrations/versions/e5f6g7h8i9j0_add_installed_plugins.py
@@ -1,0 +1,28 @@
+"""add installed_plugins to user_settings
+
+Revision ID: e5f6g7h8i9j0
+Revises: d4e5f6g7h8i9
+Create Date: 2025-12-29 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e5f6g7h8i9j0'
+down_revision: Union[str, None] = 'd4e5f6g7h8i9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'user_settings',
+        sa.Column('installed_plugins', sa.JSON(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('user_settings', 'installed_plugins')

--- a/backend/tests/test_marketplace.py
+++ b/backend/tests/test_marketplace.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+# Real plugin from GitHub marketplace for integration tests
+TEST_PLUGIN = "pr-review-toolkit"
+
+
+class TestGetCatalog:
+    async def test_get_catalog_success(
+        self,
+        marketplace_client: AsyncClient,
+    ) -> None:
+        response = await marketplace_client.get("/api/v1/marketplace/catalog")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+        plugin_names = [p["name"] for p in data]
+        assert TEST_PLUGIN in plugin_names
+
+    async def test_get_catalog_force_refresh(
+        self,
+        marketplace_client: AsyncClient,
+    ) -> None:
+        response = await marketplace_client.get(
+            "/api/v1/marketplace/catalog",
+            params={"force_refresh": True},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+    async def test_get_catalog_returns_correct_schema(
+        self,
+        marketplace_client: AsyncClient,
+    ) -> None:
+        response = await marketplace_client.get("/api/v1/marketplace/catalog")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        for plugin in data:
+            assert "name" in plugin
+            assert "description" in plugin
+            assert "category" in plugin
+            assert "source" in plugin
+
+
+class TestGetPluginDetails:
+    async def test_get_plugin_details_success(
+        self,
+        marketplace_client: AsyncClient,
+    ) -> None:
+        response = await marketplace_client.get(
+            f"/api/v1/marketplace/catalog/{TEST_PLUGIN}"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == TEST_PLUGIN
+        assert "description" in data
+        assert "components" in data
+
+    async def test_get_plugin_details_not_found(
+        self,
+        marketplace_client: AsyncClient,
+    ) -> None:
+        response = await marketplace_client.get(
+            "/api/v1/marketplace/catalog/nonexistent-plugin-xyz123"
+        )
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    async def test_get_plugin_details_includes_components(
+        self,
+        marketplace_client: AsyncClient,
+    ) -> None:
+        response = await marketplace_client.get(
+            f"/api/v1/marketplace/catalog/{TEST_PLUGIN}"
+        )
+
+        assert response.status_code == 200
+        components = response.json()["components"]
+        assert "agents" in components
+        assert "commands" in components
+        assert "skills" in components
+        assert "mcp_servers" in components
+
+
+class TestInstallComponents:
+    @pytest.fixture
+    async def plugin_with_agent(
+        self, marketplace_client: AsyncClient
+    ) -> tuple[str, str]:
+        response = await marketplace_client.get("/api/v1/marketplace/catalog")
+        plugins = response.json()
+
+        for plugin in plugins:
+            details_response = await marketplace_client.get(
+                f"/api/v1/marketplace/catalog/{plugin['name']}"
+            )
+            if details_response.status_code == 200:
+                components = details_response.json().get("components", {})
+                agents = components.get("agents", [])
+                if agents:
+                    return plugin["name"], agents[0]
+
+        pytest.skip("No plugin with agents found in marketplace")
+
+    @pytest.fixture
+    async def plugin_with_command(
+        self, marketplace_client: AsyncClient
+    ) -> tuple[str, str]:
+        response = await marketplace_client.get("/api/v1/marketplace/catalog")
+        plugins = response.json()
+
+        for plugin in plugins:
+            details_response = await marketplace_client.get(
+                f"/api/v1/marketplace/catalog/{plugin['name']}"
+            )
+            if details_response.status_code == 200:
+                components = details_response.json().get("components", {})
+                commands = components.get("commands", [])
+                if commands:
+                    return plugin["name"], commands[0]
+
+        pytest.skip("No plugin with commands found in marketplace")
+
+    async def test_install_agent_success(
+        self,
+        marketplace_client: AsyncClient,
+        marketplace_auth_headers: dict[str, str],
+        plugin_with_agent: tuple[str, str],
+    ) -> None:
+        plugin_name, agent_name = plugin_with_agent
+
+        response = await marketplace_client.post(
+            "/api/v1/marketplace/install",
+            json={
+                "plugin_name": plugin_name,
+                "components": [f"agent:{agent_name}"],
+            },
+            headers=marketplace_auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["plugin_name"] == plugin_name
+        assert f"agent:{agent_name}" in data["installed"]
+        assert data["failed"] == []
+
+    async def test_install_command_success(
+        self,
+        marketplace_client: AsyncClient,
+        marketplace_auth_headers: dict[str, str],
+        plugin_with_command: tuple[str, str],
+    ) -> None:
+        plugin_name, command_name = plugin_with_command
+
+        response = await marketplace_client.post(
+            "/api/v1/marketplace/install",
+            json={
+                "plugin_name": plugin_name,
+                "components": [f"command:{command_name}"],
+            },
+            headers=marketplace_auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert f"command:{command_name}" in data["installed"]
+        assert data["failed"] == []
+
+    async def test_install_unauthorized(
+        self,
+        marketplace_client: AsyncClient,
+    ) -> None:
+        response = await marketplace_client.post(
+            "/api/v1/marketplace/install",
+            json={
+                "plugin_name": TEST_PLUGIN,
+                "components": ["agent:test"],
+            },
+        )
+
+        assert response.status_code == 401
+
+    async def test_install_plugin_not_found(
+        self,
+        marketplace_client: AsyncClient,
+        marketplace_auth_headers: dict[str, str],
+    ) -> None:
+        response = await marketplace_client.post(
+            "/api/v1/marketplace/install",
+            json={
+                "plugin_name": "nonexistent-plugin-xyz123",
+                "components": ["agent:test"],
+            },
+            headers=marketplace_auth_headers,
+        )
+
+        assert response.status_code == 404
+
+    async def test_install_invalid_component_format(
+        self,
+        marketplace_client: AsyncClient,
+        marketplace_auth_headers: dict[str, str],
+    ) -> None:
+        response = await marketplace_client.post(
+            "/api/v1/marketplace/install",
+            json={
+                "plugin_name": TEST_PLUGIN,
+                "components": ["invalid-format"],
+            },
+            headers=marketplace_auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["installed"] == []
+        assert len(data["failed"]) == 1
+        assert data["failed"][0]["component"] == "invalid-format"
+        assert "format" in data["failed"][0]["error"].lower()
+
+    async def test_install_unknown_component_type(
+        self,
+        marketplace_client: AsyncClient,
+        marketplace_auth_headers: dict[str, str],
+    ) -> None:
+        response = await marketplace_client.post(
+            "/api/v1/marketplace/install",
+            json={
+                "plugin_name": TEST_PLUGIN,
+                "components": ["unknown:test"],
+            },
+            headers=marketplace_auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["installed"] == []
+        assert len(data["failed"]) == 1
+        assert "unknown" in data["failed"][0]["error"].lower()
+
+    async def test_install_component_not_in_plugin(
+        self,
+        marketplace_client: AsyncClient,
+        marketplace_auth_headers: dict[str, str],
+    ) -> None:
+        response = await marketplace_client.post(
+            "/api/v1/marketplace/install",
+            json={
+                "plugin_name": TEST_PLUGIN,
+                "components": ["agent:nonexistent-agent-xyz123"],
+            },
+            headers=marketplace_auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["installed"] == []
+        assert len(data["failed"]) == 1
+        assert "not found" in data["failed"][0]["error"].lower()
+
+
+class TestGetInstalledPlugins:
+    async def test_get_installed_empty(
+        self,
+        marketplace_client: AsyncClient,
+        marketplace_auth_headers: dict[str, str],
+    ) -> None:
+        response = await marketplace_client.get(
+            "/api/v1/marketplace/installed",
+            headers=marketplace_auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 0
+
+    async def test_get_installed_unauthorized(
+        self,
+        marketplace_client: AsyncClient,
+    ) -> None:
+        response = await marketplace_client.get("/api/v1/marketplace/installed")
+
+        assert response.status_code == 401
+
+
+class TestUninstallComponents:
+    async def test_uninstall_unauthorized(
+        self,
+        marketplace_client: AsyncClient,
+    ) -> None:
+        response = await marketplace_client.post(
+            "/api/v1/marketplace/uninstall",
+            json={
+                "plugin_name": TEST_PLUGIN,
+                "components": ["agent:test"],
+            },
+        )
+
+        assert response.status_code == 401
+
+    async def test_uninstall_component_not_found(
+        self,
+        marketplace_client: AsyncClient,
+        marketplace_auth_headers: dict[str, str],
+    ) -> None:
+        response = await marketplace_client.post(
+            "/api/v1/marketplace/uninstall",
+            json={
+                "plugin_name": TEST_PLUGIN,
+                "components": ["agent:never-installed"],
+            },
+            headers=marketplace_auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["uninstalled"] == []
+        assert len(data["failed"]) == 1
+        assert "not found" in data["failed"][0]["error"].lower()
+
+    async def test_uninstall_invalid_format(
+        self,
+        marketplace_client: AsyncClient,
+        marketplace_auth_headers: dict[str, str],
+    ) -> None:
+        response = await marketplace_client.post(
+            "/api/v1/marketplace/uninstall",
+            json={
+                "plugin_name": TEST_PLUGIN,
+                "components": ["invalid-format"],
+            },
+            headers=marketplace_auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["uninstalled"] == []
+        assert len(data["failed"]) == 1
+        assert "format" in data["failed"][0]["error"].lower()
+
+    async def test_uninstall_unknown_type(
+        self,
+        marketplace_client: AsyncClient,
+        marketplace_auth_headers: dict[str, str],
+    ) -> None:
+        response = await marketplace_client.post(
+            "/api/v1/marketplace/uninstall",
+            json={
+                "plugin_name": TEST_PLUGIN,
+                "components": ["unknown:test"],
+            },
+            headers=marketplace_auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["uninstalled"] == []
+        assert len(data["failed"]) == 1
+        assert "unknown" in data["failed"][0]["error"].lower()
+
+
+class TestInstallUninstallFlow:
+    @pytest.fixture
+    async def plugin_with_agent(
+        self, marketplace_client: AsyncClient
+    ) -> tuple[str, str]:
+        response = await marketplace_client.get("/api/v1/marketplace/catalog")
+        plugins = response.json()
+
+        for plugin in plugins:
+            details_response = await marketplace_client.get(
+                f"/api/v1/marketplace/catalog/{plugin['name']}"
+            )
+            if details_response.status_code == 200:
+                components = details_response.json().get("components", {})
+                agents = components.get("agents", [])
+                if agents:
+                    return plugin["name"], agents[0]
+
+        pytest.skip("No plugin with agents found in marketplace")
+
+    async def test_install_then_uninstall(
+        self,
+        marketplace_client: AsyncClient,
+        marketplace_auth_headers: dict[str, str],
+        plugin_with_agent: tuple[str, str],
+    ) -> None:
+        plugin_name, agent_name = plugin_with_agent
+        component_id = f"agent:{agent_name}"
+
+        install_response = await marketplace_client.post(
+            "/api/v1/marketplace/install",
+            json={
+                "plugin_name": plugin_name,
+                "components": [component_id],
+            },
+            headers=marketplace_auth_headers,
+        )
+        assert install_response.status_code == 200
+        assert component_id in install_response.json()["installed"]
+
+        installed_response = await marketplace_client.get(
+            "/api/v1/marketplace/installed",
+            headers=marketplace_auth_headers,
+        )
+        assert installed_response.status_code == 200
+        assert len(installed_response.json()) == 1
+        assert installed_response.json()[0]["name"] == plugin_name
+
+        uninstall_response = await marketplace_client.post(
+            "/api/v1/marketplace/uninstall",
+            json={
+                "plugin_name": plugin_name,
+                "components": [component_id],
+            },
+            headers=marketplace_auth_headers,
+        )
+        assert uninstall_response.status_code == 200
+        assert component_id in uninstall_response.json()["uninstalled"]
+
+        final_installed = await marketplace_client.get(
+            "/api/v1/marketplace/installed",
+            headers=marketplace_auth_headers,
+        )
+        assert final_installed.status_code == 200
+        assert len(final_installed.json()) == 0

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   # Test PostgreSQL database
   postgres-test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   postgres:
     image: postgres:13-alpine
@@ -33,7 +35,7 @@ services:
       retries: 5
 
   sandbox-setup:
-    image: docker:27-cli
+    image: docker:20.10-cli
     container_name: claudex-sandbox-setup
     restart: "no"
     volumes:

--- a/frontend/src/components/settings/dialogs/PluginDetailModal.tsx
+++ b/frontend/src/components/settings/dialogs/PluginDetailModal.tsx
@@ -1,0 +1,373 @@
+import { useState, useEffect } from 'react';
+import { BaseModal } from '@/components/ui/shared/BaseModal';
+import { Button } from '@/components/ui/primitives/Button';
+import { Spinner } from '@/components/ui/primitives/Spinner';
+import MarkDown from '@/components/ui/MarkDown';
+import { Bot, Terminal, Zap, Plug, ExternalLink, X, AlertCircle } from 'lucide-react';
+import {
+  usePluginDetailsQuery,
+  useInstallComponentsMutation,
+  useUninstallComponentsMutation,
+  useInstalledPluginsQuery,
+} from '@/hooks/queries/useMarketplaceQueries';
+import type { MarketplacePlugin } from '@/types/marketplace.types';
+import toast from 'react-hot-toast';
+
+interface PluginDetailModalProps {
+  plugin: MarketplacePlugin | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const COMPONENT_ICONS = {
+  agent: Bot,
+  command: Terminal,
+  skill: Zap,
+  mcp: Plug,
+} as const;
+
+export const PluginDetailModal: React.FC<PluginDetailModalProps> = ({
+  plugin,
+  isOpen,
+  onClose,
+}) => {
+  const [selectedComponents, setSelectedComponents] = useState<Set<string>>(new Set());
+  const [selectedForUninstall, setSelectedForUninstall] = useState<Set<string>>(new Set());
+
+  const {
+    data: details,
+    isLoading,
+    isError,
+    error,
+  } = usePluginDetailsQuery(isOpen ? (plugin?.name ?? null) : null);
+  const { data: installedPlugins = [] } = useInstalledPluginsQuery();
+  const installMutation = useInstallComponentsMutation();
+  const uninstallMutation = useUninstallComponentsMutation();
+
+  const installedPlugin = installedPlugins.find((p) => p.name === plugin?.name);
+  const installedComponents = new Set(installedPlugin?.components ?? []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedComponents(new Set());
+      setSelectedForUninstall(new Set());
+    }
+  }, [isOpen]);
+
+  if (!plugin) return null;
+
+  const allComponents = details
+    ? [
+        ...details.components.agents.map((name) => ({
+          type: 'agent' as const,
+          name,
+        })),
+        ...details.components.commands.map((name) => ({
+          type: 'command' as const,
+          name,
+        })),
+        ...details.components.skills.map((name) => ({
+          type: 'skill' as const,
+          name,
+        })),
+        ...details.components.mcp_servers.map((name) => ({
+          type: 'mcp' as const,
+          name,
+        })),
+      ]
+    : [];
+
+  const toggleComponent = (componentId: string) => {
+    const newSelected = new Set(selectedComponents);
+    if (newSelected.has(componentId)) {
+      newSelected.delete(componentId);
+    } else {
+      newSelected.add(componentId);
+    }
+    setSelectedComponents(newSelected);
+  };
+
+  const toggleUninstall = (componentId: string) => {
+    const newSelected = new Set(selectedForUninstall);
+    if (newSelected.has(componentId)) {
+      newSelected.delete(componentId);
+    } else {
+      newSelected.add(componentId);
+    }
+    setSelectedForUninstall(newSelected);
+  };
+
+  const selectAll = () => {
+    const notInstalled = allComponents
+      .map((c) => `${c.type}:${c.name}`)
+      .filter((id) => !installedComponents.has(id));
+    setSelectedComponents(new Set(notInstalled));
+  };
+
+  const selectAllForUninstall = () => {
+    const installed = allComponents
+      .map((c) => `${c.type}:${c.name}`)
+      .filter((id) => installedComponents.has(id));
+    setSelectedForUninstall(new Set(installed));
+  };
+
+  const hasUninstalledComponents = allComponents.some(
+    (c) => !installedComponents.has(`${c.type}:${c.name}`),
+  );
+  const hasInstalledComponents = allComponents.some((c) =>
+    installedComponents.has(`${c.type}:${c.name}`),
+  );
+
+  const handleInstall = async () => {
+    if (selectedComponents.size === 0) {
+      toast.error('Select at least one component to install');
+      return;
+    }
+
+    try {
+      const result = await installMutation.mutateAsync({
+        plugin_name: plugin.name,
+        components: Array.from(selectedComponents),
+      });
+
+      if (result.installed.length > 0) {
+        toast.success(`Installed ${result.installed.length} component(s)`);
+      }
+      if (result.failed.length > 0) {
+        const errorMessages = result.failed
+          .map((f) => f.error || 'Unknown error')
+          .filter((e) => e)
+          .join(', ');
+        toast.error(`Failed: ${errorMessages || 'Installation failed'}`);
+      }
+      if (result.installed.length > 0) {
+        onClose();
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Installation failed');
+    }
+  };
+
+  const handleUninstall = async () => {
+    if (selectedForUninstall.size === 0) {
+      toast.error('Select at least one component to uninstall');
+      return;
+    }
+
+    try {
+      const result = await uninstallMutation.mutateAsync({
+        plugin_name: plugin.name,
+        components: Array.from(selectedForUninstall),
+      });
+
+      if (result.uninstalled.length > 0) {
+        toast.success(`Uninstalled ${result.uninstalled.length} component(s)`);
+        setSelectedForUninstall(new Set());
+      }
+      if (result.failed.length > 0) {
+        const errorMessages = result.failed
+          .map((f) => f.error || 'Unknown error')
+          .filter((e) => e)
+          .join(', ');
+        toast.error(`Failed: ${errorMessages || 'Uninstallation failed'}`);
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Uninstallation failed');
+    }
+  };
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="xl">
+      <div className="flex max-h-[80vh] flex-col">
+        <div className="border-border-primary bg-surface-primary dark:border-border-dark-primary dark:bg-surface-dark-primary flex items-center justify-between border-b p-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h2 className="truncate text-lg font-semibold text-text-primary dark:text-text-dark-primary">
+                {plugin.name}
+              </h2>
+              {plugin.version && (
+                <span className="rounded bg-surface-secondary px-2 py-0.5 text-xs dark:bg-surface-dark-secondary">
+                  v{plugin.version}
+                </span>
+              )}
+            </div>
+            {plugin.author?.name && (
+              <p className="mt-0.5 text-sm text-text-secondary dark:text-text-dark-secondary">
+                by {plugin.author.name}
+              </p>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {plugin.homepage && (
+              <a
+                href={plugin.homepage}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded p-1.5 text-text-tertiary hover:bg-surface-secondary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-secondary dark:hover:text-text-dark-primary"
+              >
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            )}
+            <button
+              onClick={onClose}
+              className="rounded p-1.5 text-text-tertiary hover:bg-surface-secondary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-secondary dark:hover:text-text-dark-primary"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4">
+          <p className="mb-4 text-sm text-text-secondary dark:text-text-dark-secondary">
+            {plugin.description}
+          </p>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Spinner size="lg" />
+            </div>
+          ) : isError ? (
+            <div className="rounded-lg border border-error-200 bg-error-50 p-6 text-center dark:border-error-800 dark:bg-error-900/20">
+              <AlertCircle className="mx-auto mb-3 h-6 w-6 text-error-500 dark:text-error-400" />
+              <p className="mb-1 text-sm font-medium text-error-700 dark:text-error-300">
+                Failed to load plugin details
+              </p>
+              <p className="text-xs text-error-600 dark:text-error-400">
+                {error instanceof Error ? error.message : 'An error occurred'}
+              </p>
+            </div>
+          ) : details && allComponents.length > 0 ? (
+            <>
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-sm font-medium text-text-primary dark:text-text-dark-primary">
+                  Components
+                </h3>
+                <div className="flex gap-3">
+                  {hasInstalledComponents && (
+                    <button
+                      onClick={selectAllForUninstall}
+                      className="text-xs text-error-600 hover:text-error-700 dark:text-error-400 dark:hover:text-error-300"
+                    >
+                      Select all installed
+                    </button>
+                  )}
+                  {hasUninstalledComponents && (
+                    <button
+                      onClick={selectAll}
+                      className="text-xs text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+                    >
+                      Select all available
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              <div className="mb-4 space-y-2">
+                {allComponents.map((comp) => {
+                  const componentId = `${comp.type}:${comp.name}`;
+                  const Icon = COMPONENT_ICONS[comp.type];
+                  const isInstalled = installedComponents.has(componentId);
+                  const isSelected = selectedComponents.has(componentId);
+                  const isSelectedForUninstall = selectedForUninstall.has(componentId);
+
+                  return (
+                    <label
+                      key={componentId}
+                      className={`flex cursor-pointer items-center justify-between rounded-lg border p-3 transition-colors ${
+                        isSelectedForUninstall
+                          ? 'border-error-500 bg-error-50 dark:border-error-400 dark:bg-error-900/20'
+                          : isInstalled
+                            ? 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/20'
+                            : isSelected
+                              ? 'border-brand-500 bg-brand-50 dark:border-brand-400 dark:bg-brand-900/20'
+                              : 'border-border-primary dark:border-border-dark-primary hover:border-brand-300 dark:hover:border-brand-600'
+                      }`}
+                    >
+                      <div className="flex items-center gap-3">
+                        <Icon
+                          className={`h-4 w-4 ${
+                            isSelectedForUninstall
+                              ? 'text-error-600 dark:text-error-400'
+                              : isInstalled
+                                ? 'text-green-600 dark:text-green-400'
+                                : 'text-text-tertiary dark:text-text-dark-tertiary'
+                          }`}
+                        />
+                        <div>
+                          <span className="text-sm font-medium text-text-primary dark:text-text-dark-primary">
+                            {comp.name}
+                          </span>
+                          <span className="ml-2 text-xs capitalize text-text-tertiary dark:text-text-dark-tertiary">
+                            {comp.type}
+                          </span>
+                        </div>
+                      </div>
+                      {isInstalled ? (
+                        <input
+                          type="checkbox"
+                          checked={isSelectedForUninstall}
+                          onChange={() => toggleUninstall(componentId)}
+                          className="h-4 w-4 rounded border-gray-300 text-error-600 focus:ring-error-500"
+                        />
+                      ) : (
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleComponent(componentId)}
+                          className="h-4 w-4 rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                        />
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+
+              {details.readme && (
+                <div className="mb-4">
+                  <h3 className="mb-2 text-sm font-medium text-text-primary dark:text-text-dark-primary">
+                    Documentation
+                  </h3>
+                  <div className="max-h-64 overflow-y-auto rounded-lg bg-surface-secondary p-3 dark:bg-surface-dark-secondary">
+                    <MarkDown content={details.readme} />
+                  </div>
+                </div>
+              )}
+            </>
+          ) : (
+            <p className="py-4 text-center text-sm text-text-tertiary dark:text-text-dark-tertiary">
+              No components available
+            </p>
+          )}
+        </div>
+
+        <div className="border-border-primary bg-surface-primary dark:border-border-dark-primary dark:bg-surface-dark-primary flex justify-end gap-2 border-t p-4">
+          <Button variant="outline" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          {selectedForUninstall.size > 0 && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleUninstall}
+              disabled={uninstallMutation.isPending}
+              isLoading={uninstallMutation.isPending}
+            >
+              Uninstall ({selectedForUninstall.size})
+            </Button>
+          )}
+          {selectedComponents.size > 0 && (
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleInstall}
+              disabled={installMutation.isPending || isError}
+              isLoading={installMutation.isPending}
+            >
+              Install ({selectedComponents.size})
+            </Button>
+          )}
+        </div>
+      </div>
+    </BaseModal>
+  );
+};

--- a/frontend/src/components/settings/tabs/MarketplaceSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/MarketplaceSettingsTab.tsx
@@ -1,0 +1,154 @@
+import { useState, useMemo } from 'react';
+import { Input } from '@/components/ui/primitives/Input';
+import { Spinner } from '@/components/ui/primitives/Spinner';
+import { Store, Search, RefreshCw, AlertCircle } from 'lucide-react';
+import {
+  useMarketplaceCatalogQuery,
+  useInstalledPluginsQuery,
+  useRefreshCatalogMutation,
+} from '@/hooks/queries/useMarketplaceQueries';
+import { PluginCard } from './marketplace/PluginCard';
+import { PluginDetailModal } from '../dialogs/PluginDetailModal';
+import type { MarketplacePlugin } from '@/types/marketplace.types';
+
+const CATEGORIES = [
+  'all',
+  'development',
+  'productivity',
+  'testing',
+  'database',
+  'deployment',
+  'security',
+  'design',
+  'other',
+] as const;
+
+export const MarketplaceSettingsTab: React.FC = () => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<string>('all');
+  const [selectedPlugin, setSelectedPlugin] = useState<MarketplacePlugin | null>(null);
+
+  const { data: plugins = [], isLoading, isError, error } = useMarketplaceCatalogQuery();
+  const { data: installedPlugins = [] } = useInstalledPluginsQuery();
+  const refreshMutation = useRefreshCatalogMutation();
+
+  const installedNames = useMemo(
+    () => new Set(installedPlugins.map((p) => p.name)),
+    [installedPlugins],
+  );
+
+  const filteredPlugins = useMemo(() => {
+    return plugins.filter((plugin) => {
+      const matchesSearch =
+        !searchQuery ||
+        plugin.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        plugin.description.toLowerCase().includes(searchQuery.toLowerCase());
+
+      const matchesCategory = selectedCategory === 'all' || plugin.category === selectedCategory;
+
+      return matchesSearch && matchesCategory;
+    });
+  }, [plugins, searchQuery, selectedCategory]);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-medium text-text-primary dark:text-text-dark-primary">
+            Plugin Marketplace
+          </h2>
+          <button
+            onClick={() => refreshMutation.mutate()}
+            disabled={refreshMutation.isPending}
+            className="flex items-center gap-1.5 rounded px-2 py-1 text-xs text-text-secondary hover:bg-surface-secondary hover:text-text-primary disabled:opacity-50 dark:text-text-dark-secondary dark:hover:bg-surface-dark-secondary dark:hover:text-text-dark-primary"
+          >
+            <RefreshCw
+              className={`h-3.5 w-3.5 ${refreshMutation.isPending ? 'animate-spin' : ''}`}
+            />
+            Refresh
+          </button>
+        </div>
+
+        <p className="mb-4 text-xs text-text-tertiary dark:text-text-dark-tertiary">
+          Browse and install plugins from the official Claude Code marketplace. Plugins can include
+          agents, commands, skills, and MCP servers.
+        </p>
+
+        <div className="mb-4 flex flex-col gap-2 sm:flex-row">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-tertiary dark:text-text-dark-tertiary" />
+            <Input
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search plugins..."
+              className="pl-9"
+            />
+          </div>
+          <select
+            value={selectedCategory}
+            onChange={(e) => setSelectedCategory(e.target.value)}
+            className="border-border-primary bg-surface-primary dark:border-border-dark-primary dark:bg-surface-dark-primary rounded-md border px-3 py-2 text-sm text-text-primary focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:text-text-dark-primary"
+          >
+            {CATEGORIES.map((category) => (
+              <option key={category} value={category}>
+                {category === 'all'
+                  ? 'All Categories'
+                  : category.charAt(0).toUpperCase() + category.slice(1)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-12">
+            <Spinner size="lg" />
+          </div>
+        ) : isError ? (
+          <div className="rounded-lg border border-error-200 bg-error-50 p-6 text-center dark:border-error-800 dark:bg-error-900/20">
+            <AlertCircle className="mx-auto mb-3 h-8 w-8 text-error-500 dark:text-error-400" />
+            <p className="mb-2 text-sm font-medium text-error-700 dark:text-error-300">
+              Failed to load marketplace
+            </p>
+            <p className="mb-4 text-xs text-error-600 dark:text-error-400">
+              {error instanceof Error ? error.message : 'An error occurred while fetching plugins'}
+            </p>
+            <button
+              onClick={() => refreshMutation.mutate()}
+              disabled={refreshMutation.isPending}
+              className="inline-flex items-center gap-1.5 rounded-md bg-error-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-error-700 disabled:opacity-50"
+            >
+              <RefreshCw
+                className={`h-3.5 w-3.5 ${refreshMutation.isPending ? 'animate-spin' : ''}`}
+              />
+              Try Again
+            </button>
+          </div>
+        ) : filteredPlugins.length === 0 ? (
+          <div className="border-border-primary dark:border-border-dark-primary rounded-lg border p-8 text-center">
+            <Store className="mx-auto mb-3 h-8 w-8 text-text-quaternary dark:text-text-dark-quaternary" />
+            <p className="text-sm text-text-tertiary dark:text-text-dark-tertiary">
+              {plugins.length === 0 ? 'No plugins available' : 'No plugins match your search'}
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {filteredPlugins.map((plugin) => (
+              <PluginCard
+                key={plugin.name}
+                plugin={plugin}
+                isInstalled={installedNames.has(plugin.name)}
+                onClick={() => setSelectedPlugin(plugin)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <PluginDetailModal
+        plugin={selectedPlugin}
+        isOpen={!!selectedPlugin}
+        onClose={() => setSelectedPlugin(null)}
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/settings/tabs/marketplace/PluginCard.tsx
+++ b/frontend/src/components/settings/tabs/marketplace/PluginCard.tsx
@@ -1,0 +1,67 @@
+import type { MarketplacePlugin } from '@/types/marketplace.types';
+import { ChevronRight } from 'lucide-react';
+import { Badge } from '@/components/ui/primitives/Badge';
+
+interface PluginCardProps {
+  plugin: MarketplacePlugin;
+  isInstalled: boolean;
+  onClick: () => void;
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  development: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+  productivity: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+  testing: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
+  database: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300',
+  deployment: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+  security: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300',
+  design: 'bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-300',
+  other: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+};
+
+export const PluginCard: React.FC<PluginCardProps> = ({ plugin, isInstalled, onClick }) => {
+  const categoryColor = CATEGORY_COLORS[plugin.category] || CATEGORY_COLORS.other;
+
+  return (
+    <button
+      onClick={onClick}
+      className="border-border-primary bg-surface-primary dark:border-border-dark-primary dark:bg-surface-dark-primary group flex w-full flex-col rounded-lg border p-4 text-left transition-all hover:border-brand-500 hover:shadow-md dark:hover:border-brand-400"
+    >
+      <div className="mb-2 flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-sm font-medium text-text-primary dark:text-text-dark-primary">
+              {plugin.name}
+            </h3>
+            {isInstalled && (
+              <Badge variant="success" size="sm">
+                Installed
+              </Badge>
+            )}
+          </div>
+          {plugin.author?.name && (
+            <p className="mt-0.5 text-xs text-text-tertiary dark:text-text-dark-tertiary">
+              by {plugin.author.name}
+            </p>
+          )}
+        </div>
+        {plugin.version && (
+          <span className="flex-shrink-0 rounded bg-surface-secondary px-1.5 py-0.5 text-xs text-text-secondary dark:bg-surface-dark-secondary dark:text-text-dark-secondary">
+            v{plugin.version}
+          </span>
+        )}
+      </div>
+
+      <p className="mb-3 line-clamp-2 flex-1 text-xs text-text-secondary dark:text-text-dark-secondary">
+        {plugin.description}
+      </p>
+
+      <div className="flex items-center justify-between">
+        <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${categoryColor}`}>
+          {plugin.category}
+        </span>
+        <ChevronRight className="h-4 w-4 text-text-tertiary transition-colors group-hover:text-brand-500 dark:text-text-dark-tertiary dark:group-hover:text-brand-400" />
+      </div>
+    </button>
+  );
+};

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -22,4 +22,9 @@ export const queryKeys = {
     task: (taskId: string) => ['scheduling', 'tasks', taskId] as const,
     history: (taskId: string) => ['scheduling', 'tasks', taskId, 'history'] as const,
   },
+  marketplace: {
+    catalog: ['marketplace', 'catalog'] as const,
+    pluginDetails: (pluginName: string) => ['marketplace', 'plugin', pluginName] as const,
+    installed: ['marketplace', 'installed'] as const,
+  },
 } as const;

--- a/frontend/src/hooks/queries/useMarketplaceQueries.ts
+++ b/frontend/src/hooks/queries/useMarketplaceQueries.ts
@@ -1,0 +1,70 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { marketplaceService } from '@/services/marketplaceService';
+import type {
+  InstallComponentRequest,
+  InstallResponse,
+  InstalledPlugin,
+  MarketplacePlugin,
+  PluginDetails,
+  UninstallComponentRequest,
+  UninstallResponse,
+} from '@/types/marketplace.types';
+import { queryKeys } from './queryKeys';
+
+export const useMarketplaceCatalogQuery = (forceRefresh = false) => {
+  return useQuery<MarketplacePlugin[]>({
+    queryKey: queryKeys.marketplace.catalog,
+    queryFn: () => marketplaceService.getCatalog(forceRefresh),
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+export const usePluginDetailsQuery = (pluginName: string | null) => {
+  return useQuery<PluginDetails>({
+    queryKey: queryKeys.marketplace.pluginDetails(pluginName ?? ''),
+    queryFn: () => marketplaceService.getPluginDetails(pluginName!),
+    enabled: !!pluginName,
+  });
+};
+
+export const useInstalledPluginsQuery = () => {
+  return useQuery<InstalledPlugin[]>({
+    queryKey: queryKeys.marketplace.installed,
+    queryFn: () => marketplaceService.getInstalledPlugins(),
+  });
+};
+
+export const useInstallComponentsMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<InstallResponse, Error, InstallComponentRequest>({
+    mutationFn: (request) => marketplaceService.installComponents(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.installed });
+      queryClient.invalidateQueries({ queryKey: [queryKeys.settings] });
+    },
+  });
+};
+
+export const useUninstallComponentsMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<UninstallResponse, Error, UninstallComponentRequest>({
+    mutationFn: (request) => marketplaceService.uninstallComponents(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.installed });
+      queryClient.invalidateQueries({ queryKey: [queryKeys.settings] });
+    },
+  });
+};
+
+export const useRefreshCatalogMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<MarketplacePlugin[], Error>({
+    mutationFn: () => marketplaceService.getCatalog(true),
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKeys.marketplace.catalog, data);
+    },
+  });
+};

--- a/frontend/src/hooks/useCrudForm.ts
+++ b/frontend/src/hooks/useCrudForm.ts
@@ -1,11 +1,18 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, type Dispatch, type SetStateAction } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
 import { logger } from '@/utils/logger';
+import { queryKeys } from './queries/queryKeys';
 
 interface UseCrudFormOptions<S, T, K extends keyof S> {
   createDefault: () => T;
   validateForm: (form: T, editingIndex: number | null) => string | null;
   getArrayKey: K;
   itemName: string;
+  createFn?: (data: T) => Promise<T>;
+  updateFn?: (name: string, data: Partial<T>) => Promise<T>;
+  deleteFn?: (name: string) => Promise<void>;
+  toggleFn?: (name: string, enabled: boolean) => Promise<T>;
 }
 
 type PersistFn<S> = (
@@ -16,8 +23,10 @@ type PersistFn<S> = (
 export const useCrudForm = <S, T, K extends keyof S>(
   settings: S,
   persistSettings: PersistFn<S>,
+  setLocalSettings: Dispatch<SetStateAction<S>>,
   options: UseCrudFormOptions<S, T, K>,
 ) => {
+  const queryClient = useQueryClient();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [form, setForm] = useState<T>(options.createDefault());
@@ -53,7 +62,7 @@ export const useCrudForm = <S, T, K extends keyof S>(
   );
 
   const handleDelete = useCallback(
-    (index: number) => {
+    async (index: number) => {
       const items = getItems();
       const item = items[index];
       const targetName =
@@ -61,42 +70,81 @@ export const useCrudForm = <S, T, K extends keyof S>(
           ? (item as { name: string }).name
           : undefined;
 
-      persistSettings(
-        (prev: S) => {
-          const arr = [...((prev[options.getArrayKey] as T[] | null | undefined) || [])];
-          arr.splice(index, 1);
-          return {
-            ...prev,
-            [options.getArrayKey]: arr.length > 0 ? arr : null,
-          } as S;
-        },
-        {
-          successMessage: targetName ? `Deleted ${targetName}` : `${options.itemName} deleted`,
-          errorMessage: `Failed to delete ${options.itemName}`,
-        },
-      ).catch((error) => {
+      try {
+        if (options.deleteFn && targetName) {
+          await options.deleteFn(targetName);
+          setLocalSettings((prev) => {
+            const arr = [...((prev[options.getArrayKey] as T[] | null | undefined) || [])];
+            arr.splice(index, 1);
+            return {
+              ...prev,
+              [options.getArrayKey]: arr.length > 0 ? arr : null,
+            } as S;
+          });
+          queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.installed });
+          toast.success(`Deleted ${targetName}`);
+        } else {
+          await persistSettings(
+            (prev: S) => {
+              const arr = [...((prev[options.getArrayKey] as T[] | null | undefined) || [])];
+              arr.splice(index, 1);
+              return {
+                ...prev,
+                [options.getArrayKey]: arr.length > 0 ? arr : null,
+              } as S;
+            },
+            {
+              successMessage: targetName ? `Deleted ${targetName}` : `${options.itemName} deleted`,
+              errorMessage: `Failed to delete ${options.itemName}`,
+            },
+          );
+          queryClient.invalidateQueries({ queryKey: queryKeys.marketplace.installed });
+        }
+      } catch (error) {
         logger.error(`Failed to delete ${options.itemName}`, 'useCrudForm', error);
-      });
+        toast.error(`Failed to delete ${options.itemName}`);
+      }
     },
-    [getItems, persistSettings, options],
+    [getItems, persistSettings, setLocalSettings, options, queryClient],
   );
 
   const handleToggleEnabled = useCallback(
-    (index: number, enabled: boolean) => {
-      persistSettings(
-        (prev: S) => {
-          const arr = [...((prev[options.getArrayKey] as T[] | null | undefined) || [])];
-          if (arr[index]) {
-            arr[index] = { ...arr[index], enabled };
-          }
-          return { ...prev, [options.getArrayKey]: arr } as S;
-        },
-        { errorMessage: `Failed to update ${options.itemName} state` },
-      ).catch((error) => {
+    async (index: number, enabled: boolean) => {
+      const items = getItems();
+      const item = items[index];
+      const targetName =
+        item && typeof item === 'object' && 'name' in item
+          ? (item as { name: string }).name
+          : undefined;
+
+      try {
+        if (options.toggleFn && targetName) {
+          const updatedItem = await options.toggleFn(targetName, enabled);
+          setLocalSettings((prev) => {
+            const arr = [...((prev[options.getArrayKey] as T[] | null | undefined) || [])];
+            if (arr[index]) {
+              arr[index] = updatedItem;
+            }
+            return { ...prev, [options.getArrayKey]: arr } as S;
+          });
+        } else {
+          await persistSettings(
+            (prev: S) => {
+              const arr = [...((prev[options.getArrayKey] as T[] | null | undefined) || [])];
+              if (arr[index]) {
+                arr[index] = { ...arr[index], enabled };
+              }
+              return { ...prev, [options.getArrayKey]: arr } as S;
+            },
+            { errorMessage: `Failed to update ${options.itemName} state` },
+          );
+        }
+      } catch (error) {
         logger.error(`Failed to toggle ${options.itemName}`, 'useCrudForm', error);
-      });
+        toast.error(`Failed to update ${options.itemName} state`);
+      }
     },
-    [persistSettings, options],
+    [getItems, persistSettings, setLocalSettings, options],
   );
 
   const handleFormChange = useCallback(<K extends keyof T>(field: K, value: T[K]) => {
@@ -116,29 +164,58 @@ export const useCrudForm = <S, T, K extends keyof S>(
     }
 
     try {
-      await persistSettings(
-        (prev: S) => {
+      const items = getItems();
+      const existingItem = editingIndex !== null ? items[editingIndex] : null;
+      const existingName =
+        existingItem && typeof existingItem === 'object' && 'name' in existingItem
+          ? (existingItem as { name: string }).name
+          : undefined;
+
+      const isUpdate = editingIndex !== null;
+      const hasApiFn = isUpdate ? !!options.updateFn : !!options.createFn;
+
+      let savedItem: T = form;
+      if (isUpdate && options.updateFn && existingName) {
+        savedItem = await options.updateFn(existingName, form);
+      } else if (!isUpdate && options.createFn) {
+        savedItem = await options.createFn(form);
+      }
+
+      if (hasApiFn) {
+        setLocalSettings((prev) => {
           const nextItems = [...((prev[options.getArrayKey] as T[] | null | undefined) || [])];
           if (editingIndex !== null) {
-            nextItems[editingIndex] = form;
+            nextItems[editingIndex] = savedItem;
           } else {
-            nextItems.push(form);
+            nextItems.push(savedItem);
           }
           return { ...prev, [options.getArrayKey]: nextItems } as S;
-        },
-        {
-          successMessage:
-            editingIndex !== null ? `${options.itemName} updated` : `${options.itemName} added`,
-          errorMessage: `Failed to save ${options.itemName}`,
-        },
-      );
+        });
+        toast.success(isUpdate ? `${options.itemName} updated` : `${options.itemName} added`);
+      } else {
+        await persistSettings(
+          (prev: S) => {
+            const nextItems = [...((prev[options.getArrayKey] as T[] | null | undefined) || [])];
+            if (editingIndex !== null) {
+              nextItems[editingIndex] = savedItem;
+            } else {
+              nextItems.push(savedItem);
+            }
+            return { ...prev, [options.getArrayKey]: nextItems } as S;
+          },
+          {
+            successMessage: isUpdate ? `${options.itemName} updated` : `${options.itemName} added`,
+            errorMessage: `Failed to save ${options.itemName}`,
+          },
+        );
+      }
 
       setIsDialogOpen(false);
       resetForm();
     } catch (error) {
       setFormError(error instanceof Error ? error.message : 'An unexpected error occurred');
     }
-  }, [form, editingIndex, persistSettings, resetForm, options]);
+  }, [form, editingIndex, getItems, persistSettings, setLocalSettings, resetForm, options]);
 
   return {
     isDialogOpen,

--- a/frontend/src/services/marketplaceService.ts
+++ b/frontend/src/services/marketplaceService.ts
@@ -1,0 +1,57 @@
+import { apiClient } from '@/lib/api';
+import { ensureResponse, withAuth } from '@/services/base';
+import type {
+  InstallComponentRequest,
+  InstallResponse,
+  InstalledPlugin,
+  MarketplacePlugin,
+  PluginDetails,
+  UninstallComponentRequest,
+  UninstallResponse,
+} from '@/types/marketplace.types';
+
+async function getCatalog(forceRefresh = false): Promise<MarketplacePlugin[]> {
+  return withAuth(async () => {
+    const params = forceRefresh ? '?force_refresh=true' : '';
+    const response = await apiClient.get<MarketplacePlugin[]>(`/marketplace/catalog${params}`);
+    return response ?? [];
+  });
+}
+
+async function getPluginDetails(pluginName: string): Promise<PluginDetails> {
+  return withAuth(async () => {
+    const response = await apiClient.get<PluginDetails>(
+      `/marketplace/catalog/${encodeURIComponent(pluginName)}`,
+    );
+    return ensureResponse(response, 'Plugin not found');
+  });
+}
+
+async function installComponents(request: InstallComponentRequest): Promise<InstallResponse> {
+  return withAuth(async () => {
+    const response = await apiClient.post<InstallResponse>('/marketplace/install', request);
+    return ensureResponse(response, 'Installation failed');
+  });
+}
+
+async function getInstalledPlugins(): Promise<InstalledPlugin[]> {
+  return withAuth(async () => {
+    const response = await apiClient.get<InstalledPlugin[]>('/marketplace/installed');
+    return response ?? [];
+  });
+}
+
+async function uninstallComponents(request: UninstallComponentRequest): Promise<UninstallResponse> {
+  return withAuth(async () => {
+    const response = await apiClient.post<UninstallResponse>('/marketplace/uninstall', request);
+    return ensureResponse(response, 'Uninstallation failed');
+  });
+}
+
+export const marketplaceService = {
+  getCatalog,
+  getPluginDetails,
+  installComponents,
+  uninstallComponents,
+  getInstalledPlugins,
+};

--- a/frontend/src/services/mcpService.ts
+++ b/frontend/src/services/mcpService.ts
@@ -1,0 +1,58 @@
+import { apiClient } from '@/lib/api';
+import { ensureResponse, withAuth } from '@/services/base';
+import { validateRequired } from '@/utils/validation';
+import type { CustomMcp } from '@/types';
+
+interface McpCreateRequest {
+  name: string;
+  description: string;
+  command_type: 'npx' | 'bunx' | 'uvx' | 'http';
+  package?: string;
+  url?: string;
+  env_vars?: Record<string, string>;
+  args?: string[];
+  enabled?: boolean;
+}
+
+interface McpUpdateRequest {
+  description?: string;
+  command_type?: 'npx' | 'bunx' | 'uvx' | 'http';
+  package?: string;
+  url?: string;
+  env_vars?: Record<string, string>;
+  args?: string[];
+  enabled?: boolean;
+}
+
+async function createMcp(data: McpCreateRequest): Promise<CustomMcp> {
+  validateRequired(data.name, 'MCP name');
+  validateRequired(data.description, 'MCP description');
+
+  return withAuth(async () => {
+    const response = await apiClient.post<CustomMcp>('/mcps/', data);
+    return ensureResponse(response, 'Failed to create MCP');
+  });
+}
+
+async function updateMcp(mcpName: string, data: McpUpdateRequest): Promise<CustomMcp> {
+  validateRequired(mcpName, 'MCP name');
+
+  return withAuth(async () => {
+    const response = await apiClient.put<CustomMcp>(`/mcps/${mcpName}`, data);
+    return ensureResponse(response, 'Failed to update MCP');
+  });
+}
+
+async function deleteMcp(mcpName: string): Promise<void> {
+  validateRequired(mcpName, 'MCP name');
+
+  await withAuth(async () => {
+    await apiClient.delete(`/mcps/${mcpName}`);
+  });
+}
+
+export const mcpService = {
+  createMcp,
+  updateMcp,
+  deleteMcp,
+};

--- a/frontend/src/types/marketplace.types.ts
+++ b/frontend/src/types/marketplace.types.ts
@@ -1,0 +1,63 @@
+export interface MarketplaceAuthor {
+  name: string;
+  email?: string;
+  url?: string;
+}
+
+export interface MarketplacePlugin {
+  name: string;
+  description: string;
+  category: string;
+  source: string;
+  version?: string;
+  author?: MarketplaceAuthor;
+  homepage?: string;
+}
+
+export interface PluginComponents {
+  agents: string[];
+  commands: string[];
+  skills: string[];
+  mcp_servers: string[];
+}
+
+export interface PluginDetails extends MarketplacePlugin {
+  readme?: string;
+  components: PluginComponents;
+}
+
+export interface InstalledPlugin {
+  name: string;
+  version?: string;
+  installed_at: string;
+  components: string[];
+}
+
+export interface InstallComponentRequest {
+  plugin_name: string;
+  components: string[];
+}
+
+export interface InstallComponentResult {
+  component: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface InstallResponse {
+  plugin_name: string;
+  version?: string;
+  installed: string[];
+  failed: InstallComponentResult[];
+}
+
+export interface UninstallComponentRequest {
+  plugin_name: string;
+  components: string[];
+}
+
+export interface UninstallResponse {
+  plugin_name: string;
+  uninstalled: string[];
+  failed: InstallComponentResult[];
+}


### PR DESCRIPTION
## Summary

- Adds a **Marketplace** tab to Settings that integrates with the official Anthropic plugin marketplace (`anthropics/claude-plugins-official`)
- Users can browse, search, and install plugin components (agents, commands, skills, MCP servers)
- Tracks installed plugins and shows installation status

## Features

- **Browse plugins** with search and category filtering
- **View plugin details** with README preview  
- **Install individual components** - select which agents/commands/skills/MCP servers to install
- **Track installed plugins** - shows "Installed" badge on already-installed components

## Security

- Path validation to prevent traversal attacks (rejects `..`, absolute paths, invalid characters)
- Component validation against catalog before install
- Global file count limits (50 files max) for skill downloads
- Max recursion depth (5 levels) for nested skill directories
- Only `npx`/`bunx`/`uvx` MCP commands supported (rejects unknown command types)

## Performance

- Module-level + disk cache for catalog (1 hour TTL)
- 3-phase install to minimize DB lock time:
  1. Read settings without lock
  2. Network IO (downloads)
  3. Short write lock to persist

## Backend Changes

- `backend/app/services/marketplace.py` - Fetches catalog, downloads components
- `backend/app/services/plugin_installer.py` - Installs via existing services
- `backend/app/api/endpoints/marketplace.py` - REST endpoints
- `backend/app/models/schemas/marketplace.py` - Pydantic models
- `backend/app/models/types.py` - TypedDict definitions
- `backend/app/models/db_models/user.py` - Added `installed_plugins` field

## Frontend Changes

- `frontend/src/components/settings/tabs/MarketplaceSettingsTab.tsx` - Main UI
- `frontend/src/components/settings/tabs/marketplace/PluginCard.tsx` - Plugin card
- `frontend/src/components/settings/dialogs/PluginDetailModal.tsx` - Detail modal
- `frontend/src/services/marketplaceService.ts` - API client
- `frontend/src/hooks/queries/useMarketplaceQueries.ts` - React Query hooks

## Test plan

- [ ] Browse marketplace catalog loads plugins
- [ ] Search and category filters work correctly
- [ ] Plugin details modal shows components and README
- [ ] Installing a component adds it to user settings
- [ ] Installed components show "Installed" badge
- [ ] Error states display properly when API fails
- [ ] Refresh button forces cache refresh

## Note

Requires Alembic migration for `installed_plugins` column in `user_settings` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)