### PR TITLE
Refactor route detection to use useMatch

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertTriangle, ArrowLeft, Command, LogOut, Moon, Settings, Sun } from 'lucide-react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useMatch } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
 import {
@@ -258,9 +258,8 @@ function UserMenu({
 
 export function Header({ onLogout, userName = 'User', isAuthPage = false }: HeaderProps) {
   const navigate = useNavigate();
-  const location = useLocation();
-  const isChatPage = location.pathname.startsWith('/chat/');
-  const isLandingPage = location.pathname === '/';
+  const isChatPage = useMatch('/chat/:chatId');
+  const isLandingPage = useMatch('/');
   const showSidebar = isChatPage || isLandingPage;
   const theme = useUIStore((state) => state.theme);
   const toggleTheme = useUIStore((state) => state.toggleTheme);


### PR DESCRIPTION
## Summary
- Replace `useLocation` + `pathname.startsWith`/`===` string checks with React Router's `useMatch` hook in the Header component
- `useMatch` is route-definition-aware and handles parameterized paths (`/chat/:chatId`) properly, avoiding brittle string matching

## Test plan
- [ ] Verify sidebar toggle still appears on chat and landing pages only
- [ ] Verify command menu icon still appears on chat pages only
- [ ] Verify home button still appears on auth pages