### PR TITLE
feat: parallel context usage fetch via Celery task

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -13,6 +13,7 @@ REDIS_KEY_PERMISSION_REQUEST: Final[str] = "permission_request:{request_id}"
 REDIS_KEY_PERMISSION_RESPONSE: Final[str] = "permission_response:{request_id}"
 REDIS_KEY_USER_SETTINGS: Final[str] = "user_settings:{user_id}"
 REDIS_KEY_MODELS_LIST: Final[str] = "models:list:{active_only}"
+REDIS_KEY_CHAT_CONTEXT_USAGE: Final[str] = "chat:{chat_id}:context_usage"
 
 SANDBOX_AUTO_PAUSE_TIMEOUT: Final[int] = 3000
 SANDBOX_DEFAULT_COMMAND_TIMEOUT: Final[int] = 120

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -163,6 +163,8 @@ class Settings(BaseSettings):
     CHAT_REVOKED_KEY_TTL_SECONDS: int = 3600
     USER_SETTINGS_CACHE_TTL_SECONDS: int = 300
     MODELS_CACHE_TTL_SECONDS: int = 3600
+    CONTEXT_USAGE_CACHE_TTL_SECONDS: int = 600
+    CONTEXT_USAGE_POLL_INTERVAL_SECONDS: float = 5.0
 
     class Config:
         env_file = ".env"

--- a/backend/app/services/transports/docker.py
+++ b/backend/app/services/transports/docker.py
@@ -189,7 +189,7 @@ class DockerSandboxTransport(BaseSandboxTransport):
 
         try:
             while True:
-                timeout = 1.0 if self._ready else 0.2
+                timeout = 5.0 if self._ready else 0.2
                 data = await loop.run_in_executor(
                     self._executor, self._recv_with_select, timeout
                 )

--- a/backend/app/tasks/chat_processor.py
+++ b/backend/app/tasks/chat_processor.py
@@ -5,13 +5,17 @@ import uuid
 from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import AsyncIterator, Any
+from typing import TYPE_CHECKING, AsyncIterator, Any
+
+if TYPE_CHECKING:
+    from app.models.types import JSONDict
 
 from celery.exceptions import Ignore
 from redis.asyncio import Redis
 from sqlalchemy import select
 
 from app.constants import (
+    REDIS_KEY_CHAT_CONTEXT_USAGE,
     REDIS_KEY_CHAT_REVOKED,
     REDIS_KEY_CHAT_STREAM,
     REDIS_KEY_CHAT_TASK,
@@ -55,11 +59,19 @@ class SessionUpdateCallback:
         assistant_message_id: str | None,
         session_factory: Any,
         session_container: dict[str, Any],
+        sandbox_id: str,
+        sandbox_provider: str,
+        user_id: str,
+        model_id: str,
     ) -> None:
         self.chat_id = chat_id
         self.assistant_message_id = assistant_message_id
         self.session_factory = session_factory
         self.session_container = session_container
+        self.sandbox_id = sandbox_id
+        self.sandbox_provider = sandbox_provider
+        self.user_id = user_id
+        self.model_id = model_id
 
     def __call__(self, new_session_id: str) -> None:
         self.session_container["session_id"] = new_session_id
@@ -71,6 +83,16 @@ class SessionUpdateCallback:
                 self.session_factory,
             )
         )
+
+        if self.sandbox_id:
+            fetch_context_token_usage.delay(
+                chat_id=self.chat_id,
+                session_id=new_session_id,
+                sandbox_id=self.sandbox_id,
+                sandbox_provider=self.sandbox_provider,
+                user_id=self.user_id,
+                model_id=self.model_id,
+            )
 
 
 @dataclass
