### PR TITLE
Refetch editor file metadata when switching to editor tab

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -69,6 +69,12 @@ export function ChatPage() {
     chatId,
   );
 
+  useEffect(() => {
+    if (currentView === 'editor' && currentChat?.sandbox_id) {
+      refetchFilesMetadata();
+    }
+  }, [currentView, currentChat?.sandbox_id, refetchFilesMetadata]);
+
   const { contextUsage, updateContextUsage } = useContextUsageState(chatId, currentChat);
 
   const { data: settings } = useSettingsQuery();


### PR DESCRIPTION
## Summary
- Adds a `useEffect` that triggers `refetchFilesMetadata()` when switching to the editor view
- Ensures the filetree is always up-to-date when clicking on the Editor tab
- Previously, metadata was only fetched on initial page load or after file writes

## Test plan
- [ ] Open a chat with a sandbox
- [ ] Switch to a different tab (e.g., Agent or Terminal)
- [ ] Modify a file through the terminal
- [ ] Click on the Editor tab
- [ ] Verify the filetree updates to show the changes