### PR TITLE
Fix responsive design for input bar and sidebar auto-collapse

### DIFF
--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -283,7 +283,7 @@ export const Input = memo(function Input({
   const shouldShowAttachedPreview = showAttachedFilesPreview && showPreview && hasAttachments;
 
   return (
-    <form ref={formRef} onSubmit={handleSubmit} className="relative px-4 sm:px-6">
+    <form ref={formRef} onSubmit={handleSubmit} className="relative px-2 sm:px-4 md:px-6">
       <div
         {...dragHandlers}
         className={`relative rounded-2xl border bg-surface-tertiary transition-all duration-300 dark:bg-surface-dark-tertiary ${
@@ -311,7 +311,7 @@ export const Input = memo(function Input({
           </div>
         )}
 
-        <div className="relative px-3 pb-12 pt-1.5 sm:pb-9">
+        <div className="relative px-2 pb-12 pt-1.5 md:px-3 md:pb-9">
           <Textarea
             ref={textareaRef}
             message={message}
@@ -351,7 +351,7 @@ export const Input = memo(function Input({
               hasMessage={hasMessage}
             />
 
-            <div className="absolute bottom-2.5 right-3">
+            <div className="absolute bottom-2.5 right-2 md:right-3">
               <SendButton
                 isLoading={isLoading}
                 isStreaming={isStreaming}

--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -27,7 +27,7 @@ export function InputControls({
 }: InputControlsProps) {
   return (
     <div
-      className="absolute bottom-2.5 left-3 right-14 flex flex-wrap items-center gap-1.5 sm:gap-2"
+      className="absolute bottom-2.5 left-2 right-12 flex flex-wrap items-center gap-1 md:left-3 md:right-14 md:gap-2"
       onClick={(e) => e.preventDefault()}
     >
       {onAttach && <AttachButton onAttach={onAttach} />}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertTriangle, ChevronDown, LogOut, Moon, Settings, Sun } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore, useUIStore } from '@/store';
+import { useLayoutContext } from './layoutState';
 import { useCurrentUserQuery, useLogoutMutation, useUserUsageQuery } from '@/hooks/queries';
 import { Button, ToggleButton } from '@/components/ui';
 import { cn } from '@/utils/cn';
@@ -297,7 +298,7 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
-  const setSidebarOpen = useUIStore((state) => state.setSidebarOpen);
+  const { handleSidebarToggle } = useLayoutContext();
 
   const { data: user } = useCurrentUserQuery({
     enabled: isAuthenticated && !isAuthPage,
@@ -335,7 +336,7 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
           {isAuthenticated && !isAuthPage && (
             <ToggleButton
               isOpen={sidebarOpen}
-              onClick={() => setSidebarOpen(!sidebarOpen)}
+              onClick={() => handleSidebarToggle(!sidebarOpen)}
               position="left"
               className="mr-1"
             />

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -3,18 +3,21 @@ import { Header, type HeaderProps } from './Header';
 import { cn } from '@/utils/cn';
 import { LayoutContext, type LayoutContextValue } from './layoutState';
 import { useUIStore } from '@/store';
-import { useSwipeGesture, useIsMobile } from '@/hooks';
+import { useSwipeGesture, useIsMobile, useAutoCollapseSidebar } from '@/hooks';
 
-function MobileSidebarOverlay() {
+interface MobileSidebarOverlayProps {
+  onClose: () => void;
+}
+
+function MobileSidebarOverlay({ onClose }: MobileSidebarOverlayProps) {
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
-  const setSidebarOpen = useUIStore((state) => state.setSidebarOpen);
 
   if (!sidebarOpen) return null;
 
   return (
     <div
       className="fixed inset-0 z-30 bg-black/50 md:hidden"
-      onClick={() => setSidebarOpen(false)}
+      onClick={onClose}
       aria-hidden="true"
     />
   );
@@ -38,12 +41,12 @@ export function Layout({
 }: LayoutProps) {
   const [sidebarContent, setSidebarContent] = useState<ReactNode | null>(null);
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
-  const setSidebarOpen = useUIStore((state) => state.setSidebarOpen);
   const isMobile = useIsMobile();
+  const { handleManualToggle } = useAutoCollapseSidebar();
 
   useSwipeGesture({
-    onSwipeRight: () => setSidebarOpen(true),
-    onSwipeLeft: () => sidebarOpen && setSidebarOpen(false),
+    onSwipeRight: () => handleManualToggle(true),
+    onSwipeLeft: () => sidebarOpen && handleManualToggle(false),
     enabled: isMobile && !!sidebarContent,
   });
 
@@ -55,8 +58,9 @@ export function Layout({
     () => ({
       sidebar: sidebarContent,
       setSidebar,
+      handleSidebarToggle: handleManualToggle,
     }),
-    [setSidebar, sidebarContent],
+    [setSidebar, sidebarContent, handleManualToggle],
   );
 
   return (
@@ -65,7 +69,7 @@ export function Layout({
         {showHeader && <Header onLogout={onLogout} userName={userName} isAuthPage={isAuthPage} />}
 
         <div className="flex min-h-0 flex-1">
-          {sidebarContent && <MobileSidebarOverlay />}
+          {sidebarContent && <MobileSidebarOverlay onClose={() => handleManualToggle(false)} />}
 
           {sidebarContent ? (
             <div className="relative h-full flex-shrink-0">{sidebarContent}</div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import { useDeleteChatMutation, useUpdateChatMutation, usePinChatMutation } from
 import { cn } from '@/utils/cn';
 import { useUIStore, useStreamStore } from '@/store';
 import { useIsMobile } from '@/hooks';
+import { useLayoutContext } from './layoutState';
 import { SidebarChatItem } from './SidebarChatItem';
 import { ChatDropdown } from './ChatDropdown';
 import { DROPDOWN_WIDTH, DROPDOWN_HEIGHT, DROPDOWN_MARGIN } from '@/config/constants';
@@ -74,8 +75,8 @@ export function Sidebar({
 }: SidebarProps) {
   const navigate = useNavigate();
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
-  const setSidebarOpen = useUIStore((state) => state.setSidebarOpen);
   const isMobile = useIsMobile();
+  const { handleSidebarToggle } = useLayoutContext();
   const activeStreamMetadata = useStreamStore((state) => state.activeStreamMetadata);
   const streamingChatIds = useMemo(
     () => activeStreamMetadata.map((meta) => meta.chatId),
@@ -160,10 +161,10 @@ export function Sidebar({
       onChatSelect(chatId);
       setHoveredChatId(null);
       if (isMobile) {
-        setSidebarOpen(false);
+        handleSidebarToggle(false);
       }
     },
-    [onChatSelect, isMobile, setSidebarOpen],
+    [onChatSelect, isMobile, handleSidebarToggle],
   );
 
   const handleDeleteChat = useCallback((chatId: string) => {
@@ -203,7 +204,7 @@ export function Sidebar({
   const handleNewChat = () => {
     navigate('/');
     if (isMobile) {
-      setSidebarOpen(false);
+      handleSidebarToggle(false);
     }
   };
 

--- a/frontend/src/components/layout/layoutState.tsx
+++ b/frontend/src/components/layout/layoutState.tsx
@@ -3,6 +3,7 @@ import { ReactNode, createContext, useContext, useEffect } from 'react';
 export interface LayoutContextValue {
   sidebar: ReactNode | null;
   setSidebar: (content: ReactNode | null) => void;
+  handleSidebarToggle: (isOpen: boolean) => void;
 }
 
 export const LayoutContext = createContext<LayoutContextValue | undefined>(undefined);

--- a/frontend/src/components/ui/primitives/Dropdown.tsx
+++ b/frontend/src/components/ui/primitives/Dropdown.tsx
@@ -120,10 +120,10 @@ function DropdownInner<T>({
 
   const showIconOnly = compactOnMobile && LeftIcon;
   const labelClasses = showIconOnly
-    ? 'hidden sm:inline whitespace-nowrap text-xs font-medium text-text-primary dark:text-text-dark-secondary'
+    ? 'hidden md:inline whitespace-nowrap text-xs font-medium text-text-primary dark:text-text-dark-secondary'
     : 'whitespace-nowrap text-xs font-medium text-text-primary dark:text-text-dark-secondary';
   const chevronClasses = showIconOnly
-    ? 'hidden sm:block h-3.5 w-3.5 flex-shrink-0 text-text-quaternary'
+    ? 'hidden md:block h-3.5 w-3.5 flex-shrink-0 text-text-quaternary'
     : 'h-3.5 w-3.5 flex-shrink-0 text-text-quaternary';
 
   return (

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './queries';
+export * from './useAutoCollapseSidebar';
 export * from './useChatContext';
 export * from './useChatData';
 export * from './useChatStreaming';

--- a/frontend/src/hooks/useAutoCollapseSidebar.ts
+++ b/frontend/src/hooks/useAutoCollapseSidebar.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react';
+import { useUIStore } from '@/store';
+import { MOBILE_BREAKPOINT } from '@/config/constants';
+
+export function useAutoCollapseSidebar() {
+  const sidebarOpen = useUIStore((state) => state.sidebarOpen);
+  const setSidebarOpen = useUIStore((state) => state.setSidebarOpen);
+  const sidebarAutoCollapsed = useUIStore((state) => state.sidebarAutoCollapsed);
+  const setSidebarAutoCollapsed = useUIStore((state) => state.setSidebarAutoCollapsed);
+
+  const prevWidthRef = useRef(
+    typeof window !== 'undefined' ? window.innerWidth : MOBILE_BREAKPOINT,
+  );
+  const wasManuallyOpenedRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const { sidebarOpen: initialSidebarOpen, sidebarAutoCollapsed: initialAutoCollapsed } =
+      useUIStore.getState();
+
+    if (window.innerWidth < MOBILE_BREAKPOINT && initialSidebarOpen && !initialAutoCollapsed) {
+      setSidebarOpen(false);
+      setSidebarAutoCollapsed(true);
+    }
+
+    if (window.innerWidth >= MOBILE_BREAKPOINT && initialAutoCollapsed && !initialSidebarOpen) {
+      setSidebarOpen(true);
+      setSidebarAutoCollapsed(false);
+    }
+  }, [setSidebarOpen, setSidebarAutoCollapsed]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const currentWidth = window.innerWidth;
+      const prevWidth = prevWidthRef.current;
+
+      if (currentWidth < prevWidth) {
+        if (sidebarOpen && currentWidth < MOBILE_BREAKPOINT && !wasManuallyOpenedRef.current) {
+          setSidebarOpen(false);
+          setSidebarAutoCollapsed(true);
+        }
+      } else if (currentWidth > prevWidth) {
+        if (currentWidth >= MOBILE_BREAKPOINT) {
+          wasManuallyOpenedRef.current = false;
+          if (!sidebarOpen && sidebarAutoCollapsed) {
+            setSidebarOpen(true);
+            setSidebarAutoCollapsed(false);
+          }
+        }
+      }
+
+      prevWidthRef.current = currentWidth;
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [sidebarOpen, sidebarAutoCollapsed, setSidebarOpen, setSidebarAutoCollapsed]);
+
+  useEffect(() => {
+    if (!sidebarOpen && !sidebarAutoCollapsed) {
+      wasManuallyOpenedRef.current = false;
+    }
+  }, [sidebarOpen, sidebarAutoCollapsed]);
+
+  const handleManualToggle = (isOpen: boolean) => {
+    if (isOpen && typeof window !== 'undefined' && window.innerWidth < MOBILE_BREAKPOINT) {
+      wasManuallyOpenedRef.current = true;
+    } else {
+      wasManuallyOpenedRef.current = false;
+    }
+    setSidebarAutoCollapsed(false);
+    setSidebarOpen(isOpen);
+  };
+
+  return { handleManualToggle };
+}

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -17,7 +17,10 @@ type UIStoreState = ThemeState &
   Pick<UIState, 'sidebarOpen'> &
   Pick<UIActions, 'setSidebarOpen'> &
   SplitViewState &
-  SplitViewActions;
+  SplitViewActions & {
+    sidebarAutoCollapsed: boolean;
+    setSidebarAutoCollapsed: (isAutoCollapsed: boolean) => void;
+  };
 
 const getInitialSidebarState = (): boolean => {
   if (typeof window === 'undefined') return false;
@@ -38,6 +41,8 @@ export const useUIStore = create<UIStoreState>()(
       setThinkingMode: (mode) => set({ thinkingMode: mode }),
       sidebarOpen: getInitialSidebarState(),
       setSidebarOpen: (isOpen) => set({ sidebarOpen: isOpen }),
+      sidebarAutoCollapsed: false,
+      setSidebarAutoCollapsed: (isAutoCollapsed) => set({ sidebarAutoCollapsed: isAutoCollapsed }),
 
       isSplitMode: false,
       currentView: 'agent',
@@ -82,6 +87,7 @@ export const useUIStore = create<UIStoreState>()(
         secondaryView: state.secondaryView,
         isSplitMode: state.isSplitMode,
         sidebarOpen: state.sidebarOpen,
+        sidebarAutoCollapsed: state.sidebarAutoCollapsed,
       }),
       merge: (persisted, current) => ({
         ...current,


### PR DESCRIPTION
## Summary
- Adjust input bar spacing to be tighter on mobile screens (px-2, gap-1 at small widths)
- Change Dropdown `compactOnMobile` breakpoint from `sm` (640px) to `md` (768px) to match `MOBILE_BREAKPOINT`
- Add automatic sidebar collapse when viewport shrinks below 768px
- Add automatic sidebar expand when viewport returns to desktop size (if auto-collapsed)
- Persist `sidebarAutoCollapsed` state to maintain behavior across page reloads
- Centralize sidebar toggle handler via `LayoutContext` to prevent state conflicts between components

## Test plan
- [ ] Resize browser window and verify input bar controls remain accessible at all widths
- [ ] Verify dropdown labels hide on screens < 768px, showing only icons
- [ ] Open sidebar on desktop, resize to mobile width, and confirm sidebar auto-collapses
- [ ] Resize back to desktop width and confirm sidebar auto-expands
- [ ] Manually open sidebar on mobile, verify it stays open (respects user intent)
- [ ] Reload page on mobile/desktop and verify sidebar state persists correctly
- [ ] Test swipe gestures for sidebar on mobile