### PR TITLE
Fix automatic logout on transient errors

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,11 +34,7 @@ function AppContent() {
   const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const hasToken = !!authService.getToken();
-  const {
-    data: user,
-    error,
-    isLoading,
-  } = useCurrentUserQuery({
+  const { data: user, isLoading } = useCurrentUserQuery({
     enabled: hasToken,
     retry: false,
   });
@@ -46,10 +42,10 @@ function AppContent() {
   useEffect(() => {
     if (hasToken && user) {
       setAuthenticated(true);
-    } else if (isAuthenticated && error) {
+    } else if (isAuthenticated && !hasToken) {
       setAuthenticated(false);
     }
-  }, [user, hasToken, error, isAuthenticated, setAuthenticated]);
+  }, [user, hasToken, isAuthenticated, setAuthenticated]);
 
   const { data: chatsData, isLoading: isChatsLoading } = useInfiniteChatsQuery({
     enabled: isAuthenticated,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -14,6 +14,16 @@ interface TokenResponse {
   token_type: string;
 }
 
+class RefreshTokenError extends Error {
+  status: number;
+
+  constructor(status: number, message = 'Token refresh failed') {
+    super(message);
+    this.name = 'RefreshTokenError';
+    this.status = status;
+  }
+}
+
 export type { ApiStreamResponse as StreamResponse } from '@/types/stream.types';
 
 const trimTrailingSlash = (url: string): string => url.replace(/\/+$/, '');
@@ -40,7 +50,7 @@ let refreshingPromise: Promise<TokenResponse> | null = null;
 async function performTokenRefresh(baseURL: string): Promise<TokenResponse> {
   const refreshToken = authStorage.getRefreshToken();
   if (!refreshToken) {
-    throw new Error('No refresh token available');
+    throw new RefreshTokenError(401, 'No refresh token available');
   }
 
   const response = await fetch(`${baseURL}/auth/jwt/refresh`, {
@@ -50,8 +60,7 @@ async function performTokenRefresh(baseURL: string): Promise<TokenResponse> {
   });
 
   if (!response.ok) {
-    authStorage.clearAuth();
-    throw new Error('Token refresh failed');
+    throw new RefreshTokenError(response.status);
   }
 
   const data: TokenResponse = await response.json();
@@ -73,6 +82,13 @@ async function refreshTokenIfNeeded(baseURL: string): Promise<TokenResponse> {
   } finally {
     refreshingPromise = null;
   }
+}
+
+function shouldInvalidateSession(error: unknown): boolean {
+  if (!(error instanceof RefreshTokenError)) {
+    return false;
+  }
+  return error.status === 401 || error.status === 403;
 }
 
 const extractErrorMessage = async (response: Response): Promise<string> => {
@@ -146,10 +162,13 @@ class APIClient {
         try {
           await refreshTokenIfNeeded(this.baseURL);
           return this.request<T>(endpoint, method, options, additionalHeaders, true);
-        } catch {
-          authStorage.clearAuth();
-          window.location.href = '/login';
-          throw new Error('Session expired');
+        } catch (error) {
+          if (shouldInvalidateSession(error)) {
+            authStorage.clearAuth();
+            window.location.href = '/login';
+            throw new Error('Session expired');
+          }
+          throw error;
         }
       }
     }
@@ -194,10 +213,13 @@ class APIClient {
         try {
           await refreshTokenIfNeeded(this.baseURL);
           return this.getBlob(endpoint, signal, true);
-        } catch {
-          authStorage.clearAuth();
-          window.location.href = '/login';
-          throw new Error('Session expired');
+        } catch (error) {
+          if (shouldInvalidateSession(error)) {
+            authStorage.clearAuth();
+            window.location.href = '/login';
+            throw new Error('Session expired');
+          }
+          throw error;
         }
       }
     }

--- a/frontend/src/services/base/BaseService.ts
+++ b/frontend/src/services/base/BaseService.ts
@@ -139,7 +139,7 @@ export function buildQueryString(
 }
 
 function handleAuthError(): void {
-  authStorage.removeToken();
+  authStorage.clearAuth();
   window.location.href = '/login';
 }
 

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -73,10 +73,6 @@ export const authStorage = {
     cachedToken = token;
     safeSetItem('auth_token', token);
   },
-  removeToken: (): void => {
-    cachedToken = null;
-    safeRemoveItem('auth_token');
-  },
   getRefreshToken: (): string | null => {
     initTokenCache();
     return cachedRefreshToken;


### PR DESCRIPTION
## Summary
- Only invalidate session on 401/403 from token refresh, not on network errors or server failures
- Replace error-based logout trigger in `App.tsx` with token-presence check so transient API failures no longer log users out
- Introduce `RefreshTokenError` with status tracking to distinguish auth failures from network issues
- Use `clearAuth()` consistently in `handleAuthError` to clear both access and refresh tokens
- Remove unused `removeToken` from `authStorage`

## Test plan
- [ ] Verify normal login/logout flow still works
- [ ] Simulate a transient network error (e.g., disconnect briefly) and confirm user stays logged in
- [ ] Simulate a 500 from the API and confirm user stays logged in
- [ ] Verify that an expired refresh token (401 on refresh) correctly redirects to login
- [ ] Test multi-tab behavior — logout in one tab should still work