### PR TITLE
Fix immediate resend after stop (stream cancellation handoff)

### DIFF
--- a/backend/app/services/streaming/cancellation.py
+++ b/backend/app/services/streaming/cancellation.py
@@ -26,7 +26,7 @@ class CancellationHandler:
     def register(cls, chat_id: str) -> asyncio.Event:
         existing = cls._entries.get(chat_id)
         if existing is not None and existing.event.is_set():
-            if existing.expires_at is None or existing.expires_at >= time.monotonic():
+            if existing.expires_at is not None and existing.expires_at >= time.monotonic():
                 existing.expires_at = None
                 return existing.event
             cls._entries.pop(chat_id, None)


### PR DESCRIPTION
## Summary
- Fixes a bug where stopping a stream and immediately sending a new prompt could cause the new stream to be silently canceled by a stale cancellation event from the previous generation.
- Single-line condition change in `CancellationHandler.register()`: only reuse a set event when it has an unexpired TTL (pending cancel intent), not when `expires_at is None` (stale cancel from a previous runtime).

## Root cause
In `register(chat_id)`, the condition `expires_at is None or expires_at >= time.monotonic()` returned an already-set event in both the "no TTL" and "valid TTL" cases. The "no TTL" case represents a stale cancel from the previous runtime — the new stream should not inherit it.

## Test plan
- [ ] Stop a stream and immediately resend (<1s) — second message should stream normally
- [ ] Stop a stream and resend after a delay — unchanged behavior
- [ ] Cancel request before runtime starts (pending cancel with TTL) — still consumed by next runtime
- [ ] Multiple rapid stop/send cycles — no dead period where sends silently self-cancel