### PR TITLE
Fix E2B build context by copying shared files before build

### DIFF
--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -76,6 +76,11 @@ jobs:
       - name: Install E2B CLI
         run: npm install -g @e2b/cli
 
+      - name: Copy shared files into E2B build context
+        run: |
+          cp scripts/start-vnc.sh sandbox/e2b/start-vnc.sh
+          cp backend/permission_server.py sandbox/e2b/permission_server.py
+
       - name: Build E2B template
         working-directory: sandbox/e2b
         env:

--- a/sandbox/e2b/e2b.Dockerfile
+++ b/sandbox/e2b/e2b.Dockerfile
@@ -70,8 +70,8 @@ RUN OPENVSCODE_VERSION="1.105.1" && \
 RUN pip3 install --no-cache-dir mcp redis httpx uv
 
 # Copy shared scripts
-COPY backend/permission_server.py /usr/local/bin/permission_server.py
-COPY scripts/start-vnc.sh /usr/local/bin/start-vnc.sh
+COPY permission_server.py /usr/local/bin/permission_server.py
+COPY start-vnc.sh /usr/local/bin/start-vnc.sh
 RUN chmod +x /usr/local/bin/start-vnc.sh
 
 RUN curl -LO https://go.dev/dl/go1.23.3.linux-amd64.tar.gz \


### PR DESCRIPTION
The E2B CLI uses sandbox/e2b/ as build context, so files from scripts/ and backend/ are unreachable. Copy them into the build context in CI before running the template build.