### PR TITLE
Fix terminal isolation between chats

### DIFF
--- a/frontend/src/components/editor/terminal/Container.tsx
+++ b/frontend/src/components/editor/terminal/Container.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import type { FC } from 'react';
 import { TerminalTab } from './TerminalTab';
 
@@ -13,11 +13,16 @@ interface TerminalInstance {
   label: string;
 }
 
-export const Container: FC<ContainerProps> = ({ sandboxId, isVisible }) => {
+export const Container: FC<ContainerProps> = ({ sandboxId, chatId, isVisible }) => {
   const [terminals, setTerminals] = useState<TerminalInstance[]>([
     { id: 'terminal-1', label: 'Terminal 1' },
   ]);
   const [activeTerminalId, setActiveTerminalId] = useState<string>('terminal-1');
+
+  useEffect(() => {
+    setTerminals([{ id: 'terminal-1', label: 'Terminal 1' }]);
+    setActiveTerminalId('terminal-1');
+  }, [chatId]);
 
   const addTerminal = useCallback(() => {
     setTerminals((prev) => {


### PR DESCRIPTION
## Summary
- Fix terminals not being isolated between chats
- Reset terminal state when `chatId` changes so each chat has its own terminal session
- Previously the `chatId` prop was passed to `Container.tsx` but never used, causing terminal tabs to persist across chat switches

## Test plan
- [ ] Open Chat A and create multiple terminal tabs
- [ ] Navigate to Chat B
- [ ] Verify terminal view shows fresh "Terminal 1" (not tabs from Chat A)
- [ ] Return to Chat A and verify it also shows fresh state

🤖 Generated with [Claude Code](https://claude.com/claude-code)