### PR TITLE
fix: improve marketplace UI and fix theme contrast across settings

### DIFF
--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -241,7 +241,7 @@ export const Chat = memo(function Chat({
 
           {showScrollButton && <ScrollButton onClick={scrollToBottom} />}
 
-          <div className="relative border-t border-border bg-surface pb-safe dark:border-border-dark dark:bg-surface-dark">
+          <div className="relative bg-surface pb-safe dark:bg-surface-dark-secondary">
             <div className="w-full py-2 lg:mx-auto lg:max-w-3xl">
               <Input
                 message={inputMessage}

--- a/frontend/src/components/chat/message-bubble/ThinkingBlock.tsx
+++ b/frontend/src/components/chat/message-bubble/ThinkingBlock.tsx
@@ -36,7 +36,7 @@ const ThinkingBlockInner: React.FC<ThinkingBlockProps> = ({ content, isActiveThi
   }, [content]);
 
   return (
-    <div className="group relative overflow-hidden rounded-lg border border-border bg-surface-secondary transition-all duration-200 dark:border-border-dark dark:bg-surface-dark-secondary">
+    <div className="group relative overflow-hidden rounded-lg border border-border bg-surface-secondary transition-all duration-200 dark:border-border-dark dark:bg-surface-dark-tertiary">
       <Button
         onClick={toggleExpanded}
         disabled={isActiveThinking}

--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -239,7 +239,7 @@ export const Input = memo(function Input({
     <form ref={formRef} onSubmit={handleSubmit} className="relative px-4 sm:px-6">
       <div
         {...dragHandlers}
-        className={`relative rounded-2xl border bg-surface-secondary transition-all duration-300 dark:bg-surface-dark-secondary ${
+        className={`relative rounded-2xl border bg-surface shadow-sm transition-all duration-300 dark:bg-surface-dark-tertiary dark:shadow-black/20 ${
           isDragging
             ? 'scale-[1.01] border-brand-400 bg-brand-50/50 dark:border-brand-500 dark:bg-brand-950/20'
             : 'border-border dark:border-border-dark'

--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -90,7 +90,7 @@ export const ModelSelector = memo(function ModelSelector({
 
   if (isLoading || models.length === 0) {
     return (
-      <div className="flex items-center gap-1 rounded-lg border border-border/70 bg-surface-secondary px-2 py-1 shadow-sm dark:border-white/5 dark:bg-surface-dark-secondary">
+      <div className="flex items-center gap-1 rounded-lg border border-border/70 bg-surface px-2 py-1 shadow-sm dark:border-white/5 dark:bg-surface-dark-tertiary">
         <Bot className="h-3.5 w-3.5 text-text-quaternary" />
         <div className="hidden h-3.5 w-16 animate-pulse rounded bg-text-quaternary/20 sm:block" />
         <ChevronDown className="hidden h-3.5 w-3.5 text-text-quaternary sm:block" />

--- a/frontend/src/components/chat/tools/common/ToolCard.tsx
+++ b/frontend/src/components/chat/tools/common/ToolCard.tsx
@@ -97,7 +97,7 @@ const ToolCardInner: React.FC<ToolCardProps> = ({
 
   return (
     <div
-      className={`group relative overflow-hidden rounded-lg border border-border bg-surface-secondary transition-all duration-200 dark:border-border-dark dark:bg-surface-dark-secondary ${className}`}
+      className={`group relative overflow-hidden rounded-lg border border-border bg-surface-secondary transition-all duration-200 dark:border-border-dark dark:bg-surface-dark-tertiary ${className}`}
     >
       {hasExpandableContent ? (
         <button

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -329,7 +329,7 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
   );
 
   return (
-    <header className="z-50 border-b border-border bg-surface-secondary px-4 dark:border-border-dark dark:bg-surface-dark">
+    <header className="z-50 bg-surface-secondary px-4 dark:bg-surface-dark">
       <div className="relative flex h-12 items-center justify-between">
         <div className="flex items-center gap-1">
           {isAuthenticated && !isAuthPage && (

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -73,7 +73,7 @@ export function Layout({
 
           <main
             className={cn(
-              'relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden bg-surface-secondary dark:bg-surface-dark',
+              'relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden bg-surface-secondary dark:bg-surface-dark-secondary',
               contentClassName,
             )}
           >

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -266,8 +266,7 @@ export function Sidebar({
       <aside
         className={cn(
           'absolute top-0 h-full w-64',
-          'bg-surface dark:bg-surface-dark',
-          'border-r border-border dark:border-border-dark',
+          'bg-surface-secondary dark:bg-surface-dark',
           'z-40 flex flex-col transition-[left] duration-500 ease-in-out',
           sidebarOpen ? (hasActivityBar ? 'left-12' : 'left-0') : '-left-64',
         )}
@@ -278,8 +277,8 @@ export function Sidebar({
             variant="unstyled"
             className={cn(
               'w-full px-3 py-1.5',
-              'bg-surface-secondary dark:bg-surface-dark-secondary',
-              'hover:bg-surface-tertiary dark:hover:bg-surface-dark-tertiary',
+              'bg-white dark:bg-surface-dark-secondary',
+              'hover:bg-surface-secondary dark:hover:bg-surface-dark-tertiary',
               'text-text-primary dark:text-text-dark-primary',
               'rounded-lg transition-colors duration-200',
               'flex items-center justify-center gap-2 text-sm font-medium',
@@ -300,7 +299,7 @@ export function Sidebar({
               variant="unstyled"
               className={cn(
                 'w-full py-1.5 pl-8 pr-3',
-                'bg-surface-secondary dark:bg-surface-dark-secondary',
+                'bg-white dark:bg-surface-dark-secondary',
                 'rounded-lg text-text-primary dark:text-text-dark-primary',
                 'placeholder-text-tertiary dark:placeholder-text-dark-tertiary',
                 'focus:outline-none focus:ring-1 focus:ring-border-secondary dark:focus:ring-border-dark-secondary',

--- a/frontend/src/components/settings/dialogs/PluginDetailModal.tsx
+++ b/frontend/src/components/settings/dialogs/PluginDetailModal.tsx
@@ -179,7 +179,7 @@ export const PluginDetailModal: React.FC<PluginDetailModalProps> = ({
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} size="xl">
       <div className="flex max-h-[80vh] flex-col">
-        <div className="border-border-primary bg-surface-primary dark:border-border-dark-primary dark:bg-surface-dark-primary flex items-center justify-between border-b p-4">
+        <div className="flex items-center justify-between border-b border-border bg-white p-4 dark:border-border-dark dark:bg-surface-dark">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <h2 className="truncate text-lg font-semibold text-text-primary dark:text-text-dark-primary">
@@ -280,7 +280,7 @@ export const PluginDetailModal: React.FC<PluginDetailModalProps> = ({
                             ? 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/20'
                             : isSelected
                               ? 'border-brand-500 bg-brand-50 dark:border-brand-400 dark:bg-brand-900/20'
-                              : 'border-border-primary dark:border-border-dark-primary hover:border-brand-300 dark:hover:border-brand-600'
+                              : 'border-border bg-white hover:border-brand-300 dark:border-border-dark dark:bg-surface-dark-secondary dark:hover:border-brand-600'
                       }`}
                     >
                       <div className="flex items-center gap-3">
@@ -340,7 +340,7 @@ export const PluginDetailModal: React.FC<PluginDetailModalProps> = ({
           )}
         </div>
 
-        <div className="border-border-primary bg-surface-primary dark:border-border-dark-primary dark:bg-surface-dark-primary flex justify-end gap-2 border-t p-4">
+        <div className="flex justify-end gap-2 border-t border-border bg-white p-4 dark:border-border-dark dark:bg-surface-dark">
           <Button variant="outline" size="sm" onClick={onClose}>
             Cancel
           </Button>

--- a/frontend/src/components/settings/tabs/AgentsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/AgentsSettingsTab.tsx
@@ -51,7 +51,7 @@ export const AgentsSettingsTab: React.FC<AgentsSettingsTabProps> = ({
           <p className="mb-2 line-clamp-2 text-xs text-text-tertiary dark:text-text-dark-tertiary">
             {agent.description}
           </p>
-          <div className="mt-2 rounded bg-surface-secondary p-2 dark:bg-surface-dark-secondary">
+          <div className="mt-2 rounded border border-border p-2 dark:border-border-dark">
             <p className="line-clamp-2 font-mono text-xs text-text-secondary dark:text-text-dark-secondary">
               {agent.content}
             </p>

--- a/frontend/src/components/settings/tabs/MarketplaceSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/MarketplaceSettingsTab.tsx
@@ -13,6 +13,7 @@ import type { MarketplacePlugin } from '@/types/marketplace.types';
 
 const CATEGORIES = [
   'all',
+  'installed',
   'development',
   'productivity',
   'testing',
@@ -44,11 +45,14 @@ export const MarketplaceSettingsTab: React.FC = () => {
         plugin.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
         plugin.description.toLowerCase().includes(searchQuery.toLowerCase());
 
-      const matchesCategory = selectedCategory === 'all' || plugin.category === selectedCategory;
+      const matchesCategory =
+        selectedCategory === 'all' ||
+        (selectedCategory === 'installed' && installedNames.has(plugin.name)) ||
+        plugin.category === selectedCategory;
 
       return matchesSearch && matchesCategory;
     });
-  }, [plugins, searchQuery, selectedCategory]);
+  }, [plugins, searchQuery, selectedCategory, installedNames]);
 
   return (
     <div className="space-y-4">
@@ -87,13 +91,15 @@ export const MarketplaceSettingsTab: React.FC = () => {
           <select
             value={selectedCategory}
             onChange={(e) => setSelectedCategory(e.target.value)}
-            className="border-border-primary bg-surface-primary dark:border-border-dark-primary dark:bg-surface-dark-primary rounded-md border px-3 py-2 text-sm text-text-primary focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:text-text-dark-primary"
+            className="rounded-lg border border-border bg-white px-3 py-2 text-sm text-text-primary transition-colors focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40 dark:border-border-dark dark:bg-surface-dark-secondary dark:text-text-dark-primary"
           >
             {CATEGORIES.map((category) => (
               <option key={category} value={category}>
                 {category === 'all'
                   ? 'All Categories'
-                  : category.charAt(0).toUpperCase() + category.slice(1)}
+                  : category === 'installed'
+                    ? 'Installed'
+                    : category.charAt(0).toUpperCase() + category.slice(1)}
               </option>
             ))}
           </select>
@@ -124,10 +130,14 @@ export const MarketplaceSettingsTab: React.FC = () => {
             </button>
           </div>
         ) : filteredPlugins.length === 0 ? (
-          <div className="border-border-primary dark:border-border-dark-primary rounded-lg border p-8 text-center">
+          <div className="rounded-lg border border-border bg-white p-8 text-center dark:border-border-dark dark:bg-surface-dark-tertiary">
             <Store className="mx-auto mb-3 h-8 w-8 text-text-quaternary dark:text-text-dark-quaternary" />
             <p className="text-sm text-text-tertiary dark:text-text-dark-tertiary">
-              {plugins.length === 0 ? 'No plugins available' : 'No plugins match your search'}
+              {plugins.length === 0
+                ? 'No plugins available'
+                : selectedCategory === 'installed'
+                  ? 'No plugins installed yet'
+                  : 'No plugins match your search'}
             </p>
           </div>
         ) : (

--- a/frontend/src/components/settings/tabs/McpSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/McpSettingsTab.tsx
@@ -86,7 +86,7 @@ export const McpSettingsTab: React.FC<McpSettingsTabProps> = ({
           <p className="mb-2 text-xs text-text-tertiary dark:text-text-dark-tertiary">
             {mcp.description}
           </p>
-          <div className="mt-2 rounded bg-surface-secondary p-2 dark:bg-surface-dark-secondary">
+          <div className="mt-2 rounded border border-border p-2 dark:border-border-dark">
             <div className="space-y-1">
               {(mcp.command_type === 'npx' ||
                 mcp.command_type === 'bunx' ||

--- a/frontend/src/components/settings/tabs/TasksSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/TasksSettingsTab.tsx
@@ -226,7 +226,7 @@ export const TasksSettingsTab: React.FC<TasksSettingsTabProps> = ({ onAddTask, o
         </p>
 
         {tasksList.length === 0 ? (
-          <div className="rounded-lg border border-border p-8 text-center dark:border-border-dark">
+          <div className="rounded-lg border border-border bg-white p-8 text-center dark:border-border-dark dark:bg-surface-dark-tertiary">
             <CalendarClock className="mx-auto mb-3 h-8 w-8 text-text-quaternary dark:text-text-dark-quaternary" />
             <p className="mb-3 text-sm text-text-tertiary dark:text-text-dark-tertiary">
               No scheduled tasks configured yet
@@ -246,7 +246,7 @@ export const TasksSettingsTab: React.FC<TasksSettingsTabProps> = ({ onAddTask, o
               {tasksList.map((task) => (
                 <div
                   key={task.id}
-                  className="rounded-lg border border-border bg-surface p-4 transition-colors hover:border-border-hover dark:border-border-dark dark:bg-surface-dark dark:hover:border-border-dark-hover"
+                  className="rounded-lg border border-border bg-white p-4 transition-colors hover:border-border-hover dark:border-border-dark dark:bg-surface-dark-tertiary dark:hover:border-border-dark-hover"
                 >
                   <div className="flex items-start justify-between gap-4">
                     <div className="min-w-0 flex-1">

--- a/frontend/src/components/settings/tabs/marketplace/PluginCard.tsx
+++ b/frontend/src/components/settings/tabs/marketplace/PluginCard.tsx
@@ -25,7 +25,7 @@ export const PluginCard: React.FC<PluginCardProps> = ({ plugin, isInstalled, onC
   return (
     <button
       onClick={onClick}
-      className="border-border-primary bg-surface-primary dark:border-border-dark-primary dark:bg-surface-dark-primary group flex w-full flex-col rounded-lg border p-4 text-left transition-all hover:border-brand-500 hover:shadow-md dark:hover:border-brand-400"
+      className="group flex w-full flex-col rounded-lg border border-border bg-white p-4 text-left transition-all hover:border-brand-500 hover:shadow-md dark:border-border-dark dark:bg-surface-dark-tertiary dark:hover:border-brand-400"
     >
       <div className="mb-2 flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
@@ -33,11 +33,7 @@ export const PluginCard: React.FC<PluginCardProps> = ({ plugin, isInstalled, onC
             <h3 className="truncate text-sm font-medium text-text-primary dark:text-text-dark-primary">
               {plugin.name}
             </h3>
-            {isInstalled && (
-              <Badge variant="success" size="sm">
-                Installed
-              </Badge>
-            )}
+            {isInstalled && <Badge variant="success">Installed</Badge>}
           </div>
           {plugin.author?.name && (
             <p className="mt-0.5 text-xs text-text-tertiary dark:text-text-dark-tertiary">

--- a/frontend/src/components/ui/ListManagementTab.tsx
+++ b/frontend/src/components/ui/ListManagementTab.tsx
@@ -95,7 +95,7 @@ export const ListManagementTab = <T,>({
         </p>
 
         {!items || items.length === 0 ? (
-          <div className="rounded-lg border border-border p-8 text-center dark:border-border-dark">
+          <div className="rounded-lg border border-border bg-white p-8 text-center dark:border-border-dark dark:bg-surface-dark-tertiary">
             <EmptyIcon className="mx-auto mb-3 h-8 w-8 text-text-quaternary dark:text-text-dark-quaternary" />
             <p className="mb-3 text-sm text-text-tertiary dark:text-text-dark-tertiary">
               {emptyText}
@@ -109,7 +109,7 @@ export const ListManagementTab = <T,>({
             {items.map((item, index) => (
               <div
                 key={getItemKey(item, index)}
-                className="rounded-lg border border-border p-4 transition-colors hover:border-border-hover dark:border-border-dark dark:hover:border-border-dark-hover"
+                className="rounded-lg border border-border bg-white p-4 transition-colors hover:border-border-hover dark:border-border-dark dark:bg-surface-dark-tertiary dark:hover:border-border-dark-hover"
               >
                 <div className="flex items-start justify-between">
                   <div className="min-w-0 flex-1">{renderItem(item, index)}</div>

--- a/frontend/src/components/ui/ViewSwitcher.tsx
+++ b/frontend/src/components/ui/ViewSwitcher.tsx
@@ -41,7 +41,7 @@ export function ActivityBar() {
   return (
     <div
       className={cn(
-        'absolute left-0 top-0 z-50 flex h-full flex-col border-r border-border bg-surface-secondary dark:border-border-dark dark:bg-surface-dark-secondary',
+        'absolute left-0 top-0 z-50 flex h-full flex-col border-r border-border bg-surface-secondary dark:border-border-dark dark:bg-surface-dark',
         LAYOUT_CLASSES.ACTIVITY_BAR_WIDTH,
       )}
     >
@@ -52,7 +52,7 @@ export function ActivityBar() {
             className={cn(
               'flex h-12 w-full items-center justify-center border-l-2 transition-all duration-200',
               currentView === view
-                ? 'border-brand-600 bg-surface text-brand-600 dark:border-brand-400 dark:bg-surface-dark dark:text-brand-400'
+                ? 'border-brand-600 bg-surface text-brand-600 dark:border-brand-400 dark:bg-surface-dark-secondary dark:text-brand-400'
                 : 'border-transparent text-text-tertiary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary',
             )}
             aria-label={`Switch to ${label.toLowerCase()} view`}

--- a/frontend/src/components/ui/primitives/Dropdown.tsx
+++ b/frontend/src/components/ui/primitives/Dropdown.tsx
@@ -133,7 +133,7 @@ function DropdownInner<T>({
         onClick={() => !disabled && setIsOpen(!isOpen)}
         disabled={disabled}
         variant="unstyled"
-        className={`flex items-center gap-1 rounded-lg border border-border/70 bg-surface-secondary px-2 py-1 shadow-sm hover:border-border-secondary hover:shadow-md dark:border-white/5 dark:bg-surface-dark-secondary dark:hover:border-white/10 ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+        className={`flex items-center gap-1 rounded-lg border border-border/70 bg-surface px-2 py-1 shadow-sm hover:border-border-secondary hover:shadow-md dark:border-white/5 dark:bg-surface-dark-tertiary dark:hover:border-white/10 ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
       >
         <div className={`flex items-center ${LeftIcon ? 'gap-1.5' : 'gap-2'}`}>
           {LeftIcon && <LeftIcon className="h-3.5 w-3.5 text-text-quaternary" />}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -232,7 +232,7 @@ export function ChatPage() {
   return (
     <div className="relative flex h-full">
       <ViewSwitcher />
-      <div className="ml-12 flex h-full flex-1 overflow-hidden bg-surface text-text-primary dark:bg-surface-dark dark:text-text-dark-primary">
+      <div className="ml-12 flex h-full flex-1 overflow-hidden bg-surface text-text-primary dark:bg-surface-dark-secondary dark:text-text-dark-primary">
         <div className={`${isTerminalView ? 'flex' : 'hidden'} h-full flex-1`}>
           <TerminalView currentChat={currentChat} isVisible={isTerminalView} />
         </div>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -139,7 +139,7 @@ export function LandingPage() {
   useLayoutSidebar(sidebarContent);
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col bg-surface dark:bg-surface-dark-secondary">
       <div className="relative flex flex-1">
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-surface-secondary/50 via-transparent to-brand-50/30 dark:from-surface-dark/50 dark:via-transparent dark:to-brand-900/10" />
         <div className="flex flex-1 items-center justify-center px-4 pb-10">
@@ -177,7 +177,7 @@ export function LandingPage() {
                     key={prompt}
                     onClick={() => handleExampleClick(prompt)}
                     variant="unstyled"
-                    className="whitespace-nowrap rounded-full border border-border bg-surface-secondary px-4 py-2.5 text-xs text-text-secondary transition-all duration-200 hover:border-brand-500/30 hover:bg-surface-tertiary dark:border-border-dark dark:bg-surface-dark-secondary dark:text-text-dark-secondary dark:hover:border-brand-400/30 dark:hover:bg-surface-dark-tertiary"
+                    className="whitespace-nowrap rounded-full border border-border bg-surface px-4 py-2.5 text-xs text-text-secondary transition-all duration-200 hover:border-brand-500/30 hover:bg-surface-secondary dark:border-border-dark dark:bg-surface-dark-tertiary dark:text-text-dark-secondary dark:hover:border-brand-400/30 dark:hover:bg-surface-dark-hover"
                   >
                     {prompt}
                   </Button>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -453,7 +453,7 @@ const SettingsPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="min-h-viewport flex items-center justify-center bg-surface dark:bg-surface-dark">
+      <div className="flex min-h-full items-center justify-center bg-surface dark:bg-surface-dark-secondary">
         <Spinner size="lg" className="text-brand-600" />
       </div>
     );
@@ -461,14 +461,14 @@ const SettingsPage: React.FC = () => {
 
   if (fetchError && !settings) {
     return (
-      <div className="min-h-viewport flex items-center justify-center bg-surface dark:bg-surface-dark">
+      <div className="flex min-h-full items-center justify-center bg-surface dark:bg-surface-dark-secondary">
         <div className="text-text-primary dark:text-text-dark-primary">Failed to load settings</div>
       </div>
     );
   }
 
   return (
-    <div className="flex min-h-full overflow-x-hidden bg-surface dark:bg-surface-dark">
+    <div className="flex min-h-full overflow-x-hidden bg-surface dark:bg-surface-dark-secondary">
       <div className="flex min-w-0 flex-1 justify-center px-4 py-6">
         <div className="w-full min-w-0 max-w-3xl">
           <div className="mb-6">

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -82,9 +82,9 @@ export default {
         // Surface colors
         surface: {
           DEFAULT: '#ffffff',
-          secondary: '#f9f9f9',
-          tertiary: '#f3f3f3',
-          hover: '#f5f5f5',
+          secondary: '#f5f5f5',
+          tertiary: '#f0f0f0',
+          hover: '#ebebeb',
           dark: {
             DEFAULT: '#0a0a0a',
             secondary: '#141414',


### PR DESCRIPTION
## Summary

- Fix dark mode plugin cards: use proper theme tokens for visible border/background contrast
- Add "Installed" filter option to marketplace category dropdown
- Establish consistent light/dark theme hierarchy across app
- Fix theme contrast across all settings tabs and chat components
- Remove visual clutter (header bottom border, sidebar right border)
- Fix plugin detail modal header/footer theming in dark mode
- Change Agents/MCP preview content from grey fill to border outline

## Theme Architecture

**Light Mode**: Header/sidebar grey (`#f5f5f5`), main content white  
**Dark Mode**: Header/sidebar/activity bar darkest (`#0a0a0a`), main content lighter (`#141414`), cards lightest (`#1e1e1e`)

## Test plan

- [ ] Dark mode: Verify marketplace plugin cards have visible contrast
- [ ] Light mode: Verify settings page cards contrast against background
- [ ] Marketplace: Test "Installed" category filter shows only installed plugins
- [ ] Plugin modal: Confirm header/footer theming correct in dark mode
- [ ] Agents/MCP tabs: Check preview content uses border outline style
- [ ] Chat/Landing pages: Verify white background in light mode
- [ ] Sidebar: Confirm no right border (cleaner transition to content)
- [ ] Header: Confirm no bottom border
- [ ] Activity bar: Verify border separates it from sidebar