### PR TITLE
Fix file tree header icon styling

### DIFF
--- a/frontend/src/components/editor/file-tree/Header.tsx
+++ b/frontend/src/components/editor/file-tree/Header.tsx
@@ -26,16 +26,7 @@ export function Header({
   return (
     <div className="flex flex-none flex-col gap-2 border-b border-border p-3 dark:border-border-dark">
       <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <div className="rounded-md bg-surface-secondary p-1.5 dark:bg-surface-dark-secondary">
-            <Files className="h-4 w-4 text-text-tertiary dark:text-text-dark-tertiary" />
-          </div>
-          <div>
-            <h2 className="text-xs font-semibold text-text-primary dark:text-text-dark-primary">
-              Project Files
-            </h2>
-          </div>
-        </div>
+        <Files className="h-4 w-4 text-text-tertiary dark:text-text-dark-tertiary" />
 
         <div className="flex items-center gap-1">
           {onRefresh && (


### PR DESCRIPTION
## Summary
- Removes the background wrapper div from the Files icon in the file tree header
- Creates visual consistency with other header icons (refresh, download, close)

## Test plan
- [ ] Open the file tree panel
- [ ] Verify the Files icon no longer has a background
- [ ] Verify all icons in the header have consistent styling