@@ -504,6 +526,10 @@ async def process_chat_stream(  # type: ignore[return]
                     assistant_message_id=assistant_message_id,
                     session_factory=TaskSessionLocal,
                     session_container=session_container,
+                    sandbox_id=str(chat.sandbox_id) if chat.sandbox_id else "",
+                    sandbox_provider=chat.sandbox_provider or "docker",
+                    user_id=str(user.id),
+                    model_id=model_id,
                 )
 
                 stream = ai_service.get_ai_stream(
@@ -520,6 +546,19 @@ async def process_chat_stream(  # type: ignore[return]
                     attachments=attachments,
                     is_custom_prompt=is_custom_prompt,
                 )
+
+                # Trigger context usage polling for existing sessions
+                # (new sessions are handled by SessionUpdateCallback)
+                sandbox_id = str(chat.sandbox_id) if chat.sandbox_id else ""
+                if session_id and sandbox_id:
+                    fetch_context_token_usage.delay(
+                        chat_id=chat_id,
+                        session_id=session_id,
+                        sandbox_id=sandbox_id,
+                        sandbox_provider=chat.sandbox_provider or "docker",
+                        user_id=str(user.id),
+                        model_id=model_id,
+                    )
 
                 try:
                     outcome = await _drain_ai_stream(
@@ -645,6 +684,179 @@ def process_chat(
                 thinking_mode=thinking_mode,
                 attachments=attachments,
                 is_custom_prompt=is_custom_prompt,
+            )
+        )
+    finally:
+        loop.close()
+
+
+async def _is_stream_active(chat_id: str, redis_client: "Redis[str]") -> bool:
+    try:
+        task_key = REDIS_KEY_CHAT_TASK.format(chat_id=chat_id)
+        revoked_key = REDIS_KEY_CHAT_REVOKED.format(chat_id=chat_id)
+
+        task_exists = (await redis_client.get(task_key)) is not None
+        is_revoked = (await redis_client.get(revoked_key)) in ("1", b"1")
+
+        return task_exists and not is_revoked
+    except Exception:
+        return False
+
+
+async def fetch_and_broadcast_context_usage(
+    chat_id: str,
+    session_id: str,
+    sandbox_id: str,
+    sandbox_provider: str,
+    user_id: str,
+    model_id: str,
+    redis_client: "Redis[str]",
+    session_factory: Any,
+) -> dict[str, Any] | None:
+    try:
+        user_service = UserService(session_factory=session_factory)
+        user_settings = await user_service.get_user_settings(uuid.UUID(user_id))
+
+        e2b_api_key = (
+            user_settings.e2b_api_key if sandbox_provider != "docker" else None
+        )
+
+        async with ClaudeAgentService(session_factory=session_factory) as ai_service:
+            token_usage = await ai_service.get_context_token_usage(
+                session_id=session_id,
+                sandbox_id=sandbox_id,
+                sandbox_provider=sandbox_provider,
+                model_id=model_id,
+                user_settings=user_settings,
+                e2b_api_key=e2b_api_key,
+            )
+
+            if token_usage is None:
+                return None
+
+            context_window = settings.CONTEXT_WINDOW_TOKENS
+            percentage = (
+                min((token_usage / context_window) * 100, 100.0)
+                if context_window > 0
+                else 0.0
+            )
+
+            context_data: JSONDict = {
+                "tokens_used": token_usage,
+                "context_window": context_window,
+                "percentage": percentage,
+            }
+
+            async with session_factory() as db:
+                result = await db.execute(
+                    select(Chat).filter(Chat.id == uuid.UUID(chat_id))
+                )
+                chat_to_update = result.scalar_one_or_none()
+                if chat_to_update:
+                    chat_to_update.context_token_usage = token_usage
+                    db.add(chat_to_update)
+                    await db.commit()
+
+            cache_key = REDIS_KEY_CHAT_CONTEXT_USAGE.format(chat_id=chat_id)
+            await redis_client.setex(
+                cache_key,
+                settings.CONTEXT_USAGE_CACHE_TTL_SECONDS,
+                json.dumps(context_data),
+            )
+
+            system_event: StreamEvent = {
+                "type": "system",
+                "data": {"context_usage": context_data, "chat_id": chat_id},
+            }
+            await _publish_stream_entry(
+                redis_client,
+                chat_id,
+                "content",
+                {"event": system_event},
+            )
+
+            return context_data
+
+    except Exception as e:
+        logger.error("Failed to fetch context token usage for chat %s: %s", chat_id, e)
+
+    return None
+
+
+async def _poll_context_usage_while_streaming(
+    chat_id: str,
+    session_id: str,
+    sandbox_id: str,
+    sandbox_provider: str,
+    user_id: str,
+    model_id: str,
+) -> None:
+    redis_client: Redis[str] | None = None
+
+    try:
+        redis_client = Redis.from_url(settings.REDIS_URL, decode_responses=True)
+
+        async with get_celery_session() as (session_factory, _):
+            async with session_factory() as db:
+                result = await db.execute(
+                    select(Chat).filter(
+                        Chat.id == uuid.UUID(chat_id),
+                        Chat.user_id == uuid.UUID(user_id),
+                    )
+                )
+                chat = result.scalar_one_or_none()
+                if not chat:
+                    logger.warning(
+                        "Chat %s not found or not owned by user %s", chat_id, user_id
+                    )
+                    return
+
+            while True:
+                await fetch_and_broadcast_context_usage(
+                    chat_id=chat_id,
+                    session_id=session_id,
+                    sandbox_id=sandbox_id,
+                    sandbox_provider=sandbox_provider,
+                    user_id=user_id,
+                    model_id=model_id,
+                    redis_client=redis_client,
+                    session_factory=session_factory,
+                )
+
+                if not await _is_stream_active(chat_id, redis_client):
+                    break
+
+                await asyncio.sleep(settings.CONTEXT_USAGE_POLL_INTERVAL_SECONDS)
+
+    except Exception as e:
+        logger.error("Context usage polling failed for chat %s: %s", chat_id, e)
+    finally:
+        if redis_client:
+            await redis_client.close()
+
+
+@celery_app.task(bind=True, ignore_result=True)
+def fetch_context_token_usage(
+    self: Any,
+    chat_id: str,
+    session_id: str,
+    sandbox_id: str,
+    sandbox_provider: str,
+    user_id: str,
+    model_id: str,
+) -> None:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    try:
+        loop.run_until_complete(
+            _poll_context_usage_while_streaming(
+                chat_id=chat_id,
+                session_id=session_id,
+                sandbox_id=sandbox_id,
+                sandbox_provider=sandbox_provider,
+                user_id=user_id,
+                model_id=model_id,
             )
         )
     finally:

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -54,6 +54,7 @@ export const useContextUsageQuery = (
     queryKey: queryKeys.contextUsage(chatId),
     queryFn: () => chatService.getContextUsage(chatId),
     enabled: !!chatId,
+    staleTime: 0,
     ...options,
   });
 };

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -3,7 +3,7 @@ import type { Dispatch, FormEvent, SetStateAction } from 'react';
 import { logger } from '@/utils/logger';
 import { QueryClient } from '@tanstack/react-query';
 import { useStreamStore } from '@/store';
