### PR TITLE
Re-assert plan mode on denied ExitPlanMode/EnterPlanMode

### DIFF
--- a/backend/app/services/claude_agent.py
+++ b/backend/app/services/claude_agent.py
@@ -251,6 +251,12 @@ class ClaudeAgentService:
                                 await client.set_permission_mode("auto")
                             elif tool_name == "EnterPlanMode":
                                 await client.set_permission_mode("plan")
+                        elif event_type == "tool_failed":
+                            tool_name = event.get("tool", {}).get("name")
+                            if tool_name == "ExitPlanMode":
+                                await client.set_permission_mode("plan")
+                            elif tool_name == "EnterPlanMode":
+                                await client.set_permission_mode("auto")
                 if processor.usage is not prev_usage:
                     self._usage = processor.usage
 

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -343,6 +343,13 @@ export function useStreamCallbacks({
         } else if (tool?.name === 'ExitPlanMode') {
           useUIStore.getState().setPermissionMode('auto');
         }
+      } else if (envelope.kind === 'tool_failed') {
+        const tool = (envelope.payload as { tool?: ToolEventPayload })?.tool;
+        if (tool?.name === 'ExitPlanMode') {
+          useUIStore.getState().setPermissionMode('plan');
+        } else if (tool?.name === 'EnterPlanMode') {
+          useUIStore.getState().setPermissionMode('auto');
+        }
       }
 
       const renderEvent = envelopeToRenderEvent(envelope);


### PR DESCRIPTION
## Summary
- When the user denies an `ExitPlanMode` permission, the CLI may internally transition out of plan mode regardless of the denial
- Additionally, `ToolResultBlock.is_error` can be `None` (treated as falsy), causing a denied tool to emit `tool_completed` instead of `tool_failed`, which triggers an incorrect `set_permission_mode("auto")` call
- Handle `tool_failed` events for plan mode tools by re-asserting the correct permission mode — `ExitPlanMode` denied → re-assert `plan`, `EnterPlanMode` denied → re-assert `auto`
- Applied the same pattern to both backend (`claude_agent.py`) and frontend (`useStreamCallbacks.ts`)

## Test plan
- [ ] Enter plan mode, ask Claude to exit, deny the permission → verify mode stays as plan
- [ ] Enter plan mode, ask Claude to exit, deny, then ask again → verify Claude still knows it's in plan mode
- [ ] Approve ExitPlanMode → verify mode switches to auto correctly
- [ ] Approve EnterPlanMode → verify mode switches to plan correctly