### PR TITLE
Switch to single-domain path-prefix routing for API and sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ docker compose -p claudex-web -f docker-compose.yml logs -f    # Web logs
 ## Deployment
 
 For production deployment on a VPS, see the [Coolify Installation Guide](docs/coolify-installation-guide.md).
+Production routing uses a single domain with path prefixes: frontend at `/` and API at `/api/*`.
 
 ## API & Admin
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -127,9 +127,8 @@ class Settings(BaseSettings):
     DOCKER_NETWORK: str = "claudex-sandbox-net"
     DOCKER_HOST: str | None = None
     DOCKER_PREVIEW_BASE_URL: str = "http://localhost"
-    # Traefik subdomain routing for HTTPS sandbox access (see docker_provider.py)
-    # Example: DOCKER_SANDBOX_DOMAIN=sandbox.example.com, DOCKER_TRAEFIK_NETWORK=coolify
-    DOCKER_SANDBOX_DOMAIN: str = ""
+    # Traefik path-prefix routing for HTTPS sandbox access (see docker_provider.py)
+    # Example: DOCKER_PREVIEW_BASE_URL=https://yourdomain.com, DOCKER_TRAEFIK_NETWORK=coolify
     DOCKER_TRAEFIK_NETWORK: str = ""
     DOCKER_TRAEFIK_ENTRYPOINT: str = "https"
     # Override URL for sandbox->API connectivity (permission server)

--- a/backend/app/services/sandbox_providers/factory.py
+++ b/backend/app/services/sandbox_providers/factory.py
@@ -12,7 +12,6 @@ def create_docker_config() -> DockerConfig:
         network=settings.DOCKER_NETWORK,
         host=settings.DOCKER_HOST,
         preview_base_url=settings.DOCKER_PREVIEW_BASE_URL,
-        sandbox_domain=settings.DOCKER_SANDBOX_DOMAIN,
         traefik_network=settings.DOCKER_TRAEFIK_NETWORK,
         traefik_entrypoint=settings.DOCKER_TRAEFIK_ENTRYPOINT,
     )

--- a/backend/app/services/sandbox_providers/types.py
+++ b/backend/app/services/sandbox_providers/types.py
@@ -74,7 +74,6 @@ class DockerConfig:
     preview_base_url: str = "http://localhost"
     user_home: str = "/home/user"
     openvscode_port: int = 8765
-    sandbox_domain: str = ""
     traefik_network: str = ""
     traefik_entrypoint: str = "https"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,8 +92,8 @@ services:
       - ./frontend:/app
       - /app/node_modules
     environment:
-      - VITE_API_BASE_URL=http://localhost:${BACKEND_PORT:-8080}/api/v1
-      - VITE_WS_URL=ws://localhost:${BACKEND_PORT:-8080}/api/v1/ws
+      - VITE_API_BASE_URL=/api/v1
+      - VITE_WS_URL=/api/v1/ws
 
 volumes:
   postgres_data:

--- a/docs/coolify-installation-guide.md
+++ b/docs/coolify-installation-guide.md
@@ -36,18 +36,16 @@ Before starting, ensure you have:
 ### Additional Requirements
 
 - **Domain name** with DNS configured (A records pointing to your VPS IP)