-import type { Chat, Message, PermissionRequest, StreamState } from '@/types';
+import type { Chat, ContextUsage, Message, PermissionRequest, StreamState } from '@/types';
 import { cleanupExpiredPdfBlobs, storePdfBlobUrl } from '@/hooks/usePdfBlobCache';
 import { useMessageActions } from '@/hooks/useMessageActions';
 import { useInputState } from '@/hooks/useInputState';
@@ -23,7 +23,7 @@ interface UseChatStreamingParams {
   isInitialLoading: boolean;
   queryClient: QueryClient;
   refetchFilesMetadata: () => Promise<unknown>;
-  refetchContextUsage: () => Promise<unknown> | void;
+  onContextUsageUpdate?: (data: ContextUsage, chatId?: string) => void;
   selectedModelId: string | null | undefined;
   permissionMode: 'plan' | 'ask' | 'auto';
   thinkingMode: string | null | undefined;
@@ -66,7 +66,7 @@ export function useChatStreaming({
   isInitialLoading,
   queryClient,
   refetchFilesMetadata,
-  refetchContextUsage,
+  onContextUsageUpdate,
   selectedModelId,
   permissionMode,
   thinkingMode,
@@ -109,7 +109,7 @@ export function useChatStreaming({
     currentChat,
     queryClient,
     refetchFilesMetadata,
-    refetchContextUsage,
+    onContextUsageUpdate,
     onPermissionRequest,
     setMessages,
     setStreamState,

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -68,7 +68,7 @@ export function ChatPage() {
     chatId,
   );
 
-  const { contextUsage, refetchContextUsage } = useContextUsageState(chatId, currentChat);
+  const { contextUsage, updateContextUsage } = useContextUsageState(chatId, currentChat);
 
   const { data: settings } = useSettingsQuery();
 
@@ -109,7 +109,7 @@ export function ChatPage() {
     isInitialLoading: messagesQuery.isLoading,
     queryClient,
     refetchFilesMetadata,
-    refetchContextUsage,
+    onContextUsageUpdate: updateContextUsage,
     selectedModelId,
     permissionMode,
     thinkingMode,


### PR DESCRIPTION
## Summary
- Run `/context` command in parallel with streaming instead of after stream ends
- Eliminates the ~5 second delay for context usage updates in the UI
- Context usage now appears in real-time during streaming via SSE

## Changes

### Backend
- New Celery task `fetch_context_token_usage` triggered when session_id is received
- Publishes context usage to Redis stream for real-time SSE updates
- Caches in Redis with 600s TTL for fast endpoint reads
- Updates DB `Chat.context_token_usage` for persistence
- `/context-usage` endpoint checks Redis cache first, falls back to DB
- Ownership validation before publishing to stream/cache
- Warning log when E2B API key is missing

### Frontend
- Handle `system` events with `context_usage` data in stream callbacks
- Fallback query invalidation 6s after stream completion if SSE drops
- Timer cleanup on component unmount
- Removed redundant `refetchContextUsage` from streaming flow

## Test plan
- [ ] Start a chat and verify context usage updates during streaming (not after)
- [ ] Verify context usage persists after page refresh
- [ ] Verify context usage loads correctly when opening existing chat
- [ ] Test with E2B sandbox provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)