### PR TITLE
Update Docker Compose files for Docker compatibility

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # Test PostgreSQL database
   postgres-test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:13-alpine
@@ -35,7 +33,7 @@ services:
       retries: 5
 
   sandbox-setup:
-    image: docker:20.10-cli
+    image: docker:27-cli
     container_name: claudex-sandbox-setup
     restart: "no"
     volumes:


### PR DESCRIPTION
## Summary
- Bump `sandbox-setup` image from `docker:20.10-cli` to `docker:27-cli` to fix API version incompatibility with Docker Engine 29+
- Remove obsolete `version` attribute from both `docker-compose.yml` and `docker-compose.test.yml`

## Problem
Docker 20.10-cli uses API version 1.41, but Docker Engine 29+ requires minimum API version 1.44. This causes `sandbox-setup` to fail with:
```
Error response from daemon: client version 1.41 is too old. Minimum supported API version is 1.44
```
Since `api` and `celery-worker` depend on `sandbox-setup` completing successfully, this blocks the entire stack from starting on systems with recent Docker installations.

## Test plan
- [ ] Run `docker compose up -d` on a system with Docker Engine 29+
- [ ] Verify all containers start successfully (no API version errors)
- [ ] Verify `sandbox-setup` pulls the sandbox image without issues