### PR TITLE
Extract inline function to module level and add no-nested-functions rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@
 - Do not call private methods (`_method`) from outside the file where they are defined; if cross-file usage is needed, make the method public and rename it accordingly
 - Do not use inline imports; only allow inline imports when required to avoid circular imports and no cleaner module-level import structure exists
 - Strong typing only: do not use `# type: ignore`, `# pyright: ignore`, `# noqa` to silence typing/import issues; fix the types/usages directly (if absolutely unavoidable, document why in the PR description)
+- Do not define nested/inline functions; use module-level functions for standalone functions (e.g., endpoints) and class methods for classes
 - Do not add backward compatibility paths, fallback paths, or legacy shims unless explicitly requested
 
 ## Frontend UI/UX Guidelines

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -79,6 +79,16 @@ async def _ensure_chat_access(
         )
 
 
+def _parse_non_negative_seq(value: str | None) -> int:
+    if value is None:
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return parsed if parsed >= 0 else 0
+
+
 @router.post(
     "/chats",
     response_model=ChatSchema,
@@ -348,15 +358,6 @@ async def stream_events(
     chat_service: ChatService = Depends(get_chat_service),
 ) -> EventSourceResponse:
     await _ensure_chat_access(chat_id, chat_service, current_user)
-
-    def _parse_non_negative_seq(value: str | None) -> int:
-        if value is None:
-            return 0
-        try:
-            parsed = int(value)
-        except (TypeError, ValueError):
-            return 0
-        return parsed if parsed >= 0 else 0
 
     # Browser EventSource reconnects send the current cursor via Last-Event-ID.
     # Keep query-param baseline support and use whichever is more advanced.


### PR DESCRIPTION
Move _parse_non_negative_seq from inside stream_events to module level beside _ensure_chat_access. 
Add code style rule to CLAUDE.md prohibiting nested/inline function definitions.