### PR TITLE
Replace upload overlay with per-file progress bars

### DIFF
--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -16,7 +16,7 @@ import { ChatSkeleton } from './ChatSkeleton';
 import { LoadingIndicator } from './LoadingIndicator';
 import { ScrollButton } from './ScrollButton';
 import { ErrorMessage } from './ErrorMessage';
-import { Spinner, LoadingOverlay } from '@/components/ui';
+import { Spinner } from '@/components/ui';
 import type {
   Message as MessageType,
   FileStructure,
@@ -103,8 +103,6 @@ export const Chat = memo(function Chat({
   isPermissionLoading = false,
   permissionError,
 }: ChatProps) {
-  const hasAttachments = (attachedFiles?.length ?? 0) > 0;
-  const isUploadingFiles = isLoading && !isStreaming && hasAttachments;
   const activeStreams = useStreamStore((state) => state.activeStreams);
   const streamingMessageIds = useMemo(() => {
     const ids: string[] = [];
@@ -464,7 +462,6 @@ export const Chat = memo(function Chat({
           </div>
         </div>
       </div>
-      <LoadingOverlay isOpen={isUploadingFiles} message="Uploading files..." />
     </ChatProvider>
   );
 });

--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -122,6 +122,7 @@ export const Input = memo(function Input({
   const hasMessage = message.trim().length > 0;
   const hasAttachments = (attachedFiles?.length ?? 0) > 0;
   const isEnhancing = enhancePromptMutation.isPending;
+  const isUploading = isLoading && !isStreaming && hasAttachments;
   const dynamicPlaceholder = isStreaming ? 'Type to queue message...' : placeholder;
 
   const handleSlashCommandSelect = useCallback(
@@ -280,7 +281,8 @@ export const Input = memo(function Input({
     enhancePromptMutation.mutate({ prompt: message.trim(), modelId: selectedModelId });
   }, [hasMessage, isEnhancing, message, selectedModelId, enhancePromptMutation]);
 
-  const shouldShowAttachedPreview = showAttachedFilesPreview && showPreview && hasAttachments;
+  const shouldShowAttachedPreview =
+    showAttachedFilesPreview && hasAttachments && (showPreview || isUploading);
 
   return (
     <form ref={formRef} onSubmit={handleSubmit} className="relative px-4 sm:px-6">
@@ -302,6 +304,7 @@ export const Input = memo(function Input({
             previewUrls={previewUrls}
             onRemoveFile={handleRemoveFile}
             onEditImage={handleDrawClick}
+            isUploading={isUploading}
           />
         )}
 

--- a/frontend/src/components/chat/message-input/InputAttachments.tsx
+++ b/frontend/src/components/chat/message-input/InputAttachments.tsx
@@ -6,6 +6,7 @@ interface InputAttachmentsProps {
   previewUrls: string[];
   onRemoveFile: (index: number) => void;
   onEditImage: (index: number) => void;
+  isUploading?: boolean;
 }
 
 export const InputAttachments = memo(function InputAttachments({
@@ -13,6 +14,7 @@ export const InputAttachments = memo(function InputAttachments({
   previewUrls,
   onRemoveFile,
   onEditImage,
+  isUploading = false,
 }: InputAttachmentsProps) {
   if (files.length === 0) return null;
 
@@ -24,6 +26,7 @@ export const InputAttachments = memo(function InputAttachments({
         onRemoveFile={onRemoveFile}
         onEditImage={onEditImage}
         compact={true}
+        isUploading={isUploading}
       />
     </div>
   );

--- a/frontend/src/components/ui/FilePreviewList.tsx
+++ b/frontend/src/components/ui/FilePreviewList.tsx
@@ -9,6 +9,7 @@ interface FilePreviewItemProps {
   onRemove: () => void;
   onEdit?: () => void;
   compact?: boolean;
+  isUploading?: boolean;
 }
 
 interface FileActionButtonsProps {
@@ -50,12 +51,28 @@ const FileActionButtons = ({
   </div>
 );
 
+const UploadProgressOverlay = memo(function UploadProgressOverlay({
+  compact = false,
+}: {
+  compact?: boolean;
+}) {
+  return (
+    <div className="absolute inset-x-0 bottom-0 overflow-hidden rounded-b-lg bg-black/40">
+      <div className="relative h-1 w-full overflow-hidden">
+        <div className="absolute inset-y-0 w-1/3 animate-shimmer rounded-full bg-brand-400" />
+      </div>
+      {!compact && <p className="pb-1 pt-0.5 text-center text-2xs text-white">Uploading...</p>}
+    </div>
+  );
+});
+
 const FilePreviewItem = memo(function FilePreviewItem({
   file,
   previewUrl,
   onRemove,
   onEdit,
   compact = false,
+  isUploading = false,
 }: FilePreviewItemProps) {
   const isImage = isUploadedImageFile(file);
   const isPdf = isUploadedPdfFile(file);
@@ -77,20 +94,23 @@ const FilePreviewItem = memo(function FilePreviewItem({
           <img
             src={previewUrl}
             alt={`Preview of ${file.name}`}
-            className={`${previewSize} block rounded-lg object-cover`}
+            className={`${previewSize} block rounded-lg object-cover ${isUploading ? 'opacity-70' : ''}`}
           />
-          <FileActionButtons
-            onEdit={onEdit}
-            onRemove={onRemove}
-            buttonSize={buttonSize}
-            iconSize={iconSize}
-            editLabel="Edit image"
-          />
+          {!isUploading && (
+            <FileActionButtons
+              onEdit={onEdit}
+              onRemove={onRemove}
+              buttonSize={buttonSize}
+              iconSize={iconSize}
+              editLabel="Edit image"
+            />
+          )}
+          {isUploading && <UploadProgressOverlay compact={compact} />}
         </>
       ) : isPdf ? (
         <>
           <div
-            className={`${previewSize} flex flex-col items-center justify-center rounded-lg bg-surface-secondary dark:bg-surface-dark-secondary`}
+            className={`${previewSize} flex flex-col items-center justify-center rounded-lg bg-surface-secondary dark:bg-surface-dark-secondary ${isUploading ? 'opacity-70' : ''}`}
           >
             <FileText
               className={
@@ -118,18 +138,21 @@ const FilePreviewItem = memo(function FilePreviewItem({
               </p>
             </div>
           </div>
-          <FileActionButtons
-            onEdit={onEdit}
-            onRemove={onRemove}
-            buttonSize={buttonSize}
-            iconSize={iconSize}
-            editLabel="Edit PDF"
-          />
+          {!isUploading && (
+            <FileActionButtons
+              onEdit={onEdit}
+              onRemove={onRemove}
+              buttonSize={buttonSize}
+              iconSize={iconSize}
+              editLabel="Edit PDF"
+            />
+          )}
+          {isUploading && <UploadProgressOverlay compact={compact} />}
         </>
       ) : isXlsx ? (
         <>
           <div
-            className={`${previewSize} flex flex-col items-center justify-center rounded-lg border border-border bg-surface-secondary dark:border-border-dark dark:bg-surface-dark-secondary`}
+            className={`${previewSize} flex flex-col items-center justify-center rounded-lg border border-border bg-surface-secondary dark:border-border-dark dark:bg-surface-dark-secondary ${isUploading ? 'opacity-70' : ''}`}
           >
             <FileSpreadsheet
               className={
@@ -157,13 +180,16 @@ const FilePreviewItem = memo(function FilePreviewItem({
               </p>
             </div>
           </div>
-          <FileActionButtons
-            onEdit={onEdit}
-            onRemove={onRemove}
-            buttonSize={buttonSize}
-            iconSize={iconSize}
-            editLabel="Edit Excel"
-          />
+          {!isUploading && (
+            <FileActionButtons
+              onEdit={onEdit}
+              onRemove={onRemove}
+              buttonSize={buttonSize}
+              iconSize={iconSize}
+              editLabel="Edit Excel"
+            />
+          )}
+          {isUploading && <UploadProgressOverlay compact={compact} />}
         </>
       ) : null}
     </div>
@@ -176,6 +202,7 @@ interface FilePreviewListProps {
   onRemoveFile: (index: number) => void;
   onEditImage?: (index: number) => void;
   compact?: boolean;
+  isUploading?: boolean;
 }
 
 export const FilePreviewList = memo(function FilePreviewList({
@@ -184,6 +211,7 @@ export const FilePreviewList = memo(function FilePreviewList({
   onRemoveFile,
   onEditImage,
   compact = false,
+  isUploading = false,
 }: FilePreviewListProps) {
   if (!files || files.length === 0 || !previewUrls || previewUrls.length === 0) {
     return null;
@@ -206,6 +234,7 @@ export const FilePreviewList = memo(function FilePreviewList({
                 : undefined
             }
             compact={compact}
+            isUploading={isUploading}
           />
         ))}
       </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -123,6 +123,10 @@ export default {
       },
 
       keyframes: {
+        shimmer: {
+          '0%': { left: '-33%' },
+          '100%': { left: '100%' },
+        },
         fadeIn: {
           '0%': { opacity: '0', transform: 'translateY(10px)' },
           '100%': { opacity: '1', transform: 'translateY(0)' },
@@ -160,6 +164,7 @@ export default {
       },
 
       animation: {
+        shimmer: 'shimmer 1.5s ease-in-out infinite',
         fadeIn: 'fadeIn 0.3s ease-out forwards',
         'fade-in': 'fade-in 0.2s ease-out forwards',
         'fade-out': 'fade-out 0.2s ease-out forwards',


### PR DESCRIPTION
Show animated loading bars on each file preview during upload instead of a full-screen overlay. Hides edit/remove buttons and reduces opacity while uploading for better visual feedback.