### PR TITLE
Fix input bar controls wrapping in split view and narrow viewports

### DIFF
--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo, useEffect } from 'react';
 import { Bot, ChevronDown } from 'lucide-react';
 import { Dropdown } from '@/components/ui';
 import type { DropdownItemType } from '@/components/ui';
-import { useAuthStore } from '@/store';
+import { useAuthStore, useUIStore } from '@/store';
 import { useModelSelection } from '@/hooks/queries';
 import type { Model } from '@/types/chat.types';
 
@@ -37,6 +37,7 @@ export const ModelSelector = memo(function ModelSelector({
   disabled = false,
 }: ModelSelectorProps) {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const isSplitMode = useUIStore((state) => state.isSplitMode);
   const { models, isLoading } = useModelSelection({ enabled: isAuthenticated });
 
   const groupedItems = useMemo(() => {
@@ -93,6 +94,7 @@ export const ModelSelector = memo(function ModelSelector({
       dropdownPosition={dropdownPosition}
       disabled={disabled}
       compactOnMobile
+      forceCompact={isSplitMode}
       searchable
       searchPlaceholder="Search models..."
       renderItem={(model, isSelected) => (

--- a/frontend/src/components/chat/permission-mode-selector/PermissionModeSelector.tsx
+++ b/frontend/src/components/chat/permission-mode-selector/PermissionModeSelector.tsx
@@ -26,6 +26,7 @@ export const PermissionModeSelector = memo(function PermissionModeSelector({
 }: PermissionModeSelectorProps) {
   const permissionMode = useUIStore((state) => state.permissionMode);
   const setPermissionMode = useUIStore((state) => state.setPermissionMode);
+  const isSplitMode = useUIStore((state) => state.isSplitMode);
 
   const selectedMode =
     PERMISSION_MODES.find((m) => m.value === permissionMode) || PERMISSION_MODES[2];
@@ -43,6 +44,7 @@ export const PermissionModeSelector = memo(function PermissionModeSelector({
       dropdownPosition={dropdownPosition}
       disabled={disabled}
       compactOnMobile
+      forceCompact={isSplitMode}
       renderItem={(mode, isSelected) => (
         <>
           <span

--- a/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
+++ b/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
@@ -28,6 +28,7 @@ export const ThinkingModeSelector = memo(function ThinkingModeSelector({
 }: ThinkingModeSelectorProps) {
   const thinkingMode = useUIStore((state) => state.thinkingMode);
   const setThinkingMode = useUIStore((state) => state.setThinkingMode);
+  const isSplitMode = useUIStore((state) => state.isSplitMode);
 
   const selectedMode = THINKING_MODES.find((m) => m.value === thinkingMode) || THINKING_MODES[0];
 
@@ -43,6 +44,7 @@ export const ThinkingModeSelector = memo(function ThinkingModeSelector({
       dropdownPosition={dropdownPosition}
       disabled={disabled}
       compactOnMobile
+      forceCompact={isSplitMode}
       renderItem={(mode, isSelected) => (
         <div className="flex w-full items-center justify-between">
           <span

--- a/frontend/src/components/ui/primitives/Dropdown.tsx
+++ b/frontend/src/components/ui/primitives/Dropdown.tsx
@@ -21,6 +21,7 @@ export interface DropdownProps<T> {
   dropdownPosition?: 'top' | 'bottom';
   disabled?: boolean;
   compactOnMobile?: boolean;
+  forceCompact?: boolean;
   searchable?: boolean;
   searchPlaceholder?: string;
 }
@@ -47,6 +48,7 @@ function DropdownInner<T>({
   dropdownPosition = 'bottom',
   disabled = false,
   compactOnMobile = false,
+  forceCompact = false,
   searchable = false,
   searchPlaceholder = 'Search...',
 }: DropdownProps<T>) {
@@ -118,12 +120,16 @@ function DropdownInner<T>({
     ? getFilteredGroupedItems()
     : filterItems(items as readonly T[]);
 
-  const showIconOnly = compactOnMobile && LeftIcon;
+  const showIconOnly = (compactOnMobile || forceCompact) && LeftIcon;
   const labelClasses = showIconOnly
-    ? 'hidden sm:inline whitespace-nowrap text-xs font-medium text-text-primary dark:text-text-dark-secondary'
+    ? forceCompact
+      ? 'hidden whitespace-nowrap text-xs font-medium text-text-primary dark:text-text-dark-secondary'
+      : 'hidden lg:inline whitespace-nowrap text-xs font-medium text-text-primary dark:text-text-dark-secondary'
     : 'whitespace-nowrap text-xs font-medium text-text-primary dark:text-text-dark-secondary';
   const chevronClasses = showIconOnly
-    ? 'hidden sm:block h-3.5 w-3.5 flex-shrink-0 text-text-quaternary'
+    ? forceCompact
+      ? 'hidden h-3.5 w-3.5 flex-shrink-0 text-text-quaternary'
+      : 'hidden lg:block h-3.5 w-3.5 flex-shrink-0 text-text-quaternary'
     : 'h-3.5 w-3.5 flex-shrink-0 text-text-quaternary';
 
   return (


### PR DESCRIPTION
Change responsive breakpoint from sm: (640px) to lg: (1024px) so labels only appear on wider screens, preventing controls from wrapping to multiple rows at medium viewport widths.