### PR TITLE
Require host/allowedHosts in sandbox prompts

### DIFF
--- a/backend/app/prompts/system_prompt.py
+++ b/backend/app/prompts/system_prompt.py
@@ -72,7 +72,9 @@ def _get_runtime_context_section(
 - Sandbox Provider: {provider_label}
 - Available ports for dev servers: {ports_str}
 - IMPORTANT: Only use ports from the available ports list above. Other ports will not be accessible.
-- IMPORTANT: When running dev servers (Vite, Next.js, etc.), always use `--host 0.0.0.0` flag to bind to all interfaces. Example: `npm run dev -- --host 0.0.0.0` or `npx vite --host 0.0.0.0`. Without this, the preview panel cannot connect to the server.
+- IMPORTANT: For sandbox providers (Docker/E2B/Modal), ensure dev servers bind to all interfaces and allow external hosts:
+  - Set `host: "0.0.0.0"` in the framework config (e.g., Vite `server.host`).
+  - Set `allowedHosts: true` in the framework config (e.g., Vite `server.allowedHosts`).
 - IMPORTANT: Do NOT tell users specific localhost URLs. The actual port is dynamically mapped. Direct users to check the Preview panel for the correct URL.
 </runtime_context>"""
 


### PR DESCRIPTION
Updates the runtime context prompt to instruct config-based host binding (0.0.0.0) and allowedHosts=true for sandbox providers, and removes the dev-server CLI host example to avoid conflicts.