### PR TITLE
Decompose ChatPage and SettingsPage mega-components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { useEffect, useState, Suspense, lazy } from 'react';
+import { useEffect, useMemo, useState, Suspense, lazy } from 'react';
 import { Layout } from '@/components/layout/Layout';
 import { Toaster } from 'react-hot-toast';
 import { useAuthStore } from '@/store/authStore';
@@ -53,7 +53,10 @@ function AppContent() {
     enabled: isAuthenticated,
   });
 
-  const allChats = chatsData?.pages.flatMap((page) => page.items) ?? [];
+  const allChats = useMemo(
+    () => chatsData?.pages.flatMap((page) => page.items) ?? [],
+    [chatsData?.pages],
+  );
 
   useStreamRestoration({
     chats: allChats,

--- a/frontend/src/components/chat/ChatSessionOrchestrator.tsx
+++ b/frontend/src/components/chat/ChatSessionOrchestrator.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useMemo, useCallback, type ReactNode } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useQueryClient } from '@tanstack/react-query';
+import { ChatSessionProvider } from '@/contexts/ChatSessionContext';
+import { ChatInputMessageProvider } from '@/contexts/ChatInputMessageContext';
+import type { ChatSessionState, ChatSessionActions } from '@/contexts/ChatSessionContextDefinition';
+import { useChatStore } from '@/store/chatStore';
+import { useUIStore } from '@/store/uiStore';
+import { useChatStreaming } from '@/hooks/useChatStreaming';
+import { usePermissionRequest } from '@/hooks/usePermissionRequest';
+import { useInitialPrompt } from '@/hooks/useInitialPrompt';
+import { useContextUsageState } from '@/hooks/useContextUsageState';
+import { useMessageInitialization } from '@/hooks/useMessageInitialization';
+import { useModelSelection } from '@/hooks/queries/useModelQueries';
+import type { Chat, Message } from '@/types/chat.types';
+import type { useInfiniteMessagesQuery } from '@/hooks/queries/useChatQueries';
+
+interface ChatSessionOrchestratorProps {
+  chatId: string;
+  currentChat: Chat | undefined;
+  fetchedMessages: Message[];
+  hasFetchedMessages: boolean;
+  messagesQuery: ReturnType<typeof useInfiniteMessagesQuery>;
+  refetchFilesMetadata: () => Promise<unknown>;
+  selectedModelId: string;
+  children: ReactNode;
+}
+
+export function ChatSessionOrchestrator({
+  chatId,
+  currentChat,
+  fetchedMessages,
+  hasFetchedMessages,
+  messagesQuery,
+  refetchFilesMetadata,
+  selectedModelId,
+  children,
+}: ChatSessionOrchestratorProps) {
+  const queryClient = useQueryClient();
+
+  const { attachedFiles, setAttachedFiles } = useChatStore(
+    useShallow((state) => ({
+      attachedFiles: state.attachedFiles,
+      setAttachedFiles: state.setAttachedFiles,
+    })),
+  );
+
+  const { permissionMode, thinkingMode } = useUIStore(
+    useShallow((state) => ({
+      permissionMode: state.permissionMode,
+      thinkingMode: state.thinkingMode,
+    })),
+  );
+
+  const { selectModel } = useModelSelection();
+
+  const {
+    initialPrompt,
+    setInitialPrompt,
+    initialPromptSent,
+    setInitialPromptSent,
+    initialPromptFromRoute,
+  } = useInitialPrompt();
+
+  const { contextUsage, updateContextUsage } = useContextUsageState(chatId, currentChat);
+
+  const {
+    pendingRequest,
+    isLoading: isPermissionLoading,
+    error: permissionError,
+    handlePermissionRequest,
+    handleApprove,
+    handleReject,
+  } = usePermissionRequest(chatId);
+
+  const streamingState = useChatStreaming({
+    chatId,
+    currentChat,
+    fetchedMessages,
+    hasFetchedMessages,
+    isInitialLoading: messagesQuery.isLoading,
+    queryClient,
+    refetchFilesMetadata,
+    onContextUsageUpdate: updateContextUsage,
+    selectedModelId,
+    permissionMode,
+    thinkingMode,
+    onPermissionRequest: handlePermissionRequest,
+  });
+
+  const {
+    messages,
+    sendMessage,
+    isLoading,
+    isStreaming,
+    error,
+    wasAborted,
+    setWasAborted,
+    setMessages,
+  } = streamingState;
+
+  useMessageInitialization({
+    fetchedMessages,
+    chatId,
+    selectedModelId,
+    hasMessages: messages.length > 0,
+    initialPromptFromRoute,
+    initialPromptSent,
+    wasAborted,
+    attachedFiles,
+    isLoading,
+    isStreaming,
+    setMessages,
+    setInitialPrompt,
+  });
+
+  useEffect(() => {
+    if (
+      initialPrompt &&
+      messages.length === 1 &&
+      !isLoading &&
+      !isStreaming &&
+      !initialPromptSent &&
+      !error &&
+      !messagesQuery.isLoading &&
+      !hasFetchedMessages
+    ) {
+      const userMessage = messages[0];
+      sendMessage(initialPrompt, chatId, userMessage, attachedFiles);
+      setInitialPromptSent(true);
+      setAttachedFiles([]);
+    }
+  }, [
+    initialPrompt,
+    messages,
+    messages.length,
+    isLoading,
+    isStreaming,
+    sendMessage,
+    chatId,
+    initialPromptSent,
+    error,
+    setAttachedFiles,
+    messagesQuery.isLoading,
+    hasFetchedMessages,
+    attachedFiles,
+    setInitialPromptSent,
+  ]);
+
+  useEffect(() => {
+    setInitialPromptSent(false);
+  }, [chatId, setInitialPromptSent]);
+
+  const handleRestoreSuccess = useCallback(() => {
+    setWasAborted(false);
+    messagesQuery.refetch();
+    if (currentChat?.sandbox_id) {
+      refetchFilesMetadata();
+    }
+  }, [setWasAborted, messagesQuery, currentChat?.sandbox_id, refetchFilesMetadata]);
+
+  const chatSessionState = useMemo<ChatSessionState>(
+    () => ({
+      messages,
+      isLoading,
+      isStreaming,
+      isInitialLoading: messagesQuery.isLoading,
+      error,
+      copiedMessageId: streamingState.copiedMessageId,
+      pendingUserMessageId: streamingState.pendingUserMessageId ?? null,
+      attachedFiles: streamingState.inputFiles ?? null,
+      selectedModelId,
+      contextUsage,
+      hasNextPage: messagesQuery.hasNextPage ?? false,
+      isFetchingNextPage: messagesQuery.isFetchingNextPage ?? false,
+      pendingPermissionRequest: pendingRequest ?? null,
+      isPermissionLoading,
+      permissionError: permissionError ?? null,
+    }),
+    [
+      messages,
+      streamingState.copiedMessageId,
+      streamingState.pendingUserMessageId,
+      streamingState.inputFiles,
+      isLoading,
+      isStreaming,
+      messagesQuery.isLoading,
+      messagesQuery.hasNextPage,
+      messagesQuery.isFetchingNextPage,
+      error,
+      selectedModelId,
+      contextUsage,
+      pendingRequest,
+      isPermissionLoading,
+      permissionError,
+    ],
+  );
+
+  const chatSessionActions = useMemo<ChatSessionActions>(
+    () => ({
+      onSubmit: streamingState.handleMessageSend,
+      onStopStream: streamingState.handleStop,
+      onCopy: streamingState.handleCopy,
+      onAttach: streamingState.setInputFiles,
+      onModelChange: selectModel,
+      onDismissError: streamingState.handleDismissError,
+      fetchNextPage: messagesQuery.fetchNextPage,
+      onRestoreSuccess: handleRestoreSuccess,
+      onPermissionApprove: handleApprove,
+      onPermissionReject: handleReject,
+    }),
+    [
+      streamingState.handleMessageSend,
+      streamingState.handleStop,
+      streamingState.handleCopy,
+      streamingState.setInputFiles,
+      streamingState.handleDismissError,
+      selectModel,
+      messagesQuery.fetchNextPage,
+      handleRestoreSuccess,
+      handleApprove,
+      handleReject,
+    ],
+  );
+
+  return (
+    <ChatSessionProvider state={chatSessionState} actions={chatSessionActions}>
+      <ChatInputMessageProvider
+        inputMessage={streamingState.inputMessage}
+        setInputMessage={streamingState.setInputMessage}
+      >
+        {children}
+      </ChatInputMessageProvider>
+    </ChatSessionProvider>
+  );
+}

