### PR TITLE
Fix license reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,4 +173,4 @@ Default admin: `admin@example.com` / `admin123`
 
 ## License
 
-MIT - see [LICENSE](LICENSE)
+Apache 2.0 - see [LICENSE](LICENSE)


### PR DESCRIPTION
## Summary
- Update license section at bottom of README from MIT to Apache 2.0

## Test plan
- [ ] Verify README license section displays "Apache 2.0 - see LICENSE"

🤖 Generated with [Claude Code](https://claude.com/claude-code)