### PR TITLE
Lazy-load heavy components to improve initial page load performance

### DIFF
--- a/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
@@ -1,10 +1,11 @@
-import React, { memo } from 'react';
-import { MarkDown } from '@/components/ui';
+import React, { memo, Suspense } from 'react';
+import { LazyMarkDown } from '@/components/ui/LazyMarkDown';
 import { ThinkingBlock } from './ThinkingBlock';
 import { PromptSuggestions } from './PromptSuggestions';
 import { getToolComponent } from '@/components/chat/tools/registry';
 import { buildSegments } from './segmentBuilder';
 import type { AssistantStreamEvent } from '@/types';
+import { Spinner } from '@/components/ui/primitives/Spinner';
 
 interface MessageRendererProps {
   contentText: string;
@@ -58,7 +59,7 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
                 key={segment.id}
                 className="prose prose-sm dark:prose-invert max-w-none break-words"
               >
-                <MarkDown content={segment.text} />
+                <LazyMarkDown content={segment.text} />
               </div>
             );
           case 'thinking': {
@@ -75,7 +76,21 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
             const Component = getToolComponent(segment.tool.name);
             return (
               <div key={segment.id} className="mb-2 mt-1">
-                <Component tool={segment.tool} chatId={chatId} />
+                <Suspense
+                  fallback={
+                    <div className="flex items-center gap-2 rounded-lg border border-border/50 px-3 py-2 dark:border-border-dark/50">
+                      <Spinner
+                        size="sm"
+                        className="text-text-quaternary dark:text-text-dark-quaternary"
+                      />
+                      <span className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
+                        Loading tool output...
+                      </span>
+                    </div>
+                  }
+                >
+                  <Component tool={segment.tool} chatId={chatId} />
+                </Suspense>
               </div>
             );
           }

--- a/frontend/src/components/chat/tools/PlanModeTool.tsx
+++ b/frontend/src/components/chat/tools/PlanModeTool.tsx
@@ -1,6 +1,7 @@
 import { memo, useState, useCallback } from 'react';
 import { Map, CheckCircle, XCircle, AlertCircle, Terminal } from 'lucide-react';
-import { Button, MarkDown } from '@/components/ui';
+import { Button } from '@/components/ui/primitives/Button';
+import { LazyMarkDown } from '@/components/ui/LazyMarkDown';
 import type { ToolAggregate } from '@/types';
 import { ToolCard } from './common';
 import { useExitPlanMode } from '@/hooks/useExitPlanMode';
