### PR TITLE
Fix layout shift when message actions appear and enhance user message visibility

### DIFF
--- a/frontend/src/components/chat/chat-window/LoadingIndicator.tsx
+++ b/frontend/src/components/chat/chat-window/LoadingIndicator.tsx
@@ -4,7 +4,7 @@ import iconLight from '/assets/images/icon-white.svg';
 
 export const LoadingIndicator = memo(function LoadingIndicator() {
   return (
-    <div className="flex items-center justify-center gap-3 py-3">
+    <div className="flex items-center justify-center gap-3 pb-2 pt-4">
       <div className="relative">
         <img
           src={iconDark}

--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -107,7 +107,9 @@ export const Message = memo(function Message({
         <div className="flex items-center gap-3 sm:gap-4">
           <div className="flex-shrink-0">{isBot ? <BotAvatar /> : <UserAvatar />}</div>
           <div className="flex flex-wrap items-center gap-2 text-xs sm:gap-3">
-            <span className="font-medium text-text-secondary dark:text-text-dark-tertiary">
+            <span
+              className={`${isBot ? 'font-medium text-text-secondary dark:text-text-dark-tertiary' : 'font-bold text-text-secondary dark:text-text-dark-tertiary'}`}
+            >
               {isBot ? 'Claudex' : 'You'}
             </span>
             {formattedDate && (
@@ -132,7 +134,7 @@ export const Message = memo(function Message({
             className={`prose prose-sm max-w-none break-words ${
               isBot
                 ? 'text-text-primary dark:text-text-dark-primary'
-                : 'text-text-primary dark:text-text-dark-secondary'
+                : 'font-semibold text-text-primary dark:text-text-dark-secondary'
             }`}
           >
             <MessageContent
@@ -146,11 +148,11 @@ export const Message = memo(function Message({
 
           {isBot && content.trim() && !isThisMessageStreaming && (
             <div className="pt-2">
-              <div className="mt-3 flex items-center gap-2">
+              <div className="mt-2 flex items-center gap-2">
                 <Button
                   onClick={() => onCopy(content, id)}
                   variant="unstyled"
-                  className={`relative min-h-[44px] min-w-[44px] overflow-hidden rounded-xl p-2.5 transition-all duration-200 sm:min-h-0 sm:min-w-0 sm:p-2 ${
+                  className={`relative overflow-hidden rounded-xl px-1.5 py-0.5 transition-all duration-200 sm:px-1.5 sm:py-0.5 ${
                     copiedMessageId === id
                       ? 'bg-success-100 text-success-600 dark:bg-success-500/10 dark:text-success-400'
                       : 'text-text-secondary opacity-70 hover:bg-surface-secondary hover:text-text-primary hover:opacity-100 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
@@ -177,7 +179,7 @@ export const Message = memo(function Message({
                       onClick={handleRestore}
                       disabled={isRestoring || isGloballyStreaming}
                       variant="unstyled"
-                      className={`relative rounded-xl p-2.5 transition-all duration-200 sm:p-2 ${
+                      className={`relative rounded-xl px-1.5 py-0.5 transition-all duration-200 sm:px-1.5 sm:py-0.5 ${
                         isRestoring || isGloballyStreaming
                           ? 'cursor-not-allowed opacity-50'
                           : 'text-text-secondary opacity-70 hover:bg-surface-secondary hover:text-text-primary hover:opacity-100 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
@@ -204,7 +206,7 @@ export const Message = memo(function Message({
                         onClick={handleFork}
                         disabled={isForking || isGloballyStreaming}
                         variant="unstyled"
-                        className={`relative rounded-xl p-2.5 transition-all duration-200 sm:p-2 ${
+                        className={`relative rounded-xl px-1.5 py-0.5 transition-all duration-200 sm:px-1.5 sm:py-0.5 ${
                           isForking || isGloballyStreaming
                             ? 'cursor-not-allowed opacity-50'
                             : 'text-text-secondary opacity-70 hover:bg-surface-secondary hover:text-text-primary hover:opacity-100 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'

--- a/frontend/src/components/chat/message-bubble/MessageAvatars.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageAvatars.tsx
@@ -50,11 +50,14 @@ export const UserAvatar = () => {
   const displayName = user?.username || user?.email || 'User';
 
   return (
-    <AvatarWrapper>
-      <div className="flex h-4 w-4 items-center justify-center text-xs font-semibold text-text-secondary dark:text-text-dark-secondary">
-        {displayName?.[0]?.toUpperCase() || <User className="h-4 w-4" />}
+    <div className="group relative">
+      <div className="absolute inset-0 rounded-full bg-gradient-to-br from-brand-500/20 to-brand-600/20 opacity-0 blur-xl transition-opacity duration-300 group-hover:opacity-100 dark:from-brand-400/20 dark:to-brand-500/20" />
+      <div className="relative flex items-center justify-center rounded-full border-2 border-blue-500/30 bg-surface p-2 shadow-sm backdrop-blur-sm transition-all duration-200 group-hover:border-blue-500/50 dark:border-blue-400/30 dark:bg-surface-dark dark:group-hover:border-blue-400/50 sm:p-2.5">
+        <div className="flex h-4 w-4 items-center justify-center text-xs font-semibold text-text-secondary dark:text-text-dark-secondary">
+          {displayName?.[0]?.toUpperCase() || <User className="h-4 w-4" />}
+        </div>
       </div>
-    </AvatarWrapper>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- Prevent layout shift when streaming completes and copy/restore/fork buttons appear
- Make user messages more visually distinct from assistant messages
- Reduce button padding for more compact UI

## Changes
**Layout Shift Prevention:**
- Adjusted LoadingIndicator padding (`pb-2 pt-4`) to match message action button heights
- Reduced button padding to `px-1.5 py-0.5` (consistent across mobile and desktop)
- Removed `min-h-[44px]` mobile constraints that were forcing extra height
- Reduced button container top margin from `mt-3` to `mt-2`

**User Message Enhancement:**
- Bold user name ("You") with `font-bold`
- Semibold user message content with `font-semibold`
- Added subtle blue outline to user avatar (`border-2 border-blue-500/30`)

## Test plan
- [ ] Verify no layout shift occurs when message streaming completes on desktop
- [ ] Verify no layout shift occurs when message streaming completes on mobile
- [ ] Confirm user messages are more visually distinct from bot messages
- [ ] Check that blue avatar outline appears on user messages
- [ ] Test button hover states and interactions work correctly