### PR TITLE
fix: make traefik entrypoint configurable for sandbox preview

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -137,6 +137,7 @@ class Settings(BaseSettings):
     # Example: DOCKER_SANDBOX_DOMAIN=sandbox.example.com, DOCKER_TRAEFIK_NETWORK=coolify
     DOCKER_SANDBOX_DOMAIN: str = ""
     DOCKER_TRAEFIK_NETWORK: str = ""
+    DOCKER_TRAEFIK_ENTRYPOINT: str = "websecure"
     # Override URL for sandbox->API connectivity (permission server)
     # Use when host.docker.internal doesn't work (Linux VPS, Coolify, etc.)
     # Example: DOCKER_PERMISSION_API_URL=http://api:8080

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -83,7 +83,7 @@ class LocalDockerProvider(SandboxProvider):
             router_name = f"sandbox-{sandbox_id}-{port}"
             subdomain = f"{router_name}.{self.config.sandbox_domain}"
             labels[f"traefik.http.routers.{router_name}.rule"] = f"Host(`{subdomain}`)"
-            labels[f"traefik.http.routers.{router_name}.entrypoints"] = "https"
+            labels[f"traefik.http.routers.{router_name}.entrypoints"] = self.config.traefik_entrypoint
             labels[f"traefik.http.routers.{router_name}.tls"] = "true"
             labels[f"traefik.http.routers.{router_name}.service"] = router_name
             labels[f"traefik.http.services.{router_name}.loadbalancer.server.port"] = (

--- a/backend/app/services/sandbox_providers/factory.py
+++ b/backend/app/services/sandbox_providers/factory.py
@@ -14,6 +14,7 @@ def create_docker_config() -> DockerConfig:
         preview_base_url=settings.DOCKER_PREVIEW_BASE_URL,
         sandbox_domain=settings.DOCKER_SANDBOX_DOMAIN,
         traefik_network=settings.DOCKER_TRAEFIK_NETWORK,
+        traefik_entrypoint=settings.DOCKER_TRAEFIK_ENTRYPOINT,
     )
 
 

--- a/backend/app/services/sandbox_providers/types.py
+++ b/backend/app/services/sandbox_providers/types.py
@@ -75,6 +75,7 @@ class DockerConfig:
     openvscode_port: int = 8765
     sandbox_domain: str = ""
     traefik_network: str = ""
+    traefik_entrypoint: str = "websecure"
 
 
 PtyDataCallbackType = Callable[[bytes], Coroutine[Any, Any, None]]


### PR DESCRIPTION
Change hardcoded 'https' entrypoint to configurable DOCKER_TRAEFIK_ENTRYPOINT with 'websecure' as default to match Coolify's Traefik configuration.