### PR TITLE
fix: eliminate gap at bottom of chat during message streaming

### DIFF
--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -144,18 +144,16 @@ export const Message = memo(function Message({
             />
           </div>
 
-          {isBot && content.trim() && (
+          {isBot && content.trim() && !isThisMessageStreaming && (
             <div className="pt-2">
               <div className="mt-3 flex items-center gap-2">
                 <Button
                   onClick={() => onCopy(content, id)}
                   variant="unstyled"
                   className={`relative min-h-[44px] min-w-[44px] overflow-hidden rounded-xl p-2.5 transition-all duration-200 sm:min-h-0 sm:min-w-0 sm:p-2 ${
-                    isThisMessageStreaming
-                      ? 'pointer-events-none opacity-0'
-                      : copiedMessageId === id
-                        ? 'bg-success-100 text-success-600 dark:bg-success-500/10 dark:text-success-400'
-                        : 'text-text-secondary opacity-70 hover:bg-surface-secondary hover:text-text-primary hover:opacity-100 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
+                    copiedMessageId === id
+                      ? 'bg-success-100 text-success-600 dark:bg-success-500/10 dark:text-success-400'
+                      : 'text-text-secondary opacity-70 hover:bg-surface-secondary hover:text-text-primary hover:opacity-100 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
                   }`}
                 >
                   <div className="relative z-10 flex items-center gap-1.5">
@@ -177,14 +175,12 @@ export const Message = memo(function Message({
                   <>
                     <Button
                       onClick={handleRestore}
-                      disabled={isRestoring}
+                      disabled={isRestoring || isGloballyStreaming}
                       variant="unstyled"
                       className={`relative rounded-xl p-2.5 transition-all duration-200 sm:p-2 ${
-                        isThisMessageStreaming || isGloballyStreaming
-                          ? 'pointer-events-none opacity-0'
-                          : isRestoring
-                            ? 'cursor-not-allowed opacity-50'
-                            : 'text-text-secondary opacity-70 hover:bg-surface-secondary hover:text-text-primary hover:opacity-100 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
+                        isRestoring || isGloballyStreaming
+                          ? 'cursor-not-allowed opacity-50'
+                          : 'text-text-secondary opacity-70 hover:bg-surface-secondary hover:text-text-primary hover:opacity-100 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
                       }`}
                       title="Restore to this message"
                     >
@@ -206,14 +202,12 @@ export const Message = memo(function Message({
                     {sandboxProvider === SandboxProvider.DOCKER && sandboxId && (
                       <Button
                         onClick={handleFork}
-                        disabled={isForking}
+                        disabled={isForking || isGloballyStreaming}
                         variant="unstyled"
                         className={`relative rounded-xl p-2.5 transition-all duration-200 sm:p-2 ${
-                          isThisMessageStreaming || isGloballyStreaming
-                            ? 'pointer-events-none opacity-0'
-                            : isForking
-                              ? 'cursor-not-allowed opacity-50'
-                              : 'text-text-secondary opacity-70 hover:bg-surface-secondary hover:text-text-primary hover:opacity-100 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
+                          isForking || isGloballyStreaming
+                            ? 'cursor-not-allowed opacity-50'
+                            : 'text-text-secondary opacity-70 hover:bg-surface-secondary hover:text-text-primary hover:opacity-100 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
                         }`}
                         title="Fork chat from this message"
                       >


### PR DESCRIPTION
Previously, copy/restore/fork buttons were hidden with opacity during streaming but still took up layout space, creating an unwanted gap between the streaming message and the bottom of the chat page. Now buttons don't render at all during streaming and appear only on completion, removing the visual gap.