### PR TITLE
Add VNC, OpenVSCode, and missing services to backend Dockerfile

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'backend/**'
       - 'sandbox/**'
+      - 'scripts/**'
       - '.github/workflows/backend-checks.yml'
   pull_request:
     branches: [main]
     paths:
       - 'backend/**'
       - 'sandbox/**'
+      - 'scripts/**'
       - '.github/workflows/backend-checks.yml'
 
 jobs:

--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'sandbox/**'
+      - 'scripts/**'
       - '.github/workflows/build-sandbox.yml'
   workflow_dispatch:
 
@@ -57,3 +58,26 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  build-e2b-template:
+    name: Build E2B Sandbox Template
+    runs-on: ubuntu-latest
+    if: ${{ vars.E2B_ENABLED == 'true' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install E2B CLI
+        run: npm install -g @e2b/cli
+
+      - name: Build E2B template
+        working-directory: sandbox/e2b
+        env:
+          E2B_ACCESS_TOKEN: ${{ secrets.E2B_ACCESS_TOKEN }}
+        run: e2b template build --cpu-count 2 --memory-mb 4098

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,25 +10,38 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends gcc libpq-dev curl git wget gnupg \
     chromium chromium-sandbox chromium-driver \
     fonts-liberation ca-certificates \
-    gosu docker-cli && \
+    gosu docker-cli \
+    xvfb x11vnc websockify x11-xserver-utils xdotool \
+    libnss3 libxss1 libasound2 \
+    rsync unzip zip build-essential \
+    sudo openssh-client jq htop tmux vim nano iproute2 && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.32 @gongrzhe/server-gmail-autoauth-mcp
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y gh && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code@2.1.41 @gongrzhe/server-gmail-autoauth-mcp @openai/codex @playwright/mcp@latest
 
 # Install uv package manager
 RUN curl -LsSf https://astral.sh/uv/install.sh | bash
 
-COPY requirements.lock .
+COPY backend/requirements.lock .
 
 RUN /root/.local/bin/uv pip install --system --no-cache -r requirements.lock
 
-COPY . /app/
+COPY backend/ /app/
+COPY scripts/start-vnc.sh /usr/local/bin/start-vnc.sh
 
 RUN cp /app/permission_server.py /usr/local/bin/permission_server.py && \
-    chmod +x /usr/local/bin/permission_server.py
+    chmod +x /usr/local/bin/permission_server.py && \
+    chmod +x /usr/local/bin/start-vnc.sh
 
 RUN chown -R appuser:appuser /app && \
     chmod -R 755 /app && \
@@ -39,10 +52,25 @@ ENV CLAUDE_CONFIG_DIR=/app/storage/claude-data
 ENV CLAUDE_HOME=/app/storage/claude-data
 ENV CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 ENV PYTHONUNBUFFERED=1
+ENV DISPLAY=:99
+ENV OPENVSCODE_PORT=8765
+ENV TERM=xterm-256color
+
+RUN OPENVSCODE_VERSION="1.105.1" && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
+        ARCH_SUFFIX="arm64"; \
+    else \
+        ARCH_SUFFIX="x64"; \
+    fi && \
+    curl -fsSL "https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v${OPENVSCODE_VERSION}/openvscode-server-v${OPENVSCODE_VERSION}-linux-${ARCH_SUFFIX}.tar.gz" | \
+    tar -xz -C /tmp && \
+    mv /tmp/openvscode-server-v${OPENVSCODE_VERSION}-linux-${ARCH_SUFFIX} /opt/openvscode-server && \
+    ln -s /opt/openvscode-server/bin/openvscode-server /usr/local/bin/openvscode-server
 
 RUN mkdir -p /app/storage/claude-data /app/storage/images /app/storage/pdfs /app/storage/xlsx /app/storage/chrome-profile
 
-EXPOSE 8080
+EXPOSE 8080 5900 6080 8765
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD []

--- a/backend/Dockerfile.test
+++ b/backend/Dockerfile.test
@@ -28,13 +28,13 @@ RUN npm install -g @anthropic-ai/claude-code
 RUN curl -LsSf https://astral.sh/uv/install.sh | bash
 
 # Copy requirements files
-COPY requirements.lock requirements-test.lock ./
+COPY backend/requirements.lock backend/requirements-test.lock ./
 
 # Install Python dependencies
 RUN /root/.local/bin/uv pip install --system --no-cache -r requirements-test.lock
 
 # Copy application code
-COPY . .
+COPY backend/ .
 
 # Set Python path
 ENV PYTHONPATH=/app

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -17,6 +17,9 @@ ensure_docker_network
 
 WORKERS=1
 
+echo "Starting VNC server..."
+start-vnc.sh &
+
 echo "Starting API server..."
 if [ -S /var/run/docker.sock ]; then
     echo "Docker socket detected, running as current user for Docker access..."

--- a/docker-compose.desktop.yml
+++ b/docker-compose.desktop.yml
@@ -48,8 +48,8 @@ services:
 
   api:
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: backend/Dockerfile
     container_name: claudex-api-desktop
     restart: unless-stopped
     command: ["api"]
@@ -66,6 +66,9 @@ services:
         condition: service_completed_successfully
     ports:
       - "8081:8081"
+      - "${VNC_PORT:-15900}:5900"
+      - "${VNC_WS_PORT:-16080}:6080"
+      - "${OPENVSCODE_PORT:-18765}:8765"
     volumes:
       - ./backend:/app
       - ./storage:/app/storage

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -34,8 +34,8 @@ services:
   # Backend test runner
   backend-test:
     build:
-      context: ./backend
-      dockerfile: Dockerfile.test
+      context: .
+      dockerfile: backend/Dockerfile.test
     container_name: claudex-backend-test
     depends_on:
       postgres-test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,8 @@ services:
 
   api:
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: backend/Dockerfile
     container_name: claudex-api-web
     restart: unless-stopped
     command: ["api"]
@@ -62,6 +62,9 @@ services:
         condition: service_completed_successfully
     ports:
       - "${BACKEND_PORT:-8080}:8080"
+      - "${VNC_PORT:-5900}:5900"
+      - "${VNC_WS_PORT:-6080}:6080"
+      - "${OPENVSCODE_PORT:-8765}:8765"
     volumes:
       - ./backend:/app
       - ./storage:/app/storage

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.32 @openai/codex @gongrzhe/server-gmail-autoauth-mcp @playwright/mcp@latest
+    npm install -g @anthropic-ai/claude-code@2.1.41 @openai/codex @gongrzhe/server-gmail-autoauth-mcp @playwright/mcp@latest
 
 RUN python3 -m pip install --user --upgrade pip && \
     python3 -m pip install --user \
@@ -112,7 +112,7 @@ RUN mkdir -p /home/user/.claude && \
 
 EXPOSE 3000 3001 5000 5900 6080 8000 8080 8765 5173 4200 8888 4321 3030 5500 1234 4000
 
-COPY sandbox/e2b/start-vnc.sh /usr/local/bin/start-vnc.sh
+COPY scripts/start-vnc.sh /usr/local/bin/start-vnc.sh
 RUN sudo chmod +x /usr/local/bin/start-vnc.sh
 
 COPY sandbox/docker/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/sandbox/e2b/e2b.Dockerfile
+++ b/sandbox/e2b/e2b.Dockerfile
@@ -51,7 +51,7 @@ RUN curl -fsSLO https://nodejs.org/dist/v20.19.0/node-v20.19.0-linux-x64.tar.xz 
     && echo '#!/bin/sh\nexec bun x "$@"' > /usr/local/bin/bunx \
     && chmod +x /usr/local/bin/bunx
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.32
+RUN npm install -g @anthropic-ai/claude-code@2.1.41
 
 RUN pip3 install anthropic-bridge==0.1.34
 
@@ -71,7 +71,7 @@ RUN pip3 install --no-cache-dir mcp redis httpx uv
 
 # Copy shared scripts
 COPY backend/permission_server.py /usr/local/bin/permission_server.py
-COPY sandbox/e2b/start-vnc.sh /usr/local/bin/start-vnc.sh
+COPY scripts/start-vnc.sh /usr/local/bin/start-vnc.sh
 RUN chmod +x /usr/local/bin/start-vnc.sh
 
 RUN curl -LO https://go.dev/dl/go1.23.3.linux-amd64.tar.gz \

--- a/scripts/start-vnc.sh
+++ b/scripts/start-vnc.sh
@@ -12,7 +12,3 @@ pgrep -f "Xvfb :${DISPLAY_NUM}" > /dev/null && exit 0
 Xvfb :${DISPLAY_NUM} -screen 0 ${RESOLUTION} -ac +extension RANDR &
 x11vnc -display :${DISPLAY_NUM} -forever -shared -nopw -listen 0.0.0.0 -rfbport ${VNC_PORT} -bg
 websockify 0.0.0.0:${WS_PORT} 127.0.0.1:${VNC_PORT} &
-
-chromium --no-sandbox --disable-gpu --disable-dev-shm-usage \
-  --window-size=1920,1080 --window-position=0,0 \
-  --remote-debugging-port=9222 about:blank &


### PR DESCRIPTION
- Add VNC stack (xvfb, x11vnc, websockify), X11 libs, GitHub CLI, OpenVSCode Server, and utility packages to backend Dockerfile
- Add @openai/codex and @playwright/mcp to npm global installs
- Add host provider get_vnc_url and reverse path mapping in execute_command so file paths are consistent across providers
- Expose dev server ports in docker-compose for host provider previews
- Move start-vnc.sh to shared scripts/ directory, update all Dockerfiles and compose build contexts to use repo root
- Remove port 5000 from available ports (conflicts with macOS AirPlay)