### PR TITLE
Exclude anthropic-bridge from deptry DEP002 check

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -135,4 +135,5 @@ DEP002 = [
     "psycopg",
     "python-multipart",
     "bcrypt",
+    "anthropic-bridge",
 ]


### PR DESCRIPTION
Runtime dependency not directly imported in application code.