### PR TITLE
Re-assert plan mode on denied ExitPlanMode/EnterPlanMode

### DIFF
--- a/backend/app/services/claude_agent.py
+++ b/backend/app/services/claude_agent.py
@@ -251,6 +251,12 @@ class ClaudeAgentService:
                                 await client.set_permission_mode("auto")
                             elif tool_name == "EnterPlanMode":
                                 await client.set_permission_mode("plan")
+                        elif event_type == "tool_failed":
+                            tool_name = event.get("tool", {}).get("name")
+                            if tool_name == "ExitPlanMode":
+                                await client.set_permission_mode("plan")
+                            elif tool_name == "EnterPlanMode":
+                                await client.set_permission_mode("auto")
                 if processor.usage is not prev_usage:
                     self._usage = processor.usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,10 @@ services:
       - PYTHONUNBUFFERED=1
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - HOST_PERMISSION_API_URL=http://api:8080
+      - DOCKER_PERMISSION_API_URL=http://claudex-api-web:8080
+    networks:
+      - default
+      - sandbox
 
   frontend:
     build:
@@ -94,6 +98,11 @@ services:
     environment:
       - VITE_API_BASE_URL=/api/v1
       - VITE_WS_URL=/api/v1/ws
+
+networks:
+  sandbox:
+    name: claudex-sandbox-net
+    external: true
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- When the user denies `ExitPlanMode`, the CLI internally exits plan mode regardless of the denial
- Handle `tool_failed` events for plan mode tools by re-asserting the correct permission mode (`ExitPlanMode` denied → re-assert `plan`, `EnterPlanMode` denied → re-assert `auto`)
- Include docker-compose network changes for sandbox connectivity

## Test plan
- [x] Deny ExitPlanMode → verified via logs that `set_permission_mode("plan")` fires
- [x] Ask Claude to exit plan mode again after denial → Claude correctly retries instead of saying "not in plan mode"