### PR TITLE
Fix slash command output not rendering in chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@
 ## Code Style
 
 - Do not optimize for no regressions or long-term resilience unless explicitly requested — favor simple, direct changes over defensive scaffolding
+- Do not handle hypothetical input shapes — if you have evidence of the actual data format (logs, tests, type definitions), write code for that format only; do not add branches for types or structures you have not observed
 - Don't add comments or docstrings for self-explanatory code
 - Let the code speak for itself - use clear variable/function names instead of comments
 - Do not use decorative section comments (e.g., `# ── Section ──────`) — code structure should be self-evident from class/method organization

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     apt-get install -y gh && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.41 @gongrzhe/server-gmail-autoauth-mcp @openai/codex @playwright/mcp@latest
+RUN npm install -g @anthropic-ai/claude-code@2.1.42 @gongrzhe/server-gmail-autoauth-mcp @openai/codex @playwright/mcp@latest
 
 # Install uv package manager
 RUN curl -LsSf https://astral.sh/uv/install.sh | bash

--- a/backend/app/services/streaming/processor.py
+++ b/backend/app/services/streaming/processor.py
@@ -24,6 +24,10 @@ PROMPT_SUGGESTIONS_PATTERN = re.compile(
     r"<prompt_suggestions>\s*(.*?)\s*</prompt_suggestions>",
     re.DOTALL,
 )
+LOCAL_COMMAND_STDOUT_PATTERN = re.compile(
+    r"<local-command-stdout>(.*?)</local-command-stdout>",
+    re.DOTALL,
+)
 
 
 class StreamProcessor:
@@ -59,12 +63,23 @@ class StreamProcessor:
             return
 
         if isinstance(message, UserMessage):
-            yield from self._emit_user_events(message.content)
+            text = self._extract_command_stdout(message.content)
+            if text is not None:
+                yield from self._emit_text_block(text, event_type="assistant_text")
+            else:
+                yield from self._emit_user_events(message.content)
             return
 
         if isinstance(message, ResultMessage):
             if message.total_cost_usd is not None:
                 self.total_cost_usd = message.total_cost_usd
+
+    @staticmethod
+    def _extract_command_stdout(content: str | list[Any]) -> str | None:
+        if not isinstance(content, str):
+            return None
+        match = LOCAL_COMMAND_STDOUT_PATTERN.search(content)
+        return match.group(1).strip() if match else None
 
     def _emit_assistant_events(
         self, message: AssistantMessage

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.41 @openai/codex @gongrzhe/server-gmail-autoauth-mcp @playwright/mcp@latest
+    npm install -g @anthropic-ai/claude-code@2.1.42 @openai/codex @gongrzhe/server-gmail-autoauth-mcp @playwright/mcp@latest
 
 RUN python3 -m pip install --user --upgrade pip && \
     python3 -m pip install --user \

--- a/sandbox/e2b/e2b.Dockerfile
+++ b/sandbox/e2b/e2b.Dockerfile
@@ -51,7 +51,7 @@ RUN curl -fsSLO https://nodejs.org/dist/v20.19.0/node-v20.19.0-linux-x64.tar.xz 
     && echo '#!/bin/sh\nexec bun x "$@"' > /usr/local/bin/bunx \
     && chmod +x /usr/local/bin/bunx
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.41
+RUN npm install -g @anthropic-ai/claude-code@2.1.42
 
 RUN pip3 install anthropic-bridge==0.1.34
 


### PR DESCRIPTION
## Summary
- Slash commands (`/context`, `/compact`, `/review`, etc.) returned no visible output in the chat
- Root cause: the CLI returns slash command output as a `UserMessage` wrapped in `<local-command-stdout>` tags, which the stream processor emitted as `user_text` — a kind not rendered in the assistant message bubble
- Extract content from `<local-command-stdout>` tags and emit as `assistant_text` so it renders properly
- Add code style rule about not handling hypothetical input shapes
- Bump claude-code to 2.1.42

## Test plan
- [ ] Send `/context` in a chat — verify context usage table renders in the assistant bubble
- [ ] Send `/compact` — verify compaction summary renders
- [ ] Send a regular message — verify no duplication or regressions