### PR TITLE
Fix docker streaming delay

### DIFF
--- a/backend/app/services/transports/docker.py
+++ b/backend/app/services/transports/docker.py
@@ -189,7 +189,7 @@ class DockerSandboxTransport(BaseSandboxTransport):
 
         try:
             while True:
-                timeout = 5.0 if self._ready else 0.2
+                timeout = 1.0 if self._ready else 0.2
                 data = await loop.run_in_executor(
                     self._executor, self._recv_with_select, timeout
                 )


### PR DESCRIPTION
## Summary

- Reduce Docker transport select timeout from 5.0s to 1s, fixing an 11-second delay before the "Thinking" banner disappears

## Details

The main issue was a 5-second select timeout in the Docker transport that caused the stream to appear "stuck" after completion. Reducing this to 1s makes the UI responsive quicker.