### PR TITLE
Fix backend lint dependency install

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-pip-
       
       - name: Install linting tools
-        run: pip install -r backend/requirements-test.lock
+        run: pip install ruff==0.15.0 mypy types-redis types-PyYAML deptry pip-audit
 
       - name: Run ruff linting
         run: |


### PR DESCRIPTION
Summary
- pin linting tools explicitly in the backend workflow so the checkout doesn’t install the full locked requirements
- avoid pulling in unrelated packages when the CI job only needs ruff/mypy and related helpers