### PR TITLE
fix: improve user_settings type annotations and remove inline imports

### DIFF
--- a/backend/app/prompts/system_prompt.py
+++ b/backend/app/prompts/system_prompt.py
@@ -126,23 +126,19 @@ def build_custom_system_prompt(
 
 def build_system_prompt_for_chat(
     sandbox_id: str,
-    user_settings: "UserSettings | None",
+    user_settings: "UserSettings",
     selected_prompt_name: str | None = None,
 ) -> str:
-    github_token_configured = bool(
-        user_settings and user_settings.github_personal_access_token
-    )
+    github_token_configured = bool(user_settings.github_personal_access_token)
     env_vars_formatted = None
-    if user_settings and user_settings.custom_env_vars:
+    if user_settings.custom_env_vars:
         env_vars_formatted = "\n".join(
             f"- {env_var['key']}" for env_var in user_settings.custom_env_vars
         )
 
-    sandbox_provider = (
-        user_settings.sandbox_provider if user_settings else None
-    ) or "docker"
+    sandbox_provider = user_settings.sandbox_provider
 
-    if selected_prompt_name and user_settings and user_settings.custom_prompts:
+    if selected_prompt_name and user_settings.custom_prompts:
         custom_prompt = next(
             (
                 p

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -541,7 +541,7 @@ class ChatService(BaseDbService[Chat]):
             UserSettings, await self.user_service.get_user_settings(user.id)
         )
 
-        sandbox_provider = user_settings.sandbox_provider or "docker"
+        sandbox_provider = user_settings.sandbox_provider
         if sandbox_provider != "docker":
             raise ChatException(
                 "Fork is only supported with Docker sandbox provider",

--- a/backend/app/services/scheduler/__init__.py
+++ b/backend/app/services/scheduler/__init__.py
@@ -12,8 +12,8 @@ from app.services.scheduler.recurrence import (
     validate_recurrence_constraints,
 )
 from app.services.scheduler.runner import (
-    cleanup_expired_tokens_async,
-    execute_scheduled_task_async,
+    cleanup_expired_tokens,
+    run_scheduled_task,
 )
 from app.services.scheduler.service import MAX_TASKS_PER_USER, SchedulerService
 
@@ -25,9 +25,9 @@ __all__ = [
     "calculate_next_execution",
     "check_due_tasks",
     "check_duplicate_execution",
-    "cleanup_expired_tokens_async",
+    "cleanup_expired_tokens",
     "complete_task_execution",
-    "execute_scheduled_task_async",
+    "run_scheduled_task",
     "load_task_and_user",
     "update_task_after_execution",
     "validate_recurrence_constraints",

--- a/backend/app/services/scheduler/recurrence.py
+++ b/backend/app/services/scheduler/recurrence.py
@@ -164,12 +164,12 @@ def validate_recurrence_constraints(
     recurrence_type: RecurrenceType, scheduled_day: int | None
 ) -> None:
     if recurrence_type == RecurrenceType.WEEKLY:
-        if scheduled_day is None or not (0 <= scheduled_day <= 6):
+        if scheduled_day is None or not 0 <= scheduled_day <= 6:
             raise SchedulerException(
                 "Weekly tasks require scheduled_day between 0 (Monday) and 6 (Sunday)"
             )
     elif recurrence_type == RecurrenceType.MONTHLY:
-        if scheduled_day is None or not (1 <= scheduled_day <= 31):
+        if scheduled_day is None or not 1 <= scheduled_day <= 31:
             raise SchedulerException(
                 "Monthly tasks require scheduled_day between 1 and 31"
             )

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -2,11 +2,10 @@ import asyncio
 from typing import Any
 
 from app.core.celery import celery_app
-from app.db.session import get_celery_session
 from app.services.scheduler import (
     check_due_tasks,
-    cleanup_expired_tokens_async,
-    execute_scheduled_task_async,
+    cleanup_expired_tokens,
+    run_scheduled_task,
 )
 
 
@@ -14,52 +13,29 @@ from app.services.scheduler import (
 def check_scheduled_tasks() -> dict[str, Any]:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-
     try:
-        return loop.run_until_complete(_check_scheduled_tasks_wrapper())
+        return loop.run_until_complete(
+            check_due_tasks(execute_task_trigger=execute_scheduled_task.delay)
+        )
     finally:
         loop.close()
-
-
-async def _check_scheduled_tasks_wrapper() -> dict[str, Any]:
-    async with get_celery_session() as (session_factory, _):
-        return await check_due_tasks(
-            session_factory=session_factory,
-            execute_task_trigger=execute_scheduled_task.delay,
-        )
 
 
 @celery_app.task(bind=True, name="execute_scheduled_task")
 def execute_scheduled_task(self: Any, task_id: str) -> dict[str, Any]:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-
     try:
-        return loop.run_until_complete(_execute_scheduled_task_wrapper(self, task_id))
+        return loop.run_until_complete(run_scheduled_task(task=self, task_id=task_id))
     finally:
         loop.close()
-
-
-async def _execute_scheduled_task_wrapper(task: Any, task_id: str) -> dict[str, Any]:
-    async with get_celery_session() as (session_factory, _):
-        return await execute_scheduled_task_async(
-            task=task,
-            task_id=task_id,
-            session_factory=session_factory,
-        )
 
 
 @celery_app.task(name="cleanup_expired_refresh_tokens")
 def cleanup_expired_refresh_tokens() -> dict[str, Any]:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-
     try:
-        return loop.run_until_complete(_cleanup_tokens_wrapper())
+        return loop.run_until_complete(cleanup_expired_tokens())
     finally:
         loop.close()
-
-
-async def _cleanup_tokens_wrapper() -> dict[str, Any]:
-    async with get_celery_session() as (session_factory, _):
-        return await cleanup_expired_tokens_async(session_factory=session_factory)

--- a/backend/app/utils/validators.py
+++ b/backend/app/utils/validators.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from app.models.db_models.enums import ModelProvider
 from app.models.types import JSONList
@@ -13,14 +13,6 @@ if TYPE_CHECKING:
 
 class APIKeyValidationError(ValueError):
     pass
-
-
-def validate_e2b_api_key(user_settings: UserSettings) -> str:
-    if not user_settings.e2b_api_key:
-        raise APIKeyValidationError(
-            "E2B API key is required. Please configure your E2B API key in Settings."
-        )
-    return cast(str, user_settings.e2b_api_key)
 
 
 def normalize_json_list(value: JSONList | None) -> JSONList:


### PR DESCRIPTION
- Remove validate_e2b_api_key function, raise exception directly like modal
- Make user_settings required parameter in _create_sandbox_transport
- Get e2b_api_key from user_settings instead of passing as parameter
- Change user_settings: Any to user_settings: UserSettings in scheduler
- Make user_settings required in build_system_prompt_for_chat
- Move inline imports to top of file in runner.py and sandbox.py