### PR TITLE
Add OpenAI provider support

### DIFF
--- a/backend/app/core/user_manager.py
+++ b/backend/app/core/user_manager.py
@@ -59,35 +59,51 @@ def _get_default_custom_providers() -> list[dict[str, Any]]:
             "enabled": True,
             "models": [
                 {
-                    "model_id": "openai/gpt-5.2",
+                    "model_id": "openrouter/openai/gpt-5.2",
                     "name": "GPT-5.2",
                     "enabled": True,
                 },
                 {
-                    "model_id": "openai/gpt-5.1-codex",
+                    "model_id": "openrouter/openai/gpt-5.1-codex",
                     "name": "GPT-5.1 Codex",
                     "enabled": True,
                 },
                 {
-                    "model_id": "x-ai/grok-code-fast-1",
+                    "model_id": "openrouter/x-ai/grok-code-fast-1",
                     "name": "Grok Code Fast",
                     "enabled": True,
                 },
                 {
-                    "model_id": "moonshotai/kimi-k2-thinking",
+                    "model_id": "openrouter/moonshotai/kimi-k2-thinking",
                     "name": "Kimi K2 Thinking",
                     "enabled": True,
                 },
                 {
-                    "model_id": "minimax/minimax-m2",
+                    "model_id": "openrouter/minimax/minimax-m2",
                     "name": "Minimax M2",
                     "enabled": True,
                 },
                 {
-                    "model_id": "deepseek/deepseek-v3.2",
+                    "model_id": "openrouter/deepseek/deepseek-v3.2",
                     "name": "Deepseek V3.2",
                     "enabled": True,
                 },
+            ],
+        },
+        {
+            "id": "openai-default",
+            "name": "OpenAI",
+            "provider_type": "openai",
+            "base_url": None,
+            "auth_token": None,
+            "enabled": True,
+            "models": [
+                {
+                    "model_id": "openai/gpt-5.2-codex",
+                    "name": "GPT-5.2 Codex",
+                    "enabled": True,
+                },
+                {"model_id": "openai/gpt-5.2", "name": "GPT-5.2", "enabled": True},
             ],
         },
     ]

--- a/backend/app/models/db_models/user.py
+++ b/backend/app/models/db_models/user.py
@@ -71,7 +71,6 @@ class UserSettings(Base):
     e2b_api_key: Mapped[str | None] = mapped_column(EncryptedString, nullable=True)
     modal_api_key: Mapped[str | None] = mapped_column(EncryptedString, nullable=True)
     sandbox_provider: Mapped[str] = mapped_column(String, default="docker")
