### PR TITLE
fix: send EOF before transport cleanup to allow graceful CLI exit

### DIFF
--- a/backend/app/services/transports/base.py
+++ b/backend/app/services/transports/base.py
@@ -120,6 +120,15 @@ class BaseSandboxTransport(Transport, ABC):
         pass
 
     async def close(self) -> None:
+        # Send EOF first while connection is still ready, so CLI exits gracefully
+        if self._is_connection_ready():
+            await self.end_input()
+            if self._monitor_task:
+                try:
+                    await asyncio.wait_for(asyncio.shield(self._monitor_task), timeout=0.5)
+                except (asyncio.TimeoutError, Exception):
+                    pass
+
         self._ready = False
         await self._cancel_task(self._monitor_task)
         self._monitor_task = None


### PR DESCRIPTION
## Summary
Send EOF to Claude CLI before cleanup so it can exit gracefully instead of being killed.

## Problem
Claude CLI with `--input-format stream-json` waits for stdin EOF to know when to exit. The previous `close()` method would:
1. Set `_ready = False`
2. Kill the process via `_cleanup_resources()`

But the process was just waiting for more input, not stuck.

## Solution
```python
async def close(self) -> None:
    # Send EOF first while connection is still ready
    if self._is_connection_ready():
        await self.end_input()  # Sends EOF (Ctrl+D)
        if self._monitor_task:
            try:
                await asyncio.wait_for(asyncio.shield(self._monitor_task), timeout=0.5)
            except (asyncio.TimeoutError, Exception):
                pass  # Continue to cleanup

    # Then do normal cleanup (kill if still running)
    self._ready = False
    await self._cancel_task(self._monitor_task)
    ...
```

## Test plan
- [ ] Start chat → Send messages → Check `ps aux | grep claude`
- [ ] Processes should exit gracefully after each query
- [ ] Stop chat → All processes should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)