-  - Main domain: `yourdomain.com` (frontend)
-  - API subdomain: `api.yourdomain.com` (backend)
+  - Main domain: `yourdomain.com` (frontend and API path routing)
 - **Coolify installed** on your VPS ([Installation Guide](https://coolify.io/docs/installation))
 - **GitHub account** with access to your Claudex repository fork
 
 ### DNS Configuration
 
-Create the following DNS A records pointing to your VPS IP:
+Create this DNS A record pointing to your VPS IP:
 
 ```
-yourdomain.com      →  YOUR_VPS_IP
-api.yourdomain.com  →  YOUR_VPS_IP
+yourdomain.com  →  YOUR_VPS_IP
 ```
 
 ---
@@ -176,7 +174,7 @@ Navigate to the **General** tab and configure:
 ### Step 3: Configure Domain
 
 1. Navigate to the **Domains** section
-2. Add your API domain: `api.yourdomain.com`
+2. Add your API domain with path prefix: `yourdomain.com/api`
 3. Enable **HTTPS** (Coolify will auto-provision SSL via Let's Encrypt)
 
 ### Step 4: Configure Docker Options (Required for Sandbox)
@@ -199,12 +197,12 @@ ENVIRONMENT=production
 SECRET_KEY=your-secure-secret-key-minimum-32-characters
 DATABASE_URL=postgresql+asyncpg://postgres:YOUR_POSTGRES_PASSWORD@postgres:5432/postgres
 REDIS_URL=redis://redis:6379/0
-BASE_URL=https://api.yourdomain.com
+BASE_URL=https://yourdomain.com
 FRONTEND_URL=https://yourdomain.com
 ALLOWED_ORIGINS=https://yourdomain.com
 SANDBOX_PROVIDER=docker
+DOCKER_PREVIEW_BASE_URL=https://yourdomain.com
 DOCKER_TRAEFIK_NETWORK=YOUR_COOLIFY_NETWORK
-DOCKER_SANDBOX_DOMAIN=yourdomain.com
 DOCKER_PERMISSION_API_URL=http://api:8080
 REQUIRE_EMAIL_VERIFICATION=false
 TRUSTED_PROXY_HOSTS=*
@@ -223,7 +221,7 @@ TRUSTED_PROXY_HOSTS=*
 | `ALLOWED_ORIGINS` | CORS allowed origins (frontend URL) |
 | `SANDBOX_PROVIDER` | Set to `docker` to enable Docker-based sandbox execution |
 | `DOCKER_TRAEFIK_NETWORK` | Coolify's Docker network name (find in Docker networks) |
-| `DOCKER_SANDBOX_DOMAIN` | Base domain for sandbox containers |
+| `DOCKER_PREVIEW_BASE_URL` | Public base URL used for sandbox preview path routing |
 | `DOCKER_PERMISSION_API_URL` | Internal API URL for sandbox permission checks |
 | `REQUIRE_EMAIL_VERIFICATION` | Set to `false` to skip email verification |
 | `TRUSTED_PROXY_HOSTS` | Trust proxy headers (set to `*` behind Coolify's Traefik) |
@@ -295,8 +293,8 @@ Enable the following options:
 ### Step 5: Configure Environment Variables
 
 ```env
-VITE_API_BASE_URL=https://api.yourdomain.com/api/v1
-VITE_WS_URL=wss://api.yourdomain.com/api/v1/ws
+VITE_API_BASE_URL=/api/v1
+VITE_WS_URL=/api/v1/ws
 ```
 
 | Variable | Description |
@@ -320,7 +318,7 @@ Your production environment should now have the following resources:
 |---------|------|--------|
 | postgres | Database | (internal) |
 | redis | Database | (internal) |
-| api | Application | api.yourdomain.com |
+| api | Application | yourdomain.com/api |
 | frontend | Application | yourdomain.com |
 
 ### Step 2: Deploy in Order
@@ -338,7 +336,7 @@ All services should show green health indicators:
 
 ### Step 4: Check API Health and Readiness
 
-Visit `https://api.yourdomain.com/health` to verify liveness:
+Visit `https://yourdomain.com/health` to verify liveness:
 
 ```json
 {
@@ -346,7 +344,7 @@ Visit `https://api.yourdomain.com/health` to verify liveness:
 }
 ```
 
-Visit `https://api.yourdomain.com/api/v1/readyz` to verify dependency readiness:
+Visit `https://yourdomain.com/api/v1/readyz` to verify dependency readiness:
 
 ```json
 {
@@ -538,14 +536,14 @@ DATABASE_URL=postgresql+asyncpg://postgres:PASSWORD@postgres:5432/postgres
 REDIS_URL=redis://redis:6379/0
 
 # URLs
-BASE_URL=https://api.yourdomain.com
+BASE_URL=https://yourdomain.com
 FRONTEND_URL=https://yourdomain.com
 ALLOWED_ORIGINS=https://yourdomain.com
 
 # Docker/Sandbox
 SANDBOX_PROVIDER=docker
+DOCKER_PREVIEW_BASE_URL=https://yourdomain.com
 DOCKER_TRAEFIK_NETWORK=coolify-network-name
-DOCKER_SANDBOX_DOMAIN=yourdomain.com
 DOCKER_PERMISSION_API_URL=http://api:8080
 
 # Authentication
@@ -556,8 +554,8 @@ TRUSTED_PROXY_HOSTS=*
 ### Complete Frontend Environment Variables
 
 ```env
-VITE_API_BASE_URL=https://api.yourdomain.com/api/v1
-VITE_WS_URL=wss://api.yourdomain.com/api/v1/ws
+VITE_API_BASE_URL=/api/v1
+VITE_WS_URL=/api/v1/ws
 ```
 
 ## Optional Environment Variables
@@ -623,7 +621,7 @@ DOCKER_TRAEFIK_ENTRYPOINT=https
 | `DOCKER_TRAEFIK_ENTRYPOINT` | `https` | Traefik entrypoint for sandbox routing |
 | `SANDBOX_PROVIDER` | `docker` | Sandbox provider (`docker` or `e2b`) |
 
-> **Note**: `DOCKER_TRAEFIK_NETWORK`, `DOCKER_SANDBOX_DOMAIN`, and `DOCKER_PERMISSION_API_URL` are documented in the main configuration section above as they're typically required for Coolify deployments.
+> **Note**: `DOCKER_PREVIEW_BASE_URL`, `DOCKER_TRAEFIK_NETWORK`, and `DOCKER_PERMISSION_API_URL` are documented in the main configuration section above as they're typically required for Coolify deployments.
 
 ### E2B Sandbox Configuration (Alternative)
 

--- a/frontend/src/hooks/useGmailIntegration.ts
+++ b/frontend/src/hooks/useGmailIntegration.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { integrationsService, type GmailStatus } from '@/services/integrationsService';
-import { API_BASE_URL } from '@/lib/api';
+import { API_ORIGIN } from '@/lib/api';
 import toast from 'react-hot-toast';
 
 const GMAIL_STATUS_KEY = ['integrations', 'gmail', 'status'] as const;
@@ -56,7 +56,7 @@ export const useGmailIntegration = () => {
         return;
       }
 
-      const expectedOrigin = new URL(API_BASE_URL).origin;
+      const expectedOrigin = API_ORIGIN;
 
       const handleMessage = (event: MessageEvent) => {
         if (event.origin !== expectedOrigin) return;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,6 +16,17 @@ interface TokenResponse {
 
 export type { ApiStreamResponse as StreamResponse } from '@/types/stream.types';
 
+const trimTrailingSlash = (url: string): string => url.replace(/\/+$/, '');
+
+const resolveHttpBaseUrl = (rawUrl: string): string =>
+  trimTrailingSlash(new URL(rawUrl, window.location.origin).toString());
+
+const resolveWsBaseUrl = (rawUrl: string): string => {
+  const normalized = new URL(rawUrl, window.location.origin);
+  normalized.protocol = ['https:', 'wss:'].includes(normalized.protocol) ? 'wss:' : 'ws:';
+  return trimTrailingSlash(normalized.toString());
+};
+
 const getAuthHeaders = (includeContentType = true): Record<string, string> => {
   const token = authStorage.getToken();
   return {
@@ -200,7 +211,8 @@ class APIClient {
   }
 }
 
-export const API_BASE_URL: string = import.meta.env.VITE_API_BASE_URL;
-export const WS_BASE_URL: string = import.meta.env.VITE_WS_URL;
+export const API_BASE_URL: string = resolveHttpBaseUrl(import.meta.env.VITE_API_BASE_URL);
+export const WS_BASE_URL: string = resolveWsBaseUrl(import.meta.env.VITE_WS_URL);
+export const API_ORIGIN: string = new URL(API_BASE_URL).origin;
 
 export const apiClient = new APIClient(API_BASE_URL);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://backend:8080',
+        target: 'http://api:8080',
         changeOrigin: true,
         ws: true,
         secure: false,


### PR DESCRIPTION
Replace multi-domain architecture (api.yourdomain.com subdomain + *.sandbox.example.com wildcard) with path-prefix routing on a single domain: frontend at /, API at /api/*, sandboxes at /sandbox/{id}/{port}.

This eliminates the need for wildcard DNS and wildcard SSL certificates.

- Remove DOCKER_SANDBOX_DOMAIN config; derive routing from DOCKER_PREVIEW_BASE_URL + DOCKER_TRAEFIK_NETWORK
- Generate Traefik PathPrefix + StripPrefix labels instead of Host-based subdomain rules
- Resolve relative VITE_API_BASE_URL/VITE_WS_URL against page origin
- Fix wss:// preservation in WebSocket URL resolver
- Update Coolify installation guide for single-domain setup