### PR TITLE
fix: run Claude CLI as non-root user in Modal sandbox

### DIFF
--- a/backend/app/services/transports/modal.py
+++ b/backend/app/services/transports/modal.py
@@ -59,6 +59,10 @@ class ModalSandboxTransport(BaseSandboxTransport):
         try:
             assert self._sandbox is not None
             self._process = await self._sandbox.exec.aio(
+                "runuser",
+                "-u",
+                user,
+                "--",
                 "bash",
                 "-c",
                 f"cd {cwd} && {command_line}",


### PR DESCRIPTION
Modal's exec.aio() runs commands as root by default, but Claude CLI refuses --dangerously-skip-permissions with root privileges. Use runuser to switch to the non-root user before executing the CLI command.