@@ -81,7 +82,7 @@ const ExitPlanModeInner: React.FC<PlanModeToolProps> = ({ tool, chatId }) => {
           {planContent && (
             <div className="mt-3 overflow-auto rounded-md bg-black/5 px-2 py-1.5 text-xs dark:bg-white/5">
               <div className="prose prose-sm dark:prose-invert max-w-none text-text-primary dark:text-text-dark-primary">
-                <MarkDown content={planContent} />
+                <LazyMarkDown content={planContent} />
               </div>
             </div>
           )}

--- a/frontend/src/components/chat/tools/ToolPermissionInline.tsx
+++ b/frontend/src/components/chat/tools/ToolPermissionInline.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { ShieldAlert, CheckCircle, XCircle, AlertCircle } from 'lucide-react';
-import { Button, MarkDown } from '@/components/ui';
+import { Button } from '@/components/ui/primitives/Button';
+import { LazyMarkDown } from '@/components/ui/LazyMarkDown';
 import type { PermissionRequest } from '@/types';
 
 function formatValue(value: unknown): string {
@@ -79,7 +80,7 @@ export function ToolPermissionInline({
                   {key}
                 </div>
                 <div className="overflow-auto rounded-md bg-black/5 px-2 py-1.5 text-xs text-text-primary dark:bg-white/5 dark:text-text-dark-primary">
-                  <MarkDown content={formatValue(value)} />
+                  <LazyMarkDown content={formatValue(value)} />
                 </div>
               </div>
             ))}

--- a/frontend/src/components/editor/file-preview/MarkdownPreview.tsx
+++ b/frontend/src/components/editor/file-preview/MarkdownPreview.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { MarkDown } from '@/components/ui';
+import { LazyMarkDown } from '@/components/ui/LazyMarkDown';
 import type { FileStructure } from '@/types';
 import { PreviewContainer } from './PreviewContainer';
 import { getDisplayFileName } from './previewUtils';
@@ -22,7 +22,7 @@ export const MarkdownPreview = memo(function MarkdownPreview({
       onToggleFullscreen={onToggleFullscreen}
       contentClassName="overflow-auto p-6 prose max-w-none dark:prose-invert"
     >
-      <MarkDown content={file.content} />
+      <LazyMarkDown content={file.content} />
     </PreviewContainer>
   );
 });

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -135,6 +135,7 @@ function UserMenu({
   theme,
   onToggleTheme,
   onSettings,
+  onPrefetchSettings,
   onLogout,
 }: {
   displayName: string;
@@ -142,6 +143,7 @@ function UserMenu({
   theme: string;
   onToggleTheme: () => void;
   onSettings: () => void;
+  onPrefetchSettings: () => void;
   onLogout: () => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -221,6 +223,8 @@ function UserMenu({
                 onSettings();
                 closeMenu();
               }}
+              onMouseEnter={onPrefetchSettings}
+              onFocus={onPrefetchSettings}
               variant="unstyled"
               className={menuItemClasses}
             >
@@ -284,6 +288,10 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
     [navigate],
   );
 
+  const prefetchSettingsPage = useCallback(() => {
+    void import('@/pages/SettingsPage');
+  }, []);
+
   const showStandaloneThemeToggle = isAuthPage || !isAuthenticated;
 
   return (
@@ -308,7 +316,11 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
               usage={usage}
               theme={theme}
               onToggleTheme={toggleTheme}
-              onSettings={() => handleNavigate('/settings')}
+              onSettings={() => {
+                prefetchSettingsPage();
+                handleNavigate('/settings');
+              }}
+              onPrefetchSettings={prefetchSettingsPage}
               onLogout={handleLogout}
             />
           ) : (

--- a/frontend/src/components/settings/tabs/AgentsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/AgentsSettingsTab.tsx
@@ -1,4 +1,5 @@
-import { Switch, ListManagementTab } from '@/components/ui';
+import { Switch } from '@/components/ui/primitives/Switch';
+import { ListManagementTab } from '@/components/ui/ListManagementTab';
 import type { CustomAgent } from '@/types';
 import { Bot } from 'lucide-react';
 

--- a/frontend/src/components/settings/tabs/CommandsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/CommandsSettingsTab.tsx
@@ -1,4 +1,5 @@
-import { Switch, ListManagementTab } from '@/components/ui';
+import { Switch } from '@/components/ui/primitives/Switch';
+import { ListManagementTab } from '@/components/ui/ListManagementTab';
 import type { CustomCommand } from '@/types';
 import { Terminal } from 'lucide-react';
 

--- a/frontend/src/components/settings/tabs/EnvVarsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/EnvVarsSettingsTab.tsx
@@ -1,4 +1,5 @@
-import { Button, ListManagementTab } from '@/components/ui';
+import { Button } from '@/components/ui/primitives/Button';
+import { ListManagementTab } from '@/components/ui/ListManagementTab';
 import type { CustomEnvVar } from '@/types';
 import { Key, Eye, EyeOff } from 'lucide-react';
 import { useState } from 'react';
@@ -35,9 +36,9 @@ export const EnvVarsSettingsTab: React.FC<EnvVarsSettingsTabProps> = ({
     await onDeleteEnvVar(index);
     if (deletedKey) {
       setRevealedValues((prev) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { [deletedKey]: _, ...rest } = prev;
-        return rest;
+        const next = { ...prev };
+        delete next[deletedKey];
+        return next;
       });
     }
   };

--- a/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
@@ -1,4 +1,7 @@
-import { Button, Input, Switch, SegmentedControl } from '@/components/ui';
+import { Button } from '@/components/ui/primitives/Button';
+import { Input } from '@/components/ui/primitives/Input';
+import { Switch } from '@/components/ui/primitives/Switch';
+import { SegmentedControl } from '@/components/ui/primitives/SegmentedControl';
 import type {
   UserSettings,
   GeneralSecretFieldConfig,

--- a/frontend/src/components/settings/tabs/InstructionsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/InstructionsSettingsTab.tsx
@@ -1,4 +1,5 @@
-import { Label, Textarea } from '@/components/ui';
+import { Label } from '@/components/ui/primitives/Label';
+import { Textarea } from '@/components/ui/primitives/Textarea';
 import { cn } from '@/utils/cn';
 
 interface InstructionsSettingsTabProps {

--- a/frontend/src/components/settings/tabs/MarketplaceSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/MarketplaceSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, lazy, Suspense } from 'react';
 import { Input } from '@/components/ui/primitives/Input';
 import { Select } from '@/components/ui/primitives/Select';
 import { Spinner } from '@/components/ui/primitives/Spinner';
@@ -9,8 +9,11 @@ import {
   useRefreshCatalogMutation,
 } from '@/hooks/queries/useMarketplaceQueries';
 import { PluginCard } from './marketplace/PluginCard';
-import { PluginDetailModal } from '../dialogs/PluginDetailModal';
 import type { MarketplacePlugin } from '@/types/marketplace.types';
+
+const PluginDetailModal = lazy(() =>
+  import('../dialogs/PluginDetailModal').then((m) => ({ default: m.PluginDetailModal })),
+);
 
 const CATEGORIES = [
   'all',
@@ -143,11 +146,21 @@ export const MarketplaceSettingsTab: React.FC = () => {
         )}
       </div>
 
-      <PluginDetailModal
-        plugin={selectedPlugin}
-        isOpen={!!selectedPlugin}
-        onClose={() => setSelectedPlugin(null)}
-      />
+      {selectedPlugin && (
+        <Suspense
+          fallback={
+            <div className="flex items-center justify-center py-8">
+              <Spinner size="lg" />
+            </div>
+          }
+        >
+          <PluginDetailModal
+            plugin={selectedPlugin}
+            isOpen={!!selectedPlugin}
+            onClose={() => setSelectedPlugin(null)}
+          />
+        </Suspense>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/settings/tabs/McpSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/McpSettingsTab.tsx
@@ -1,4 +1,5 @@
-import { Switch, ListManagementTab } from '@/components/ui';
+import { Switch } from '@/components/ui/primitives/Switch';
+import { ListManagementTab } from '@/components/ui/ListManagementTab';
 import type { CustomMcp } from '@/types';
 import { Plug } from 'lucide-react';
 

--- a/frontend/src/components/settings/tabs/PromptsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/PromptsSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { ListManagementTab } from '@/components/ui';
+import { ListManagementTab } from '@/components/ui/ListManagementTab';
 import type { CustomPrompt } from '@/types';
 import { FileText } from 'lucide-react';
 

--- a/frontend/src/components/settings/tabs/ProvidersSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/ProvidersSettingsTab.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Plus, Pencil, Trash2, ChevronDown, ChevronRight, Circle } from 'lucide-react';
-import { Button, Switch, ConfirmDialog } from '@/components/ui';
+import { Button } from '@/components/ui/primitives/Button';
+import { Switch } from '@/components/ui/primitives/Switch';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { cn } from '@/utils/cn';
 import type { CustomProvider, ProviderType } from '@/types';
 

--- a/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
@@ -1,4 +1,5 @@
-import { Switch, ListManagementTab } from '@/components/ui';
+import { Switch } from '@/components/ui/primitives/Switch';
+import { ListManagementTab } from '@/components/ui/ListManagementTab';
 import type { CustomSkill } from '@/types';
 import { Zap } from 'lucide-react';
 

--- a/frontend/src/components/settings/tabs/TasksSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/TasksSettingsTab.tsx
@@ -2,7 +2,8 @@ import { useCallback, useMemo, useState } from 'react';
 import { logger } from '@/utils/logger';
 import type { ScheduledTask } from '@/types';
 import { RecurrenceType, TaskStatus } from '@/types';
-import { Button, ConfirmDialog } from '@/components/ui';
+import { Button } from '@/components/ui/primitives/Button';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import {
   Plus,
   CalendarClock,

--- a/frontend/src/components/ui/LazyMarkDown.tsx
+++ b/frontend/src/components/ui/LazyMarkDown.tsx
@@ -1,0 +1,20 @@
+import { lazy, Suspense } from 'react';
+
+const MarkDown = lazy(() => import('./MarkDown'));
+
+interface LazyMarkDownProps {
+  content: string;
+  className?: string;
+}
+
+export function LazyMarkDown({ content, className }: LazyMarkDownProps) {
+  return (
+    <Suspense
+      fallback={
+        <div className={`whitespace-pre-wrap text-sm ${className ?? ''}`.trim()}>{content}</div>
+      }
+    >
+      <MarkDown content={content} className={className} />
+    </Suspense>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -20,8 +20,6 @@ export { AttachmentViewer } from './AttachmentViewer';
 export { DrawingModal } from './DrawingModal';
 export { FileUploadDialog } from './FileUploadDialog';
 export { FilePreviewList } from './FilePreviewList';
-export { default as MarkDown } from './MarkDown';
-export { Mermaid } from './Mermaid';
 export { ListManagementTab } from './ListManagementTab';
 export { ViewSwitcher } from './ViewSwitcher';
 export { SplitViewContainer } from './SplitViewContainer';

--- a/frontend/src/components/views/BrowserView.tsx
+++ b/frontend/src/components/views/BrowserView.tsx
@@ -1,7 +1,7 @@
-import { memo, useState, useCallback } from 'react';
+import { memo, useState, useCallback, lazy, Suspense } from 'react';
 import { Globe, RotateCcw, Play, Square } from 'lucide-react';
-import { Button, Spinner } from '@/components/ui';
-import { VNCClient } from '@/components/sandbox/vnc-browser/VNCClient';
+import { Button } from '@/components/ui/primitives/Button';
+import { Spinner } from '@/components/ui/primitives/Spinner';
 import {
   useVNCUrlQuery,
   useBrowserStatusQuery,
@@ -9,6 +9,10 @@ import {
   useStopBrowserMutation,
 } from '@/hooks/queries';
 import { cn } from '@/utils/cn';
+
+const VNCClient = lazy(() =>
+  import('@/components/sandbox/vnc-browser/VNCClient').then((m) => ({ default: m.VNCClient })),
+);
 
 const DEFAULT_BROWSER_URL = 'https://www.google.com';
 
@@ -192,14 +196,27 @@ export const BrowserView = memo(function BrowserView({
           </div>
         )}
 
-        <VNCClient
-          wsUrl={vncUrl ?? null}
-          isActive={isActive && !!vncUrl && !!isBrowserRunning}
-          instanceKey={vncInstanceKey}
-          onConnect={handleConnect}
-          onDisconnect={handleDisconnect}
-          onError={handleError}
-        />
+        {vncUrl && isBrowserRunning && (
+          <Suspense
+            fallback={
+              <div className="absolute inset-0 z-10 flex items-center justify-center bg-surface-secondary/70 dark:bg-surface-dark-secondary/70">
+                <Spinner
+                  size="md"
+                  className="text-text-quaternary dark:text-text-dark-quaternary"
+                />
+              </div>
+            }
+          >
+            <VNCClient
+              wsUrl={vncUrl}
+              isActive={isActive}
+              instanceKey={vncInstanceKey}
+              onConnect={handleConnect}
+              onDisconnect={handleDisconnect}
+              onError={handleError}
+            />
+          </Suspense>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/views/IDEView.tsx
+++ b/frontend/src/components/views/IDEView.tsx
@@ -1,6 +1,7 @@
 import { memo, useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { Download, ExternalLink, RotateCcw } from 'lucide-react';
-import { Button, Spinner } from '@/components/ui';
+import { Button } from '@/components/ui/primitives/Button';
+import { Spinner } from '@/components/ui/primitives/Spinner';
 import { useIDEUrlQuery } from '@/hooks/queries';
 import { useUIStore } from '@/store';
 import { sandboxService } from '@/services/sandboxService';


### PR DESCRIPTION
Lazy-load settings tabs, dialogs, tool components, views, and markdown/math rendering to reduce the main bundle size. Prefetch the settings page on hover to mask navigation latency. 
Replace barrel imports with direct imports to improve tree-shaking.