### PR TITLE
Polish chat UX: styling, animations, and mobile improvements

### DIFF
--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -123,16 +123,18 @@ export const Message = memo(function Message({
             />
           </div>
 
-          {isBot && content.trim() && !isThisMessageStreaming && !isGloballyStreaming && (
+          {isBot && content.trim() && (
             <div className="pt-2">
-              <div className="mt-3 flex items-center gap-2 opacity-70 transition-opacity duration-200 hover:opacity-100">
+              <div className="mt-3 flex items-center gap-2">
                 <Button
                   onClick={() => onCopy(content, id)}
                   variant="unstyled"
                   className={`relative min-h-[44px] min-w-[44px] overflow-hidden rounded-xl p-2.5 transition-all duration-200 sm:min-h-0 sm:min-w-0 sm:p-2 ${
-                    copiedMessageId === id
-                      ? 'bg-success-100 text-success-600 dark:bg-success-500/10 dark:text-success-400'
-                      : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
+                    isThisMessageStreaming
+                      ? 'pointer-events-none opacity-0'
+                      : copiedMessageId === id
+                        ? 'bg-success-100 text-success-600 dark:bg-success-500/10 dark:text-success-400'
+                        : 'text-text-secondary opacity-70 hover:bg-surface-secondary hover:text-text-primary hover:opacity-100 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
                   }`}
                 >
                   <div className="relative z-10 flex items-center gap-1.5">
@@ -156,9 +158,11 @@ export const Message = memo(function Message({
                     disabled={isRestoring}
                     variant="unstyled"
                     className={`relative rounded-xl p-2.5 transition-all duration-200 sm:p-2 ${
-                      isRestoring
-                        ? 'cursor-not-allowed opacity-50'
-                        : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
+                      isThisMessageStreaming || isGloballyStreaming
+                        ? 'pointer-events-none opacity-0'
+                        : isRestoring
+                          ? 'cursor-not-allowed opacity-50'
+                          : 'text-text-secondary opacity-70 hover:bg-surface-secondary hover:text-text-primary hover:opacity-100 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
                     }`}
                     title="Restore to this message"
                   >

--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -33,6 +33,8 @@ export interface InputProps {
   dropdownPosition?: 'top' | 'bottom';
   showAttachedFilesPreview?: boolean;
   contextUsage?: ContextUsageInfo;
+  showTip?: boolean;
+  compact?: boolean;
 }
 
 export const Input = memo(function Input({
@@ -49,6 +51,8 @@ export const Input = memo(function Input({
   dropdownPosition = 'top',
   showAttachedFilesPreview = true,
   contextUsage,
+  showTip = true,
+  compact = true,
 }: InputProps) {
   const { fileStructure, customAgents, customSlashCommands, customPrompts } = useChatContext();
   const formRef = useRef<HTMLFormElement>(null);
@@ -233,7 +237,6 @@ export const Input = memo(function Input({
   }, [hasMessage, isEnhancing, message, selectedModelId, enhancePromptMutation]);
 
   const shouldShowAttachedPreview = showAttachedFilesPreview && showPreview && hasAttachments;
-  const showAttachmentTip = !hasAttachments;
 
   return (
     <form ref={formRef} onSubmit={handleSubmit} className="relative px-4 sm:px-6">
@@ -273,6 +276,7 @@ export const Input = memo(function Input({
             isLoading={isLoading}
             onKeyDown={handleKeyDown}
             onCursorPositionChange={(pos) => setCursorPosition(pos)}
+            compact={compact}
           />
           <InputSuggestionsPanel
             isMentionActive={isMentionActive}
@@ -333,7 +337,7 @@ export const Input = memo(function Input({
           />
         )}
 
-      {showAttachmentTip && (
+      {showTip && !hasAttachments && (
         <div className="mt-1 animate-fade-in text-center text-2xs text-text-quaternary dark:text-text-dark-tertiary">
           <span className="font-medium">Tip:</span> Drag and drop images, pdfs and xlsx files into
           the input area, type `/` for slash commands, or `@` to mention files, agents, and prompts

--- a/frontend/src/components/chat/message-input/Textarea.tsx
+++ b/frontend/src/components/chat/message-input/Textarea.tsx
@@ -8,12 +8,13 @@ export interface TextareaProps {
   isLoading: boolean;
   onKeyDown: (e: React.KeyboardEvent) => void;
   onCursorPositionChange?: (position: number) => void;
+  compact?: boolean;
 }
 
 const CURSOR_DEBOUNCE_MS = 150;
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
-  { message, setMessage, placeholder, isLoading, onKeyDown, onCursorPositionChange },
+  { message, setMessage, placeholder, isLoading, onKeyDown, onCursorPositionChange, compact },
   ref,
 ) {
   const internalRef = useRef<HTMLTextAreaElement>(null);
@@ -99,7 +100,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
       placeholder={placeholder}
       disabled={isLoading}
       rows={1}
-      className="max-h-[180px] min-h-[56px] w-full resize-none overflow-y-auto bg-transparent py-1.5 pr-14 text-sm leading-normal text-text-primary outline-none transition-all duration-200 placeholder:text-text-quaternary focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary"
+      className={`max-h-[180px] w-full resize-none overflow-y-auto bg-transparent py-1.5 pr-14 text-sm leading-normal text-text-primary outline-none transition-all duration-200 placeholder:text-text-quaternary focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary ${isMobile && compact ? 'min-h-[28px]' : 'min-h-[56px]'}`}
       style={{ scrollbarWidth: 'thin' }}
       aria-label="Message input"
     />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -329,7 +329,7 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
   );
 
   return (
-    <header className="z-50 border-b border-border bg-surface px-4 dark:border-border-dark dark:bg-surface-dark">
+    <header className="z-50 bg-surface px-4 dark:bg-surface-dark">
       <div className="relative flex h-12 items-center justify-between">
         <div className="flex items-center gap-1">
           {isAuthenticated && !isAuthPage && (

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -267,7 +267,6 @@ export function Sidebar({
         className={cn(
           'absolute top-0 h-full w-64',
           'bg-surface dark:bg-surface-dark',
-          'border-r border-border dark:border-border-dark',
           'z-40 flex flex-col transition-[left] duration-500 ease-in-out',
           sidebarOpen ? (hasActivityBar ? 'left-12' : 'left-0') : '-left-64',
         )}

--- a/frontend/src/components/ui/Mermaid.tsx
+++ b/frontend/src/components/ui/Mermaid.tsx
@@ -28,7 +28,7 @@ const sanitizeSvg = (svg: string): string =>
 
 export function Mermaid({ content }: MermaidProps) {
   const theme = useUIStore((state) => state.theme);
-  const [showPreview, setShowPreview] = useState(false);
+  const [showPreview, setShowPreview] = useState(true);
   const [state, setState] = useState<RenderState>({ status: 'idle' });
   const renderIdRef = useRef(0);
 
@@ -82,8 +82,8 @@ export function Mermaid({ content }: MermaidProps) {
           className="flex items-center gap-1.5 rounded-md border border-border bg-surface-secondary px-2 py-1 text-xs text-text-secondary transition-colors hover:bg-surface-hover dark:border-border-dark dark:bg-surface-dark-secondary dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover"
           disabled={state.status === 'loading'}
         >
-          {showPreview ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
-          {showPreview ? 'Hide Preview' : 'Show Preview'}
+          {showPreview ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
+          {showPreview ? 'Show Code' : 'Show Preview'}
         </Button>
       </div>
 

--- a/frontend/src/components/ui/ViewSwitcher.tsx
+++ b/frontend/src/components/ui/ViewSwitcher.tsx
@@ -41,7 +41,7 @@ export function ActivityBar() {
   return (
     <div
       className={cn(
-        'absolute left-0 top-0 z-50 flex h-full flex-col border-r border-border bg-surface dark:border-border-dark dark:bg-surface-dark',
+        'absolute left-0 top-0 z-50 flex h-full flex-col bg-surface dark:bg-surface-dark',
         LAYOUT_CLASSES.ACTIVITY_BAR_WIDTH,
       )}
     >


### PR DESCRIPTION
## Summary

Visual polish and UX improvements for the chat interface, reducing layout shifts, improving mobile experience, and adding smooth auto-scroll for dynamic content.

## Changes

### Layout Stability
- **Button visibility uses opacity instead of conditional render** - Buttons stay in DOM with `opacity-0` during streaming to prevent layout shift when they reappear.

### Button Behavior During Streaming
- **Copy button** - Available on all previous messages while streaming. Only hidden on the message currently being streamed (content incomplete).
- **Restore button** - Hidden during any streaming to prevent accidental checkpoint restore mid-response.

### Border Cleanup
- **Remove visual borders** - Removed `border-b` from header, `border-r` from sidebar and activity bar, `border-t` from input container for a cleaner, less visually noisy interface.

### Auto-Scroll for Dynamic Content
- **Smooth scroll when content expands** - Added ResizeObserver to detect when content height increases (e.g., Mermaid diagrams rendering). When user is near bottom, chat smoothly scrolls to show new content.
- **Debounced scroll** - Waits 100ms for content to settle before scrolling, ensuring it reaches the actual bottom.

### Mobile Improvements
- **Compact input on mobile** - Reduced min-height (28px vs 56px) gives more screen space for messages on small devices.
- **Remove redundant tip in chat** - The drag-and-drop tip is already shown on the landing page; showing it again in chat wastes space.

### Mermaid Diagrams
- **Show preview by default** - Diagrams render immediately instead of requiring a click. Button changes to "Show Code" for users who want the raw syntax.

## Test Plan
- [ ] During streaming: copy button visible on previous messages, hidden on current
- [ ] During streaming: restore button hidden on all messages
- [ ] After streaming: both buttons fade in smoothly (no layout jump)
- [ ] Verify no borders on header, sidebar, activity bar, or input container
- [ ] On mobile: input should be compact, no tip shown below input
- [ ] Mermaid code blocks show rendered diagram by default
- [ ] When Mermaid diagram renders, chat auto-scrolls smoothly to bottom