### PR TITLE
Refactor Chat and Input to composition patterns with context providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,10 @@
 - Run backend static checks (`ruff`, `mypy`) inside the Docker backend container (not on host)
 - Do not run `ruff` or `mypy` directly on the host machine
 - Use Docker-based commands such as `docker compose exec api pytest ...`
-- Use Docker-based commands such as `docker compose exec api ruff check ...` 
+- Use Docker-based commands such as `docker compose exec api ruff check ...`
+- Run frontend type checks via `docker compose exec frontend npx tsc --noEmit`
+- Run frontend lint via `docker compose exec frontend npx eslint src/`
+
 ## Code Style
 
 - Do not optimize for no regressions or long-term resilience unless explicitly requested — favor simple, direct changes over defensive scaffolding
@@ -62,6 +65,41 @@
 - Group related free functions into a class with static methods rather than leaving them as loose module-level functions (e.g., `StreamEnvelope.build()` + `StreamEnvelope.sanitize_payload()` instead of separate `build_envelope()` + `redact_for_audit()`)
 - Prefer one data structure over two when one can serve both purposes — don't add a second dict/set to handle an edge case that can be folded into the primary structure
 - Do not create multiple overlapping data containers for the same concept — if fields are shared across dataclasses, consolidate into one
+
+## Frontend Component Architecture
+
+### React Version
+- Project uses React 19 — use `use()` instead of `useContext()`, pass `ref` as a regular prop instead of `forwardRef`
+
+### Composition Patterns
+- Avoid boolean prop proliferation — don't add `isX`, `showX`, `hideX` boolean props to customize component behavior; use composition instead
+- When a component exceeds ~10 props or has 3+ boolean flags, refactor to a context provider + compound components
+- Use the `state / actions` context interface pattern: define a context with `{ state: StateType; actions: ActionsType }` so UI components consume a generic interface, not a specific implementation
+- Context definitions go in a separate `*Definition.ts` file (e.g., `ChatSessionContextDefinition.ts`), providers in a `*Context.tsx` or `*Provider.tsx` file, and consumer hooks in `hooks/use*.ts`
+- Consumer hooks must use React 19 `use()` and throw if context is null (see `useChatSessionContext.ts` pattern)
+- Provider values must be wrapped in `useMemo` to prevent unnecessary re-renders
+
+### Provider Pattern for Complex Components
+- When a component has extensive internal hook logic (file handling, suggestions, mutations), lift that logic into a dedicated `*Provider.tsx` that wraps children with context
+- The outer component keeps its prop-based API for backward compatibility, internally wrapping `<Provider {...props}><Layout /></Provider>`
+- Sub-components read from context via `use*Context()` hooks instead of receiving props from the parent
+- Reference implementations: `InputProvider.tsx` (wraps Input internals), `ChatSessionProvider` (wraps Chat session state), `FileTreeProvider` (wraps file tree state)
+
+### No Fallback Patterns in Context Interfaces
+- Context interface fields must not be optional (`?`) when the provider always supplies them — optional markers on always-provided fields are legacy shims
+- Do not add nullability guards (`value && doSomething()`) on context values that are guaranteed by the provider — these are leftover prop-era checks
+- Do not add `?? null` / `?? false` / `?? []` coercions in the provider unless the upstream source genuinely returns `undefined` and the context type requires a concrete value — if the types already match, pass directly
+
+### Existing Context Hierarchy
+- `ChatProvider` (`contexts/ChatContext.tsx`) — static chat metadata: `chatId`, `sandboxId`, `fileStructure`, `customAgents`, `customSlashCommands`, `customPrompts`
+- `ChatSessionProvider` (`contexts/ChatSessionContext.tsx`) — dynamic chat session state: messages, streaming, loading, permissions, input message, model selection
+- `InputProvider` (`components/chat/message-input/InputProvider.tsx`) — input-specific internal state: file handling, drag-and-drop, suggestions, enhancement, submit logic
+- `LayoutContext` (`components/layout/layoutState.tsx`) — sidebar state
+- `FileTreeProvider` (`components/editor/file-tree/FileTreeProvider.tsx`) — file tree selection and expansion state
+
+### Component Variants
+- Create explicit variant components instead of one component with many boolean modes (e.g., `ThreadComposer`, `EditComposer` instead of `<Composer isThread isEditing />`)
+- Use `children` for composing static structure; use render props only when the parent needs to pass data back to the child (e.g., `renderItem` in lists)
 
 ## Frontend UI/UX Guidelines
 

--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -19,80 +19,53 @@ import { LoadingIndicator } from './LoadingIndicator';
 import { ScrollButton } from './ScrollButton';
 import { ErrorMessage } from './ErrorMessage';
 import { Spinner } from '@/components/ui';
-import type { Message as MessageType, PermissionRequest } from '@/types';
 import { useStreamStore, useMessageQueueStore, EMPTY_QUEUE } from '@/store';
 import { ToolPermissionInline } from '@/components/chat/tools/ToolPermissionInline';
 import { useChatContext } from '@/hooks/useChatContext';
+import { useChatSessionContext } from '@/hooks/useChatSessionContext';
 
 const SCROLL_THRESHOLD_PERCENT = 20;
 
