### PR TITLE
Show icons for input bar selectors on mobile

### DIFF
--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo, useEffect } from 'react';
+import { Cpu } from 'lucide-react';
 import { Dropdown } from '@/components/ui/primitives/Dropdown';
 import type { DropdownItemType } from '@/components/ui/primitives/Dropdown';
 import { useAuthStore } from '@/store/authStore';
@@ -86,6 +87,7 @@ export const ModelSelector = memo(function ModelSelector({
       getItemLabel={(model) => `${model.provider_name} - ${model.name}`}
       getItemShortLabel={(model) => model.name}
       onSelect={(model) => onModelChange(model.model_id)}
+      leftIcon={Cpu}
       width="w-64"
       dropdownPosition={dropdownPosition}
       disabled={disabled}

--- a/frontend/src/components/chat/permission-mode-selector/PermissionModeSelector.tsx
+++ b/frontend/src/components/chat/permission-mode-selector/PermissionModeSelector.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Shield } from 'lucide-react';
 import { Dropdown } from '@/components/ui/primitives/Dropdown';
 import { useUIStore } from '@/store/uiStore';
 
@@ -37,6 +38,7 @@ export const PermissionModeSelector = memo(function PermissionModeSelector({
       getItemKey={(mode) => mode.value}
       getItemLabel={(mode) => mode.label}
       onSelect={(mode) => setPermissionMode(mode.value)}
+      leftIcon={Shield}
       width="w-48"
       itemClassName="flex flex-col gap-0.5"
       dropdownPosition={dropdownPosition}

--- a/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
+++ b/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Brain } from 'lucide-react';
 import { Dropdown } from '@/components/ui/primitives/Dropdown';
 import { useUIStore } from '@/store/uiStore';
 
@@ -38,6 +39,7 @@ export const ThinkingModeSelector = memo(function ThinkingModeSelector({
       getItemKey={(mode) => mode.value || 'off'}
       getItemLabel={(mode) => mode.label}
       onSelect={(mode) => setThinkingMode(mode.value)}
+      leftIcon={Brain}
       width="w-32"
       dropdownPosition={dropdownPosition}
       disabled={disabled}


### PR DESCRIPTION
## Summary
- Add `leftIcon` props (`Cpu`, `Brain`, `Shield`) to the model, thinking, and permission selectors so the existing `compactOnMobile` logic displays icon-only buttons on mobile (`< lg`)
- On desktop (`lg+`), text labels and chevrons continue to show as before
- Fix a missing space bug in the Dropdown icon className that prevented `lg:hidden` from applying correctly

## Test plan
- [ ] Resize browser below `lg` breakpoint (1024px) — selectors should show only icons
- [ ] Resize above `lg` — selectors should show text labels with chevrons
- [ ] Verify split mode still shows icon-only (forceCompact)
- [ ] Confirm dropdowns still open and function correctly on both mobile and desktop