### PR TITLE
Move loading progress bars from input area to message bubble

### DIFF
--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -122,7 +122,6 @@ export const Input = memo(function Input({
   const hasMessage = message.trim().length > 0;
   const hasAttachments = (attachedFiles?.length ?? 0) > 0;
   const isEnhancing = enhancePromptMutation.isPending;
-  const isUploading = isLoading && !isStreaming && hasAttachments;
   const dynamicPlaceholder = isStreaming ? 'Type to queue message...' : placeholder;
 
   const handleSlashCommandSelect = useCallback(
@@ -281,8 +280,7 @@ export const Input = memo(function Input({
     enhancePromptMutation.mutate({ prompt: message.trim(), modelId: selectedModelId });
   }, [hasMessage, isEnhancing, message, selectedModelId, enhancePromptMutation]);
 
-  const shouldShowAttachedPreview =
-    showAttachedFilesPreview && hasAttachments && (showPreview || isUploading);
+  const shouldShowAttachedPreview = showAttachedFilesPreview && hasAttachments && showPreview;
 
   return (
     <form ref={formRef} onSubmit={handleSubmit} className="relative px-4 sm:px-6">
@@ -304,7 +302,6 @@ export const Input = memo(function Input({
             previewUrls={previewUrls}
             onRemoveFile={handleRemoveFile}
             onEditImage={handleDrawClick}
-            isUploading={isUploading}
           />
         )}
 

--- a/frontend/src/components/chat/message-input/InputAttachments.tsx
+++ b/frontend/src/components/chat/message-input/InputAttachments.tsx
@@ -6,7 +6,6 @@ interface InputAttachmentsProps {
   previewUrls: string[];
   onRemoveFile: (index: number) => void;
   onEditImage: (index: number) => void;
-  isUploading?: boolean;
 }
 
 export const InputAttachments = memo(function InputAttachments({
@@ -14,7 +13,6 @@ export const InputAttachments = memo(function InputAttachments({
   previewUrls,
   onRemoveFile,
   onEditImage,
-  isUploading = false,
 }: InputAttachmentsProps) {
   if (files.length === 0) return null;
 
@@ -26,7 +24,6 @@ export const InputAttachments = memo(function InputAttachments({
         onRemoveFile={onRemoveFile}
         onEditImage={onEditImage}
         compact={true}
-        isUploading={isUploading}
       />
     </div>
   );

--- a/frontend/src/components/ui/AttachmentViewer.tsx
+++ b/frontend/src/components/ui/AttachmentViewer.tsx
@@ -100,6 +100,17 @@ const getDefaultFilename = (fileType: string, index: number): string => {
   }
 };
 
+const LoadingProgressOverlay = memo(function LoadingProgressOverlay() {
+  return (
+    <div className="absolute inset-x-0 bottom-0 overflow-hidden rounded-b-md bg-black/40">
+      <div className="relative h-1 w-full overflow-hidden">
+        <div className="absolute inset-y-0 w-1/3 animate-shimmer rounded-full bg-brand-400" />
+      </div>
+      <p className="pb-1 pt-0.5 text-center text-2xs text-white">Loading...</p>
+    </div>
+  );
+});
+
 const downloadButtonClass =
   'h-7 w-7 rounded-full bg-black/60 text-white shadow-md backdrop-blur-sm hover:bg-black/70 focus-visible:ring-white/70';
 
@@ -130,7 +141,13 @@ function ThumbnailWrapper({ attachment, onDownload, children }: ThumbnailWrapper
   );
 }
 
-function IconThumbnail({ attachment }: { attachment: MessageAttachment }) {
+function IconThumbnail({
+  attachment,
+  isLoading = false,
+}: {
+  attachment: MessageAttachment;
+  isLoading?: boolean;
+}) {
   const { icon: Icon, color, label } = getIconConfig(attachment.file_type, attachment.filename);
   const filename = attachment.filename || getDefaultFilename(attachment.file_type, 0);
 
@@ -141,6 +158,7 @@ function IconThumbnail({ attachment }: { attachment: MessageAttachment }) {
         {filename}
       </p>
       <p className="text-2xs text-text-tertiary dark:text-text-dark-tertiary">{label}</p>
+      {isLoading && <LoadingProgressOverlay />}
     </div>
   );
 }
@@ -158,8 +176,8 @@ function ImageThumbnail({
 
   if (state.isLoading) {
     return (
-      <div className="flex h-32 w-32 items-center justify-center rounded-md bg-surface-secondary dark:bg-surface-dark-secondary">
-        <div className="h-4 w-4 animate-pulse rounded-full bg-text-quaternary dark:bg-text-dark-quaternary"></div>
+      <div className="relative h-32 w-32 rounded-md bg-surface-secondary dark:bg-surface-dark-secondary">
+        <LoadingProgressOverlay />
       </div>
     );
   }

--- a/frontend/src/components/ui/FilePreviewList.tsx
+++ b/frontend/src/components/ui/FilePreviewList.tsx
@@ -9,7 +9,6 @@ interface FilePreviewItemProps {
   onRemove: () => void;
   onEdit?: () => void;
   compact?: boolean;
-  isUploading?: boolean;
 }
 
 interface FileActionButtonsProps {
@@ -51,28 +50,12 @@ const FileActionButtons = ({
   </div>
 );
 
-const UploadProgressOverlay = memo(function UploadProgressOverlay({
-  compact = false,
-}: {
-  compact?: boolean;
-}) {
-  return (
-    <div className="absolute inset-x-0 bottom-0 overflow-hidden rounded-b-lg bg-black/40">
-      <div className="relative h-1 w-full overflow-hidden">
-        <div className="absolute inset-y-0 w-1/3 animate-shimmer rounded-full bg-brand-400" />
-      </div>
-      {!compact && <p className="pb-1 pt-0.5 text-center text-2xs text-white">Uploading...</p>}
-    </div>
-  );
-});
-
 const FilePreviewItem = memo(function FilePreviewItem({
   file,
   previewUrl,
   onRemove,
   onEdit,
   compact = false,
-  isUploading = false,
 }: FilePreviewItemProps) {
   const isImage = isUploadedImageFile(file);
   const isPdf = isUploadedPdfFile(file);
@@ -94,23 +77,20 @@ const FilePreviewItem = memo(function FilePreviewItem({
           <img
             src={previewUrl}
             alt={`Preview of ${file.name}`}
-            className={`${previewSize} block rounded-lg object-cover ${isUploading ? 'opacity-70' : ''}`}
+            className={`${previewSize} block rounded-lg object-cover`}
           />
-          {!isUploading && (
-            <FileActionButtons
-              onEdit={onEdit}
-              onRemove={onRemove}
-              buttonSize={buttonSize}
-              iconSize={iconSize}
-              editLabel="Edit image"
-            />
-          )}
-          {isUploading && <UploadProgressOverlay compact={compact} />}
+          <FileActionButtons
+            onEdit={onEdit}
+            onRemove={onRemove}
+            buttonSize={buttonSize}
+            iconSize={iconSize}
+            editLabel="Edit image"
+          />
         </>
       ) : isPdf ? (
         <>
           <div
-            className={`${previewSize} flex flex-col items-center justify-center rounded-lg bg-surface-secondary dark:bg-surface-dark-secondary ${isUploading ? 'opacity-70' : ''}`}
+            className={`${previewSize} flex flex-col items-center justify-center rounded-lg bg-surface-secondary dark:bg-surface-dark-secondary`}
           >
             <FileText
               className={
@@ -138,21 +118,18 @@ const FilePreviewItem = memo(function FilePreviewItem({
               </p>
             </div>
           </div>
-          {!isUploading && (
-            <FileActionButtons
-              onEdit={onEdit}
-              onRemove={onRemove}
-              buttonSize={buttonSize}
-              iconSize={iconSize}
-              editLabel="Edit PDF"
-            />
-          )}
-          {isUploading && <UploadProgressOverlay compact={compact} />}
+          <FileActionButtons
+            onEdit={onEdit}
+            onRemove={onRemove}
+            buttonSize={buttonSize}
+            iconSize={iconSize}
+            editLabel="Edit PDF"
+          />
         </>
       ) : isXlsx ? (
         <>
           <div
-            className={`${previewSize} flex flex-col items-center justify-center rounded-lg border border-border bg-surface-secondary dark:border-border-dark dark:bg-surface-dark-secondary ${isUploading ? 'opacity-70' : ''}`}
+            className={`${previewSize} flex flex-col items-center justify-center rounded-lg border border-border bg-surface-secondary dark:border-border-dark dark:bg-surface-dark-secondary`}
           >
             <FileSpreadsheet
               className={
@@ -180,16 +157,13 @@ const FilePreviewItem = memo(function FilePreviewItem({
               </p>
             </div>
           </div>
-          {!isUploading && (
-            <FileActionButtons
-              onEdit={onEdit}
-              onRemove={onRemove}
-              buttonSize={buttonSize}
-              iconSize={iconSize}
-              editLabel="Edit Excel"
-            />
-          )}
-          {isUploading && <UploadProgressOverlay compact={compact} />}
+          <FileActionButtons
+            onEdit={onEdit}
+            onRemove={onRemove}
+            buttonSize={buttonSize}
+            iconSize={iconSize}
+            editLabel="Edit Excel"
+          />
         </>
       ) : null}
     </div>
@@ -202,7 +176,6 @@ interface FilePreviewListProps {
   onRemoveFile: (index: number) => void;
   onEditImage?: (index: number) => void;
   compact?: boolean;
-  isUploading?: boolean;
 }
 
 export const FilePreviewList = memo(function FilePreviewList({
@@ -211,7 +184,6 @@ export const FilePreviewList = memo(function FilePreviewList({
   onRemoveFile,
   onEditImage,
   compact = false,
-  isUploading = false,
 }: FilePreviewListProps) {
   if (!files || files.length === 0 || !previewUrls || previewUrls.length === 0) {
     return null;
@@ -234,7 +206,6 @@ export const FilePreviewList = memo(function FilePreviewList({
                 : undefined
             }
             compact={compact}
-            isUploading={isUploading}
           />
         ))}
       </div>


### PR DESCRIPTION
Loading bars now appear on attachments in the message bubble (AttachmentViewer) while images load from the server, instead of in the input area (FilePreviewList).