### PR TITLE
Fix backend Dockerfile for Coolify build context

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -37,10 +37,10 @@ COPY backend/requirements.lock .
 RUN /root/.local/bin/uv pip install --system --no-cache -r requirements.lock
 
 COPY backend/ /app/
-COPY scripts/start-vnc.sh /usr/local/bin/start-vnc.sh
 
 RUN cp /app/permission_server.py /usr/local/bin/permission_server.py && \
     chmod +x /usr/local/bin/permission_server.py && \
+    cp /app/start-vnc.sh /usr/local/bin/start-vnc.sh && \
     chmod +x /usr/local/bin/start-vnc.sh
 
 RUN chown -R appuser:appuser /app && \

--- a/backend/start-vnc.sh
+++ b/backend/start-vnc.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+DISPLAY_NUM=${DISPLAY_NUM:-99}
+VNC_PORT=${VNC_PORT:-5900}
+WS_PORT=${WS_PORT:-6080}
+RESOLUTION=${RESOLUTION:-1920x1080x24}
+
+export DISPLAY=:${DISPLAY_NUM}
+
+pgrep -f "Xvfb :${DISPLAY_NUM}" > /dev/null && exit 0
+
+Xvfb :${DISPLAY_NUM} -screen 0 ${RESOLUTION} -ac +extension RANDR &
+x11vnc -display :${DISPLAY_NUM} -forever -shared -nopw -listen 0.0.0.0 -rfbport ${VNC_PORT} -bg
+websockify 0.0.0.0:${WS_PORT} 127.0.0.1:${VNC_PORT} &


### PR DESCRIPTION
Copy start-vnc.sh into backend/ so the Dockerfile works with both repo root context (docker-compose) and backend/ context (Coolify). Uses the same cp pattern as permission_server.py.