### PR TITLE
Add persistent chat session registry with config-aware invalidation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@
 - Do not define nested/inline functions; use module-level functions for standalone functions (e.g., endpoints) and class methods for classes — if a helper is only used by a class, it must be a method (or static method) on that class, not a module-level function
 - Do not add backward compatibility paths, fallback paths, or legacy shims unless explicitly requested
 - Do not create type aliases that add no semantic value (e.g., `StreamKind = str`) — use the base type directly
+- Module-level constants must be placed at the top of the file, immediately after imports and logger/settings initialization — never between classes or functions
 
 ## Naming Conventions
 

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -168,12 +168,10 @@ async def enhance_prompt(
     current_user: User = Depends(get_current_user),
 ) -> dict[str, str]:
     try:
-        async with ClaudeAgentService(
-            session_factory=chat_service.session_factory
-        ) as ai_service:
-            enhanced_prompt = await ai_service.enhance_prompt(
-                prompt, model_id, current_user
-            )
+        ai_service = ClaudeAgentService(session_factory=chat_service.session_factory)
+        enhanced_prompt = await ai_service.enhance_prompt(
+            prompt, model_id, current_user
+        )
         return {"enhanced_prompt": enhanced_prompt}
     except ClaudeAgentException as e:
         raise HTTPException(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -181,6 +181,7 @@ class Settings(BaseSettings):
     CONTEXT_USAGE_CACHE_TTL_SECONDS: int = 600
     CONTEXT_USAGE_POLL_INTERVAL_SECONDS: float = 5.0
     CANCEL_PENDING_TTL_SECONDS: float = 10.0
+    CHAT_PROCESS_IDLE_TTL_SECONDS: float = 300.0
 
     # GitHub Copilot OAuth (default ID from https://github.com/anomalyco/opencode)
     GITHUB_CLIENT_ID: str = "Ov23li8tweQw6odWQebz"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from app.core.middleware import (
     setup_middleware,
 )
 from app.db.session import engine, SessionLocal
+from app.services.claude_session_registry import session_registry
 from app.services.maintenance import MaintenanceService
 from app.services.streaming.runtime import ChatStreamRuntime
 from app.utils.redis import redis_connection
@@ -59,6 +60,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     finally:
         await maintenance_service.stop()
         await ChatStreamRuntime.stop_background_chats()
+        await session_registry.terminate_all()
         await engine.dispose()
 
 

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -46,6 +46,7 @@ from app.services.sandbox_providers import (
 )
 from app.services.streaming.runtime import ChatStreamRuntime
 from app.services.streaming.types import ChatStreamRequest
+from app.services.claude_session_registry import session_registry
 from app.services.storage import StorageService
 from app.services.user import UserService
 
@@ -269,6 +270,8 @@ class ChatService(BaseDbService[Chat]):
 
             await db.commit()
 
+            await session_registry.terminate(str(chat_id))
+
             if chat.sandbox_id:
                 asyncio.create_task(
                     self.sandbox_service.delete_sandbox(chat.sandbox_id)
@@ -300,13 +303,14 @@ class ChatService(BaseDbService[Chat]):
 
     async def delete_all_chats(self, user: User) -> int:
         async with self.session_factory() as db:
-            sandbox_query = select(Chat.sandbox_id).filter(
+            chat_query = select(Chat.id, Chat.sandbox_id).filter(
                 Chat.user_id == user.id,
-                Chat.sandbox_id.isnot(None),
                 Chat.deleted_at.is_(None),
             )
-            result = await db.execute(sandbox_query)
-            sandbox_ids = [row[0] for row in result.fetchall()]
+            result = await db.execute(chat_query)
+            rows = result.fetchall()
+            chat_ids = [str(row[0]) for row in rows]
+            sandbox_ids = [row[1] for row in rows if row[1] is not None]
 
             now = datetime.now(timezone.utc)
 
@@ -330,6 +334,11 @@ class ChatService(BaseDbService[Chat]):
             await db.execute(messages_update)
 
             await db.commit()
+
+            await asyncio.gather(
+                *(session_registry.terminate(cid) for cid in chat_ids),
+                return_exceptions=True,
+            )
 
             for sandbox_id in sandbox_ids:
                 asyncio.create_task(self.sandbox_service.delete_sandbox(sandbox_id))

--- a/backend/app/services/claude_agent.py
+++ b/backend/app/services/claude_agent.py
@@ -1,8 +1,8 @@
 import logging
 import re
 from collections.abc import AsyncIterator, Callable
-from types import TracebackType
-from typing import Any, Literal, Self
+from functools import partial
+from typing import Any, Literal, NamedTuple
 
 from claude_agent_sdk import (
     ClaudeAgentOptions,
@@ -27,6 +27,7 @@ from app.services.transports import (
     E2BSandboxTransport,
     HostSandboxTransport,
     ModalSandboxTransport,
+    SandboxTransport,
 )
 from app.services.streaming.types import StreamEvent
 from app.services.streaming.processor import StreamProcessor
@@ -37,6 +38,14 @@ SDKPermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
+
+
+class SessionParams(NamedTuple):
+    options: ClaudeAgentOptions
+    sandbox_id: str
+    sandbox_provider: str
+    transport_factory: Callable[[], SandboxTransport]
+
 
 THINKING_MODE_TOKENS = {
     "low": 4000,
@@ -96,40 +105,12 @@ class ClaudeAgentService:
         self.tool_registry = ToolHandlerRegistry()
         self.session_factory = session_factory or SessionLocal
         self._total_cost_usd = 0.0
-        self._active_transport: (
-            E2BSandboxTransport
-            | DockerSandboxTransport
-            | HostSandboxTransport
-            | ModalSandboxTransport
-            | None
-        ) = None
         self._provider_service = ProviderService()
-
-    async def __aenter__(self) -> Self:
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        _exc_val: BaseException | None,
-        _exc_tb: TracebackType | None,
-    ) -> bool:
-        try:
-            await self.cancel_active_stream()
-        except Exception as cleanup_error:
-            logger.error(
-                f"Error during ClaudeAgentService cleanup: {cleanup_error}",
-                exc_info=True,
-            )
-            if exc_type is None:
-                raise
-        return False
 
     def _create_sandbox_transport(
         self,
         sandbox_provider: str,
         sandbox_id: str,
-        prompt_iterable: AsyncIterator[dict[str, Any]],
         options: ClaudeAgentOptions,
         user_settings: UserSettings,
     ) -> (
@@ -147,14 +128,12 @@ class ClaudeAgentService:
             return DockerSandboxTransport(
                 sandbox_id=sandbox_id,
                 docker_config=docker_config,
-                prompt=prompt_iterable,
                 options=options,
             )
 
         if sandbox_provider == SandboxProviderType.HOST.value:
             return HostSandboxTransport(
                 sandbox_id=sandbox_id,
-                prompt=prompt_iterable,
                 options=options,
             )
 
@@ -167,7 +146,6 @@ class ClaudeAgentService:
             return ModalSandboxTransport(
                 sandbox_id=sandbox_id,
                 api_key=user_settings.modal_api_key,
-                prompt=prompt_iterable,
                 options=options,
             )
 
@@ -179,33 +157,34 @@ class ClaudeAgentService:
         return E2BSandboxTransport(
             sandbox_id=sandbox_id,
             api_key=user_settings.e2b_api_key,
-            prompt=prompt_iterable,
             options=options,
         )
 
-    async def get_ai_stream(
+    async def build_session_params(
         self,
-        prompt: str,
-        system_prompt: str,
-        custom_instructions: str | None,
+        *,
         user: User,
         chat: Chat,
+        system_prompt: str,
+        custom_instructions: str | None,
         model_id: str,
-        permission_mode: str = "auto",
-        session_id: str | None = None,
-        session_callback: Callable[[str], None] | None = None,
-        thinking_mode: str | None = None,
-        attachments: list[dict[str, Any]] | None = None,
-        is_custom_prompt: bool = False,
-    ) -> AsyncIterator[StreamEvent]:
+        permission_mode: str,
+        session_id: str | None,
+        thinking_mode: str | None,
+        is_custom_prompt: bool,
+    ) -> SessionParams:
         chat_id = str(chat.id)
         user_settings = await UserService(
             session_factory=self.session_factory
         ).get_user_settings(user.id)
 
-        self._total_cost_usd = 0.0
-
         sandbox_provider = user_settings.sandbox_provider
+        sandbox_id = chat.sandbox_id
+        if not sandbox_id:
+            raise ClaudeAgentException(
+                "Chat does not have an associated sandbox environment"
+            )
+        sandbox_id_str = str(sandbox_id)
 
         options = await self._build_claude_options(
             user=user,
@@ -219,13 +198,32 @@ class ClaudeAgentService:
             is_custom_prompt=is_custom_prompt,
         )
 
+        transport_factory = partial(
+            self._create_sandbox_transport,
+            sandbox_provider=sandbox_provider,
+            sandbox_id=sandbox_id_str,
+            options=options,
+            user_settings=user_settings,
+        )
+
+        return SessionParams(
+            options=options,
+            sandbox_id=sandbox_id_str,
+            sandbox_provider=sandbox_provider,
+            transport_factory=transport_factory,
+        )
+
+    async def stream_with_client(
+        self,
+        client: ClaudeSDKClient,
+        prompt: str,
+        custom_instructions: str | None,
+        session_id: str | None,
+        session_callback: Callable[[str], None] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        self._total_cost_usd = 0.0
         user_prompt = self.prepare_user_prompt(prompt, custom_instructions, attachments)
-        sandbox_id = chat.sandbox_id
-        if not sandbox_id:
-            raise ClaudeAgentException(
-                "Chat does not have an associated sandbox environment"
-            )
-        sandbox_id_str = str(sandbox_id)
 
         prompt_message = {
             "type": "user",
@@ -235,41 +233,24 @@ class ClaudeAgentService:
         }
         prompt_iterable = self._create_prompt_iterable(prompt_message)
 
-        transport = self._create_sandbox_transport(
-            sandbox_provider=sandbox_provider,
-            sandbox_id=sandbox_id_str,
-            prompt_iterable=prompt_iterable,
-            options=options,
-            user_settings=user_settings,
+        processor = StreamProcessor(
+            tool_registry=self.tool_registry,
+            session_handler=self._create_session_handler(session_callback),
         )
 
-        async with transport:
-            self._active_transport = transport
+        try:
+            await client.query(prompt_iterable)
+            async for message in client.receive_response():
+                for event in processor.emit_events_for_message(message):
+                    if event:
+                        yield event
+                        if event.get("tool", {}).get("name") == "ExitPlanMode":
+                            await client.set_permission_mode("auto")
 
-            processor = StreamProcessor(
-                tool_registry=self.tool_registry,
-                session_handler=self._create_session_handler(session_callback),
-            )
+            self._total_cost_usd = processor.total_cost_usd
 
-            try:
-                async with ClaudeSDKClient(
-                    options=options, transport=transport
-                ) as client:
-                    await client.query(prompt_iterable)
-                    async for message in client.receive_response():
-                        for event in processor.emit_events_for_message(message):
-                            if event:
-                                yield event
-                                if event.get("tool", {}).get("name") == "ExitPlanMode":
-                                    await client.set_permission_mode("auto")
-
-                self._total_cost_usd = processor.total_cost_usd
-
-            except ClaudeSDKError as e:
-                raise ClaudeAgentException(f"Claude SDK error: {str(e)}")
-
-            finally:
-                self._active_transport = None
+        except ClaudeSDKError as e:
+            raise ClaudeAgentException(f"Claude SDK error: {str(e)}") from e
 
     def get_total_cost_usd(self) -> float:
         return self._total_cost_usd
@@ -278,15 +259,6 @@ class ClaudeAgentService:
         self, session_callback: Callable[[str], None] | None
     ) -> SessionHandler:
         return SessionHandler(session_callback)
-
-    async def cancel_active_stream(self) -> None:
-        if self._active_transport:
-            try:
-                await self._active_transport.close()
-            except Exception as e:
-                logger.error("Error closing transport: %s", e)
-            finally:
-                self._active_transport = None
 
     def _build_auth_env(
         self, model_id: str, user_settings: UserSettings
@@ -622,30 +594,24 @@ class ClaudeAgentService:
             transport = self._create_sandbox_transport(
                 sandbox_provider=user_settings.sandbox_provider,
                 sandbox_id=sandbox_id,
-                prompt_iterable=prompt_iterable,
                 options=options,
                 user_settings=user_settings,
             )
 
             async with transport:
-                self._active_transport = transport
-
                 response_content = ""
-                try:
-                    async with ClaudeSDKClient(
-                        options=options, transport=transport
-                    ) as client:
-                        await client.query(prompt_iterable)
-                        async for message in client.receive_response():
-                            if isinstance(message, UserMessage):
-                                if isinstance(message.content, str):
-                                    response_content += message.content
-                                elif isinstance(message.content, list):
-                                    for item in message.content:
-                                        if isinstance(item, TextBlock) and item.text:
-                                            response_content += item.text
-                finally:
-                    self._active_transport = None
+                async with ClaudeSDKClient(
+                    options=options, transport=transport
+                ) as client:
+                    await client.query(prompt_iterable)
+                    async for message in client.receive_response():
+                        if isinstance(message, UserMessage):
+                            if isinstance(message.content, str):
+                                response_content += message.content
+                            elif isinstance(message.content, list):
+                                for item in message.content:
+                                    if isinstance(item, TextBlock) and item.text:
+                                        response_content += item.text
 
             if not response_content:
                 return None

--- a/backend/app/services/claude_session_registry.py
+++ b/backend/app/services/claude_session_registry.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from claude_agent_sdk import ClaudeSDKClient
+from claude_agent_sdk.types import ClaudeAgentOptions
+
+from app.services.transports import SandboxTransport
+
+logger = logging.getLogger(__name__)
+
+TASK_CANCEL_TIMEOUT_SECONDS = 5.0
+
+REAPER_INTERVAL_SECONDS = 60.0
+
+EPHEMERAL_MCP_ENV_KEYS = frozenset({"CHAT_TOKEN"})
+
+
+@dataclass
+class ChatSession:
+    chat_id: str
+    sandbox_id: str
+    provider: str
+    transport: SandboxTransport
+    client: ClaudeSDKClient
+    max_thinking_tokens: int | None
+    config_fingerprint: str
+    active_generation_task: asyncio.Task[Any] | None = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    last_used_at: float = field(default_factory=time.monotonic)
+
+
+class SessionRegistry:
+    def __init__(self) -> None:
+        self._sessions: dict[str, ChatSession] = {}
+        self._lock = asyncio.Lock()
+
+    async def get_or_create(
+        self,
+        *,
+        chat_id: str,
+        sandbox_id: str,
+        provider: str,
+        max_thinking_tokens: int | None,
+        options: ClaudeAgentOptions,
+        transport_factory: Callable[[], SandboxTransport],
+    ) -> ChatSession:
+        async with self._lock:
+            session = self._sessions.get(chat_id)
+
+            fingerprint = self._options_fingerprint(options)
+
+            if session is not None:
+                needs_restart = (
+                    session.sandbox_id != sandbox_id
+                    or session.provider != provider
+                    or session.max_thinking_tokens != max_thinking_tokens
+                    or session.config_fingerprint != fingerprint
+                )
+                if needs_restart:
+                    await self._close_session(session)
+                    session = None
+
+            if session is None:
+                session = await self._create_session(
+                    chat_id=chat_id,
+                    sandbox_id=sandbox_id,
+                    provider=provider,
+                    max_thinking_tokens=max_thinking_tokens,
+                    config_fingerprint=fingerprint,
+                    options=options,
+                    transport_factory=transport_factory,
+                )
+                self._sessions[chat_id] = session
+
+            session.last_used_at = time.monotonic()
+            return session
+
+    async def interrupt_generation(self, chat_id: str) -> None:
+        session = self._sessions.get(chat_id)
+        if session is None:
+            return
+        await session.client.interrupt()
+
+    async def terminate(self, chat_id: str) -> None:
+        async with self._lock:
+            session = self._sessions.pop(chat_id, None)
+            if session is not None:
+                await self._close_session(session)
+
+    async def terminate_all(self) -> None:
+        async with self._lock:
+            sessions = list(self._sessions.values())
+            self._sessions.clear()
+        for session in sessions:
+            await self._close_session(session)
+
+    async def reap_idle(self, ttl_seconds: float) -> None:
+        now = time.monotonic()
+        expired: list[str] = []
+
+        async with self._lock:
+            for chat_id, session in self._sessions.items():
+                task = session.active_generation_task
+                if task is not None and not task.done():
+                    continue
+                if (now - session.last_used_at) >= ttl_seconds:
+                    expired.append(chat_id)
+
+            removed = [self._sessions.pop(cid) for cid in expired]
+
+        for session in removed:
+            await self._close_session(session)
+
+        if expired:
+            logger.info("Reaped %d idle chat session(s)", len(expired))
+
+    @staticmethod
+    def _stable_mcp_key(mcp_servers: Any) -> Any:
+        if not isinstance(mcp_servers, dict):
+            return mcp_servers
+        stable: dict[str, Any] = {}
+        for name, cfg in mcp_servers.items():
+            if not isinstance(cfg, dict):
+                stable[name] = cfg
+                continue
+            env = cfg.get("env")
+            if isinstance(env, dict):
+                filtered_env = {
+                    k: v for k, v in env.items() if k not in EPHEMERAL_MCP_ENV_KEYS
+                }
+                stable[name] = {**cfg, "env": filtered_env}
+            else:
+                stable[name] = cfg
+        return stable
+
+    @staticmethod
+    def _options_fingerprint(options: ClaudeAgentOptions) -> str:
+        # Persistent sessions reuse the underlying CLI subprocess across messages.
+        # Only model and permission_mode can be updated at runtime via SDK setters
+        # (set_model / set_permission_mode). All other ClaudeAgentOptions fields
+        # (system_prompt, env, mcp_servers, disallowed_tools) are baked into the
+        # subprocess at spawn time. If any of these change between messages — e.g.
+        # the user edits custom instructions, rotates API keys, switches to a
+        # different provider, or adds an MCP server — we must tear down the session
+        # and start a new CLI process. This fingerprint captures those immutable
+        # fields so get_or_create can detect the drift and restart.
+        #
+        # Ephemeral MCP env keys (e.g. CHAT_TOKEN from create_chat_scoped_token)
+        # are excluded because they change on every request, which would defeat
+        # session reuse. Other MCP env values (user-configured credentials) are
+        # kept so that credential changes trigger a session restart.
+        data = json.dumps(
+            {
+                "system_prompt": options.system_prompt,
+                "env": options.env,
+                "mcp_servers": SessionRegistry._stable_mcp_key(options.mcp_servers),
+                "disallowed_tools": options.disallowed_tools,
+            },
+            sort_keys=True,
+            default=str,
+        )
+        return hashlib.sha256(data.encode()).hexdigest()
+
+    @staticmethod
+    async def _create_session(
+        *,
+        chat_id: str,
+        sandbox_id: str,
+        provider: str,
+        max_thinking_tokens: int | None,
+        config_fingerprint: str,
+        options: ClaudeAgentOptions,
+        transport_factory: Callable[[], SandboxTransport],
+    ) -> ChatSession:
+        transport: SandboxTransport = transport_factory()
+        client = ClaudeSDKClient(options=options, transport=transport)
+        try:
+            await client.connect()
+        except Exception:
+            await client.disconnect()
+            await transport.close()
+            raise
+
+        return ChatSession(
+            chat_id=chat_id,
+            sandbox_id=sandbox_id,
+            provider=provider,
+            transport=transport,
+            client=client,
+            max_thinking_tokens=max_thinking_tokens,
+            config_fingerprint=config_fingerprint,
+        )
+
+    @staticmethod
+    async def _close_session(session: ChatSession) -> None:
+        task = session.active_generation_task
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=TASK_CANCEL_TIMEOUT_SECONDS)
+            except BaseException:
+                pass
+
+        try:
+            await session.client.disconnect()
+        except Exception as exc:
+            logger.debug(
+                "Error disconnecting session for chat %s: %s",
+                session.chat_id,
+                exc,
+            )
+
+        try:
+            await session.transport.close()
+        except Exception as exc:
+            logger.debug(
+                "Error closing transport for chat %s: %s",
+                session.chat_id,
+                exc,
+            )
+
+
+session_registry = SessionRegistry()

--- a/backend/app/services/maintenance.py
+++ b/backend/app/services/maintenance.py
@@ -7,9 +7,16 @@ from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 
+from app.core.config import get_settings
+from app.services.claude_session_registry import (
+    REAPER_INTERVAL_SECONDS,
+    session_registry,
+)
 from app.services.refresh_token import RefreshTokenService
 from app.services.sandbox import SandboxService
 from app.services.scheduler import SchedulerService
+
+settings = get_settings()
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +39,7 @@ class MaintenanceService:
             asyncio.create_task(self._run_job_loop(self._scheduled_tasks_job())),
             asyncio.create_task(self._run_job_loop(self._refresh_tokens_job())),
             asyncio.create_task(self._run_job_loop(self._orphaned_sandboxes_job())),
+            asyncio.create_task(self._run_job_loop(self._session_reaper_job())),
         ]
 
     async def stop(self) -> None:
@@ -65,8 +73,20 @@ class MaintenanceService:
             run=SandboxService.cleanup_orphaned_sandboxes,
         )
 
+    def _session_reaper_job(self) -> MaintenanceJob:
+        return MaintenanceJob(
+            name="chat_session_reaper",
+            interval_seconds=REAPER_INTERVAL_SECONDS,
+            run=self._reap_idle_sessions,
+        )
+
     async def _run_scheduled_tasks(self) -> dict[str, Any]:
         return await self._scheduler_service.check_due_tasks(limit=100)
+
+    @staticmethod
+    async def _reap_idle_sessions() -> dict[str, Any]:
+        await session_registry.reap_idle(settings.CHAT_PROCESS_IDLE_TTL_SECONDS)
+        return {}
 
     async def _run_job_loop(self, job: MaintenanceJob) -> None:
         while not self._stop_event.is_set():

--- a/backend/app/services/streaming/cancellation.py
+++ b/backend/app/services/streaming/cancellation.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING
 
 from app.core.config import get_settings
-
-if TYPE_CHECKING:
-    from app.services.claude_agent import ClaudeAgentService
+from app.services.claude_session_registry import session_registry
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -69,8 +66,8 @@ class CancellationHandler:
         return True
 
     @staticmethod
-    async def cancel_stream(chat_id: str, ai_service: ClaudeAgentService) -> None:
+    async def cancel_stream(chat_id: str) -> None:
         try:
-            await ai_service.cancel_active_stream()
+            await session_registry.interrupt_generation(chat_id)
         except Exception as exc:
             logger.error("Failed to cancel active stream for chat %s: %s", chat_id, exc)

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -22,7 +22,8 @@ from app.models.db_models import (
     User,
 )
 from app.prompts.system_prompt import build_system_prompt_for_chat
-from app.services.claude_agent import ClaudeAgentService
+from claude_agent_sdk import CLIConnectionError, CLIJSONDecodeError
+from app.services.claude_agent import ClaudeAgentService, SessionParams
 from app.services.db import SessionFactoryType
 from app.services.exceptions import ClaudeAgentException
 from app.services.message import MessageService
@@ -36,11 +37,19 @@ from app.services.streaming.types import (
     StreamEvent,
     StreamSnapshotAccumulator,
 )
+from app.services.claude_session_registry import session_registry
 from app.services.user import UserService
 from app.utils.redis import redis_connection
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
+TRANSPORT_FATAL_TYPES = (
+    CLIConnectionError,
+    CLIJSONDecodeError,
+    ConnectionError,
+    OSError,
+)
 
 SNAPSHOT_EVENT_KINDS = frozenset(
     {
@@ -183,7 +192,7 @@ class ChatStreamRuntime:
                     last_seq=start_seq,
                     active_stream_id=self.stream_id,
                 )
-            await self._consume_stream(ai_service, stream)
+            await self._consume_stream(stream)
 
             if self._cancelled:
                 return await self._complete_stream(
@@ -209,7 +218,6 @@ class ChatStreamRuntime:
 
     async def _consume_stream(
         self,
-        ai_service: ClaudeAgentService,
         stream: AsyncIterator[StreamEvent],
     ) -> None:
         stream_iter = aiter(stream)
@@ -230,7 +238,7 @@ class ChatStreamRuntime:
             self._cancelled = True
 
         if self._cancelled:
-            await CancellationHandler.cancel_stream(self.chat_id, ai_service)
+            await CancellationHandler.cancel_stream(self.chat_id)
 
     @staticmethod
     def _cancel_task_if_running(
@@ -567,6 +575,17 @@ class ChatStreamRuntime:
         for task in finished_tasks:
             cls._background_task_chat_ids.pop(task, None)
 
+    @staticmethod
+    def _is_transport_fatal(exc: BaseException) -> bool:
+        current: BaseException | None = exc
+        while current is not None:
+            if isinstance(current, asyncio.CancelledError):
+                return False
+            if isinstance(current, TRANSPORT_FATAL_TYPES):
+                return True
+            current = current.__cause__ or current.__context__
+        return False
+
     @classmethod
     def has_active_chat(cls, chat_id: str) -> bool:
         if CancellationHandler.get_event(chat_id) is not None:
@@ -669,37 +688,75 @@ class ChatStreamRuntime:
             await runtime._connect_redis()
             runtime._cancel_event = cancel_event
 
-            async with ClaudeAgentService(
-                session_factory=runtime.session_factory
-            ) as ai_service:
-                session_callback = SessionUpdateCallback(
-                    chat_id=runtime.chat_id,
-                    assistant_message_id=request.assistant_message_id,
-                    session_factory=runtime.session_factory,
-                    session_container=runtime.session_container,
-                )
-                user = User(id=runtime.chat.user_id)
-                stream = ai_service.get_ai_stream(
-                    prompt=request.prompt,
-                    system_prompt=request.system_prompt,
-                    custom_instructions=request.custom_instructions,
-                    user=user,
-                    chat=runtime.chat,
-                    permission_mode=request.permission_mode,
-                    model_id=request.model_id,
-                    session_id=request.session_id,
-                    session_callback=session_callback,
-                    thinking_mode=request.thinking_mode,
-                    attachments=request.attachments,
-                    is_custom_prompt=request.is_custom_prompt,
-                )
-                context_poller = ContextUsagePoller(runtime=runtime)
-                poll_task, stop_event = context_poller.start(ai_service)
+            ai_service = ClaudeAgentService(session_factory=runtime.session_factory)
+            user = User(id=runtime.chat.user_id)
+
+            params: SessionParams = await ai_service.build_session_params(
+                user=user,
+                chat=runtime.chat,
+                system_prompt=request.system_prompt,
+                custom_instructions=request.custom_instructions,
+                model_id=request.model_id,
+                permission_mode=request.permission_mode,
+                session_id=request.session_id,
+                thinking_mode=request.thinking_mode,
+                is_custom_prompt=request.is_custom_prompt,
+            )
+
+            session = await session_registry.get_or_create(
+                chat_id=runtime.chat_id,
+                sandbox_id=params.sandbox_id,
+                provider=params.sandbox_provider,
+                max_thinking_tokens=params.options.max_thinking_tokens,
+                options=params.options,
+                transport_factory=params.transport_factory,
+            )
+
+            session_callback = SessionUpdateCallback(
+                chat_id=runtime.chat_id,
+                assistant_message_id=request.assistant_message_id,
+                session_factory=runtime.session_factory,
+                session_container=runtime.session_container,
+            )
+
+            async with session.lock:
+                session.active_generation_task = asyncio.current_task()
                 try:
-                    return await runtime.run(ai_service, stream)
+                    if params.options.model:
+                        await session.client.set_model(params.options.model)
+                    if params.options.permission_mode:
+                        await session.client.set_permission_mode(
+                            params.options.permission_mode
+                        )
+                    stream = ai_service.stream_with_client(
+                        client=session.client,
+                        prompt=request.prompt,
+                        custom_instructions=request.custom_instructions,
+                        session_id=request.session_id,
+                        session_callback=session_callback,
+                        attachments=request.attachments,
+                    )
+                    context_poller = ContextUsagePoller(runtime=runtime)
+                    poll_task, stop_event = context_poller.start(ai_service)
+                    try:
+                        return await runtime.run(ai_service, stream)
+                    finally:
+                        await ContextUsagePoller.stop(poll_task, stop_event)
+                except (
+                    ClaudeAgentException,
+                    asyncio.CancelledError,
+                ) as exc:
+                    if cls._is_transport_fatal(exc):
+                        session.active_generation_task = None
+                        await session_registry.terminate(runtime.chat_id)
+                    raise
+                except Exception:
+                    session.active_generation_task = None
+                    await session_registry.terminate(runtime.chat_id)
+                    raise
                 finally:
-                    await ContextUsagePoller.stop(poll_task, stop_event)
-            raise RuntimeError("ClaudeAgentService exited without returning")
+                    session.active_generation_task = None
+                    session.last_used_at = time.monotonic()
 
         except asyncio.CancelledError:
             await cls._mark_message_failed(

--- a/backend/app/services/transports/__init__.py
+++ b/backend/app/services/transports/__init__.py
@@ -3,9 +3,17 @@ from app.services.transports.e2b import E2BSandboxTransport
 from app.services.transports.host import HostSandboxTransport
 from app.services.transports.modal import ModalSandboxTransport
 
+SandboxTransport = (
+    DockerSandboxTransport
+    | E2BSandboxTransport
+    | HostSandboxTransport
+    | ModalSandboxTransport
+)
+
 __all__ = [
     "DockerSandboxTransport",
     "E2BSandboxTransport",
     "HostSandboxTransport",
     "ModalSandboxTransport",
+    "SandboxTransport",
 ]

--- a/backend/app/services/transports/base.py
+++ b/backend/app/services/transports/base.py
@@ -3,7 +3,7 @@ import json
 import re
 import shlex
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterable, AsyncIterator
+from collections.abc import AsyncIterator
 from contextlib import suppress
 from dataclasses import asdict
 from types import TracebackType
@@ -26,11 +26,9 @@ class BaseSandboxTransport(Transport, ABC):
         self,
         *,
         sandbox_id: str,
-        prompt: str | AsyncIterable[dict[str, Any]],
         options: ClaudeAgentOptions,
     ) -> None:
         self._sandbox_id = sandbox_id
-        self._prompt = prompt
         self._options = options
         self._max_buffer_size = (
             options.max_buffer_size
@@ -295,7 +293,6 @@ class BaseSandboxTransport(Transport, ABC):
 
         json_buffer = ""
         json_started = False
-        should_stop = False
 
         while True:
             chunk = await self._stdout_queue.get()
@@ -343,14 +340,8 @@ class BaseSandboxTransport(Transport, ABC):
                         yield data
                         if isinstance(data, dict) and data.get("type") == "result":
                             json_buffer = ""
-                            should_stop = True
-                            break
                     if not json_buffer:
                         json_started = False
-                if should_stop:
-                    break
-            if should_stop:
-                break
 
         if json_buffer:
             leftover, parsed_messages = self._parse_json_buffer(json_buffer)

--- a/backend/app/services/transports/docker.py
+++ b/backend/app/services/transports/docker.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import select
 import socket
-from collections.abc import AsyncIterable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from typing import Any
@@ -23,10 +22,9 @@ class DockerSandboxTransport(BaseSandboxTransport):
         *,
         sandbox_id: str,
         docker_config: DockerConfig,
-        prompt: str | AsyncIterable[dict[str, Any]],
         options: ClaudeAgentOptions,
     ) -> None:
-        super().__init__(sandbox_id=sandbox_id, prompt=prompt, options=options)
+        super().__init__(sandbox_id=sandbox_id, options=options)
         self._docker_config = docker_config
         self._executor = ThreadPoolExecutor(max_workers=4)
         self._docker_client: Any = None

--- a/backend/app/services/transports/e2b.py
+++ b/backend/app/services/transports/e2b.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-from collections.abc import AsyncIterable
 from contextlib import suppress
 from typing import Any
 
@@ -22,10 +21,9 @@ class E2BSandboxTransport(BaseSandboxTransport):
         *,
         sandbox_id: str,
         api_key: str,
-        prompt: str | AsyncIterable[dict[str, Any]],
         options: ClaudeAgentOptions,
     ) -> None:
-        super().__init__(sandbox_id=sandbox_id, prompt=prompt, options=options)
+        super().__init__(sandbox_id=sandbox_id, options=options)
         self._api_key = api_key
         self._sandbox: AsyncSandbox | None = None
         self._command: AsyncCommandHandle | None = None

--- a/backend/app/services/transports/host.py
+++ b/backend/app/services/transports/host.py
@@ -4,7 +4,6 @@ import logging
 import os
 import pwd
 import shlex
-from collections.abc import AsyncIterable
 from pathlib import Path
 from typing import Any
 
@@ -24,10 +23,9 @@ class HostSandboxTransport(BaseSandboxTransport):
         self,
         *,
         sandbox_id: str,
-        prompt: str | AsyncIterable[dict[str, Any]],
         options: ClaudeAgentOptions,
     ) -> None:
-        super().__init__(sandbox_id=sandbox_id, prompt=prompt, options=options)
+        super().__init__(sandbox_id=sandbox_id, options=options)
         self._process: asyncio.subprocess.Process | None = None
         self._stdout_task: asyncio.Task[None] | None = None
         self._stderr_task: asyncio.Task[None] | None = None

--- a/backend/app/services/transports/modal.py
+++ b/backend/app/services/transports/modal.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-from collections.abc import AsyncIterable
 from contextlib import suppress
 from typing import Any
 
@@ -20,10 +19,9 @@ class ModalSandboxTransport(BaseSandboxTransport):
         *,
         sandbox_id: str,
         api_key: str,
-        prompt: str | AsyncIterable[dict[str, Any]],
         options: ClaudeAgentOptions,
     ) -> None:
-        super().__init__(sandbox_id=sandbox_id, prompt=prompt, options=options)
+        super().__init__(sandbox_id=sandbox_id, options=options)
         self._api_key = api_key
         self._sandbox: modal.Sandbox | None = None
         self._process: Any | None = None


### PR DESCRIPTION
Introduce SessionRegistry to keep Claude SDK sessions alive across messages instead of spawning a fresh CLI subprocess per request. Sessions are reused when sandbox, provider, thinking tokens, and a fingerprint of immutable CLI options (system_prompt, env, mcp_servers, disallowed_tools) all match; any drift tears down the old session and starts a new one.

Key fixes on top of the base persistent-session work:
- Preserve SDK error cause chain (from e) so _is_transport_fatal can detect CLIConnectionError through the ClaudeAgentException wrapper
- Use client.interrupt() instead of task.cancel() for user-initiated cancellation to avoid self-cancelling the running task
- Clear active_generation_task before calling terminate() to prevent _close_session from cancelling the currently executing task
- Move set_model/set_permission_mode inside the guarded try block so failures on a dead CLI process trigger session termination
- Remove eager session.lock.locked() check that raced with queued follow-up messages from _process_next_queued
- Exclude only ephemeral CHAT_TOKEN from MCP env fingerprint so real credential changes still trigger restarts
- Update last_used_at after generation completes so idle TTL is measured from end of work, not start