-export interface ChatProps {
-  messages: MessageType[];
-  pendingUserMessageId?: string | null;
-  copiedMessageId: string | null;
-  isLoading: boolean;
-  isStreaming: boolean;
-  isInitialLoading?: boolean;
-  error: Error | null;
-  onCopy: (content: string, id: string) => void;
-  inputMessage: string;
-  setInputMessage: (message: string) => void;
-  onMessageSend: (e: React.FormEvent) => void;
-  onStopStream: () => void;
-  onAttach?: (files: File[]) => void;
-  attachedFiles?: File[] | null;
-  selectedModelId: string;
-  onModelChange: (modelId: string) => void;
-  contextUsage?: {
-    tokensUsed: number;
-    contextWindow: number;
-  };
-  onDismissError?: () => void;
-  fetchNextPage?: () => void;
-  hasNextPage?: boolean;
-  isFetchingNextPage?: boolean;
-  onRestoreSuccess?: () => void;
-  pendingPermissionRequest?: PermissionRequest | null;
-  onPermissionApprove?: () => void;
-  onPermissionReject?: (alternativeInstruction?: string) => void;
-  isPermissionLoading?: boolean;
-  permissionError?: string | null;
-}
-
-export const Chat = memo(function Chat({
-  messages,
-  pendingUserMessageId = null,
-  copiedMessageId,
-  isLoading,
-  isStreaming,
-  isInitialLoading = false,
-  error,
-  onCopy,
-  inputMessage,
-  setInputMessage,
-  onMessageSend,
-  onStopStream,
-  onAttach,
-  attachedFiles,
-  selectedModelId,
-  onModelChange,
-  contextUsage,
-  onDismissError,
-  fetchNextPage,
-  hasNextPage,
-  isFetchingNextPage,
-  onRestoreSuccess,
-  pendingPermissionRequest,
-  onPermissionApprove,
-  onPermissionReject,
-  isPermissionLoading = false,
-  permissionError,
-}: ChatProps) {
+export const Chat = memo(function Chat() {
   const { chatId } = useChatContext();
+  const { state, actions } = useChatSessionContext();
+
+  const {
+    messages,
+    pendingUserMessageId,
+    copiedMessageId,
+    isLoading,
+    isStreaming,
+    isInitialLoading,
+    error,
+    attachedFiles,
+    selectedModelId,
+    contextUsage,
+    hasNextPage,
+    isFetchingNextPage,
+    pendingPermissionRequest,
+    isPermissionLoading,
+    permissionError,
+  } = state;
+
+  const {
+    setInputMessage,
+    onSubmit,
+    onStopStream,
+    onCopy,
+    onAttach,
+    onModelChange,
+    onDismissError,
+    fetchNextPage,
+    onRestoreSuccess,
+    onPermissionApprove,
+    onPermissionReject,
+  } = actions;
+
   const streamingMessageIds = useStreamStore(
-    useShallow((state) => {
+    useShallow((s) => {
       const ids: string[] = [];
-      state.activeStreams.forEach((stream) => {
+      s.activeStreams.forEach((stream) => {
         if (stream.chatId === chatId && stream.isActive) {
           ids.push(stream.messageId);
         }
@@ -101,18 +74,18 @@ export const Chat = memo(function Chat({
     }),
   );
 
-  const pendingMessages = useMessageQueueStore((state) =>
-    chatId ? (state.queues.get(chatId) ?? EMPTY_QUEUE) : EMPTY_QUEUE,
+  const pendingMessages = useMessageQueueStore((s) =>
+    chatId ? (s.queues.get(chatId) ?? EMPTY_QUEUE) : EMPTY_QUEUE,
   );
-  const updateQueuedMessage = useMessageQueueStore((state) => state.updateQueuedMessage);
-  const clearAndSync = useMessageQueueStore((state) => state.clearAndSync);
-  const fetchQueue = useMessageQueueStore((state) => state.fetchQueue);
+  const updateQueuedMessage = useMessageQueueStore((s) => s.updateQueuedMessage);
+  const clearAndSync = useMessageQueueStore((s) => s.clearAndSync);
+  const fetchQueueFn = useMessageQueueStore((s) => s.fetchQueue);
 
   useEffect(() => {
     if (chatId) {
-      void fetchQueue(chatId);
+      void fetchQueueFn(chatId);
     }
-  }, [chatId, fetchQueue]);
+  }, [chatId, fetchQueueFn]);
 
   const handleCancelPending = useCallback(() => {
     if (chatId) {
@@ -307,8 +280,6 @@ export const Chat = memo(function Chat({
 
   const canShowPermissionInline =
     pendingPermissionRequest &&
-    onPermissionApprove &&
-    onPermissionReject &&
     pendingPermissionRequest.tool_name !== 'AskUserQuestion' &&
     pendingPermissionRequest.tool_name !== 'ExitPlanMode';
   const lastBotMessage = lastBotMessageIndex >= 0 ? messages[lastBotMessageIndex] : undefined;
@@ -411,25 +382,22 @@ export const Chat = memo(function Chat({
                 </React.Fragment>
               );
             })}
-            {showPermissionAtEnd &&
-              pendingPermissionRequest &&
-              onPermissionApprove &&
-              onPermissionReject && (
-                <div className="px-4 sm:px-6">
-                  <div className="flex items-start gap-3 sm:gap-4">
-                    <div className="h-8 w-8 flex-shrink-0" />
-                    <div className="mb-3 mt-1 min-w-0 flex-1">
-                      <ToolPermissionInline
-                        request={pendingPermissionRequest}
-                        onApprove={onPermissionApprove}
-                        onReject={onPermissionReject}
-                        isLoading={isPermissionLoading}
-                        error={permissionError}
-                      />
-                    </div>
+            {showPermissionAtEnd && pendingPermissionRequest && (
+              <div className="px-4 sm:px-6">
+                <div className="flex items-start gap-3 sm:gap-4">
+                  <div className="h-8 w-8 flex-shrink-0" />
+                  <div className="mb-3 mt-1 min-w-0 flex-1">
+                    <ToolPermissionInline
+                      request={pendingPermissionRequest}
+                      onApprove={onPermissionApprove}
+                      onReject={onPermissionReject}
+                      isLoading={isPermissionLoading}
+                      error={permissionError}
+                    />
                   </div>
                 </div>
-              )}
+              </div>
+            )}
             {pendingMessages.map((pending) => (
               <PendingMessage
                 key={pending.id}
@@ -454,9 +422,9 @@ export const Chat = memo(function Chat({
         <div className="relative bg-surface pb-safe dark:bg-surface-dark">
           <div className="w-full py-2 lg:mx-auto lg:max-w-3xl">
             <Input
-              message={inputMessage}
+              message={state.inputMessage}
               setMessage={setInputMessage}
-              onSubmit={onMessageSend}
+              onSubmit={onSubmit}
               onAttach={onAttach}
               attachedFiles={attachedFiles}
               isLoading={isLoading}

--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -1,9 +1,6 @@
-import { useRef, memo, useState, useCallback, useEffect } from 'react';
+import { memo } from 'react';
 import { FileUploadDialog } from '@/components/ui/FileUploadDialog';
 import { DrawingModal } from '@/components/ui/DrawingModal';
-import { useDragAndDrop } from '@/hooks/useDragAndDrop';
-import { useFileHandling } from '@/hooks/useFileHandling';
-import { useInputFileOperations } from '@/hooks/useInputFileOperations';
 import { DropIndicator } from './DropIndicator';
 import { SendButton } from './SendButton';
 import { AttachButton } from './AttachButton';
@@ -11,13 +8,10 @@ import { Textarea } from './Textarea';
 import { InputControls } from './InputControls';
 import { InputAttachments } from './InputAttachments';
 import { InputSuggestionsPanel } from './InputSuggestionsPanel';
-import { useMessageQueueStore, useUIStore } from '@/store';
-import { ContextUsageIndicator, ContextUsageInfo } from './ContextUsageIndicator';
-import { useSlashCommandSuggestions } from '@/hooks/useSlashCommandSuggestions';
-import { useEnhancePromptMutation } from '@/hooks/queries';
-import { useMentionSuggestions } from '@/hooks/useMentionSuggestions';
-import type { MentionItem, SlashCommand } from '@/types';
-import { useChatContext } from '@/hooks/useChatContext';
+import { ContextUsageIndicator } from './ContextUsageIndicator';
+import { InputProvider } from './InputProvider';
+import { useInputContext } from '@/hooks/useInputContext';
+import type { ContextUsageInfo } from './ContextUsageIndicator';
 
 export interface InputProps {
   message: string;
@@ -40,320 +34,100 @@ export interface InputProps {
   showLoadingSpinner?: boolean;
 }
 
-export const Input = memo(function Input({
-  message,
-  setMessage,
-  onSubmit,
-  onAttach,
-  attachedFiles,
-  isLoading,
-  isStreaming = false,
-  onStopStream,
-  placeholder = 'Message Claudex...',
-  selectedModelId,
-  onModelChange,
-  dropdownPosition = 'top',
-  showAttachedFilesPreview = true,
-  contextUsage,
-  showTip = true,
-  compact = true,
-  chatId,
-  showLoadingSpinner = false,
-}: InputProps) {
-  const { fileStructure, customAgents, customSlashCommands, customPrompts } = useChatContext();
-  const formRef = useRef<HTMLFormElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [showPreview, setShowPreview] = useState(true);
-  const [cursorPosition, setCursorPosition] = useState(0);
-
-  const queueMessage = useMessageQueueStore((state) => state.queueMessage);
-  const permissionMode = useUIStore((state) => state.permissionMode);
-  const thinkingMode = useUIStore((state) => state.thinkingMode);
-  const clearAttachedFiles = onAttach;
-
-  const { previewUrls } = useFileHandling({
-    initialFiles: attachedFiles,
-  });
-
-  const {
-    showFileUpload,
-    setShowFileUpload,
-    showDrawingModal,
-    editingImageIndex,
-    handleFileSelect,
-    handleRemoveFile,
-    handleDrawClick,
-    handleDrawingSave,
-    handleDroppedFiles,
-    closeDrawingModal,
-  } = useInputFileOperations({
-    attachedFiles,
-    onAttach,
-  });
-
-  const { isDragging, dragHandlers, resetDragState } = useDragAndDrop({
-    onFilesDrop: handleDroppedFiles,
-  });
-
-  const focusTextarea = useCallback((text: string) => {
-    const textarea = textareaRef.current;
-    if (textarea) {
-      setTimeout(() => {
-        textarea.focus();
-        const length = text.length;
-        textarea.setSelectionRange(length, length);
-      }, 0);
-    }
-  }, []);
-
-  const enhancePromptMutation = useEnhancePromptMutation({
-    onSuccess: (enhancedPrompt) => {
-      setMessage(enhancedPrompt);
-      focusTextarea(enhancedPrompt);
-    },
-  });
-
-  const hasMessage = message.trim().length > 0;
-  const hasAttachments = (attachedFiles?.length ?? 0) > 0;
-  const isEnhancing = enhancePromptMutation.isPending;
-  const dynamicPlaceholder = isStreaming ? 'Type to queue message...' : placeholder;
-
-  const handleSlashCommandSelect = useCallback(
-    (command: SlashCommand) => {
-      setShowPreview(false);
-      const newMessage = `${command.value} `;
-      setMessage(newMessage);
-      focusTextarea(newMessage);
-    },
-    [setMessage, focusTextarea],
+export const Input = memo(function Input(props: InputProps) {
+  return (
+    <InputProvider {...props}>
+      <InputLayout />
+    </InputProvider>
   );
+});
 
-  const {
-    filteredCommands: slashCommandSuggestions,
-    highlightedIndex: highlightedSlashCommandIndex,
-    selectCommand: selectSlashCommand,
-    handleKeyDown: handleSlashCommandKeyDown,
-  } = useSlashCommandSuggestions({
-    message,
-    onSelect: handleSlashCommandSelect,
-    customSlashCommands,
-  });
+function InputLayout() {
+  const ctx = useInputContext();
 
-  const handleMentionSelect = useCallback(
-    (item: MentionItem, mentionStartPos: number, mentionEndPos: number) => {
-      const beforeMention = message.slice(0, mentionStartPos);
-      const afterMention = message.slice(mentionEndPos);
-      const newMessage = `${beforeMention}@${item.path} ${afterMention}`;
-      const newCursorPos = mentionStartPos + item.path.length + 2;
-
-      setMessage(newMessage);
-
-      setTimeout(() => {
-        if (textareaRef.current) {
-          textareaRef.current.setSelectionRange(newCursorPos, newCursorPos);
-          setCursorPosition(newCursorPos);
-        }
-      }, 0);
-    },
-    [message, setMessage],
-  );
-
-  const {
-    filteredFiles,
-    filteredAgents,
-    filteredPrompts,
-    highlightedIndex: highlightedMentionIndex,
-    selectItem: selectMention,
-    handleKeyDown: handleMentionKeyDown,
-    isActive: isMentionActive,
-  } = useMentionSuggestions({
-    message,
-    cursorPosition: cursorPosition,
-    fileStructure,
-    customAgents,
-    customPrompts,
-    onSelect: handleMentionSelect,
-  });
-
-  useEffect(() => {
-    setShowPreview(showAttachedFilesPreview && hasAttachments);
-  }, [hasAttachments, showAttachedFilesPreview]);
-
-  const handleSubmit = useCallback(
-    (event: React.FormEvent) => {
-      event.preventDefault();
-      if (!hasMessage) return;
-
-      setShowPreview(false);
-      onSubmit(event);
-    },
-    [hasMessage, onSubmit],
-  );
-
-  const submitOrStop = useCallback(() => {
-    if (isStreaming && !hasMessage) {
-      onStopStream?.();
-      return;
-    }
-
-    if (isStreaming && hasMessage && chatId) {
-      void queueMessage(
-        chatId,
-        message.trim(),
-        selectedModelId,
-        permissionMode,
-        thinkingMode,
-        attachedFiles ?? undefined,
-      );
-      setMessage('');
-      clearAttachedFiles?.([]);
-      setShowPreview(false);
-      return;
-    }
-
-    if (isLoading) {
-      onStopStream?.();
-      return;
-    }
-
-    if (!hasMessage) return;
-
-    setShowPreview(false);
-
-    const formElement = formRef.current;
-    if (formElement && typeof formElement.requestSubmit === 'function') {
-      formElement.requestSubmit();
-      return;
-    }
-
-    const formEvent = new Event('submit', {
-      bubbles: true,
-      cancelable: true,
-    }) as unknown as React.FormEvent;
-    onSubmit(formEvent);
-  }, [
-    hasMessage,
-    isLoading,
-    isStreaming,
-    onStopStream,
-    onSubmit,
-    chatId,
-    message,
-    attachedFiles,
-    queueMessage,
-    setMessage,
-    clearAttachedFiles,
-    selectedModelId,
-    permissionMode,
-    thinkingMode,
-  ]);
-
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<Element>) => {
-      const handledByMentions = handleMentionKeyDown(event);
-      if (handledByMentions) return;
-
-      const handledBySlashCommands = handleSlashCommandKeyDown(event);
-      if (handledBySlashCommands) return;
-
-      if (event.key === 'Enter' && !event.shiftKey) {
-        event.preventDefault();
-        submitOrStop();
-      }
-    },
-    [handleMentionKeyDown, handleSlashCommandKeyDown, submitOrStop],
-  );
-
-  const handleSendClick = (event: React.MouseEvent) => {
-    event.preventDefault();
-    submitOrStop();
-  };
-
-  const handleEnhancePrompt = useCallback(() => {
-    if (!hasMessage || isEnhancing) return;
-    enhancePromptMutation.mutate({ prompt: message.trim(), modelId: selectedModelId });
-  }, [hasMessage, isEnhancing, message, selectedModelId, enhancePromptMutation]);
-
-  const shouldShowAttachedPreview = showAttachedFilesPreview && hasAttachments && showPreview;
+  const shouldShowAttachedPreview =
+    ctx.hasAttachments && ctx.showPreview && ctx.attachedFiles && ctx.attachedFiles.length > 0;
 
   return (
-    <form ref={formRef} onSubmit={handleSubmit} className="relative px-4 sm:px-6">
+    <form ref={ctx.formRef} onSubmit={ctx.handleSubmit} className="relative px-4 sm:px-6">
       <div
-        {...dragHandlers}
+        {...ctx.dragHandlers}
         className={`relative rounded-2xl border bg-surface-secondary shadow-soft transition-all duration-300 dark:bg-surface-dark-secondary ${
-          isDragging
+          ctx.isDragging
             ? 'scale-[1.01] border-border-hover dark:border-border-dark-hover'
             : 'border-border dark:border-border-dark'
         }`}
       >
-        <DropIndicator visible={isDragging} fileType="any" message="Drop your files here" />
+        <DropIndicator visible={ctx.isDragging} fileType="any" message="Drop your files here" />
 
-        {shouldShowAttachedPreview && attachedFiles && (
+        {shouldShowAttachedPreview && (
           <InputAttachments
-            files={attachedFiles}
-            previewUrls={previewUrls}
-            onRemoveFile={handleRemoveFile}
-            onEditImage={handleDrawClick}
+            files={ctx.attachedFiles!}
+            previewUrls={ctx.previewUrls}
+            onRemoveFile={ctx.handleRemoveFile}
+            onEditImage={ctx.handleDrawClick}
           />
         )}
 
-        {contextUsage && (
+        {ctx.contextUsage && (
           <div className="absolute right-3 top-3 z-10">
-            <ContextUsageIndicator usage={contextUsage} />
+            <ContextUsageIndicator usage={ctx.contextUsage} />
           </div>
         )}
 
         <div className="relative px-3 pb-12 pt-1.5 sm:pb-9">
           <Textarea
-            ref={textareaRef}
-            message={message}
-            setMessage={setMessage}
-            placeholder={dynamicPlaceholder}
-            isLoading={isLoading}
-            onKeyDown={handleKeyDown}
-            onCursorPositionChange={(pos) => setCursorPosition(pos)}
-            compact={compact}
+            ref={ctx.textareaRef}
+            message={ctx.message}
+            setMessage={ctx.setMessage}
+            placeholder={ctx.placeholder}
+            isLoading={ctx.isLoading}
+            onKeyDown={ctx.handleKeyDown}
+            onCursorPositionChange={ctx.setCursorPosition}
+            compact={ctx.compact}
           />
           <InputSuggestionsPanel
-            isMentionActive={isMentionActive}
-            slashCommands={slashCommandSuggestions}
-            highlightedSlashIndex={highlightedSlashCommandIndex}
-            onSlashSelect={selectSlashCommand}
-            mentionFiles={filteredFiles}
-            mentionAgents={filteredAgents}
-            mentionPrompts={filteredPrompts}
-            highlightedMentionIndex={highlightedMentionIndex}
-            onMentionSelect={selectMention}
+            isMentionActive={ctx.isMentionActive}
+            slashCommands={ctx.slashCommandSuggestions}
+            highlightedSlashIndex={ctx.highlightedSlashCommandIndex}
+            onSlashSelect={ctx.selectSlashCommand}
+            mentionFiles={ctx.filteredFiles}
+            mentionAgents={ctx.filteredAgents}
+            mentionPrompts={ctx.filteredPrompts}
+            highlightedMentionIndex={ctx.highlightedMentionIndex}
+            onMentionSelect={ctx.selectMention}
           />
         </div>
 
         <div className="absolute bottom-0 left-0 right-0 px-3 py-2 pb-safe">
           <div className="relative flex items-center justify-between">
             <InputControls
-              selectedModelId={selectedModelId}
-              onModelChange={onModelChange}
-              onEnhance={handleEnhancePrompt}
-              dropdownPosition={dropdownPosition}
-              isLoading={isLoading}
-              isEnhancing={isEnhancing}
-              hasMessage={hasMessage}
+              selectedModelId={ctx.selectedModelId}
+              onModelChange={ctx.onModelChange}
+              onEnhance={ctx.handleEnhancePrompt}
+              dropdownPosition={ctx.dropdownPosition}
+              isLoading={ctx.isLoading}
+              isEnhancing={ctx.isEnhancing}
+              hasMessage={ctx.hasMessage}
             />
 
             <div className="absolute bottom-2.5 right-3 flex items-center gap-1">
               <AttachButton
                 onAttach={() => {
-                  resetDragState();
-                  setShowFileUpload(true);
+                  ctx.resetDragState();
+                  ctx.setShowFileUpload(true);
                 }}
               />
               <SendButton
-                isLoading={isLoading}
-                isStreaming={isStreaming}
-                disabled={(!isLoading && !isStreaming && !hasMessage) || isEnhancing}
-                onClick={handleSendClick}
+                isLoading={ctx.isLoading}
+                isStreaming={ctx.isStreaming}
+                disabled={
+                  (!ctx.isLoading && !ctx.isStreaming && !ctx.hasMessage) || ctx.isEnhancing
+                }
+                onClick={ctx.handleSendClick}
                 type="button"
-                hasMessage={hasMessage}
-                showLoadingSpinner={showLoadingSpinner}
+                hasMessage={ctx.hasMessage}
+                showLoadingSpinner={ctx.showLoadingSpinner}
               />
             </div>
           </div>
@@ -361,23 +135,23 @@ export const Input = memo(function Input({
       </div>
 
       <FileUploadDialog
-        isOpen={showFileUpload}
-        onClose={() => setShowFileUpload(false)}
-        onFileSelect={handleFileSelect}
+        isOpen={ctx.showFileUpload}
+        onClose={() => ctx.setShowFileUpload(false)}
+        onFileSelect={ctx.handleFileSelect}
       />
 
-      {editingImageIndex !== null &&
-        editingImageIndex < previewUrls.length &&
-        previewUrls[editingImageIndex] && (
+      {ctx.editingImageIndex !== null &&
+        ctx.editingImageIndex < ctx.previewUrls.length &&
+        ctx.previewUrls[ctx.editingImageIndex] && (
           <DrawingModal
-            imageUrl={previewUrls[editingImageIndex]}
-            isOpen={showDrawingModal}
-            onClose={closeDrawingModal}
-            onSave={handleDrawingSave}
+            imageUrl={ctx.previewUrls[ctx.editingImageIndex]}
+            isOpen={ctx.showDrawingModal}
+            onClose={ctx.closeDrawingModal}
+            onSave={ctx.handleDrawingSave}
           />
         )}
 
-      {showTip && !hasAttachments && (
+      {ctx.showTip && !ctx.hasAttachments && (
         <div className="mt-1 animate-fade-in text-center text-2xs text-text-quaternary dark:text-text-dark-tertiary">
           <span className="font-medium">Tip:</span> Drag and drop images, pdfs and xlsx files into
           the input area, type `/` for slash commands, or `@` to mention files, agents, and prompts
@@ -385,4 +159,4 @@ export const Input = memo(function Input({
       )}
     </form>
   );
-});
+}

--- a/frontend/src/components/chat/message-input/InputContext.ts
+++ b/frontend/src/components/chat/message-input/InputContext.ts
@@ -1,0 +1,57 @@
+import { createContext, type RefObject } from 'react';
+import type { MentionItem, SlashCommand } from '@/types';
+import type { ContextUsageInfo } from './ContextUsageIndicator';
+
+export interface InputContextValue {
+  message: string;
+  setMessage: (value: string) => void;
+  isLoading: boolean;
+  isStreaming: boolean;
+  chatId?: string;
+  placeholder: string;
+  compact: boolean;
+  formRef: RefObject<HTMLFormElement | null>;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  hasMessage: boolean;
+  hasAttachments: boolean;
+  isEnhancing: boolean;
+  handleSubmit: (e: React.FormEvent) => void;
+  submitOrStop: () => void;
+  handleKeyDown: (e: React.KeyboardEvent<Element>) => void;
+  handleSendClick: (e: React.MouseEvent) => void;
+  showLoadingSpinner: boolean;
+  selectedModelId: string;
+  onModelChange: (modelId: string) => void;
+  dropdownPosition: 'top' | 'bottom';
+  attachedFiles: File[] | null;
+  previewUrls: string[];
+  showPreview: boolean;
+  isDragging: boolean;
+  dragHandlers: Record<string, (e: React.DragEvent) => void>;
+  resetDragState: () => void;
+  showFileUpload: boolean;
+  setShowFileUpload: (v: boolean) => void;
+  showDrawingModal: boolean;
+  editingImageIndex: number | null;
+  handleFileSelect: (files: File[]) => void;
+  handleRemoveFile: (index: number) => void;
+  handleDrawClick: (index: number) => void;
+  handleDrawingSave: (dataUrl: string) => Promise<void>;
+  closeDrawingModal: () => void;
+  handleEnhancePrompt: () => void;
+  contextUsage?: ContextUsageInfo;
+  showTip: boolean;
+  cursorPosition: number;
+  setCursorPosition: (pos: number) => void;
+  slashCommandSuggestions: SlashCommand[];
+  highlightedSlashCommandIndex: number;
+  selectSlashCommand: (command: SlashCommand) => void;
+  isMentionActive: boolean;
+  filteredFiles: MentionItem[];
+  filteredAgents: MentionItem[];
+  filteredPrompts: MentionItem[];
+  highlightedMentionIndex: number;
+  selectMention: (item: MentionItem) => void;
+}
+
+export const InputContext = createContext<InputContextValue | null>(null);

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -1,0 +1,357 @@
+import { useRef, useState, useCallback, useEffect, useMemo, type ReactNode } from 'react';
+import { useDragAndDrop } from '@/hooks/useDragAndDrop';
+import { useFileHandling } from '@/hooks/useFileHandling';
+import { useInputFileOperations } from '@/hooks/useInputFileOperations';
+import { useSlashCommandSuggestions } from '@/hooks/useSlashCommandSuggestions';
+import { useEnhancePromptMutation } from '@/hooks/queries';
+import { useMentionSuggestions } from '@/hooks/useMentionSuggestions';
+import { useMessageQueueStore, useUIStore } from '@/store';
+import { useChatContext } from '@/hooks/useChatContext';
+import { InputContext } from './InputContext';
+import type { InputProps } from './Input';
+import type { MentionItem, SlashCommand } from '@/types';
+
+export function InputProvider({
+  message,
+  setMessage,
+  onSubmit,
+  onAttach,
+  attachedFiles = null,
+  isLoading,
+  isStreaming = false,
+  onStopStream,
+  placeholder = 'Message Claudex...',
+  selectedModelId,
+  onModelChange,
+  dropdownPosition = 'top',
+  showAttachedFilesPreview = true,
+  contextUsage,
+  showTip = true,
+  compact = true,
+  chatId,
+  showLoadingSpinner = false,
+  children,
+}: InputProps & { children: ReactNode }) {
+  const { fileStructure, customAgents, customSlashCommands, customPrompts } = useChatContext();
+  const formRef = useRef<HTMLFormElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [showPreview, setShowPreview] = useState(true);
+  const [cursorPosition, setCursorPosition] = useState(0);
+
+  const queueMessage = useMessageQueueStore((state) => state.queueMessage);
+  const permissionMode = useUIStore((state) => state.permissionMode);
+  const thinkingMode = useUIStore((state) => state.thinkingMode);
+  const clearAttachedFiles = onAttach;
+
+  const { previewUrls } = useFileHandling({
+    initialFiles: attachedFiles,
+  });
+
+  const {
+    showFileUpload,
+    setShowFileUpload,
+    showDrawingModal,
+    editingImageIndex,
+    handleFileSelect,
+    handleRemoveFile,
+    handleDrawClick,
+    handleDrawingSave,
+    handleDroppedFiles,
+    closeDrawingModal,
+  } = useInputFileOperations({
+    attachedFiles,
+    onAttach,
+  });
+
+  const { isDragging, dragHandlers, resetDragState } = useDragAndDrop({
+    onFilesDrop: handleDroppedFiles,
+  });
+
+  const focusTextarea = useCallback((text: string) => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      setTimeout(() => {
+        textarea.focus();
+        const length = text.length;
+        textarea.setSelectionRange(length, length);
+      }, 0);
+    }
+  }, []);
+
+  const enhancePromptMutation = useEnhancePromptMutation({
+    onSuccess: (enhancedPrompt) => {
+      setMessage(enhancedPrompt);
+      focusTextarea(enhancedPrompt);
+    },
+  });
+
+  const hasMessage = message.trim().length > 0;
+  const hasAttachments = (attachedFiles?.length ?? 0) > 0;
+  const isEnhancing = enhancePromptMutation.isPending;
+
+  const handleSlashCommandSelect = useCallback(
+    (command: SlashCommand) => {
+      setShowPreview(false);
+      const newMessage = `${command.value} `;
+      setMessage(newMessage);
+      focusTextarea(newMessage);
+    },
+    [setMessage, focusTextarea],
+  );
+
+  const {
+    filteredCommands: slashCommandSuggestions,
+    highlightedIndex: highlightedSlashCommandIndex,
+    selectCommand: selectSlashCommand,
+    handleKeyDown: handleSlashCommandKeyDown,
+  } = useSlashCommandSuggestions({
+    message,
+    onSelect: handleSlashCommandSelect,
+    customSlashCommands,
+  });
+
+  const handleMentionSelect = useCallback(
+    (item: MentionItem, mentionStartPos: number, mentionEndPos: number) => {
+      const beforeMention = message.slice(0, mentionStartPos);
+      const afterMention = message.slice(mentionEndPos);
+      const newMessage = `${beforeMention}@${item.path} ${afterMention}`;
+      const newCursorPos = mentionStartPos + item.path.length + 2;
+
+      setMessage(newMessage);
+
+      setTimeout(() => {
+        if (textareaRef.current) {
+          textareaRef.current.setSelectionRange(newCursorPos, newCursorPos);
+          setCursorPosition(newCursorPos);
+        }
+      }, 0);
+    },
+    [message, setMessage],
+  );
+
+  const {
+    filteredFiles,
+    filteredAgents,
+    filteredPrompts,
+    highlightedIndex: highlightedMentionIndex,
+    selectItem: selectMention,
+    handleKeyDown: handleMentionKeyDown,
+    isActive: isMentionActive,
+  } = useMentionSuggestions({
+    message,
+    cursorPosition: cursorPosition,
+    fileStructure,
+    customAgents,
+    customPrompts,
+    onSelect: handleMentionSelect,
+  });
+
+  useEffect(() => {
+    setShowPreview(showAttachedFilesPreview && hasAttachments);
+  }, [hasAttachments, showAttachedFilesPreview]);
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent) => {
+      event.preventDefault();
+      if (!hasMessage) return;
+
+      setShowPreview(false);
+      onSubmit(event);
+    },
+    [hasMessage, onSubmit],
+  );
+
+  const submitOrStop = useCallback(() => {
+    if (isStreaming && !hasMessage) {
+      onStopStream?.();
+      return;
+    }
+
+    if (isStreaming && hasMessage && chatId) {
+      void queueMessage(
+        chatId,
+        message.trim(),
+        selectedModelId,
+        permissionMode,
+        thinkingMode,
+        attachedFiles ?? undefined,
+      );
+      setMessage('');
+      clearAttachedFiles?.([]);
+      setShowPreview(false);
+      return;
+    }
+
+    if (isLoading) {
+      onStopStream?.();
+      return;
+    }
+
+    if (!hasMessage) return;
+
+    setShowPreview(false);
+
+    const formElement = formRef.current;
+    if (formElement && typeof formElement.requestSubmit === 'function') {
+      formElement.requestSubmit();
+      return;
+    }
+
+    const formEvent = new Event('submit', {
+      bubbles: true,
+      cancelable: true,
+    }) as unknown as React.FormEvent;
+    onSubmit(formEvent);
+  }, [
+    hasMessage,
+    isLoading,
+    isStreaming,
+    onStopStream,
+    onSubmit,
+    chatId,
+    message,
+    attachedFiles,
+    queueMessage,
+    setMessage,
+    clearAttachedFiles,
+    selectedModelId,
+    permissionMode,
+    thinkingMode,
+  ]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<Element>) => {
+      const handledByMentions = handleMentionKeyDown(event);
+      if (handledByMentions) return;
+
+      const handledBySlashCommands = handleSlashCommandKeyDown(event);
+      if (handledBySlashCommands) return;
+
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        submitOrStop();
+      }
+    },
+    [handleMentionKeyDown, handleSlashCommandKeyDown, submitOrStop],
+  );
+
+  const handleSendClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      submitOrStop();
+    },
+    [submitOrStop],
+  );
+
+  const handleEnhancePrompt = useCallback(() => {
+    if (!hasMessage || isEnhancing) return;
+    enhancePromptMutation.mutate({ prompt: message.trim(), modelId: selectedModelId });
+  }, [hasMessage, isEnhancing, message, selectedModelId, enhancePromptMutation]);
+
+  const dynamicPlaceholder = isStreaming ? 'Type to queue message...' : placeholder;
+
+  const value = useMemo(
+    () => ({
+      message,
+      setMessage,
+      isLoading,
+      isStreaming,
+      chatId,
+      placeholder: dynamicPlaceholder,
+      compact,
+      formRef,
+      textareaRef,
+      hasMessage,
+      hasAttachments,
+      isEnhancing,
+      handleSubmit,
+      submitOrStop,
+      handleKeyDown,
+      handleSendClick,
+      showLoadingSpinner,
+      selectedModelId,
+      onModelChange,
+      dropdownPosition,
+      attachedFiles,
+      previewUrls,
+      showPreview,
+      isDragging,
+      dragHandlers,
+      resetDragState,
+      showFileUpload,
+      setShowFileUpload,
+      showDrawingModal,
+      editingImageIndex,
+      handleFileSelect,
+      handleRemoveFile,
+      handleDrawClick,
+      handleDrawingSave,
+      closeDrawingModal,
+      handleEnhancePrompt,
+      contextUsage,
+      showTip,
+      cursorPosition,
+      setCursorPosition,
+      slashCommandSuggestions,
+      highlightedSlashCommandIndex,
+      selectSlashCommand,
+      isMentionActive,
+      filteredFiles,
+      filteredAgents,
+      filteredPrompts,
+      highlightedMentionIndex,
+      selectMention,
+    }),
+    [
+      message,
+      setMessage,
+      isLoading,
+      isStreaming,
+      chatId,
+      dynamicPlaceholder,
+      compact,
+      hasMessage,
+      hasAttachments,
+      isEnhancing,
+      handleSubmit,
+      submitOrStop,
+      handleKeyDown,
+      handleSendClick,
+      showLoadingSpinner,
+      selectedModelId,
+      onModelChange,
+      dropdownPosition,
+      attachedFiles,
+      previewUrls,
+      showPreview,
+      isDragging,
+      dragHandlers,
+      resetDragState,
+      showFileUpload,
+      setShowFileUpload,
+      showDrawingModal,
+      editingImageIndex,
+      handleFileSelect,
+      handleRemoveFile,
+      handleDrawClick,
+      handleDrawingSave,
+      closeDrawingModal,
+      handleEnhancePrompt,
+      contextUsage,
+      showTip,
+      cursorPosition,
+      setCursorPosition,
+      slashCommandSuggestions,
+      highlightedSlashCommandIndex,
+      selectSlashCommand,
+      isMentionActive,
+      filteredFiles,
+      filteredAgents,
+      filteredPrompts,
+      highlightedMentionIndex,
+      selectMention,
+    ],
+  );
+
+  return <InputContext.Provider value={value}>{children}</InputContext.Provider>;
+}

--- a/frontend/src/contexts/ChatSessionContext.tsx
+++ b/frontend/src/contexts/ChatSessionContext.tsx
@@ -1,0 +1,17 @@
+import { type ReactNode, useMemo } from 'react';
+import {
+  ChatSessionContext,
+  type ChatSessionState,
+  type ChatSessionActions,
+} from './ChatSessionContextDefinition';
+
+interface ChatSessionProviderProps {
+  state: ChatSessionState;
+  actions: ChatSessionActions;
+  children: ReactNode;
+}
+
+export function ChatSessionProvider({ state, actions, children }: ChatSessionProviderProps) {
+  const value = useMemo(() => ({ state, actions }), [state, actions]);
+  return <ChatSessionContext.Provider value={value}>{children}</ChatSessionContext.Provider>;
+}

--- a/frontend/src/contexts/ChatSessionContextDefinition.ts
+++ b/frontend/src/contexts/ChatSessionContextDefinition.ts
@@ -1,0 +1,43 @@
+import { createContext } from 'react';
+import type { Message, PermissionRequest } from '@/types';
+import type { ContextUsageInfo } from '@/components/chat/message-input/ContextUsageIndicator';
+
+export interface ChatSessionState {
+  messages: Message[];
+  inputMessage: string;
+  isLoading: boolean;
+  isStreaming: boolean;
+  isInitialLoading: boolean;
+  error: Error | null;
+  copiedMessageId: string | null;
+  pendingUserMessageId: string | null;
+  attachedFiles: File[] | null;
+  selectedModelId: string;
+  contextUsage?: ContextUsageInfo;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  pendingPermissionRequest: PermissionRequest | null;
+  isPermissionLoading: boolean;
+  permissionError: string | null;
+}
+
+export interface ChatSessionActions {
+  setInputMessage: (msg: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  onStopStream: () => void;
+  onCopy: (content: string, id: string) => void;
+  onAttach: (files: File[]) => void;
+  onModelChange: (modelId: string) => void;
+  onDismissError: () => void;
+  fetchNextPage: () => void;
+  onRestoreSuccess: () => void;
+  onPermissionApprove: () => void;
+  onPermissionReject: (alternativeInstruction?: string) => void;
+}
+
+export interface ChatSessionContextValue {
+  state: ChatSessionState;
+  actions: ChatSessionActions;
+}
+
+export const ChatSessionContext = createContext<ChatSessionContextValue | null>(null);

--- a/frontend/src/hooks/useChatSessionContext.ts
+++ b/frontend/src/hooks/useChatSessionContext.ts
@@ -1,0 +1,10 @@
+import { use } from 'react';
+import { ChatSessionContext } from '@/contexts/ChatSessionContextDefinition';
+
+export function useChatSessionContext() {
+  const context = use(ChatSessionContext);
+  if (!context) {
+    throw new Error('useChatSessionContext must be used within a ChatSessionProvider');
+  }
+  return context;
+}

--- a/frontend/src/hooks/useInputContext.ts
+++ b/frontend/src/hooks/useInputContext.ts
@@ -1,0 +1,10 @@
+import { use } from 'react';
+import { InputContext } from '@/components/chat/message-input/InputContext';
+
+export function useInputContext() {
+  const context = use(InputContext);
+  if (!context) {
+    throw new Error('useInputContext must be used within an InputProvider');
+  }
+  return context;
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -20,6 +20,8 @@ import { useContextUsageState } from '@/hooks/useContextUsageState';
 import { useSettingsQuery, useModelSelection } from '@/hooks/queries';
 import { mergeAgents } from '@/utils/settings';
 import { ChatProvider } from '@/contexts/ChatContext';
+import { ChatSessionProvider } from '@/contexts/ChatSessionContext';
+import type { ChatSessionState, ChatSessionActions } from '@/contexts/ChatSessionContextDefinition';
 
 const Editor = lazy(() =>
   import('@/components/editor/editor-core/Editor').then((m) => ({ default: m.Editor })),
@@ -274,40 +276,82 @@ export function ChatPage() {
 
   useLayoutSidebar(sidebarContent);
 
+  const chatSessionState = useMemo<ChatSessionState>(
+    () => ({
+      messages,
+      inputMessage: streamingState.inputMessage,
+      isLoading,
+      isStreaming,
+      isInitialLoading: messagesQuery.isLoading,
+      error,
+      copiedMessageId: streamingState.copiedMessageId,
+      pendingUserMessageId: streamingState.pendingUserMessageId ?? null,
+      attachedFiles: streamingState.inputFiles ?? null,
+      selectedModelId,
+      contextUsage,
+      hasNextPage: messagesQuery.hasNextPage ?? false,
+      isFetchingNextPage: messagesQuery.isFetchingNextPage ?? false,
+      pendingPermissionRequest: pendingRequest ?? null,
+      isPermissionLoading,
+      permissionError: permissionError ?? null,
+    }),
+    [
+      messages,
+      streamingState.inputMessage,
+      streamingState.copiedMessageId,
+      streamingState.pendingUserMessageId,
+      streamingState.inputFiles,
+      isLoading,
+      isStreaming,
+      messagesQuery.isLoading,
+      messagesQuery.hasNextPage,
+      messagesQuery.isFetchingNextPage,
+      error,
+      selectedModelId,
+      contextUsage,
+      pendingRequest,
+      isPermissionLoading,
+      permissionError,
+    ],
+  );
+
+  const chatSessionActions = useMemo<ChatSessionActions>(
+    () => ({
+      setInputMessage: streamingState.setInputMessage,
+      onSubmit: streamingState.handleMessageSend,
+      onStopStream: streamingState.handleStop,
+      onCopy: streamingState.handleCopy,
+      onAttach: streamingState.setInputFiles,
+      onModelChange: selectModel,
+      onDismissError: streamingState.handleDismissError,
+      fetchNextPage: messagesQuery.fetchNextPage,
+      onRestoreSuccess: handleRestoreSuccess,
+      onPermissionApprove: handleApprove,
+      onPermissionReject: handleReject,
+    }),
+    [
+      streamingState.setInputMessage,
+      streamingState.handleMessageSend,
+      streamingState.handleStop,
+      streamingState.handleCopy,
+      streamingState.setInputFiles,
+      streamingState.handleDismissError,
+      selectModel,
+      messagesQuery.fetchNextPage,
+      handleRestoreSuccess,
+      handleApprove,
+      handleReject,
+    ],
+  );
+
   const renderNonTerminalView = useCallback(
     (view: ViewType): ReactNode => {
       switch (view) {
         case 'agent':
           return (
-            <ChatComponent
-              messages={messages}
-              pendingUserMessageId={streamingState.pendingUserMessageId}
-              copiedMessageId={streamingState.copiedMessageId}
-              isLoading={isLoading}
-              isStreaming={isStreaming}
-              isInitialLoading={messagesQuery.isLoading}
-              error={error}
-              onCopy={streamingState.handleCopy}
-              inputMessage={streamingState.inputMessage}
-              setInputMessage={streamingState.setInputMessage}
-              onMessageSend={streamingState.handleMessageSend}
-              onStopStream={streamingState.handleStop}
-              onAttach={streamingState.setInputFiles}
-              selectedModelId={selectedModelId}
-              onModelChange={selectModel}
-              attachedFiles={streamingState.inputFiles}
-              contextUsage={contextUsage}
-              onDismissError={streamingState.handleDismissError}
-              fetchNextPage={messagesQuery.fetchNextPage}
-              hasNextPage={messagesQuery.hasNextPage}
-              isFetchingNextPage={messagesQuery.isFetchingNextPage}
-              onRestoreSuccess={handleRestoreSuccess}
-              pendingPermissionRequest={pendingRequest}
-              onPermissionApprove={handleApprove}
-              onPermissionReject={handleReject}
-              isPermissionLoading={isPermissionLoading}
-              permissionError={permissionError}
-            />
+            <ChatSessionProvider state={chatSessionState} actions={chatSessionActions}>
+              <ChatComponent />
+            </ChatSessionProvider>
           );
         case 'editor':
           return (
@@ -360,29 +404,16 @@ export function ChatPage() {
       }
     },
     [
-      messages,
-      streamingState,
-      isLoading,
-      isStreaming,
-      messagesQuery,
-      error,
-      selectedModelId,
-      selectModel,
-      contextUsage,
+      chatSessionState,
+      chatSessionActions,
       currentChat,
       chatId,
-      handleRestoreSuccess,
       fileStructure,
       selectedFile,
       handleFileSelect,
       isFileMetadataLoading,
       handleRefresh,
       isRefreshing,
-      pendingRequest,
-      handleApprove,
-      handleReject,
-      isPermissionLoading,
-      permissionError,
     ],
   );
 


### PR DESCRIPTION
Lift prop-drilled state into ChatSessionContext and InputContext providers, eliminating boolean prop proliferation in Chat (28→0 props) and Input (18 props preserved externally, internals moved to InputProvider). 
Update CLAUDE.md with frontend composition architecture guidelines.