### PR TITLE
Refine user settings contracts and cleanup unused imports

### DIFF
--- a/backend/app/api/endpoints/agents.py
+++ b/backend/app/api/endpoints/agents.py
@@ -1,12 +1,10 @@
-from typing import cast
-
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.core.deps import get_db, get_agent_service, get_user_service
 from app.core.security import get_current_user
-from app.models.db_models import DeleteResponseStatus, User, UserSettings
+from app.models.db_models import DeleteResponseStatus, User
 from app.models.schemas import AgentDeleteResponse, AgentResponse, AgentUpdateRequest
 from app.models.types import CustomAgentDict
 from app.services.exceptions import AgentException, UserException
@@ -27,11 +25,8 @@ async def upload_agent(
     user_service: UserService = Depends(get_user_service),
 ) -> CustomAgentDict:
     try:
-        user_settings = cast(
-            UserSettings,
-            await user_service.get_user_settings(
-                current_user.id, db=db, for_update=True
-            ),
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -84,11 +79,8 @@ async def update_agent(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     try:
-        user_settings = cast(
-            UserSettings,
-            await user_service.get_user_settings(
-                current_user.id, db=db, for_update=True
-            ),
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -149,8 +141,8 @@ async def delete_agent(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     try:
-        user_settings = await user_service.get_user_settings(
-            current_user.id, db=db, for_update=True
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/api/endpoints/ai_model.py
+++ b/backend/app/api/endpoints/ai_model.py
@@ -6,7 +6,6 @@ from app.models.db_models import User
 from app.models.schemas import AIModelResponse
 from app.services.provider import ProviderService
 from app.services.user import UserService
-from app.utils.redis import redis_connection
 
 router = APIRouter()
 
@@ -17,9 +16,6 @@ async def list_models(
     provider_service: ProviderService = Depends(get_provider_service),
     user_service: UserService = Depends(get_user_service),
 ) -> list[AIModelResponse]:
-    async with redis_connection() as redis:
-        user_settings = await user_service.get_user_settings(
-            current_user.id, redis=redis
-        )
-        models = provider_service.get_all_models(user_settings)
-        return [AIModelResponse(**model) for model in models]
+    user_settings = await user_service.get_user_settings(current_user.id)
+    models = provider_service.get_all_models(user_settings)
+    return [AIModelResponse(**model) for model in models]

--- a/backend/app/api/endpoints/commands.py
+++ b/backend/app/api/endpoints/commands.py
@@ -1,12 +1,10 @@
-from typing import cast
-
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.core.deps import get_db, get_command_service, get_user_service
 from app.core.security import get_current_user
-from app.models.db_models import DeleteResponseStatus, User, UserSettings
+from app.models.db_models import DeleteResponseStatus, User
 from app.models.schemas import (
     CommandDeleteResponse,
     CommandResponse,
@@ -31,11 +29,8 @@ async def upload_command(
     user_service: UserService = Depends(get_user_service),
 ) -> CustomSlashCommandDict:
     try:
-        user_settings = cast(
-            UserSettings,
-            await user_service.get_user_settings(
-                current_user.id, db=db, for_update=True
-            ),
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -90,11 +85,8 @@ async def update_command(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     try:
-        user_settings = cast(
-            UserSettings,
-            await user_service.get_user_settings(
-                current_user.id, db=db, for_update=True
-            ),
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -157,8 +149,8 @@ async def delete_command(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     try:
-        user_settings = await user_service.get_user_settings(
-            current_user.id, db=db, for_update=True
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/api/endpoints/integrations.py
+++ b/backend/app/api/endpoints/integrations.py
@@ -44,8 +44,8 @@ async def upload_oauth_client(
         )
 
     try:
-        user_settings = await user_service.get_user_settings(
-            current_user.id, db=db, for_update=True
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -71,8 +71,8 @@ async def delete_oauth_client(
     user_service: UserService = Depends(get_user_service),
 ) -> OAuthClientResponse:
     try:
-        user_settings = await user_service.get_user_settings(
-            current_user.id, db=db, for_update=True
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -134,9 +134,7 @@ async def oauth_callback(
         )
 
     try:
-        user_settings = await user_service.get_user_settings(
-            user_id, db=db, for_update=True
-        )
+        user_settings = await user_service.get_user_settings_for_update(user_id, db=db)
     except UserException:
         return HTMLResponse(
             content=_callback_html("Authentication failed: User not found"),
@@ -210,8 +208,8 @@ async def disconnect_gmail(
     user_service: UserService = Depends(get_user_service),
 ) -> OAuthClientResponse:
     try:
-        user_settings = await user_service.get_user_settings(
-            current_user.id, db=db, for_update=True
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/api/endpoints/mcps.py
+++ b/backend/app/api/endpoints/mcps.py
@@ -39,8 +39,8 @@ async def create_mcp(
         )
 
     try:
-        user_settings = await user_service.get_user_settings(
-            current_user.id, db=db, for_update=True
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -98,8 +98,8 @@ async def update_mcp(
         )
 
     try:
-        user_settings = await user_service.get_user_settings(
-            current_user.id, db=db, for_update=True
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -147,8 +147,8 @@ async def delete_mcp(
         )
 
     try:
-        user_settings = await user_service.get_user_settings(
-            current_user.id, db=db, for_update=True
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/api/endpoints/skills.py
+++ b/backend/app/api/endpoints/skills.py
@@ -1,12 +1,10 @@
-from typing import cast
-
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.core.deps import get_db, get_skill_service, get_user_service
 from app.core.security import get_current_user
-from app.models.db_models import DeleteResponseStatus, User, UserSettings
+from app.models.db_models import DeleteResponseStatus, User
 from app.models.schemas import SkillDeleteResponse, SkillResponse
 from app.models.types import CustomSkillDict
 from app.services.exceptions import SkillException, UserException
@@ -27,11 +25,8 @@ async def upload_skill(
     user_service: UserService = Depends(get_user_service),
 ) -> CustomSkillDict:
     try:
-        user_settings = cast(
-            UserSettings,
-            await user_service.get_user_settings(
-                current_user.id, db=db, for_update=True
-            ),
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -83,8 +78,8 @@ async def delete_skill(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     try:
-        user_settings = await user_service.get_user_settings(
-            current_user.id, db=db, for_update=True
+        user_settings = await user_service.get_user_settings_for_update(
+            current_user.id, db=db
         )
     except UserException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -4,7 +4,7 @@ import logging
 import math
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from sqlalchemy import exists, func, select, update
@@ -133,9 +133,7 @@ class ChatService(BaseDbService[Chat]):
     async def create_chat(self, user: User, chat_data: ChatCreate) -> Chat:
         await self._check_message_limit(user.id)
 
-        user_settings = cast(
-            UserSettings, await self.user_service.get_user_settings(user.id)
-        )
+        user_settings = await self.user_service.get_user_settings(user.id)
         self._validate_api_keys(user_settings, chat_data.model_id)
 
         sandbox_id = await self.sandbox_service.create_sandbox()
@@ -1097,9 +1095,7 @@ class ChatService(BaseDbService[Chat]):
 
         target_message = messages[-1]
 
-        user_settings = cast(
-            UserSettings, await self.user_service.get_user_settings(user.id)
-        )
+        user_settings = await self.user_service.get_user_settings(user.id)
 
         sandbox_provider = user_settings.sandbox_provider
         if sandbox_provider != SandboxProviderType.DOCKER.value:

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -153,8 +153,11 @@ class SchedulerService(BaseDbService[ScheduledTask]):
                 )
 
     async def _user_tz(self, user_id: UUID, db: AsyncSession) -> str:
-        user_settings = await UserService().get_user_settings(user_id, db=db)
-        return user_settings.timezone
+        user_settings: UserSettings = await UserService().get_user_settings(
+            user_id, db=db
+        )
+        timezone_name: str = user_settings.timezone
+        return timezone_name
 
     async def _get_user_task(
         self, task_id: UUID, user_id: UUID, db: AsyncSession
@@ -516,9 +519,8 @@ class SchedulerService(BaseDbService[ScheduledTask]):
                     if not user:
                         return {"error": "User not found"}
 
-                    user_settings = cast(
-                        UserSettings,
-                        await UserService().get_user_settings(user.id, db=db),
+                    user_settings = await UserService().get_user_settings(
+                        user.id, db=db
                     )
                     if not scheduled_task.model_id:
                         raise SchedulerException("Scheduled task missing model_id")


### PR DESCRIPTION
Summary
- split `UserService` settings accessors into read/write variants and moved cached response handling to a dedicated method
- updated endpoints to consume the new contracts and removed unused redis/user settings imports
- simplified settings response handling in the settings endpoint and ensured `list_models` reads settings without redis when not needed