### PR TITLE
Fix permission selector sync for plan mode transitions

### DIFF
--- a/frontend/src/hooks/usePermissionRequest.ts
+++ b/frontend/src/hooks/usePermissionRequest.ts
@@ -1,7 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { permissionService } from '@/services/permissionService';
 import { usePermissionStore } from '@/store/permissionStore';
-import { useUIStore } from '@/store/uiStore';
 import { addResolvedRequestId, isRequestResolved } from '@/utils/permissionStorage';
 import type { PermissionRequest } from '@/types/chat.types';
 
@@ -27,7 +26,6 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
   const pendingRequests = usePermissionStore((state) => state.pendingRequests);
   const setPermissionRequest = usePermissionStore((state) => state.setPermissionRequest);
   const clearPermissionRequest = usePermissionStore((state) => state.clearPermissionRequest);
-  const setPermissionMode = useUIStore((state) => state.setPermissionMode);
 
   const pendingRequest = chatId ? (pendingRequests.get(chatId) ?? null) : null;
 
@@ -55,11 +53,6 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
       await permissionService.respondToPermission(chatId, pendingRequest.request_id, true);
       addResolvedRequestId(pendingRequest.request_id);
       clearPermissionRequest(chatId);
-      if (pendingRequest.tool_name === 'ExitPlanMode') {
-        setPermissionMode('auto');
-      } else if (pendingRequest.tool_name === 'EnterPlanMode') {
-        setPermissionMode('plan');
-      }
     } catch (err) {
       if (isExpiredRequestError(err)) {
         addResolvedRequestId(pendingRequest.request_id);
@@ -70,7 +63,7 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
     } finally {
       setIsLoading(false);
     }
-  }, [chatId, pendingRequest, clearPermissionRequest, setPermissionMode]);
+  }, [chatId, pendingRequest, clearPermissionRequest]);
 
   const handleReject = useCallback(
     async (alternativeInstruction?: string) => {

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -17,6 +17,7 @@ import type { QueueProcessingData, StreamEnvelope, StreamState } from '@/types/s
 import { useMessageCache } from '@/hooks/useMessageCache';
 import { streamService } from '@/services/streamService';
 import type { StreamOptions } from '@/services/streamService';
+import { useUIStore } from '@/store/uiStore';
 
 const STREAM_FLUSH_INTERVAL_MS = 200;
 
@@ -333,6 +334,15 @@ export function useStreamCallbacks({
           onContextUsageUpdate(contextUsage, eventChatId);
         }
         return;
+      }
+
+      if (envelope.kind === 'tool_completed') {
+        const tool = (envelope.payload as { tool?: ToolEventPayload })?.tool;
+        if (tool?.name === 'EnterPlanMode') {
+          useUIStore.getState().setPermissionMode('plan');
+        } else if (tool?.name === 'ExitPlanMode') {
+          useUIStore.getState().setPermissionMode('auto');
+        }
       }
 
       const renderEvent = envelopeToRenderEvent(envelope);


### PR DESCRIPTION
## Summary
- move permission mode updates to stream tool_completed events in useStreamCallbacks
- update UI mode to plan on EnterPlanMode completion and to auto on ExitPlanMode completion
- remove Enter/Exit mode switching from usePermissionRequest approval flow so mode transitions use a single source of truth

## Notes
- frontend Docker checks could not be run locally because Docker daemon was unavailable
