### PR TITLE
Simplify cache module and remove redundant Redis lifecycle methods

### DIFF
--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 
 from app.constants import REDIS_KEY_CHAT_CONTEXT_USAGE, REDIS_KEY_CHAT_STREAM_LIVE
 from app.core.config import get_settings
-from app.utils.cache import CacheStore, MemoryStore, get_store
+from app.utils.cache import CacheStore, cache_connection
 from app.db.session import SessionLocal
 from app.models.db_models import (
     Chat,
@@ -39,7 +39,6 @@ from app.services.streaming.types import (
 )
 from app.services.claude_session_registry import session_registry
 from app.services.user import UserService
-from app.utils.cache import cache_connection
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -153,30 +152,6 @@ class ChatStreamRuntime:
         self.cache: CacheStore | None = None
         self._cancel_event: asyncio.Event | None = None
         self._cancelled: bool = False
-
-    async def _connect_redis(self) -> None:
-        try:
-            self.cache = get_store()
-        except Exception as exc:
-            logger.error("Failed to connect to Redis: %s", exc)
-            if self.cache:
-                try:
-                    await self.cache.close()
-                except Exception:
-                    logger.debug("Error closing Redis client during connect rollback")
-            self.cache = None
-
-    async def _close_redis(self) -> None:
-        if not self.cache:
-            return
-        if isinstance(self.cache, MemoryStore):
-            self.cache = None
-            return
-        try:
-            await self.cache.close()
-        except Exception as exc:
-            logger.debug("Error closing Redis client: %s", exc)
-        self.cache = None
 
     async def run(
         self, ai_service: ClaudeAgentService, stream: AsyncIterator[StreamEvent]
@@ -726,73 +701,74 @@ class ChatStreamRuntime:
         )
         cancel_event = CancellationHandler.register(runtime.chat_id)
         try:
-            await runtime._connect_redis()
-            runtime._cancel_event = cancel_event
+            async with cache_connection() as cache:
+                runtime.cache = cache
+                runtime._cancel_event = cancel_event
 
-            ai_service = ClaudeAgentService(session_factory=runtime.session_factory)
-            user = User(id=runtime.chat.user_id)
+                ai_service = ClaudeAgentService(session_factory=runtime.session_factory)
+                user = User(id=runtime.chat.user_id)
 
-            params: SessionParams = await ai_service.build_session_params(
-                user=user,
-                chat=runtime.chat,
-                system_prompt=request.system_prompt,
-                custom_instructions=request.custom_instructions,
-                model_id=request.model_id,
-                permission_mode=request.permission_mode,
-                session_id=request.session_id,
-                thinking_mode=request.thinking_mode,
-                is_custom_prompt=request.is_custom_prompt,
-            )
+                params: SessionParams = await ai_service.build_session_params(
+                    user=user,
+                    chat=runtime.chat,
+                    system_prompt=request.system_prompt,
+                    custom_instructions=request.custom_instructions,
+                    model_id=request.model_id,
+                    permission_mode=request.permission_mode,
+                    session_id=request.session_id,
+                    thinking_mode=request.thinking_mode,
+                    is_custom_prompt=request.is_custom_prompt,
+                )
 
-            session = await session_registry.get_or_create(
-                chat_id=runtime.chat_id,
-                sandbox_id=params.sandbox_id,
-                provider=params.sandbox_provider,
-                max_thinking_tokens=params.options.max_thinking_tokens,
-                options=params.options,
-                transport_factory=params.transport_factory,
-            )
+                session = await session_registry.get_or_create(
+                    chat_id=runtime.chat_id,
+                    sandbox_id=params.sandbox_id,
+                    provider=params.sandbox_provider,
+                    max_thinking_tokens=params.options.max_thinking_tokens,
+                    options=params.options,
+                    transport_factory=params.transport_factory,
+                )
 
-            session_callback = SessionUpdateCallback(
-                chat_id=runtime.chat_id,
-                assistant_message_id=request.assistant_message_id,
-                session_factory=runtime.session_factory,
-                session_container=runtime.session_container,
-            )
+                session_callback = SessionUpdateCallback(
+                    chat_id=runtime.chat_id,
+                    assistant_message_id=request.assistant_message_id,
+                    session_factory=runtime.session_factory,
+                    session_container=runtime.session_container,
+                )
 
-            async with session.lock:
-                session.active_generation_task = asyncio.current_task()
-                try:
-                    if params.options.model:
-                        await session.client.set_model(params.options.model)
-                    if params.options.permission_mode:
-                        await session.client.set_permission_mode(
-                            params.options.permission_mode
+                async with session.lock:
+                    session.active_generation_task = asyncio.current_task()
+                    try:
+                        if params.options.model:
+                            await session.client.set_model(params.options.model)
+                        if params.options.permission_mode:
+                            await session.client.set_permission_mode(
+                                params.options.permission_mode
+                            )
+                        stream = ai_service.stream_with_client(
+                            client=session.client,
+                            prompt=request.prompt,
+                            custom_instructions=request.custom_instructions,
+                            session_id=request.session_id,
+                            session_callback=session_callback,
+                            attachments=request.attachments,
                         )
-                    stream = ai_service.stream_with_client(
-                        client=session.client,
-                        prompt=request.prompt,
-                        custom_instructions=request.custom_instructions,
-                        session_id=request.session_id,
-                        session_callback=session_callback,
-                        attachments=request.attachments,
-                    )
-                    return await runtime.run(ai_service, stream)
-                except (
-                    ClaudeAgentException,
-                    asyncio.CancelledError,
-                ) as exc:
-                    if cls._is_transport_fatal(exc):
+                        return await runtime.run(ai_service, stream)
+                    except (
+                        ClaudeAgentException,
+                        asyncio.CancelledError,
+                    ) as exc:
+                        if cls._is_transport_fatal(exc):
+                            session.active_generation_task = None
+                            await session_registry.terminate(runtime.chat_id)
+                        raise
+                    except Exception:
                         session.active_generation_task = None
                         await session_registry.terminate(runtime.chat_id)
-                    raise
-                except Exception:
-                    session.active_generation_task = None
-                    await session_registry.terminate(runtime.chat_id)
-                    raise
-                finally:
-                    session.active_generation_task = None
-                    session.last_used_at = time.monotonic()
+                        raise
+                    finally:
+                        session.active_generation_task = None
+                        session.last_used_at = time.monotonic()
 
         except asyncio.CancelledError:
             await cls._mark_message_failed(
@@ -803,7 +779,6 @@ class ChatStreamRuntime:
             raise
         finally:
             CancellationHandler.unregister(runtime.chat_id, cancel_event)
-            await runtime._close_redis()
 
     @classmethod
     async def _bootstrap_and_execute(

--- a/backend/app/utils/cache.py
+++ b/backend/app/utils/cache.py
@@ -4,7 +4,7 @@ import time
 from collections import defaultdict
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, cast
 
 from app.core.config import get_settings
 
@@ -15,11 +15,10 @@ try:
     from redis.exceptions import RedisError as CacheError
 except ModuleNotFoundError:
 
-    class CacheError(OSError):  # type: ignore[no-redef]
+    class CacheError(OSError):  # type: ignore[no-redef]  # mypy can't resolve conditional try/except class definitions
         pass
 
 
-@runtime_checkable
 class CachePubSub(Protocol):
     async def subscribe(self, channel: str) -> None: ...
     async def unsubscribe(self, channel: str) -> None: ...
@@ -29,7 +28,6 @@ class CachePubSub(Protocol):
     async def close(self) -> None: ...
 
 
-@runtime_checkable
 class CacheStore(Protocol):
     async def get(self, key: str) -> str | None: ...
     async def set(self, key: str, value: str, ex: int | None = None) -> None: ...
@@ -69,23 +67,35 @@ class MemoryPubSub:
 
 
 class MemoryStore:
+    _instance: "MemoryStore | None" = None
+
+    @classmethod
+    def get_instance(cls) -> "MemoryStore":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
     def __init__(self) -> None:
         self._data: dict[str, str] = {}
         self._expiry: dict[str, float] = {}
         self._subscribers: dict[str, list[MemoryPubSub]] = defaultdict(list)
         self._timers: dict[str, asyncio.TimerHandle] = {}
 
-    def _is_expired(self, key: str) -> bool:
-        if key in self._expiry:
-            if time.monotonic() >= self._expiry[key]:
-                self._data.pop(key, None)
-                self._expiry.pop(key, None)
-                self._timers.pop(key, None)
-                return True
+    def _evict_if_expired(self, key: str) -> bool:
+        if key in self._expiry and time.monotonic() >= self._expiry[key]:
+            self._remove_key(key)
+            return True
         return False
 
+    def _remove_key(self, key: str) -> None:
+        self._data.pop(key, None)
+        self._expiry.pop(key, None)
+        timer = self._timers.pop(key, None)
+        if timer is not None:
+            timer.cancel()
+
     async def get(self, key: str) -> str | None:
-        if self._is_expired(key):
+        if self._evict_if_expired(key):
             return None
         return self._data.get(key)
 
@@ -104,32 +114,22 @@ class MemoryStore:
         if old_timer is not None:
             old_timer.cancel()
         loop = asyncio.get_running_loop()
-        self._timers[key] = loop.call_later(ttl, self._expire_key, key)
-
-    def _expire_key(self, key: str) -> None:
-        self._data.pop(key, None)
-        self._expiry.pop(key, None)
-        self._timers.pop(key, None)
+        self._timers[key] = loop.call_later(ttl, self._remove_key, key)
 
     async def delete(self, *keys: str) -> int:
         count = 0
         for key in keys:
-            if self._data.pop(key, None) is not None:
+            if key in self._data:
                 count += 1
-            self._expiry.pop(key, None)
-            timer = self._timers.pop(key, None)
-            if timer is not None:
-                timer.cancel()
+            self._remove_key(key)
         return count
 
     async def getdel(self, key: str) -> str | None:
-        if self._is_expired(key):
+        if self._evict_if_expired(key):
             return None
         value = self._data.pop(key, None)
-        self._expiry.pop(key, None)
-        timer = self._timers.pop(key, None)
-        if timer is not None:
-            timer.cancel()
+        if value is not None:
+            self._remove_key(key)
         return value
 
     async def publish(self, channel: str, message: str) -> int:
@@ -153,33 +153,29 @@ class MemoryStore:
         return True
 
     async def close(self) -> None:
-        pass
-
-
-_memory_store: dict[str, MemoryStore] = {}
-
-
-def get_store() -> CacheStore:
-    if settings.DESKTOP_MODE:
-        if "default" not in _memory_store:
-            _memory_store["default"] = MemoryStore()
-        return _memory_store["default"]
-    from redis.asyncio import Redis
-
-    return Redis.from_url(settings.REDIS_URL, decode_responses=True)  # type: ignore[return-value]
+        for timer in self._timers.values():
+            timer.cancel()
+        self._timers.clear()
+        self._data.clear()
+        self._expiry.clear()
+        self._subscribers.clear()
 
 
 @asynccontextmanager
 async def cache_connection() -> AsyncIterator[CacheStore]:
-    store = get_store()
+    if settings.DESKTOP_MODE:
+        yield MemoryStore.get_instance()
+        return
+    from redis.asyncio import Redis
+
+    store = cast(CacheStore, Redis.from_url(settings.REDIS_URL, decode_responses=True))
     try:
         yield store
     finally:
-        if not settings.DESKTOP_MODE:
-            try:
-                await store.close()
-            except Exception as e:
-                logger.warning("Error closing Redis connection: %s", e)
+        try:
+            await store.close()
+        except Exception as e:
+            logger.warning("Error closing Redis connection: %s", e)
 
 
 @asynccontextmanager

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -128,10 +128,16 @@ exclude = [
 "email-validator" = "email_validator"
 "fastapi-users" = "fastapi_users"
 "python-multipart" = "multipart"
+"pydantic-settings" = "pydantic_settings"
+"claude-agent-sdk" = "claude_agent_sdk"
+"prometheus-fastapi-instrumentator" = "prometheus_fastapi_instrumentator"
+"sse-starlette" = "sse_starlette"
+"anthropic-bridge" = "anthropic_bridge"
 
 [tool.deptry.per_rule_ignores]
 DEP002 = [
     "asyncpg",
+    "aiosqlite",
     "psycopg",
     "python-multipart",
     "bcrypt",


### PR DESCRIPTION
## Summary
- Remove `_connect_redis`/`_close_redis` from `ChatStreamRuntime` — use `cache_connection()` context manager instead, eliminating dead rollback code and duplicated desktop-mode checks
- Extract `_remove_key` in `MemoryStore` to consolidate the key cleanup pattern that was duplicated across 4 methods
- Rename `_is_expired` → `_evict_if_expired` to reflect its mutation side effect
- Replace module-level singleton dict with `MemoryStore.get_instance()` class method
- Remove unused `@runtime_checkable` decorators and `# type: ignore` comments
- Inline `get_store()` into `cache_connection()` (sole caller) and remove dead `DESKTOP_MODE` guard in finally block
- Make `MemoryStore.close()` actually clean up timers and internal state

## Test plan
- [ ] Run backend tests via `docker compose exec api pytest`
- [ ] Run type checks via `docker compose exec api mypy`
- [ ] Run linter via `docker compose exec api ruff check`
- [ ] Verify streaming works in desktop mode (MemoryStore path)
- [ ] Verify streaming works with Redis (non-desktop path)