### PR TITLE
Add attachment upload progress indicators and local file previews

### DIFF
--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -19,6 +19,7 @@ export interface MessageProps {
   content: string;
   isBot: boolean;
   attachments?: MessageAttachment[];
+  uploadingAttachmentIds?: string[];
   copiedMessageId: string | null;
   onCopy: (content: string, id: string) => void;
   error?: string | null;
@@ -47,6 +48,7 @@ export const Message = memo(function Message({
   onRestoreSuccess,
   isLastBotMessage,
   onSuggestionSelect,
+  uploadingAttachmentIds,
 }: MessageProps) {
   const { chatId, sandboxId } = useChatContext();
   const { data: models = [] } = useModelsQuery();
@@ -135,6 +137,7 @@ export const Message = memo(function Message({
                   content={content}
                   isBot={isBot}
                   attachments={attachments}
+                  uploadingAttachmentIds={uploadingAttachmentIds}
                   isStreaming={isThisMessageStreaming}
                   chatId={chatId}
                 />

--- a/frontend/src/components/chat/message-bubble/MessageAttachments.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageAttachments.tsx
@@ -4,18 +4,22 @@ import type { MessageAttachment } from '@/types';
 
 interface MessageAttachmentsProps {
   attachments?: MessageAttachment[];
+  uploadingAttachmentIds?: string[];
   className?: string;
 }
 
 export const MessageAttachments = memo(
-  ({ attachments, className = '' }: MessageAttachmentsProps) => {
+  ({ attachments, uploadingAttachmentIds, className = '' }: MessageAttachmentsProps) => {
     if (!attachments || attachments.length === 0) {
       return null;
     }
 
     return (
       <div className={className}>
-        <AttachmentViewer attachments={attachments} />
+        <AttachmentViewer
+          attachments={attachments}
+          uploadingAttachmentIds={uploadingAttachmentIds}
+        />
       </div>
     );
   },

--- a/frontend/src/components/chat/message-bubble/MessageContent.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageContent.tsx
@@ -7,6 +7,7 @@ interface MessageContentProps {
   content: string;
   isBot: boolean;
   attachments?: MessageAttachment[];
+  uploadingAttachmentIds?: string[];
   isStreaming: boolean;
   chatId?: string;
   isLastBotMessage?: boolean;
@@ -18,6 +19,7 @@ export const MessageContent = memo(
     content,
     isBot,
     attachments,
+    uploadingAttachmentIds,
     isStreaming,
     chatId,
     isLastBotMessage,
@@ -26,7 +28,10 @@ export const MessageContent = memo(
     if (!isBot) {
       return (
         <div className="space-y-1">
-          <MessageAttachments attachments={attachments} />
+          <MessageAttachments
+            attachments={attachments}
+            uploadingAttachmentIds={uploadingAttachmentIds}
+          />
           <MessageRenderer content={content} isStreaming={isStreaming} chatId={chatId} />
         </div>
       );

--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -38,6 +38,7 @@ export interface InputProps {
   showTip?: boolean;
   compact?: boolean;
   chatId?: string;
+  showLoadingSpinner?: boolean;
 }
 
 export const Input = memo(function Input({
@@ -58,6 +59,7 @@ export const Input = memo(function Input({
   showTip = true,
   compact = true,
   chatId,
+  showLoadingSpinner = false,
 }: InputProps) {
   const { fileStructure, customAgents, customSlashCommands, customPrompts } = useChatContext();
   const formRef = useRef<HTMLFormElement>(null);
@@ -362,6 +364,7 @@ export const Input = memo(function Input({
                 onClick={handleSendClick}
                 type="button"
                 hasMessage={hasMessage}
+                showLoadingSpinner={showLoadingSpinner}
               />
             </div>
           </div>

--- a/frontend/src/components/chat/message-input/SendButton.tsx
+++ b/frontend/src/components/chat/message-input/SendButton.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, Pause } from 'lucide-react';
+import { ArrowUp, LoaderCircle, Pause } from 'lucide-react';
 import { Button } from '@/components/ui';
 
 export interface SendButtonProps {
@@ -9,6 +9,7 @@ export interface SendButtonProps {
   type?: 'button' | 'submit';
   hasMessage?: boolean;
   className?: string;
+  showLoadingSpinner?: boolean;
 }
 
 export function SendButton({
@@ -19,16 +20,21 @@ export function SendButton({
   type = 'button',
   hasMessage = false,
   className = '',
+  showLoadingSpinner = false,
 }: SendButtonProps) {
   const baseClasses =
     'p-1.5 rounded-full transition-all duration-200 transform disabled:opacity-50 disabled:cursor-not-allowed active:scale-95';
 
   const scaleClass = hasMessage && !disabled ? 'scale-100' : 'scale-90';
 
-  const showStopIcon = (isLoading || isStreaming) && !hasMessage;
+  const showSpinnerIcon = showLoadingSpinner && isLoading && !isStreaming;
+  const showStopIcon = !showSpinnerIcon && (isLoading || isStreaming) && !hasMessage;
 
   let colorClasses;
-  if (showStopIcon) {
+  if (showSpinnerIcon) {
+    colorClasses =
+      'bg-text-primary dark:bg-text-dark-primary hover:bg-text-secondary dark:hover:bg-text-dark-secondary';
+  } else if (showStopIcon) {
     colorClasses = 'bg-error-500 hover:bg-error-600';
   } else if (hasMessage) {
     colorClasses =
@@ -40,11 +46,18 @@ export function SendButton({
   const cursorClass = !isLoading && !isStreaming && !hasMessage ? 'cursor-not-allowed' : '';
 
   const getAriaLabel = () => {
+    if (showSpinnerIcon) return 'Starting chat';
     if (showStopIcon) return 'Stop generating';
     return 'Send message';
   };
 
   const renderIcon = () => {
+    if (showSpinnerIcon) {
+      return (
+        <LoaderCircle className="h-4 w-4 animate-spin text-text-dark-primary dark:text-text-primary" />
+      );
+    }
+
     if (showStopIcon) {
       return <Pause className="h-3.5 w-3.5 animate-pulse text-text-dark-primary" />;
     }

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -33,6 +33,7 @@ interface UseChatStreamingParams {
 interface UseChatStreamingResult {
   messages: Message[];
   setMessages: Dispatch<SetStateAction<Message[]>>;
+  pendingUserMessageId: string | null;
   inputMessage: string;
   setInputMessage: Dispatch<SetStateAction<string>>;
   inputFiles: File[];
@@ -77,6 +78,7 @@ export function useChatStreaming({
   const [currentMessageId, setCurrentMessageId] = useState<string | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [wasAborted, setWasAborted] = useState(false);
+  const [pendingUserMessageId, setPendingUserMessageIdState] = useState<string | null>(null);
   const pendingStopRef = useRef<Set<string>>(new Set());
   const prevChatIdRef = useRef<string | undefined>(chatId);
   const lastConnectedStreamRef = useRef<string | null>(null);
@@ -126,6 +128,7 @@ export function useChatStreaming({
     setCurrentMessageId,
     setError,
     pendingStopRef,
+    onPendingUserMessageIdChange: setPendingUserMessageIdState,
   });
 
   useEffect(() => {
@@ -162,6 +165,7 @@ export function useChatStreaming({
       setCurrentMessageId(null);
       setError(null);
       setWasAborted(false);
+      setPendingUserMessageIdState(null);
       prevChatIdRef.current = chatId;
     }
 
@@ -257,6 +261,7 @@ export function useChatStreaming({
       setStreamState('idle');
       setCurrentMessageId(null);
       setWasAborted(true);
+      setPendingUserMessageId(null);
 
       try {
         if (messageId) {
@@ -269,7 +274,7 @@ export function useChatStreaming({
         pendingStopRef.current.clear();
       }
     },
-    [chatId, stopStream],
+    [chatId, setPendingUserMessageId, stopStream],
   );
 
   const handleDismissError = useCallback(() => {
@@ -307,6 +312,7 @@ export function useChatStreaming({
   return {
     messages,
     setMessages,
+    pendingUserMessageId,
     inputMessage,
     setInputMessage,
     inputFiles,

--- a/frontend/src/hooks/useMessageActions.ts
+++ b/frontend/src/hooks/useMessageActions.ts
@@ -69,6 +69,9 @@ export function useMessageActions({
       setCurrentMessageId(null);
       setError(null);
       setWasAborted(false);
+      if (filesToSend && filesToSend.length > 0 && userMessage?.id) {
+        setPendingUserMessageId(userMessage.id);
+      }
 
       try {
         const { promptName, cleanedMessage } = extractPromptMention(normalizedPrompt);
@@ -107,6 +110,7 @@ export function useMessageActions({
         });
         addMessageToCache(initialMessage, userMessage);
       } catch (streamStartError) {
+        setPendingUserMessageId(null);
         setStreamState('error');
         const error =
           streamStartError instanceof Error
@@ -127,6 +131,7 @@ export function useMessageActions({
       setError,
       setWasAborted,
       setMessages,
+      setPendingUserMessageId,
     ],
   );
 
@@ -182,7 +187,6 @@ export function useMessageActions({
           clearReviewsForChat(chatId);
         }
 
-        setPendingUserMessageId(null);
         return { success: true };
       } catch (error) {
         logger.error('Failed to send message', 'useMessageActions', error);

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -260,6 +260,7 @@ export function ChatPage() {
           return (
             <ChatComponent
               messages={messages}
+              pendingUserMessageId={streamingState.pendingUserMessageId}
               copiedMessageId={streamingState.copiedMessageId}
               isLoading={isLoading}
               isStreaming={isStreaming}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -179,6 +179,7 @@ export function LandingPage() {
                 onAttach={handleFileAttach}
                 attachedFiles={attachedFiles}
                 isLoading={isLoading}
+                showLoadingSpinner={true}
                 selectedModelId={selectedModelId}
                 onModelChange={selectModel}
                 showTip={false}


### PR DESCRIPTION
Show spinner overlays on attachment thumbnails during upload, display actual file previews (images, PDF, Excel icons) in pending messages, and add a loading spinner to the send button. 
Track pendingUserMessageId through streaming hooks to correctly identify uploading attachments.