-    codex_auth_json: Mapped[str | None] = mapped_column(EncryptedString, nullable=True)
     custom_instructions: Mapped[str | None] = mapped_column(Text, nullable=True)
     custom_providers: Mapped[list[CustomProviderDict] | None] = mapped_column(
         EncryptedJSON, nullable=True

--- a/backend/app/models/schemas/settings.py
+++ b/backend/app/models/schemas/settings.py
@@ -12,6 +12,7 @@ from app.utils.validators import normalize_json_list
 class ProviderType(str, Enum):
     ANTHROPIC = "anthropic"
     OPENROUTER = "openrouter"
+    OPENAI = "openai"
     CUSTOM = "custom"
 
 
@@ -111,7 +112,6 @@ class UserSettingsBase(BaseModel):
     e2b_api_key: str | None = None
     modal_api_key: str | None = None
     sandbox_provider: Literal["docker", "e2b", "modal"] = "docker"
-    codex_auth_json: str | None = None
     custom_instructions: str | None = Field(default=None, max_length=1500)
     custom_providers: list[CustomProvider] | None = None
     custom_agents: list[CustomAgent] | None = None

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -155,7 +155,7 @@ class CustomProviderModelDict(TypedDict, total=False):
 class CustomProviderDict(TypedDict, total=False):
     id: str
     name: str
-    provider_type: Literal["anthropic", "openrouter", "custom"]
+    provider_type: Literal["anthropic", "openrouter", "openai", "custom"]
     base_url: str | None
     auth_token: str | None
     enabled: bool

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -131,7 +131,6 @@ class ChatService(BaseDbService[Chat]):
         custom_agents = user_settings.custom_agents
         auto_compact_disabled = user_settings.auto_compact_disabled
         attribution_disabled = user_settings.attribution_disabled
-        codex_auth_json = user_settings.codex_auth_json
         custom_providers = user_settings.custom_providers
 
         await self.sandbox_service.initialize_sandbox(
@@ -144,7 +143,6 @@ class ChatService(BaseDbService[Chat]):
             user_id=str(user.id),
             auto_compact_disabled=auto_compact_disabled,
             attribution_disabled=attribution_disabled,
-            codex_auth_json=codex_auth_json,
             custom_providers=custom_providers,
         )
 

--- a/backend/app/services/claude_agent.py
+++ b/backend/app/services/claude_agent.py
@@ -16,6 +16,7 @@ from app.core.config import get_settings
 from app.core.security import create_chat_scoped_token
 from app.db.session import SessionLocal
 from app.models.db_models import Chat, User, UserSettings
+from app.models.schemas.settings import ProviderType
 from app.prompts.enhance_prompt import get_enhance_prompt
 from app.services.provider import ProviderService
 from app.services.exceptions import ClaudeAgentException
@@ -28,6 +29,7 @@ from app.services.transports import (
 from app.services.streaming.events import StreamEvent
 from app.services.streaming.processor import StreamProcessor
 from app.services.tool_handler import ToolHandlerRegistry
+from app.services.base_resource import AVAILABLE_TOOLS
 from app.services.user import UserService
 
 SDKPermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions"]
@@ -287,8 +289,8 @@ class ClaudeAgentService:
         if provider_type == "anthropic":
             if auth_token:
                 env["CLAUDE_CODE_OAUTH_TOKEN"] = auth_token
-        elif provider_type == "openrouter":
-            if auth_token:
+        elif provider_type in ("openrouter", "openai"):
+            if auth_token and provider_type == "openrouter":
                 env["OPENROUTER_API_KEY"] = auth_token
             env["ANTHROPIC_BASE_URL"] = "http://127.0.0.1:3456"
             env["ANTHROPIC_AUTH_TOKEN"] = "placeholder"
@@ -482,7 +484,7 @@ class ClaudeAgentService:
                 env[env_var["key"]] = env_var["value"]
 
         disallowed_tools: list[str] = []
-        if provider_type != "anthropic":
+        if provider_type != ProviderType.ANTHROPIC.value:
             disallowed_tools.append("WebSearch")
 
         sdk_permission_mode: SDKPermissionMode = SDK_PERMISSION_MODE_MAP.get(

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -520,9 +520,12 @@ class SandboxService:
         await self.execute_command(sandbox_id, setup_cmd)
 
     async def _setup_anthropic_bridge(
-        self, sandbox_id: str, openrouter_api_key: str, skip_secret: bool = False
+        self,
+        sandbox_id: str,
+        openrouter_api_key: str | None = None,
+        skip_secret: bool = False,
     ) -> None:
-        if not skip_secret:
+        if openrouter_api_key and not skip_secret:
             await self.provider.add_secret(
                 sandbox_id, "OPENROUTER_API_KEY", openrouter_api_key
             )
@@ -602,10 +605,10 @@ class SandboxService:
                 sandbox_id, settings_path, json.dumps(settings, indent=2)
             )
 
-    async def _setup_codex_auth(self, sandbox_id: str, codex_auth_json: str) -> None:
-        codex_dir = "/home/user/.codex"
-        await self.execute_command(sandbox_id, f"mkdir -p {codex_dir}")
-        await self.write_file(sandbox_id, f"{codex_dir}/auth.json", codex_auth_json)
+    async def _setup_openai_auth(self, sandbox_id: str, openai_auth_json: str) -> None:
+        openai_dir = "/home/user/.codex"
+        await self.execute_command(sandbox_id, f"mkdir -p {openai_dir}")
+        await self.write_file(sandbox_id, f"{openai_dir}/auth.json", openai_auth_json)
 
     async def initialize_sandbox(
         self,
@@ -618,7 +621,6 @@ class SandboxService:
         user_id: str | None = None,
         auto_compact_disabled: bool = False,
         attribution_disabled: bool = False,
-        codex_auth_json: str | None = None,
         custom_providers: list[CustomProviderDict] | None = None,
         is_fork: bool = False,
     ) -> None:
@@ -655,14 +657,18 @@ class SandboxService:
             if github_token:
                 tasks.append(self._setup_github_token(sandbox_id, github_token))
 
-            if codex_auth_json:
-                tasks.append(self._setup_codex_auth(sandbox_id, codex_auth_json))
+        openai_auth = self._get_openai_auth_from_provider(custom_providers)
+        if openai_auth:
+            tasks.append(self._setup_openai_auth(sandbox_id, openai_auth))
 
         openrouter_api_key = self._get_openrouter_api_key(custom_providers)
-        if openrouter_api_key:
+        openai_enabled = self._has_openai_provider(custom_providers)
+        if openrouter_api_key or openai_enabled:
             tasks.append(
                 self._setup_anthropic_bridge(
-                    sandbox_id, openrouter_api_key, skip_secret=is_fork
+                    sandbox_id,
+                    openrouter_api_key=openrouter_api_key,
+                    skip_secret=is_fork,
                 )
             )
 
@@ -679,6 +685,32 @@ class SandboxService:
         for provider in custom_providers:
             if (
                 provider.get("provider_type") == "openrouter"
+                and provider.get("enabled", True)
+                and provider.get("auth_token")
+            ):
+                return provider["auth_token"]
+        return None
+
+    @staticmethod
+    def _has_openai_provider(
+        custom_providers: list[CustomProviderDict] | None,
+    ) -> bool:
+        if not custom_providers:
+            return False
+        return any(
+            provider.get("provider_type") == "openai" and provider.get("enabled", True)
+            for provider in custom_providers
+        )
+
+    @staticmethod
+    def _get_openai_auth_from_provider(
+        custom_providers: list[CustomProviderDict] | None,
+    ) -> str | None:
+        if not custom_providers:
+            return None
+        for provider in custom_providers:
+            if (
+                provider.get("provider_type") == "openai"
                 and provider.get("enabled", True)
                 and provider.get("auth_token")
             ):

--- a/backend/app/services/streaming/processor.py
+++ b/backend/app/services/streaming/processor.py
@@ -148,6 +148,7 @@ class StreamProcessor:
             }
             yield suggestions_event
 
+
     def _emit_thinking_block(self, thinking: str | None) -> Iterable[StreamEvent]:
         if thinking:
             event: StreamEvent = {

--- a/backend/migrations/versions/e5f6g7h8i9j1_remove_codex_auth_json.py
+++ b/backend/migrations/versions/e5f6g7h8i9j1_remove_codex_auth_json.py
@@ -1,0 +1,175 @@
+"""remove codex_auth_json from user_settings
+
+Revision ID: e5f6g7h8i9j1
+Revises: de5c3ae2e066
+Create Date: 2026-01-21 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e5f6g7h8i9j1'
+down_revision: Union[str, None] = 'de5c3ae2e066'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _parse_providers(value: object, decrypt_value) -> list[dict]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        try:
+            decrypted = decrypt_value(value)
+        except Exception:
+            decrypted = value
+    else:
+        decrypted = value
+
+    if isinstance(decrypted, str):
+        try:
+            parsed = json.loads(decrypted)
+            if isinstance(parsed, list):
+                return parsed
+        except json.JSONDecodeError:
+            return []
+    elif isinstance(decrypted, list):
+        return decrypted
+    return []
+
+
+def _get_openai_provider_template(auth_token: str) -> dict:
+    return {
+        "id": "openai-default",
+        "name": "OpenAI",
+        "provider_type": "openai",
+        "base_url": None,
+        "auth_token": auth_token,
+        "enabled": True,
+        "models": [
+            {"model_id": "openai/gpt-5.2-codex", "name": "GPT-5.2 Codex", "enabled": True},
+            {"model_id": "openai/gpt-5.2", "name": "GPT-5.2", "enabled": True},
+        ],
+    }
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    user_settings_columns = [c['name'] for c in inspector.get_columns('user_settings')]
+
+    if 'codex_auth_json' in user_settings_columns and 'custom_providers' in user_settings_columns:
+        rows = conn.execute(
+            sa.text(
+                "SELECT id, codex_auth_json, custom_providers FROM user_settings WHERE codex_auth_json IS NOT NULL"
+            )
+        ).fetchall()
+
+        if rows:
+            from app.core.security import decrypt_value, encrypt_value
+
+            for row in rows:
+                codex_auth_json = row.codex_auth_json
+                if not codex_auth_json or (
+                    isinstance(codex_auth_json, str) and not codex_auth_json.strip()
+                ):
+                    continue
+
+                if isinstance(codex_auth_json, str):
+                    try:
+                        codex_auth_json = decrypt_value(codex_auth_json)
+                    except Exception:
+                        pass
+
+                providers = _parse_providers(row.custom_providers, decrypt_value)
+                if not providers:
+                    providers = []
+
+                updated = False
+                target_provider = None
+                for provider in providers:
+                    if not isinstance(provider, dict):
+                        continue
+                    provider_type = provider.get("provider_type")
+                    if provider_type in ("openai", "codex"):
+                        target_provider = provider
+                        break
+
+                if target_provider:
+                    existing_token = target_provider.get("auth_token")
+                    if not existing_token:
+                        target_provider["auth_token"] = codex_auth_json
+                        updated = True
+                else:
+                    providers.append(_get_openai_provider_template(codex_auth_json))
+                    updated = True
+
+                if updated:
+                    serialized = json.dumps(providers, separators=(",", ":"), ensure_ascii=True)
+                    encrypted = encrypt_value(serialized)
+                    encrypted_json = json.dumps(encrypted)
+                    conn.execute(
+                        sa.text(
+                            "UPDATE user_settings SET custom_providers = CAST(:value AS JSON) WHERE id = :id"
+                        ),
+                        {"value": encrypted_json, "id": row.id},
+                    )
+
+    if 'codex_auth_json' in user_settings_columns:
+        op.drop_column('user_settings', 'codex_auth_json')
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    user_settings_columns = [c['name'] for c in inspector.get_columns('user_settings')]
+
+    if 'codex_auth_json' not in user_settings_columns:
+        op.add_column(
+            'user_settings',
+            sa.Column('codex_auth_json', sa.String(), nullable=True)
+        )
+
+    user_settings_columns = [c['name'] for c in inspector.get_columns('user_settings')]
+    if 'custom_providers' not in user_settings_columns:
+        return
+
+    rows = conn.execute(
+        sa.text(
+            "SELECT id, custom_providers FROM user_settings WHERE custom_providers IS NOT NULL"
+        )
+    ).fetchall()
+
+    if not rows:
+        return
+
+    from app.core.security import decrypt_value, encrypt_value
+
+    for row in rows:
+        providers = _parse_providers(row.custom_providers, decrypt_value)
+        if not providers:
+            continue
+
+        codex_auth_json = None
+        for provider in providers:
+            if not isinstance(provider, dict):
+                continue
+            provider_type = provider.get("provider_type")
+            if provider_type in ("openai", "codex"):
+                codex_auth_json = provider.get("auth_token")
+                if codex_auth_json:
+                    break
+
+        if codex_auth_json:
+            if not isinstance(codex_auth_json, str):
+                codex_auth_json = json.dumps(codex_auth_json, ensure_ascii=True)
+            codex_auth_json = encrypt_value(codex_auth_json)
+            conn.execute(
+                sa.text(
+                    "UPDATE user_settings SET codex_auth_json = :codex_auth_json WHERE id = :id"
+                ),
+                {"codex_auth_json": codex_auth_json, "id": row.id},
+            )

--- a/backend/migrations/versions/f6g7h8i9j0k2_rename_codex_to_openai.py
+++ b/backend/migrations/versions/f6g7h8i9j0k2_rename_codex_to_openai.py
@@ -1,0 +1,246 @@
+"""rename codex provider to openai
+
+Revision ID: f6g7h8i9j0k2
+Revises: e5f6g7h8i9j1
+Create Date: 2026-01-22 10:00:00.000000
+
+"""
+
+import json
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f6g7h8i9j0k2"
+down_revision: Union[str, None] = "e5f6g7h8i9j1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _update_providers(
+    providers: list[dict],
+    from_type: str,
+    to_type: str,
+    from_prefix: str,
+    to_prefix: str,
+    from_id: str,
+    to_id: str,
+    to_name: str,
+) -> bool:
+    updated = False
+    for provider in providers:
+        if provider.get("provider_type") == from_type:
+            provider["provider_type"] = to_type
+            updated = True
+
+        if provider.get("id") == from_id:
+            provider["id"] = to_id
+            provider["name"] = to_name
+            updated = True
+
+        if "models" in provider:
+            for model in provider["models"]:
+                model_id = model.get("model_id", "")
+                if model_id.startswith(from_prefix):
+                    model["model_id"] = to_prefix + model_id[len(from_prefix) :]
+                    updated = True
+
+    return updated
+
+
+def _add_openrouter_prefix(providers: list[dict]) -> bool:
+    updated = False
+    for provider in providers:
+        if provider.get("provider_type") != "openrouter":
+            continue
+
+        if "models" not in provider:
+            continue
+
+        for model in provider["models"]:
+            model_id = model.get("model_id", "")
+            if model_id and not model_id.startswith("openrouter/"):
+                model["model_id"] = f"openrouter/{model_id}"
+                updated = True
+
+    return updated
+
+
+def _clean_openai_model_suffixes(providers: list[dict]) -> bool:
+    updated = False
+    suffixes_to_remove = [":low", ":medium", ":high", ":xhigh"]
+    models_to_remove = ["openai/o3"]
+
+    for provider in providers:
+        if provider.get("provider_type") != "openai":
+            continue
+
+        if "models" not in provider:
+            continue
+
+        seen_model_ids: set[str] = set()
+        cleaned_models: list[dict] = []
+
+        for model in provider["models"]:
+            model_id = model.get("model_id", "")
+
+            if model_id in models_to_remove:
+                updated = True
+                continue
+
+            clean_id = model_id
+            for suffix in suffixes_to_remove:
+                if clean_id.endswith(suffix):
+                    clean_id = clean_id[: -len(suffix)]
+                    updated = True
+                    break
+
+            if clean_id in seen_model_ids:
+                updated = True
+                continue
+
+            seen_model_ids.add(clean_id)
+            model["model_id"] = clean_id
+
+            if "(" in model.get("name", ""):
+                base_name = model["name"].split(" (")[0]
+                model["name"] = base_name
+                updated = True
+
+            cleaned_models.append(model)
+
+        provider["models"] = cleaned_models
+
+    return updated
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    rows = conn.execute(
+        sa.text(
+            "SELECT id, custom_providers FROM user_settings WHERE custom_providers IS NOT NULL"
+        )
+    ).fetchall()
+
+    if not rows:
+        return
+
+    from app.core.security import decrypt_value, encrypt_value
+
+    for row in rows:
+        value = row.custom_providers
+        if value is None:
+            continue
+
+        if isinstance(value, str):
+            try:
+                decrypted = decrypt_value(value)
+            except Exception:
+                decrypted = value
+        else:
+            decrypted = value
+
+        providers: list[dict] = []
+        if isinstance(decrypted, str):
+            try:
+                parsed = json.loads(decrypted)
+                if isinstance(parsed, list):
+                    providers = parsed
+            except json.JSONDecodeError:
+                continue
+        elif isinstance(decrypted, list):
+            providers = decrypted
+        else:
+            continue
+
+        updated = _update_providers(
+            providers,
+            from_type="codex",
+            to_type="openai",
+            from_prefix="codex/",
+            to_prefix="openai/",
+            from_id="codex-default",
+            to_id="openai-default",
+            to_name="OpenAI",
+        )
+
+        suffix_cleaned = _clean_openai_model_suffixes(providers)
+        openrouter_prefixed = _add_openrouter_prefix(providers)
+        updated = updated or suffix_cleaned or openrouter_prefixed
+
+        if updated:
+            serialized = json.dumps(providers, separators=(",", ":"), ensure_ascii=True)
+            encrypted = encrypt_value(serialized)
+            encrypted_json = json.dumps(encrypted)
+            conn.execute(
+                sa.text(
+                    "UPDATE user_settings SET custom_providers = CAST(:value AS JSON) WHERE id = :id"
+                ),
+                {"value": encrypted_json, "id": row.id},
+            )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    rows = conn.execute(
+        sa.text(
+            "SELECT id, custom_providers FROM user_settings WHERE custom_providers IS NOT NULL"
+        )
+    ).fetchall()
+
+    if not rows:
+        return
+
+    from app.core.security import decrypt_value, encrypt_value
+
+    for row in rows:
+        value = row.custom_providers
+        if value is None:
+            continue
+
+        if isinstance(value, str):
+            try:
+                decrypted = decrypt_value(value)
+            except Exception:
+                decrypted = value
+        else:
+            decrypted = value
+
+        providers: list[dict] = []
+        if isinstance(decrypted, str):
+            try:
+                parsed = json.loads(decrypted)
+                if isinstance(parsed, list):
+                    providers = parsed
+            except json.JSONDecodeError:
+                continue
+        elif isinstance(decrypted, list):
+            providers = decrypted
+        else:
+            continue
+
+        updated = _update_providers(
+            providers,
+            from_type="openai",
+            to_type="codex",
+            from_prefix="openai/",
+            to_prefix="codex/",
+            from_id="openai-default",
+            to_id="codex-default",
+            to_name="Codex CLI",
+        )
+
+        if updated:
+            serialized = json.dumps(providers, separators=(",", ":"), ensure_ascii=True)
+            encrypted = encrypt_value(serialized)
+            encrypted_json = json.dumps(encrypted)
+            conn.execute(
+                sa.text(
+                    "UPDATE user_settings SET custom_providers = CAST(:value AS JSON) WHERE id = :id"
+                ),
+                {"value": encrypted_json, "id": row.id},
+            )

--- a/frontend/src/components/settings/dialogs/ProviderDialog.tsx
+++ b/frontend/src/components/settings/dialogs/ProviderDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Button, Input, Label, Switch, Select } from '@/components/ui';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { SecretInput } from '../inputs/SecretInput';
+import { CodexAuthUpload } from '../inputs/CodexAuthUpload';
 import { ModelListEditor } from '../inputs/ModelListEditor';
 import type {
   CustomProvider,
@@ -35,18 +36,29 @@ const DEFAULT_OPENROUTER_PROVIDER: Omit<CustomProvider, 'id' | 'auth_token'> = {
   provider_type: 'openrouter',
   enabled: true,
   models: [
+    { model_id: 'openrouter/openai/gpt-5.2', name: 'GPT-5.2', enabled: true },
+    { model_id: 'openrouter/openai/gpt-5.1-codex', name: 'GPT-5.1 Codex', enabled: true },
+    { model_id: 'openrouter/x-ai/grok-code-fast-1', name: 'Grok Code Fast', enabled: true },
+    { model_id: 'openrouter/moonshotai/kimi-k2-thinking', name: 'Kimi K2 Thinking', enabled: true },
+    { model_id: 'openrouter/minimax/minimax-m2', name: 'Minimax M2', enabled: true },
+    { model_id: 'openrouter/deepseek/deepseek-v3.2', name: 'Deepseek V3.2', enabled: true },
+  ],
+};
+
+const DEFAULT_OPENAI_PROVIDER: Omit<CustomProvider, 'id' | 'auth_token'> = {
+  name: 'OpenAI',
+  provider_type: 'openai',
+  enabled: true,
+  models: [
+    { model_id: 'openai/gpt-5.2-codex', name: 'GPT-5.2 Codex', enabled: true },
     { model_id: 'openai/gpt-5.2', name: 'GPT-5.2', enabled: true },
-    { model_id: 'openai/gpt-5.1-codex', name: 'GPT-5.1 Codex', enabled: true },
-    { model_id: 'x-ai/grok-code-fast-1', name: 'Grok Code Fast', enabled: true },
-    { model_id: 'moonshotai/kimi-k2-thinking', name: 'Kimi K2 Thinking', enabled: true },
-    { model_id: 'minimax/minimax-m2', name: 'Minimax M2', enabled: true },
-    { model_id: 'deepseek/deepseek-v3.2', name: 'Deepseek V3.2', enabled: true },
   ],
 };
 
 const PROVIDER_TYPE_OPTIONS = [
   { value: 'anthropic', label: 'Anthropic' },
   { value: 'openrouter', label: 'OpenRouter' },
+  { value: 'openai', label: 'OpenAI' },
   { value: 'custom', label: 'Custom' },
 ];
 
@@ -67,6 +79,8 @@ const createProviderFromType = (providerType: ProviderType): CustomProvider => {
       return { ...DEFAULT_ANTHROPIC_PROVIDER, id, auth_token: '' };
     case 'openrouter':
       return { ...DEFAULT_OPENROUTER_PROVIDER, id, auth_token: '' };
+    case 'openai':
+      return { ...DEFAULT_OPENAI_PROVIDER, id, auth_token: '' };
     default:
       return createEmptyProvider();
   }
@@ -100,6 +114,16 @@ const getAuthTokenConfig = (
           href: 'https://openrouter.ai/keys',
         },
       };
+    case 'openai':
+      return {
+        label: 'Auth (Optional)',
+        placeholder: 'Uses ~/.codex/auth.json from codex login',
+        helperText: {
+          prefix: 'Run',
+          code: 'codex login',
+          suffix: 'in terminal to authenticate with ChatGPT',
+        },
+      };
     case 'custom':
     default:
       return {
@@ -124,6 +148,7 @@ export const ProviderDialog: React.FC<ProviderDialogProps> = ({
   const [form, setForm] = useState<CustomProvider>(createEmptyProvider());
   const [showToken, setShowToken] = useState(false);
   const [selectedProviderType, setSelectedProviderType] = useState<ProviderType>('anthropic');
+  const [localError, setLocalError] = useState<string | null>(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -134,6 +159,7 @@ export const ProviderDialog: React.FC<ProviderDialogProps> = ({
         setSelectedProviderType('anthropic');
         setForm(createProviderFromType('anthropic'));
       }
+      setLocalError(null);
       setShowToken(false);
     }
   }, [isOpen, provider]);
@@ -143,10 +169,15 @@ export const ProviderDialog: React.FC<ProviderDialogProps> = ({
     const currentToken = form.auth_token;
     const newProviderForm = createProviderFromType(providerType);
     setForm({ ...newProviderForm, auth_token: currentToken });
+    setLocalError(null);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (form.provider_type === 'openai' && !form.auth_token) {
+      setLocalError('auth.json is required for OpenAI providers. Run "codex login" first.');
+      return;
+    }
     onSave(form);
   };
 
@@ -155,9 +186,13 @@ export const ProviderDialog: React.FC<ProviderDialogProps> = ({
   };
 
   const isEditing = provider !== null;
-  const isBuiltIn = form.provider_type === 'anthropic' || form.provider_type === 'openrouter';
+  const isBuiltIn =
+    form.provider_type === 'anthropic' ||
+    form.provider_type === 'openrouter' ||
+    form.provider_type === 'openai';
   const showBaseUrl = !isBuiltIn;
   const authConfig = getAuthTokenConfig(form.provider_type);
+  const errorMessage = localError ?? error;
 
   const getDialogTitle = () => {
     if (isEditing) return 'Edit Provider';
@@ -166,6 +201,8 @@ export const ProviderDialog: React.FC<ProviderDialogProps> = ({
         return 'Add Anthropic Provider';
       case 'openrouter':
         return 'Add OpenRouter Provider';
+      case 'openai':
+        return 'Add OpenAI Provider';
       default:
         return 'Add Custom Provider';
     }
@@ -183,9 +220,9 @@ export const ProviderDialog: React.FC<ProviderDialogProps> = ({
           {getDialogTitle()}
         </h3>
 
-        {error && (
+        {errorMessage && (
           <div className="mb-4 rounded-md border border-error-200 bg-error-50 p-3 dark:border-error-800 dark:bg-error-900/20">
-            <p className="text-xs text-error-700 dark:text-error-400">{error}</p>
+            <p className="text-xs text-error-700 dark:text-error-400">{errorMessage}</p>
           </div>
         )}
 
@@ -208,7 +245,9 @@ export const ProviderDialog: React.FC<ProviderDialogProps> = ({
               <p className="mt-1 text-xs text-text-tertiary dark:text-text-dark-tertiary">
                 {selectedProviderType === 'custom'
                   ? 'Configure a custom Anthropic-compatible API provider'
-                  : `Pre-configured with default ${selectedProviderType === 'anthropic' ? 'Claude' : 'OpenRouter'} models`}
+                  : selectedProviderType === 'openai'
+                    ? 'Use OpenAI models with your ChatGPT subscription'
+                    : `Pre-configured with default ${selectedProviderType === 'anthropic' ? 'Claude' : 'OpenRouter'} models`}
               </p>
             </div>
           )}
@@ -244,20 +283,46 @@ export const ProviderDialog: React.FC<ProviderDialogProps> = ({
             </div>
           )}
 
-          <div>
-            <Label className="mb-1.5 text-sm text-text-primary dark:text-text-dark-primary">
-              {authConfig.label}
-            </Label>
-            <SecretInput
-              value={form.auth_token || ''}
-              onChange={(value) => setForm((prev) => ({ ...prev, auth_token: value }))}
-              placeholder={authConfig.placeholder}
-              isVisible={showToken}
-              onToggleVisibility={() => setShowToken(!showToken)}
-              helperText={authConfig.helperText}
-              containerClassName="w-full"
-            />
-          </div>
+          {form.provider_type === 'openai' ? (
+            <div>
+              <Label className="mb-1.5 text-sm text-text-primary dark:text-text-dark-primary">
+                Codex Authentication
+              </Label>
+              <p className="mb-2 text-xs text-text-tertiary dark:text-text-dark-tertiary">
+                Upload your auth.json from{' '}
+                <code className="rounded bg-surface-tertiary px-1 dark:bg-surface-dark-tertiary">
+                  ~/.codex/auth.json
+                </code>{' '}
+                or run{' '}
+                <code className="rounded bg-surface-tertiary px-1 dark:bg-surface-dark-tertiary">
+                  codex login
+                </code>{' '}
+                in terminal. Required for OpenAI providers.
+              </p>
+              <CodexAuthUpload
+                value={form.auth_token || null}
+                onChange={(content) => {
+                  setForm((prev) => ({ ...prev, auth_token: content || '' }));
+                  setLocalError(null);
+                }}
+              />
+            </div>
+          ) : (
+            <div>
+              <Label className="mb-1.5 text-sm text-text-primary dark:text-text-dark-primary">
+                {authConfig.label}
+              </Label>
+              <SecretInput
+                value={form.auth_token || ''}
+                onChange={(value) => setForm((prev) => ({ ...prev, auth_token: value }))}
+                placeholder={authConfig.placeholder}
+                isVisible={showToken}
+                onToggleVisibility={() => setShowToken(!showToken)}
+                helperText={authConfig.helperText}
+                containerClassName="w-full"
+              />
+            </div>
+          )}
 
           <ModelListEditor models={form.models} onChange={handleModelsChange} />
 

--- a/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
@@ -6,7 +6,6 @@ import type {
   SandboxProviderType,
 } from '@/types';
 import { SecretInput } from '@/components/settings/inputs/SecretInput';
-import { CodexAuthUpload } from '@/components/settings/inputs/CodexAuthUpload';
 
 interface GeneralSettingsTabProps {
   fields: GeneralSecretFieldConfig[];
@@ -19,7 +18,6 @@ interface GeneralSettingsTabProps {
   onNotificationSoundChange: (enabled: boolean) => void;
   onAutoCompactDisabledChange: (disabled: boolean) => void;
   onAttributionDisabledChange: (disabled: boolean) => void;
-  onCodexAuthChange: (content: string | null) => void;
   onSandboxProviderChange: (provider: SandboxProviderType) => void;
 }
 
@@ -34,7 +32,6 @@ export const GeneralSettingsTab: React.FC<GeneralSettingsTabProps> = ({
   onNotificationSoundChange,
   onAutoCompactDisabledChange,
   onAttributionDisabledChange,
-  onCodexAuthChange,
   onSandboxProviderChange,
 }) => (
   <div className="space-y-6">
@@ -182,23 +179,6 @@ export const GeneralSettingsTab: React.FC<GeneralSettingsTabProps> = ({
             checked={settings.attribution_disabled ?? false}
             onCheckedChange={onAttributionDisabledChange}
           />
-        </div>
-      </div>
-    </div>
-
-    <div>
-      <h2 className="mb-4 text-sm font-medium text-text-primary dark:text-text-dark-primary">
-        OpenAI Codex
-      </h2>
-      <div className="space-y-4">
-        <div>
-          <h3 className="text-sm font-medium text-text-primary dark:text-text-dark-primary">
-            Codex Authentication
-          </h3>
-          <p className="mt-0.5 text-xs text-text-tertiary dark:text-text-dark-tertiary">
-            Upload your auth.json file from ~/.codex/ for OpenAI Codex CLI authentication.
-          </p>
-          <CodexAuthUpload value={settings.codex_auth_json} onChange={onCodexAuthChange} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/settings/tabs/ProvidersSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/ProvidersSettingsTab.tsx
@@ -14,12 +14,14 @@ interface ProvidersSettingsTabProps {
 const PROVIDER_TYPE_LABELS: Record<ProviderType, string> = {
   anthropic: 'Anthropic',
   openrouter: 'OpenRouter',
+  openai: 'OpenAI',
   custom: 'Custom',
 };
 
 const PROVIDER_TYPE_COLORS: Record<ProviderType, string> = {
   anthropic: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
   openrouter: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  openai: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
   custom: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400',
 };
 
@@ -46,7 +48,12 @@ export const ProvidersSettingsTab: React.FC<ProvidersSettingsTabProps> = ({
   };
 
   const sortedProviders = [...(providers ?? [])].sort((a, b) => {
-    const order: Record<ProviderType, number> = { anthropic: 0, openrouter: 1, custom: 2 };
+    const order: Record<ProviderType, number> = {
+      anthropic: 0,
+      openrouter: 1,
+      openai: 2,
+      custom: 3,
+    };
     return order[a.provider_type] - order[b.provider_type];
   });
 
@@ -138,6 +145,10 @@ export const ProvidersSettingsTab: React.FC<ProvidersSettingsTabProps> = ({
                           <Check className="h-3 w-3" />
                           Configured
                         </span>
+                      ) : provider.provider_type === 'openai' ? (
+                        <span className="inline-flex items-center gap-1 text-xs text-text-tertiary dark:text-text-dark-tertiary">
+                          Uses ~/.codex/auth.json
+                        </span>
                       ) : (
                         <span className="inline-flex items-center gap-1 text-xs text-warning-600 dark:text-warning-500">
                           <X className="h-3 w-3" />
@@ -151,7 +162,9 @@ export const ProvidersSettingsTab: React.FC<ProvidersSettingsTabProps> = ({
                         ? provider.base_url.replace(/^https?:\/\//, '').split('/')[0]
                         : provider.provider_type === 'anthropic'
                           ? 'api.anthropic.com'
-                          : 'openrouter.ai'}
+                          : provider.provider_type === 'openai'
+                            ? 'ChatGPT API'
+                            : 'openrouter.ai'}
                     </p>
                   </div>
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -79,7 +79,6 @@ const createFallbackSettings = (): UserSettings => ({
   e2b_api_key: null,
   modal_api_key: null,
   sandbox_provider: null,
-  codex_auth_json: null,
   custom_instructions: null,
   custom_providers: null,
   custom_agents: null,
@@ -101,7 +100,6 @@ const TAB_FIELDS: Record<TabKey, (keyof UserSettings)[]> = {
     'e2b_api_key',
     'modal_api_key',
     'sandbox_provider',
-    'codex_auth_json',
     'auto_compact_disabled',
     'attribution_disabled',
   ],
@@ -195,7 +193,6 @@ const SettingsPage: React.FC = () => {
         'e2b_api_key',
         'modal_api_key',
         'sandbox_provider',
-        'codex_auth_json',
         'custom_instructions',
         'custom_providers',
         'custom_agents',
@@ -471,10 +468,6 @@ const SettingsPage: React.FC = () => {
     persistSettings((prev) => ({ ...prev, attribution_disabled: disabled }));
   };
 
-  const handleCodexAuthChange = (content: string | null) => {
-    persistSettings((prev) => ({ ...prev, codex_auth_json: content }));
-  };
-
   const handleSandboxProviderChange = (provider: SandboxProviderType) => {
     persistSettings((prev) => ({ ...prev, sandbox_provider: provider }));
   };
@@ -632,7 +625,6 @@ const SettingsPage: React.FC = () => {
                     onNotificationSoundChange={handleNotificationSoundChange}
                     onAutoCompactDisabledChange={handleAutoCompactDisabledChange}
                     onAttributionDisabledChange={handleAttributionDisabledChange}
-                    onCodexAuthChange={handleCodexAuthChange}
                     onSandboxProviderChange={handleSandboxProviderChange}
                   />
                 </div>

--- a/frontend/src/types/user.types.ts
+++ b/frontend/src/types/user.types.ts
@@ -76,7 +76,7 @@ export interface CustomPrompt {
 
 export type SandboxProviderType = 'docker' | 'e2b' | 'modal';
 
-export type ProviderType = 'anthropic' | 'openrouter' | 'custom';
+export type ProviderType = 'anthropic' | 'openrouter' | 'openai' | 'custom';
 
 export interface CustomProviderModel {
   model_id: string;
@@ -101,7 +101,6 @@ export interface UserSettings {
   e2b_api_key: string | null;
   modal_api_key: string | null;
   sandbox_provider: SandboxProviderType | null;
-  codex_auth_json: string | null;
   custom_instructions: string | null;
   custom_providers: CustomProvider[] | null;
   custom_agents: CustomAgent[] | null;

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -75,7 +75,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.11 @openai/codex
+    npm install -g @anthropic-ai/claude-code@2.1.14 @openai/codex
 
 RUN python3 -m pip install --user --upgrade pip && \
     python3 -m pip install --user \
@@ -84,7 +84,7 @@ RUN python3 -m pip install --user --upgrade pip && \
     requests \
     pydantic \
     mcp \
-    anthropic-bridge
+    anthropic-bridge==0.1.19
 
 RUN OPENVSCODE_VERSION="1.105.1" && \
     ARCH=$(uname -m) && \

--- a/sandbox/e2b/e2b.Dockerfile
+++ b/sandbox/e2b/e2b.Dockerfile
@@ -50,9 +50,9 @@ RUN curl -fsSLO https://nodejs.org/dist/v20.19.0/node-v20.19.0-linux-x64.tar.xz 
     && echo '#!/bin/sh\nexec bun x "$@"' > /usr/local/bin/bunx \
     && chmod +x /usr/local/bin/bunx
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.11
+RUN npm install -g @anthropic-ai/claude-code@2.1.14
 
-RUN pip3 install anthropic-bridge==0.1.1
+RUN pip3 install anthropic-bridge==0.1.19
 
 RUN npm install -g @openai/codex
 


### PR DESCRIPTION
## Summary
- Add OpenAI to ProviderType enum in backend and frontend
- Support gpt-5.2-codex, gpt-5.2
- Update sandbox to detect and setup bridge for OpenAI providers
- Combine OpenRouter and OpenAI auth environment setup
- Move OpenAI auth upload from General to Providers tab
- Update anthropic-bridge to 0.1.20 for OpenAI support