--- a/frontend/src/components/settings/sections/AgentsSection.tsx
+++ b/frontend/src/components/settings/sections/AgentsSection.tsx
@@ -1,0 +1,70 @@
+import { Suspense, lazy } from 'react';
+import { FileText } from 'lucide-react';
+import { useSettingsContext } from '@/hooks/useSettingsContext';
+import { useFileResourceManagement } from '@/hooks/useFileResourceManagement';
+import { agentService } from '@/services/agentService';
+import { SettingsUploadModal } from '@/components/ui/SettingsUploadModal';
+
+const AgentsSettingsTab = lazy(() =>
+  import('@/components/settings/tabs/AgentsSettingsTab').then((m) => ({
+    default: m.AgentsSettingsTab,
+  })),
+);
+const AgentEditDialog = lazy(() =>
+  import('@/components/settings/dialogs/AgentEditDialog').then((m) => ({
+    default: m.AgentEditDialog,
+  })),
+);
+
+export function AgentsSection() {
+  const { localSettings, persistSettings, setLocalSettings } = useSettingsContext();
+
+  const agentManagement = useFileResourceManagement(
+    localSettings,
+    persistSettings,
+    setLocalSettings,
+    {
+      settingsKey: 'custom_agents',
+      itemName: 'Agent',
+      maxItems: 10,
+      uploadFn: agentService.uploadAgent,
+      deleteFn: agentService.deleteAgent,
+      updateFn: agentService.updateAgent,
+    },
+  );
+
+  return (
+    <>
+      <AgentsSettingsTab
+        agents={localSettings.custom_agents ?? null}
+        onAddAgent={agentManagement.handleAdd}
+        onEditAgent={agentManagement.handleEdit}
+        onDeleteAgent={agentManagement.handleDelete}
+        onToggleAgent={agentManagement.handleToggle}
+      />
+      <SettingsUploadModal
+        isOpen={agentManagement.isDialogOpen}
+        error={agentManagement.uploadError}
+        uploading={agentManagement.isUploading}
+        onClose={agentManagement.handleDialogClose}
+        onUpload={agentManagement.handleUpload}
+        title="Upload Agent"
+        acceptedExtension=".md"
+        icon={FileText}
+        hintText="The .md file must include YAML frontmatter with name and description fields. Optional fields: model, allowed_tools."
+      />
+      {agentManagement.isEditDialogOpen && (
+        <Suspense fallback={null}>
+          <AgentEditDialog
+            isOpen={agentManagement.isEditDialogOpen}
+            agent={agentManagement.editingItem}
+            error={agentManagement.editError}
+            saving={agentManagement.isSavingEdit}
+            onClose={agentManagement.handleEditDialogClose}
+            onSave={agentManagement.handleSaveEdit}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/settings/sections/CommandsSection.tsx
+++ b/frontend/src/components/settings/sections/CommandsSection.tsx
@@ -1,0 +1,70 @@
+import { Suspense, lazy } from 'react';
+import { FileText } from 'lucide-react';
+import { useSettingsContext } from '@/hooks/useSettingsContext';
+import { useFileResourceManagement } from '@/hooks/useFileResourceManagement';
+import { commandService } from '@/services/commandService';
+import { SettingsUploadModal } from '@/components/ui/SettingsUploadModal';
+
+const CommandsSettingsTab = lazy(() =>
+  import('@/components/settings/tabs/CommandsSettingsTab').then((m) => ({
+    default: m.CommandsSettingsTab,
+  })),
+);
+const CommandEditDialog = lazy(() =>
+  import('@/components/settings/dialogs/CommandEditDialog').then((m) => ({
+    default: m.CommandEditDialog,
+  })),
+);
+
+export function CommandsSection() {
+  const { localSettings, persistSettings, setLocalSettings } = useSettingsContext();
+
+  const commandManagement = useFileResourceManagement(
+    localSettings,
+    persistSettings,
+    setLocalSettings,
+    {
+      settingsKey: 'custom_slash_commands',
+      itemName: 'Command',
+      maxItems: 10,
+      uploadFn: commandService.uploadCommand,
+      deleteFn: commandService.deleteCommand,
+      updateFn: commandService.updateCommand,
+    },
+  );
+
+  return (
+    <>
+      <CommandsSettingsTab
+        commands={localSettings.custom_slash_commands ?? null}
+        onAddCommand={commandManagement.handleAdd}
+        onEditCommand={commandManagement.handleEdit}
+        onDeleteCommand={commandManagement.handleDelete}
+        onToggleCommand={commandManagement.handleToggle}
+      />
+      <SettingsUploadModal
+        isOpen={commandManagement.isDialogOpen}
+        error={commandManagement.uploadError}
+        uploading={commandManagement.isUploading}
+        onClose={commandManagement.handleDialogClose}
+        onUpload={commandManagement.handleUpload}
+        title="Upload Slash Command"
+        acceptedExtension=".md"
+        icon={FileText}
+        hintText="The .md file must include YAML frontmatter with name and description fields. Optional fields: argument-hint, allowed-tools, model."
+      />
+      {commandManagement.isEditDialogOpen && (
+        <Suspense fallback={null}>
+          <CommandEditDialog
+            isOpen={commandManagement.isEditDialogOpen}
+            command={commandManagement.editingItem}
+            error={commandManagement.editError}
+            saving={commandManagement.isSavingEdit}
+            onClose={commandManagement.handleEditDialogClose}
+            onSave={commandManagement.handleSaveEdit}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/settings/sections/EnvVarsSection.tsx
+++ b/frontend/src/components/settings/sections/EnvVarsSection.tsx
@@ -1,0 +1,49 @@
+import { Suspense, lazy } from 'react';
+import { useSettingsContext } from '@/hooks/useSettingsContext';
+import { useCrudForm } from '@/hooks/useCrudForm';
+import { createDefaultEnvVarForm, validateEnvVarForm } from '@/utils/settings';
+
+const EnvVarsSettingsTab = lazy(() =>
+  import('@/components/settings/tabs/EnvVarsSettingsTab').then((m) => ({
+    default: m.EnvVarsSettingsTab,
+  })),
+);
+const EnvVarDialog = lazy(() =>
+  import('@/components/settings/dialogs/EnvVarDialog').then((m) => ({ default: m.EnvVarDialog })),
+);
+
+export function EnvVarsSection() {
+  const { localSettings, persistSettings, setLocalSettings } = useSettingsContext();
+
+  const envVarCrud = useCrudForm(localSettings, persistSettings, setLocalSettings, {
+    createDefault: createDefaultEnvVarForm,
+    validateForm: (form, editingIndex) =>
+      validateEnvVarForm(form, editingIndex, localSettings.custom_env_vars || []),
+    getArrayKey: 'custom_env_vars',
+    itemName: 'environment variable',
+  });
+
+  return (
+    <>
+      <EnvVarsSettingsTab
+        envVars={localSettings.custom_env_vars ?? null}
+        onAddEnvVar={envVarCrud.handleAdd}
+        onEditEnvVar={envVarCrud.handleEdit}
+        onDeleteEnvVar={envVarCrud.handleDelete}
+      />
+      {envVarCrud.isDialogOpen && (
+        <Suspense fallback={null}>
+          <EnvVarDialog
+            isOpen={envVarCrud.isDialogOpen}
+            isEditing={envVarCrud.editingIndex !== null}
+            envVar={envVarCrud.form}
+            error={envVarCrud.formError}
+            onClose={envVarCrud.handleDialogClose}
+            onSubmit={envVarCrud.handleSave}
+            onEnvVarChange={envVarCrud.handleFormChange}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/settings/sections/McpSection.tsx
+++ b/frontend/src/components/settings/sections/McpSection.tsx
@@ -1,0 +1,55 @@
+import { Suspense, lazy } from 'react';
+import { useSettingsContext } from '@/hooks/useSettingsContext';
+import { useCrudForm } from '@/hooks/useCrudForm';
+import { mcpService } from '@/services/mcpService';
+import { createDefaultMcpForm, validateMcpForm } from '@/utils/settings';
+
+const McpSettingsTab = lazy(() =>
+  import('@/components/settings/tabs/McpSettingsTab').then((m) => ({
+    default: m.McpSettingsTab,
+  })),
+);
+const McpDialog = lazy(() =>
+  import('@/components/settings/dialogs/McpDialog').then((m) => ({ default: m.McpDialog })),
+);
+
+export function McpSection() {
+  const { localSettings, persistSettings, setLocalSettings } = useSettingsContext();
+
+  const mcpCrud = useCrudForm(localSettings, persistSettings, setLocalSettings, {
+    createDefault: createDefaultMcpForm,
+    validateForm: (form, editingIndex) =>
+      validateMcpForm(form, editingIndex, localSettings.custom_mcps || []),
+    getArrayKey: 'custom_mcps',
+    itemName: 'MCP',
+    createFn: mcpService.createMcp,
+    updateFn: mcpService.updateMcp,
+    deleteFn: mcpService.deleteMcp,
+    toggleFn: (name, enabled) => mcpService.updateMcp(name, { enabled }),
+  });
+
+  return (
+    <>
+      <McpSettingsTab
+        mcps={localSettings.custom_mcps ?? null}
+        onAddMcp={mcpCrud.handleAdd}
+        onEditMcp={mcpCrud.handleEdit}
+        onDeleteMcp={mcpCrud.handleDelete}
+        onToggleMcp={mcpCrud.handleToggleEnabled}
+      />
+      {mcpCrud.isDialogOpen && (
+        <Suspense fallback={null}>
+          <McpDialog
+            isOpen={mcpCrud.isDialogOpen}
+            isEditing={mcpCrud.editingIndex !== null}
+            mcp={mcpCrud.form}
+            error={mcpCrud.formError}
+            onClose={mcpCrud.handleDialogClose}
+            onSubmit={mcpCrud.handleSave}
+            onMcpChange={mcpCrud.handleFormChange}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/settings/sections/PromptsSection.tsx
+++ b/frontend/src/components/settings/sections/PromptsSection.tsx
@@ -1,0 +1,57 @@
+import { Suspense, lazy } from 'react';
+import { useSettingsContext } from '@/hooks/useSettingsContext';
+import { useCrudForm } from '@/hooks/useCrudForm';
+import type { CustomPrompt } from '@/types/user.types';
+
+const PromptsSettingsTab = lazy(() =>
+  import('@/components/settings/tabs/PromptsSettingsTab').then((m) => ({
+    default: m.PromptsSettingsTab,
+  })),
+);
+const PromptEditDialog = lazy(() =>
+  import('@/components/settings/dialogs/PromptEditDialog').then((m) => ({
+    default: m.PromptEditDialog,
+  })),
+);
+
+export function PromptsSection() {
+  const { localSettings, persistSettings, setLocalSettings } = useSettingsContext();
+
+  const promptCrud = useCrudForm<CustomPrompt>(localSettings, persistSettings, setLocalSettings, {
+    createDefault: (): CustomPrompt => ({ name: '', content: '' }),
+    validateForm: (form, editingIndex) => {
+      if (!form.name.trim()) return 'Name is required';
+      if (!form.content.trim()) return 'Content is required';
+      const prompts = localSettings.custom_prompts || [];
+      const duplicate = prompts.some((p, i) => p.name === form.name.trim() && i !== editingIndex);
+      if (duplicate) return 'A prompt with this name already exists';
+      return null;
+    },
+    getArrayKey: 'custom_prompts',
+    itemName: 'prompt',
+  });
+
+  return (
+    <>
+      <PromptsSettingsTab
+        prompts={localSettings.custom_prompts ?? null}
+        onAddPrompt={promptCrud.handleAdd}
+        onEditPrompt={promptCrud.handleEdit}
+        onDeletePrompt={promptCrud.handleDelete}
+      />
+      {promptCrud.isDialogOpen && (
+        <Suspense fallback={null}>
+          <PromptEditDialog
+            isOpen={promptCrud.isDialogOpen}
+            isEditing={promptCrud.editingIndex !== null}
+            prompt={promptCrud.form}
+            error={promptCrud.formError}
+            onClose={promptCrud.handleDialogClose}
+            onSubmit={promptCrud.handleSave}
+            onPromptChange={promptCrud.handleFormChange}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/settings/sections/ProvidersSection.tsx
+++ b/frontend/src/components/settings/sections/ProvidersSection.tsx
@@ -1,0 +1,116 @@
+import { useState, useCallback, Suspense, lazy } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useSettingsContext } from '@/hooks/useSettingsContext';
+import { queryKeys } from '@/hooks/queries/queryKeys';
+import type { CustomProvider } from '@/types/user.types';
+
+const ProvidersSettingsTab = lazy(() =>
+  import('@/components/settings/tabs/ProvidersSettingsTab').then((m) => ({
+    default: m.ProvidersSettingsTab,
+  })),
+);
+const ProviderDialog = lazy(() =>
+  import('@/components/settings/dialogs/ProviderDialog').then((m) => ({
+    default: m.ProviderDialog,
+  })),
+);
+
+export function ProvidersSection() {
+  const { localSettings, persistSettings } = useSettingsContext();
+  const queryClient = useQueryClient();
+
+  const [isProviderDialogOpen, setIsProviderDialogOpen] = useState(false);
+  const [editingProvider, setEditingProvider] = useState<CustomProvider | null>(null);
+
+  const handleAddProvider = useCallback(() => {
+    setEditingProvider(null);
+    setIsProviderDialogOpen(true);
+  }, []);
+
+  const handleEditProvider = useCallback((provider: CustomProvider) => {
+    setEditingProvider(provider);
+    setIsProviderDialogOpen(true);
+  }, []);
+
+  const handleDeleteProvider = useCallback(
+    (providerId: string) => {
+      void persistSettings(
+        (prev) => ({
+          ...prev,
+          custom_providers: (prev.custom_providers || []).filter((p) => p.id !== providerId),
+        }),
+        { successMessage: 'Provider deleted' },
+      ).then(() => queryClient.invalidateQueries({ queryKey: [queryKeys.models] }));
+    },
+    [persistSettings, queryClient],
+  );
+
+  const handleToggleProvider = useCallback(
+    (providerId: string, enabled: boolean) => {
+      void persistSettings((prev) => ({
+        ...prev,
+        custom_providers: (prev.custom_providers || []).map((p) =>
+          p.id === providerId ? { ...p, enabled } : p,
+        ),
+      })).then(() => queryClient.invalidateQueries({ queryKey: [queryKeys.models] }));
+    },
+    [persistSettings, queryClient],
+  );
+
+  const handleSaveProvider = useCallback(
+    (provider: CustomProvider) => {
+      const providers = localSettings.custom_providers || [];
+      const existingIndex = providers.findIndex((p) => p.id === provider.id);
+
+      if (existingIndex >= 0) {
+        void persistSettings(
+          (prev) => ({
+            ...prev,
+            custom_providers: (prev.custom_providers || []).map((p) =>
+              p.id === provider.id ? provider : p,
+            ),
+          }),
+          { successMessage: 'Provider updated' },
+        ).then(() => queryClient.invalidateQueries({ queryKey: [queryKeys.models] }));
+      } else {
+        void persistSettings(
+          (prev) => ({
+            ...prev,
+            custom_providers: [...(prev.custom_providers || []), provider],
+          }),
+          { successMessage: 'Provider added' },
+        ).then(() => queryClient.invalidateQueries({ queryKey: [queryKeys.models] }));
+      }
+      setIsProviderDialogOpen(false);
+      setEditingProvider(null);
+    },
+    [localSettings.custom_providers, persistSettings, queryClient],
+  );
+
+  const handleProviderDialogClose = useCallback(() => {
+    setIsProviderDialogOpen(false);
+    setEditingProvider(null);
+  }, []);
+
+  return (
+    <>
+      <ProvidersSettingsTab
+        providers={localSettings.custom_providers ?? null}
+        onAddProvider={handleAddProvider}
+        onEditProvider={handleEditProvider}
+        onDeleteProvider={handleDeleteProvider}
+        onToggleProvider={handleToggleProvider}
+      />
+      {isProviderDialogOpen && (
+        <Suspense fallback={null}>
+          <ProviderDialog
+            isOpen={isProviderDialogOpen}
+            provider={editingProvider}
+            onClose={handleProviderDialogClose}
+            onSave={handleSaveProvider}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/settings/sections/SkillsSection.tsx
+++ b/frontend/src/components/settings/sections/SkillsSection.tsx
@@ -1,0 +1,51 @@
+import { lazy } from 'react';
+import { FileArchive } from 'lucide-react';
+import { useSettingsContext } from '@/hooks/useSettingsContext';
+import { useFileResourceManagement } from '@/hooks/useFileResourceManagement';
+import { skillService } from '@/services/skillService';
+import { SettingsUploadModal } from '@/components/ui/SettingsUploadModal';
+
+const SkillsSettingsTab = lazy(() =>
+  import('@/components/settings/tabs/SkillsSettingsTab').then((m) => ({
+    default: m.SkillsSettingsTab,
+  })),
+);
+
+export function SkillsSection() {
+  const { localSettings, persistSettings, setLocalSettings } = useSettingsContext();
+
+  const skillManagement = useFileResourceManagement(
+    localSettings,
+    persistSettings,
+    setLocalSettings,
+    {
+      settingsKey: 'custom_skills',
+      itemName: 'Skill',
+      maxItems: 10,
+      uploadFn: skillService.uploadSkill,
+      deleteFn: skillService.deleteSkill,
+    },
+  );
+
+  return (
+    <>
+      <SkillsSettingsTab
+        skills={localSettings.custom_skills ?? null}
+        onAddSkill={skillManagement.handleAdd}
+        onDeleteSkill={skillManagement.handleDelete}
+        onToggleSkill={skillManagement.handleToggle}
+      />
+      <SettingsUploadModal
+        isOpen={skillManagement.isDialogOpen}
+        error={skillManagement.uploadError}
+        uploading={skillManagement.isUploading}
+        onClose={skillManagement.handleDialogClose}
+        onUpload={skillManagement.handleUpload}
+        title="Upload Skill"
+        acceptedExtension=".zip"
+        icon={FileArchive}
+        hintText="The ZIP must contain a SKILL.md file with YAML frontmatter including name and description fields."
+      />
+    </>
+  );
+}

--- a/frontend/src/components/settings/sections/TasksSection.tsx
+++ b/frontend/src/components/settings/sections/TasksSection.tsx
@@ -1,0 +1,44 @@
+import { Suspense, lazy } from 'react';
+import { useModelsQuery } from '@/hooks/queries/useModelQueries';
+import { useTaskManagement } from '@/hooks/useTaskManagement';
+
+const TasksSettingsTab = lazy(() =>
+  import('@/components/settings/tabs/TasksSettingsTab').then((m) => ({
+    default: m.TasksSettingsTab,
+  })),
+);
+const TaskDialog = lazy(() =>
+  import('@/components/settings/dialogs/TaskDialog').then((m) => ({ default: m.TaskDialog })),
+);
+
+interface TasksSectionProps {
+  isActive: boolean;
+}
+
+export function TasksSection({ isActive }: TasksSectionProps) {
+  const { data: models = [] } = useModelsQuery({ enabled: isActive });
+  const defaultModelId = models.length > 0 ? models[0].model_id : '';
+  const taskManagement = useTaskManagement(defaultModelId);
+
+  return (
+    <>
+      <TasksSettingsTab
+        onAddTask={taskManagement.handleAddTask}
+        onEditTask={taskManagement.handleEditTask}
+      />
+      {taskManagement.isTaskDialogOpen && (
+        <Suspense fallback={null}>
+          <TaskDialog
+            isOpen={taskManagement.isTaskDialogOpen}
+            isEditing={taskManagement.editingTaskId !== null}
+            task={taskManagement.taskForm}
+            error={taskManagement.taskFormError}
+            onClose={taskManagement.handleTaskDialogClose}
+            onSubmit={taskManagement.handleSaveTask}
+            onTaskChange={taskManagement.handleTaskFormChange}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/frontend/src/contexts/SettingsContext.tsx
+++ b/frontend/src/contexts/SettingsContext.tsx
@@ -1,0 +1,25 @@
+import { type ReactNode, useMemo } from 'react';
+import { SettingsContext, type SettingsContextValue } from './SettingsContextDefinition';
+import type { UserSettings } from '@/types/user.types';
+
+interface SettingsProviderProps {
+  localSettings: UserSettings;
+  setLocalSettings: React.Dispatch<React.SetStateAction<UserSettings>>;
+  persistSettings: SettingsContextValue['persistSettings'];
+  settings: UserSettings | undefined;
+  children: ReactNode;
+}
+
+export function SettingsProvider({
+  localSettings,
+  setLocalSettings,
+  persistSettings,
+  settings,
+  children,
+}: SettingsProviderProps) {
+  const value = useMemo<SettingsContextValue>(
+    () => ({ localSettings, setLocalSettings, persistSettings, settings }),
+    [localSettings, setLocalSettings, persistSettings, settings],
+  );
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+}

--- a/frontend/src/contexts/SettingsContextDefinition.ts
+++ b/frontend/src/contexts/SettingsContextDefinition.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+import type { UserSettings } from '@/types/user.types';
+
+export type PersistSettingsFn = (
+  updater: (previous: UserSettings) => UserSettings,
+  options?: { successMessage?: string; errorMessage?: string },
+) => Promise<void>;
+
+export interface SettingsContextValue {
+  localSettings: UserSettings;
+  setLocalSettings: React.Dispatch<React.SetStateAction<UserSettings>>;
+  persistSettings: PersistSettingsFn;
+  settings: UserSettings | undefined;
+}
+
+export const SettingsContext = createContext<SettingsContextValue | null>(null);

--- a/frontend/src/hooks/useSettingsContext.ts
+++ b/frontend/src/hooks/useSettingsContext.ts
@@ -1,0 +1,10 @@
+import { use } from 'react';
+import { SettingsContext } from '@/contexts/SettingsContextDefinition';
+
+export function useSettingsContext() {
+  const context = use(SettingsContext);
+  if (!context) {
+    throw new Error('useSettingsContext must be used within a SettingsProvider');
+  }
+  return context;
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -10,22 +10,14 @@ import { SplitViewContainer } from '@/components/ui/SplitViewContainer';
 import { Spinner } from '@/components/ui/primitives/Spinner';
 import type { ViewType } from '@/types/ui.types';
 import { Chat as ChatComponent } from '@/components/chat/chat-window/Chat';
-import { useQueryClient } from '@tanstack/react-query';
-import { useChatStreaming } from '@/hooks/useChatStreaming';
-import { usePermissionRequest } from '@/hooks/usePermissionRequest';
-import { useInitialPrompt } from '@/hooks/useInitialPrompt';
+import { ChatSessionOrchestrator } from '@/components/chat/ChatSessionOrchestrator';
 import { useEditorState } from '@/hooks/useEditorState';
-import { useMessageInitialization } from '@/hooks/useMessageInitialization';
 import { useChatData } from '@/hooks/useChatData';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
-import { useContextUsageState } from '@/hooks/useContextUsageState';
 import { useModelSelection } from '@/hooks/queries/useModelQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
 import { mergeAgents } from '@/utils/settings';
 import { ChatProvider } from '@/contexts/ChatContext';
-import { ChatSessionProvider } from '@/contexts/ChatSessionContext';
-import { ChatInputMessageProvider } from '@/contexts/ChatInputMessageContext';
-import type { ChatSessionState, ChatSessionActions } from '@/contexts/ChatSessionContextDefinition';
 
 const Editor = lazy(() =>
   import('@/components/editor/editor-core/Editor').then((m) => ({ default: m.Editor })),
@@ -58,35 +50,18 @@ const viewLoadingFallback = (
 export function ChatPage() {
   const { chatId } = useParams();
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
 
-  const { attachedFiles, setAttachedFiles, setCurrentChat } = useChatStore(
+  const setCurrentChat = useChatStore((state) => state.setCurrentChat);
+
+  const { selectedModelId } = useModelSelection();
+
+  const { currentView, secondaryView, setCurrentView } = useUIStore(
     useShallow((state) => ({
-      attachedFiles: state.attachedFiles,
-      setAttachedFiles: state.setAttachedFiles,
-      setCurrentChat: state.setCurrentChat,
-    })),
-  );
-
-  const { selectedModelId, selectModel } = useModelSelection();
-
-  const { permissionMode, thinkingMode, currentView, secondaryView, setCurrentView } = useUIStore(
-    useShallow((state) => ({
-      permissionMode: state.permissionMode,
-      thinkingMode: state.thinkingMode,
       currentView: state.currentView,
       secondaryView: state.secondaryView,
       setCurrentView: state.setCurrentView,
     })),
   );
-
-  const {
-    initialPrompt,
-    setInitialPrompt,
-    initialPromptSent,
-    setInitialPromptSent,
-    initialPromptFromRoute,
-  } = useInitialPrompt();
 
   const { chats, currentChat, fetchedMessages, hasFetchedMessages, chatsQueryMeta, messagesQuery } =
     useChatData(chatId);
@@ -130,8 +105,6 @@ export function ChatPage() {
     };
   }, [currentView, secondaryView, currentChat?.sandbox_id, refetchFilesMetadata]);
 
-  const { contextUsage, updateContextUsage } = useContextUsageState(chatId, currentChat);
-
   const { data: settings } = useSettingsQuery();
 
   const allAgents = useMemo(() => mergeAgents(settings?.custom_agents), [settings?.custom_agents]);
@@ -147,98 +120,14 @@ export function ChatPage() {
   const { selectedFile, setSelectedFile, isRefreshing, handleRefresh, handleFileSelect } =
     useEditorState(refetchFilesMetadata);
 
-  const {
-    pendingRequest,
-    isLoading: isPermissionLoading,
-    error: permissionError,
-    handlePermissionRequest,
-    handleApprove,
-    handleReject,
-  } = usePermissionRequest(chatId);
-
-  const streamingState = useChatStreaming({
-    chatId,
-    currentChat,
-    fetchedMessages,
-    hasFetchedMessages,
-    isInitialLoading: messagesQuery.isLoading,
-    queryClient,
-    refetchFilesMetadata,
-    onContextUsageUpdate: updateContextUsage,
-    selectedModelId,
-    permissionMode,
-    thinkingMode,
-    onPermissionRequest: handlePermissionRequest,
-  });
-
-  const {
-    messages,
-    sendMessage,
-    isLoading,
-    isStreaming,
-    error,
-    wasAborted,
-    setWasAborted,
-    setMessages,
-  } = streamingState;
-
-  useMessageInitialization({
-    fetchedMessages,
-    chatId,
-    selectedModelId,
-    hasMessages: messages.length > 0,
-    initialPromptFromRoute,
-    initialPromptSent,
-    wasAborted,
-    attachedFiles,
-    isLoading,
-    isStreaming,
-    setMessages,
-    setInitialPrompt,
-  });
-
-  useEffect(() => {
-    if (
-      initialPrompt &&
-      messages.length === 1 &&
-      !isLoading &&
-      !isStreaming &&
-      !initialPromptSent &&
-      !error &&
-      !messagesQuery.isLoading &&
-      !hasFetchedMessages
-    ) {
-      const userMessage = messages[0];
-      sendMessage(initialPrompt, chatId, userMessage, attachedFiles);
-      setInitialPromptSent(true);
-      setAttachedFiles([]);
-    }
-  }, [
-    initialPrompt,
-    messages,
-    messages.length,
-    isLoading,
-    isStreaming,
-    sendMessage,
-    chatId,
-    initialPromptSent,
-    error,
-    setAttachedFiles,
-    messagesQuery.isLoading,
-    hasFetchedMessages,
-    attachedFiles,
-    setInitialPromptSent,
-  ]);
-
   useEffect(() => {
     setCurrentChat(currentChat || null);
   }, [currentChat, setCurrentChat]);
 
   useEffect(() => {
-    setInitialPromptSent(false);
     setSelectedFile(null);
     setCurrentView('agent');
-  }, [chatId, setInitialPromptSent, setSelectedFile, setCurrentView]);
+  }, [chatId, setSelectedFile, setCurrentView]);
 
   const handleChatSelect = useCallback(
     (selectedChatId: string) => {
@@ -246,14 +135,6 @@ export function ChatPage() {
     },
     [navigate],
   );
-
-  const handleRestoreSuccess = useCallback(() => {
-    setWasAborted(false);
-    messagesQuery.refetch();
-    if (currentChat?.sandbox_id) {
-      refetchFilesMetadata();
-    }
-  }, [setWasAborted, messagesQuery, currentChat?.sandbox_id, refetchFilesMetadata]);
 
   const sidebarContent = useMemo(() => {
     if (currentView !== 'agent') return null;
@@ -280,84 +161,11 @@ export function ChatPage() {
 
   useLayoutSidebar(sidebarContent);
 
-  const chatSessionState = useMemo<ChatSessionState>(
-    () => ({
-      messages,
-      isLoading,
-      isStreaming,
-      isInitialLoading: messagesQuery.isLoading,
-      error,
-      copiedMessageId: streamingState.copiedMessageId,
-      pendingUserMessageId: streamingState.pendingUserMessageId ?? null,
-      attachedFiles: streamingState.inputFiles ?? null,
-      selectedModelId,
-      contextUsage,
-      hasNextPage: messagesQuery.hasNextPage ?? false,
-      isFetchingNextPage: messagesQuery.isFetchingNextPage ?? false,
-      pendingPermissionRequest: pendingRequest ?? null,
-      isPermissionLoading,
-      permissionError: permissionError ?? null,
-    }),
-    [
-      messages,
-      streamingState.copiedMessageId,
-      streamingState.pendingUserMessageId,
-      streamingState.inputFiles,
-      isLoading,
-      isStreaming,
-      messagesQuery.isLoading,
-      messagesQuery.hasNextPage,
-      messagesQuery.isFetchingNextPage,
-      error,
-      selectedModelId,
-      contextUsage,
-      pendingRequest,
-      isPermissionLoading,
-      permissionError,
-    ],
-  );
-
-  const chatSessionActions = useMemo<ChatSessionActions>(
-    () => ({
-      onSubmit: streamingState.handleMessageSend,
-      onStopStream: streamingState.handleStop,
-      onCopy: streamingState.handleCopy,
-      onAttach: streamingState.setInputFiles,
-      onModelChange: selectModel,
-      onDismissError: streamingState.handleDismissError,
-      fetchNextPage: messagesQuery.fetchNextPage,
-      onRestoreSuccess: handleRestoreSuccess,
-      onPermissionApprove: handleApprove,
-      onPermissionReject: handleReject,
-    }),
-    [
-      streamingState.handleMessageSend,
-      streamingState.handleStop,
-      streamingState.handleCopy,
-      streamingState.setInputFiles,
-      streamingState.handleDismissError,
-      selectModel,
-      messagesQuery.fetchNextPage,
-      handleRestoreSuccess,
-      handleApprove,
-      handleReject,
-    ],
-  );
-
   const renderNonTerminalView = useCallback(
     (view: ViewType): ReactNode => {
       switch (view) {
         case 'agent':
-          return (
-            <ChatSessionProvider state={chatSessionState} actions={chatSessionActions}>
-              <ChatInputMessageProvider
-                inputMessage={streamingState.inputMessage}
-                setInputMessage={streamingState.setInputMessage}
-              >
-                <ChatComponent />
-              </ChatInputMessageProvider>
-            </ChatSessionProvider>
-          );
+          return <ChatComponent />;
         case 'editor':
           return (
             <Suspense fallback={viewLoadingFallback}>
@@ -409,12 +217,8 @@ export function ChatPage() {
       }
     },
     [
-      chatSessionState,
-      chatSessionActions,
-      streamingState.inputMessage,
-      streamingState.setInputMessage,
-      currentChat,
       chatId,
+      currentChat,
       fileStructure,
       selectedFile,
       handleFileSelect,
@@ -454,12 +258,22 @@ export function ChatPage() {
       customSlashCommands={enabledSlashCommands}
       customPrompts={customPrompts}
     >
-      <div className="relative flex h-full">
-        <ViewSwitcher />
-        <div className="flex h-full flex-1 overflow-hidden bg-surface pl-12 text-text-primary dark:bg-surface-dark dark:text-text-dark-primary">
-          <SplitViewContainer renderView={renderView} />
+      <ChatSessionOrchestrator
+        chatId={chatId}
+        currentChat={currentChat}
+        fetchedMessages={fetchedMessages}
+        hasFetchedMessages={hasFetchedMessages}
+        messagesQuery={messagesQuery}
+        refetchFilesMetadata={refetchFilesMetadata}
+        selectedModelId={selectedModelId}
+      >
+        <div className="relative flex h-full">
+          <ViewSwitcher />
+          <div className="flex h-full flex-1 overflow-hidden bg-surface pl-12 text-text-primary dark:bg-surface-dark dark:text-text-dark-primary">
+            <SplitViewContainer renderView={renderView} />
+          </div>
         </div>
-      </div>
+      </ChatSessionOrchestrator>
     </ChatProvider>
   );
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,6 @@
-import { useState, useEffect, useMemo, useCallback, useRef, Suspense, lazy } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef, Suspense, lazy } from 'react';
 import {
   AlertCircle,
-  FileText,
-  FileArchive,
   Settings2,
   Layers,
   Link2,
@@ -19,76 +17,29 @@ import {
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '@/utils/cn';
-import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import type {
-  UserSettings,
-  UserSettingsUpdate,
-  CustomPrompt,
-  CustomProvider,
-  SandboxProviderType,
-} from '@/types/user.types';
+import type { UserSettings, UserSettingsUpdate, SandboxProviderType } from '@/types/user.types';
 import type { ApiFieldKey } from '@/types/settings.types';
-import { queryKeys } from '@/hooks/queries/queryKeys';
 import { useDeleteAllChatsMutation } from '@/hooks/queries/useChatQueries';
-import { useModelsQuery } from '@/hooks/queries/useModelQueries';
 import { useSettingsQuery, useUpdateSettingsMutation } from '@/hooks/queries/useSettingsQueries';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Button } from '@/components/ui/primitives/Button';
 import { Spinner } from '@/components/ui/primitives/Spinner';
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary';
-import { SettingsUploadModal } from '@/components/ui/SettingsUploadModal';
 import toast from 'react-hot-toast';
 import { GeneralSettingsTab } from '@/components/settings/tabs/GeneralSettingsTab';
-const AgentEditDialog = lazy(() =>
-  import('@/components/settings/dialogs/AgentEditDialog').then((m) => ({
-    default: m.AgentEditDialog,
-  })),
-);
-const McpDialog = lazy(() =>
-  import('@/components/settings/dialogs/McpDialog').then((m) => ({ default: m.McpDialog })),
-);
-const EnvVarDialog = lazy(() =>
-  import('@/components/settings/dialogs/EnvVarDialog').then((m) => ({ default: m.EnvVarDialog })),
-);
-const TaskDialog = lazy(() =>
-  import('@/components/settings/dialogs/TaskDialog').then((m) => ({ default: m.TaskDialog })),
-);
-const ProviderDialog = lazy(() =>
-  import('@/components/settings/dialogs/ProviderDialog').then((m) => ({
-    default: m.ProviderDialog,
-  })),
-);
-const CommandEditDialog = lazy(() =>
-  import('@/components/settings/dialogs/CommandEditDialog').then((m) => ({
-    default: m.CommandEditDialog,
-  })),
-);
-const PromptEditDialog = lazy(() =>
-  import('@/components/settings/dialogs/PromptEditDialog').then((m) => ({
-    default: m.PromptEditDialog,
-  })),
-);
-import { useCrudForm } from '@/hooks/useCrudForm';
-import { useTaskManagement } from '@/hooks/useTaskManagement';
-import { useFileResourceManagement } from '@/hooks/useFileResourceManagement';
-import { agentService } from '@/services/agentService';
-import { skillService } from '@/services/skillService';
-import { commandService } from '@/services/commandService';
-import { mcpService } from '@/services/mcpService';
-import {
-  getGeneralSecretFields,
-  createDefaultEnvVarForm,
-  validateEnvVarForm,
-  createDefaultMcpForm,
-  validateMcpForm,
-} from '@/utils/settings';
+import { SettingsProvider } from '@/contexts/SettingsContext';
+import { getGeneralSecretFields } from '@/utils/settings';
 
-const ProvidersSettingsTab = lazy(() =>
-  import('@/components/settings/tabs/ProvidersSettingsTab').then((m) => ({
-    default: m.ProvidersSettingsTab,
-  })),
-);
+import { ProvidersSection } from '@/components/settings/sections/ProvidersSection';
+import { McpSection } from '@/components/settings/sections/McpSection';
+import { AgentsSection } from '@/components/settings/sections/AgentsSection';
+import { SkillsSection } from '@/components/settings/sections/SkillsSection';
+import { CommandsSection } from '@/components/settings/sections/CommandsSection';
+import { PromptsSection } from '@/components/settings/sections/PromptsSection';
+import { EnvVarsSection } from '@/components/settings/sections/EnvVarsSection';
+import { TasksSection } from '@/components/settings/sections/TasksSection';
+
 const IntegrationsSettingsTab = lazy(() =>
   import('@/components/settings/tabs/IntegrationsSettingsTab').then((m) => ({
     default: m.IntegrationsSettingsTab,
@@ -99,44 +50,9 @@ const MarketplaceSettingsTab = lazy(() =>
     default: m.MarketplaceSettingsTab,
   })),
 );
-const McpSettingsTab = lazy(() =>
-  import('@/components/settings/tabs/McpSettingsTab').then((m) => ({
-    default: m.McpSettingsTab,
-  })),
-);
-const AgentsSettingsTab = lazy(() =>
-  import('@/components/settings/tabs/AgentsSettingsTab').then((m) => ({
-    default: m.AgentsSettingsTab,
-  })),
-);
-const SkillsSettingsTab = lazy(() =>
-  import('@/components/settings/tabs/SkillsSettingsTab').then((m) => ({
-    default: m.SkillsSettingsTab,
-  })),
-);
-const CommandsSettingsTab = lazy(() =>
-  import('@/components/settings/tabs/CommandsSettingsTab').then((m) => ({
-    default: m.CommandsSettingsTab,
-  })),
-);
-const PromptsSettingsTab = lazy(() =>
-  import('@/components/settings/tabs/PromptsSettingsTab').then((m) => ({
-    default: m.PromptsSettingsTab,
-  })),
-);
-const EnvVarsSettingsTab = lazy(() =>
-  import('@/components/settings/tabs/EnvVarsSettingsTab').then((m) => ({
-    default: m.EnvVarsSettingsTab,
-  })),
-);
 const InstructionsSettingsTab = lazy(() =>
   import('@/components/settings/tabs/InstructionsSettingsTab').then((m) => ({
     default: m.InstructionsSettingsTab,
-  })),
-);
-const TasksSettingsTab = lazy(() =>
-  import('@/components/settings/tabs/TasksSettingsTab').then((m) => ({
-    default: m.TasksSettingsTab,
   })),
 );
 
@@ -181,16 +97,7 @@ const createFallbackSettings = (): UserSettings => ({
 });
 
 const TAB_FIELDS: Record<TabKey, (keyof UserSettings)[]> = {
-  // Only include fields that require manual save (not auto-saved via persistSettings)
-  general: [
-    'github_personal_access_token',
-    'e2b_api_key',
-    'modal_api_key',
-    'timezone',
-    // Note: sandbox_provider, auto_compact_disabled, and attribution_disabled are
-    // excluded because they are auto-saved immediately and shouldn't trigger the
-    // "unsaved changes" banner.
-  ],
+  general: ['github_personal_access_token', 'e2b_api_key', 'modal_api_key', 'timezone'],
   providers: ['custom_providers'],
   integrations: [],
   marketplace: [],
@@ -257,9 +164,7 @@ const tabLoadingFallback = (
 
 const SettingsPage: React.FC = () => {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState<TabKey>('general');
-  const { data: models = [] } = useModelsQuery({ enabled: activeTab === 'tasks' });
   const [isDeleteAllDialogOpen, setIsDeleteAllDialogOpen] = useState(false);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
@@ -272,8 +177,6 @@ const SettingsPage: React.FC = () => {
     () => settings ?? createFallbackSettings(),
   );
   const localSettingsRef = useRef<UserSettings>(localSettings);
-
-  const defaultModelId = models.length > 0 ? models[0].model_id : '';
 
   const manualUpdateMutation = useUpdateSettingsMutation({
     onSuccess: (data) => {
@@ -353,146 +256,6 @@ const SettingsPage: React.FC = () => {
     },
     [instantUpdateMutation, buildChangedPayload],
   );
-
-  const agentManagement = useFileResourceManagement(
-    localSettings,
-    persistSettings,
-    setLocalSettings,
-    {
-      settingsKey: 'custom_agents',
-      itemName: 'Agent',
-      maxItems: 10,
-      uploadFn: agentService.uploadAgent,
-      deleteFn: agentService.deleteAgent,
-      updateFn: agentService.updateAgent,
-    },
-  );
-
-  const mcpCrud = useCrudForm(localSettings, persistSettings, setLocalSettings, {
-    createDefault: createDefaultMcpForm,
-    validateForm: (form, editingIndex) =>
-      validateMcpForm(form, editingIndex, localSettings.custom_mcps || []),
-    getArrayKey: 'custom_mcps',
-    itemName: 'MCP',
-    createFn: mcpService.createMcp,
-    updateFn: mcpService.updateMcp,
-    deleteFn: mcpService.deleteMcp,
-    toggleFn: (name, enabled) => mcpService.updateMcp(name, { enabled }),
-  });
-
-  const envVarCrud = useCrudForm(localSettings, persistSettings, setLocalSettings, {
-    createDefault: createDefaultEnvVarForm,
-    validateForm: (form, editingIndex) =>
-      validateEnvVarForm(form, editingIndex, localSettings.custom_env_vars || []),
-    getArrayKey: 'custom_env_vars',
-    itemName: 'environment variable',
-  });
-
-  const promptCrud = useCrudForm<CustomPrompt>(localSettings, persistSettings, setLocalSettings, {
-    createDefault: (): CustomPrompt => ({ name: '', content: '' }),
-    validateForm: (form, editingIndex) => {
-      if (!form.name.trim()) return 'Name is required';
-      if (!form.content.trim()) return 'Content is required';
-      const prompts = localSettings.custom_prompts || [];
-      const duplicate = prompts.some((p, i) => p.name === form.name.trim() && i !== editingIndex);
-      if (duplicate) return 'A prompt with this name already exists';
-      return null;
-    },
-    getArrayKey: 'custom_prompts',
-    itemName: 'prompt',
-  });
-
-  const skillManagement = useFileResourceManagement(
-    localSettings,
-    persistSettings,
-    setLocalSettings,
-    {
-      settingsKey: 'custom_skills',
-      itemName: 'Skill',
-      maxItems: 10,
-      uploadFn: skillService.uploadSkill,
-      deleteFn: skillService.deleteSkill,
-    },
-  );
-
-  const commandManagement = useFileResourceManagement(
-    localSettings,
-    persistSettings,
-    setLocalSettings,
-    {
-      settingsKey: 'custom_slash_commands',
-      itemName: 'Command',
-      maxItems: 10,
-      uploadFn: commandService.uploadCommand,
-      deleteFn: commandService.deleteCommand,
-      updateFn: commandService.updateCommand,
-    },
-  );
-  const taskManagement = useTaskManagement(defaultModelId);
-
-  const [isProviderDialogOpen, setIsProviderDialogOpen] = useState(false);
-  const [editingProvider, setEditingProvider] = useState<CustomProvider | null>(null);
-
-  const handleAddProvider = () => {
-    setEditingProvider(null);
-    setIsProviderDialogOpen(true);
-  };
-
-  const handleEditProvider = (provider: CustomProvider) => {
-    setEditingProvider(provider);
-    setIsProviderDialogOpen(true);
-  };
-
-  const handleDeleteProvider = (providerId: string) => {
-    void persistSettings(
-      (prev) => ({
-        ...prev,
-        custom_providers: (prev.custom_providers || []).filter((p) => p.id !== providerId),
-      }),
-      { successMessage: 'Provider deleted' },
-    ).then(() => queryClient.invalidateQueries({ queryKey: [queryKeys.models] }));
-  };
-
-  const handleToggleProvider = (providerId: string, enabled: boolean) => {
-    void persistSettings((prev) => ({
-      ...prev,
-      custom_providers: (prev.custom_providers || []).map((p) =>
-        p.id === providerId ? { ...p, enabled } : p,
-      ),
-    })).then(() => queryClient.invalidateQueries({ queryKey: [queryKeys.models] }));
-  };
-
-  const handleSaveProvider = (provider: CustomProvider) => {
-    const providers = localSettings.custom_providers || [];
-    const existingIndex = providers.findIndex((p) => p.id === provider.id);
-
-    if (existingIndex >= 0) {
-      void persistSettings(
-        (prev) => ({
-          ...prev,
-          custom_providers: (prev.custom_providers || []).map((p) =>
-            p.id === provider.id ? provider : p,
-          ),
-        }),
-        { successMessage: 'Provider updated' },
-      ).then(() => queryClient.invalidateQueries({ queryKey: [queryKeys.models] }));
-    } else {
-      void persistSettings(
-        (prev) => ({
-          ...prev,
-          custom_providers: [...(prev.custom_providers || []), provider],
-        }),
-        { successMessage: 'Provider added' },
-      ).then(() => queryClient.invalidateQueries({ queryKey: [queryKeys.models] }));
-    }
-    setIsProviderDialogOpen(false);
-    setEditingProvider(null);
-  };
-
-  const handleProviderDialogClose = () => {
-    setIsProviderDialogOpen(false);
-    setEditingProvider(null);
-  };
 
   const [revealedFields, setRevealedFields] = useState<Record<ApiFieldKey, boolean>>({
     github_personal_access_token: false,
@@ -791,163 +554,128 @@ const SettingsPage: React.FC = () => {
               </div>
             )}
 
-            <ErrorBoundary>
-              <div className="min-w-0 space-y-6">
-                {activeTab === 'general' && (
-                  <div role="tabpanel" id="general-panel" aria-labelledby="general-tab">
-                    <GeneralSettingsTab
-                      fields={generalSecretFields}
-                      settings={localSettings}
-                      savedSettings={settings}
-                      revealedFields={revealedFields}
-                      onSecretChange={handleSecretFieldChange}
-                      onToggleVisibility={toggleFieldVisibility}
-                      onDeleteAllChats={handleDeleteAllChats}
-                      onNotificationSoundChange={handleNotificationSoundChange}
-                      onAutoCompactDisabledChange={handleAutoCompactDisabledChange}
-                      onAttributionDisabledChange={handleAttributionDisabledChange}
-                      onSandboxProviderChange={handleSandboxProviderChange}
-                      onTimezoneChange={handleTimezoneChange}
-                    />
-                  </div>
-                )}
-
-                {activeTab === 'providers' && (
-                  <div role="tabpanel" id="providers-panel" aria-labelledby="providers-tab">
-                    <Suspense fallback={tabLoadingFallback}>
-                      <ProvidersSettingsTab
-                        providers={localSettings.custom_providers ?? null}
-                        onAddProvider={handleAddProvider}
-                        onEditProvider={handleEditProvider}
-                        onDeleteProvider={handleDeleteProvider}
-                        onToggleProvider={handleToggleProvider}
+            <SettingsProvider
+              localSettings={localSettings}
+              setLocalSettings={setLocalSettings}
+              persistSettings={persistSettings}
+              settings={settings}
+            >
+              <ErrorBoundary>
+                <div className="min-w-0 space-y-6">
+                  {activeTab === 'general' && (
+                    <div role="tabpanel" id="general-panel" aria-labelledby="general-tab">
+                      <GeneralSettingsTab
+                        fields={generalSecretFields}
+                        settings={localSettings}
+                        savedSettings={settings}
+                        revealedFields={revealedFields}
+                        onSecretChange={handleSecretFieldChange}
+                        onToggleVisibility={toggleFieldVisibility}
+                        onDeleteAllChats={handleDeleteAllChats}
+                        onNotificationSoundChange={handleNotificationSoundChange}
+                        onAutoCompactDisabledChange={handleAutoCompactDisabledChange}
+                        onAttributionDisabledChange={handleAttributionDisabledChange}
+                        onSandboxProviderChange={handleSandboxProviderChange}
+                        onTimezoneChange={handleTimezoneChange}
                       />
-                    </Suspense>
-                  </div>
-                )}
+                    </div>
+                  )}
 
-                {activeTab === 'integrations' && (
-                  <div role="tabpanel" id="integrations-panel" aria-labelledby="integrations-tab">
-                    <Suspense fallback={tabLoadingFallback}>
-                      <IntegrationsSettingsTab />
-                    </Suspense>
-                  </div>
-                )}
+                  {activeTab === 'providers' && (
+                    <div role="tabpanel" id="providers-panel" aria-labelledby="providers-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <ProvidersSection />
+                      </Suspense>
+                    </div>
+                  )}
 
-                {activeTab === 'marketplace' && (
-                  <div role="tabpanel" id="marketplace-panel" aria-labelledby="marketplace-tab">
-                    <Suspense fallback={tabLoadingFallback}>
-                      <MarketplaceSettingsTab />
-                    </Suspense>
-                  </div>
-                )}
+                  {activeTab === 'integrations' && (
+                    <div role="tabpanel" id="integrations-panel" aria-labelledby="integrations-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <IntegrationsSettingsTab />
+                      </Suspense>
+                    </div>
+                  )}
 
-                {activeTab === 'mcp' && (
-                  <div role="tabpanel" id="mcp-panel" aria-labelledby="mcp-tab">
-                    <Suspense fallback={tabLoadingFallback}>
-                      <McpSettingsTab
-                        mcps={localSettings.custom_mcps ?? null}
-                        onAddMcp={mcpCrud.handleAdd}
-                        onEditMcp={mcpCrud.handleEdit}
-                        onDeleteMcp={mcpCrud.handleDelete}
-                        onToggleMcp={mcpCrud.handleToggleEnabled}
-                      />
-                    </Suspense>
-                  </div>
-                )}
+                  {activeTab === 'marketplace' && (
+                    <div role="tabpanel" id="marketplace-panel" aria-labelledby="marketplace-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <MarketplaceSettingsTab />
+                      </Suspense>
+                    </div>
+                  )}
 
-                {activeTab === 'agents' && (
-                  <div role="tabpanel" id="agents-panel" aria-labelledby="agents-tab">
-                    <Suspense fallback={tabLoadingFallback}>
-                      <AgentsSettingsTab
-                        agents={localSettings.custom_agents ?? null}
-                        onAddAgent={agentManagement.handleAdd}
-                        onEditAgent={agentManagement.handleEdit}
-                        onDeleteAgent={agentManagement.handleDelete}
-                        onToggleAgent={agentManagement.handleToggle}
-                      />
-                    </Suspense>
-                  </div>
-                )}
+                  {activeTab === 'mcp' && (
+                    <div role="tabpanel" id="mcp-panel" aria-labelledby="mcp-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <McpSection />
+                      </Suspense>
+                    </div>
+                  )}
 
-                {activeTab === 'skills' && (
-                  <div role="tabpanel" id="skills-panel" aria-labelledby="skills-tab">
-                    <Suspense fallback={tabLoadingFallback}>
-                      <SkillsSettingsTab
-                        skills={localSettings.custom_skills ?? null}
-                        onAddSkill={skillManagement.handleAdd}
-                        onDeleteSkill={skillManagement.handleDelete}
-                        onToggleSkill={skillManagement.handleToggle}
-                      />
-                    </Suspense>
-                  </div>
-                )}
+                  {activeTab === 'agents' && (
+                    <div role="tabpanel" id="agents-panel" aria-labelledby="agents-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <AgentsSection />
+                      </Suspense>
+                    </div>
+                  )}
 
-                {activeTab === 'commands' && (
-                  <div role="tabpanel" id="commands-panel" aria-labelledby="commands-tab">
-                    <Suspense fallback={tabLoadingFallback}>
-                      <CommandsSettingsTab
-                        commands={localSettings.custom_slash_commands ?? null}
-                        onAddCommand={commandManagement.handleAdd}
-                        onEditCommand={commandManagement.handleEdit}
-                        onDeleteCommand={commandManagement.handleDelete}
-                        onToggleCommand={commandManagement.handleToggle}
-                      />
-                    </Suspense>
-                  </div>
-                )}
+                  {activeTab === 'skills' && (
+                    <div role="tabpanel" id="skills-panel" aria-labelledby="skills-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <SkillsSection />
+                      </Suspense>
+                    </div>
+                  )}
 
-                {activeTab === 'prompts' && (
-                  <div role="tabpanel" id="prompts-panel" aria-labelledby="prompts-tab">
-                    <Suspense fallback={tabLoadingFallback}>
-                      <PromptsSettingsTab
-                        prompts={localSettings.custom_prompts ?? null}
-                        onAddPrompt={promptCrud.handleAdd}
-                        onEditPrompt={promptCrud.handleEdit}
-                        onDeletePrompt={promptCrud.handleDelete}
-                      />
-                    </Suspense>
-                  </div>
-                )}
+                  {activeTab === 'commands' && (
+                    <div role="tabpanel" id="commands-panel" aria-labelledby="commands-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <CommandsSection />
+                      </Suspense>
+                    </div>
+                  )}
 
-                {activeTab === 'env_vars' && (
-                  <div role="tabpanel" id="env_vars-panel" aria-labelledby="env_vars-tab">
-                    <Suspense fallback={tabLoadingFallback}>
-                      <EnvVarsSettingsTab
-                        envVars={localSettings.custom_env_vars ?? null}
-                        onAddEnvVar={envVarCrud.handleAdd}
-                        onEditEnvVar={envVarCrud.handleEdit}
-                        onDeleteEnvVar={envVarCrud.handleDelete}
-                      />
-                    </Suspense>
-                  </div>
-                )}
+                  {activeTab === 'prompts' && (
+                    <div role="tabpanel" id="prompts-panel" aria-labelledby="prompts-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <PromptsSection />
+                      </Suspense>
+                    </div>
+                  )}
 
-                {activeTab === 'instructions' && (
-                  <div role="tabpanel" id="instructions-panel" aria-labelledby="instructions-tab">
-                    <Suspense fallback={tabLoadingFallback}>
-                      <InstructionsSettingsTab
-                        instructions={localSettings.custom_instructions || ''}
-                        onInstructionsChange={(value) =>
-                          handleInputChange('custom_instructions', value)
-                        }
-                      />
-                    </Suspense>
-                  </div>
-                )}
+                  {activeTab === 'env_vars' && (
+                    <div role="tabpanel" id="env_vars-panel" aria-labelledby="env_vars-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <EnvVarsSection />
+                      </Suspense>
+                    </div>
+                  )}
 
-                {activeTab === 'tasks' && (
-                  <div role="tabpanel" id="tasks-panel" aria-labelledby="tasks-tab">
-                    <Suspense fallback={tabLoadingFallback}>
-                      <TasksSettingsTab
-                        onAddTask={taskManagement.handleAddTask}
-                        onEditTask={taskManagement.handleEditTask}
-                      />
-                    </Suspense>
-                  </div>
-                )}
-              </div>
-            </ErrorBoundary>
+                  {activeTab === 'instructions' && (
+                    <div role="tabpanel" id="instructions-panel" aria-labelledby="instructions-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <InstructionsSettingsTab
+                          instructions={localSettings.custom_instructions || ''}
+                          onInstructionsChange={(value) =>
+                            handleInputChange('custom_instructions', value)
+                          }
+                        />
+                      </Suspense>
+                    </div>
+                  )}
+
+                  {activeTab === 'tasks' && (
+                    <div role="tabpanel" id="tasks-panel" aria-labelledby="tasks-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <TasksSection isActive={activeTab === 'tasks'} />
+                      </Suspense>
+                    </div>
+                  )}
+                </div>
+              </ErrorBoundary>
+            </SettingsProvider>
           </div>
         </div>
       </div>
@@ -961,135 +689,6 @@ const SettingsPage: React.FC = () => {
         confirmLabel="Delete All"
         cancelLabel="Cancel"
       />
-
-      <SettingsUploadModal
-        isOpen={agentManagement.isDialogOpen}
-        error={agentManagement.uploadError}
-        uploading={agentManagement.isUploading}
-        onClose={agentManagement.handleDialogClose}
-        onUpload={agentManagement.handleUpload}
-        title="Upload Agent"
-        acceptedExtension=".md"
-        icon={FileText}
-        hintText="The .md file must include YAML frontmatter with name and description fields. Optional fields: model, allowed_tools."
-      />
-
-      {agentManagement.isEditDialogOpen && (
-        <Suspense fallback={null}>
-          <AgentEditDialog
-            isOpen={agentManagement.isEditDialogOpen}
-            agent={agentManagement.editingItem}
-            error={agentManagement.editError}
-            saving={agentManagement.isSavingEdit}
-            onClose={agentManagement.handleEditDialogClose}
-            onSave={agentManagement.handleSaveEdit}
-          />
-        </Suspense>
-      )}
-
-      {mcpCrud.isDialogOpen && (
-        <Suspense fallback={null}>
-          <McpDialog
-            isOpen={mcpCrud.isDialogOpen}
-            isEditing={mcpCrud.editingIndex !== null}
-            mcp={mcpCrud.form}
-            error={mcpCrud.formError}
-            onClose={mcpCrud.handleDialogClose}
-            onSubmit={mcpCrud.handleSave}
-            onMcpChange={mcpCrud.handleFormChange}
-          />
-        </Suspense>
-      )}
-
-      {envVarCrud.isDialogOpen && (
-        <Suspense fallback={null}>
-          <EnvVarDialog
-            isOpen={envVarCrud.isDialogOpen}
-            isEditing={envVarCrud.editingIndex !== null}
-            envVar={envVarCrud.form}
-            error={envVarCrud.formError}
-            onClose={envVarCrud.handleDialogClose}
-            onSubmit={envVarCrud.handleSave}
-            onEnvVarChange={envVarCrud.handleFormChange}
-          />
-        </Suspense>
-      )}
-
-      {promptCrud.isDialogOpen && (
-        <Suspense fallback={null}>
-          <PromptEditDialog
-            isOpen={promptCrud.isDialogOpen}
-            isEditing={promptCrud.editingIndex !== null}
-            prompt={promptCrud.form}
-            error={promptCrud.formError}
-            onClose={promptCrud.handleDialogClose}
-            onSubmit={promptCrud.handleSave}
-            onPromptChange={promptCrud.handleFormChange}
-          />
-        </Suspense>
-      )}
-
-      {taskManagement.isTaskDialogOpen && (
-        <Suspense fallback={null}>
-          <TaskDialog
-            isOpen={taskManagement.isTaskDialogOpen}
-            isEditing={taskManagement.editingTaskId !== null}
-            task={taskManagement.taskForm}
-            error={taskManagement.taskFormError}
-            onClose={taskManagement.handleTaskDialogClose}
-            onSubmit={taskManagement.handleSaveTask}
-            onTaskChange={taskManagement.handleTaskFormChange}
-          />
-        </Suspense>
-      )}
-
-      <SettingsUploadModal
-        isOpen={skillManagement.isDialogOpen}
-        error={skillManagement.uploadError}
-        uploading={skillManagement.isUploading}
-        onClose={skillManagement.handleDialogClose}
-        onUpload={skillManagement.handleUpload}
-        title="Upload Skill"
-        acceptedExtension=".zip"
-        icon={FileArchive}
-        hintText="The ZIP must contain a SKILL.md file with YAML frontmatter including name and description fields."
-      />
-
-      <SettingsUploadModal
-        isOpen={commandManagement.isDialogOpen}
-        error={commandManagement.uploadError}
-        uploading={commandManagement.isUploading}
-        onClose={commandManagement.handleDialogClose}
-        onUpload={commandManagement.handleUpload}
-        title="Upload Slash Command"
-        acceptedExtension=".md"
-        icon={FileText}
-        hintText="The .md file must include YAML frontmatter with name and description fields. Optional fields: argument-hint, allowed-tools, model."
-      />
-
-      {commandManagement.isEditDialogOpen && (
-        <Suspense fallback={null}>
-          <CommandEditDialog
-            isOpen={commandManagement.isEditDialogOpen}
-            command={commandManagement.editingItem}
-            error={commandManagement.editError}
-            saving={commandManagement.isSavingEdit}
-            onClose={commandManagement.handleEditDialogClose}
-            onSave={commandManagement.handleSaveEdit}
-          />
-        </Suspense>
-      )}
-
-      {isProviderDialogOpen && (
-        <Suspense fallback={null}>
-          <ProviderDialog
-            isOpen={isProviderDialogOpen}
-            provider={editingProvider}
-            onClose={handleProviderDialogClose}
-            onSave={handleSaveProvider}
-          />
-        </Suspense>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- **Memoize `allChats` in App.tsx** — wraps `flatMap` derivation in `useMemo` to prevent new array references on every render, matching the existing pattern in `LandingPage.tsx`
- **Extract `ChatSessionOrchestrator` from ChatPage** (465→283 lines) — isolates streaming/permission/context-usage hooks into a dedicated component so streaming state changes (~200ms during active chat) no longer re-render the sidebar, editor, or view switcher
- **Decompose SettingsPage** (1098→706 lines) — introduces `SettingsContext` and 8 self-contained section components (`ProvidersSection`, `McpSection`, `AgentsSection`, `SkillsSection`, `CommandsSection`, `PromptsSection`, `EnvVarsSection`, `TasksSection`), each owning their CRUD hooks and dialogs so only the active tab's hooks run

## Test plan

- [ ] Open a chat and verify streaming works end-to-end (messages appear, stop button works)
- [ ] During streaming, confirm sidebar does not visually re-render (no flicker/scroll reset)
- [ ] Switch between views (agent, editor, terminal, IDE) and verify they still render correctly
- [ ] Open Settings and navigate through all tabs — verify each tab loads and renders content
- [ ] Test CRUD operations: add/edit/delete an MCP server, agent, skill, command, prompt, env var, provider, and task
- [ ] Verify unsaved changes banner appears on General and Instructions tabs when editing
- [ ] Verify delete all chats dialog works from General tab
- [ ] Run `npx tsc --noEmit` — passes clean
- [ ] Run `npx eslint` on all changed files — passes clean