### PR TITLE
Use getState() for Zustand actions and minor perf fixes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,7 +33,6 @@ const ResetPasswordPage = lazy(() =>
 const SettingsPage = lazy(() => import('@/pages/SettingsPage'));
 
 function AppContent() {
-  const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const hasToken = !!authService.getToken();
   const isSessionAuthenticated = isAuthenticated && hasToken;
@@ -44,11 +43,11 @@ function AppContent() {
 
   useEffect(() => {
     if (hasToken && user) {
-      setAuthenticated(true);
+      useAuthStore.getState().setAuthenticated(true);
     } else if (isAuthenticated && !hasToken) {
-      setAuthenticated(false);
+      useAuthStore.getState().setAuthenticated(false);
     }
-  }, [user, hasToken, isAuthenticated, setAuthenticated]);
+  }, [user, hasToken, isAuthenticated]);
 
   const { data: chatsData, isLoading: isChatsLoading } = useInfiniteChatsQuery({
     enabled: isSessionAuthenticated,

--- a/frontend/src/components/chat/message-input/ContextUsageIndicator.tsx
+++ b/frontend/src/components/chat/message-input/ContextUsageIndicator.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 export interface ContextUsageInfo {
   tokensUsed: number;
   contextWindow: number;
@@ -15,32 +13,25 @@ export const ContextUsageIndicator = ({ usage }: { usage: ContextUsageInfo }) =>
   const percentage =
     usage.contextWindow > 0 ? Math.min((usage.tokensUsed / usage.contextWindow) * 100, 100) : 0;
 
-  const formattedPercentage = useMemo(() => {
-    if (percentage === 0) {
-      return '0';
-    }
-    if (percentage >= 10) {
-      return percentage.toFixed(0);
-    }
-    if (percentage >= 1) {
-      return percentage.toFixed(1);
-    }
-    return percentage.toFixed(2);
-  }, [percentage]);
+  const formattedPercentage =
+    percentage === 0
+      ? '0'
+      : percentage >= 10
+        ? percentage.toFixed(0)
+        : percentage >= 1
+          ? percentage.toFixed(1)
+          : percentage.toFixed(2);
 
   const radius = 9;
   const circumference = 2 * Math.PI * radius;
   const dashOffset = circumference * (1 - percentage / 100);
 
-  const progressClass = useMemo(() => {
-    if (percentage >= 95) {
-      return 'text-error-500 dark:text-error-400';
-    }
-    if (percentage >= 75) {
-      return 'text-warning-500 dark:text-warning-400';
-    }
-    return 'text-text-primary dark:text-text-dark-primary';
-  }, [percentage]);
+  const progressClass =
+    percentage >= 95
+      ? 'text-error-500 dark:text-error-400'
+      : percentage >= 75
+        ? 'text-warning-500 dark:text-warning-400'
+        : 'text-text-primary dark:text-text-dark-primary';
 
   const tooltip = `${formatNumberCompact(usage.tokensUsed)}/${formatNumberCompact(usage.contextWindow)}`;
 

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -59,9 +59,6 @@ export function InputProvider({
 
   const showPreview = showAttachedFilesPreview && hasAttachments && !previewDismissed;
 
-  const queueMessage = useMessageQueueStore((state) => state.queueMessage);
-  const permissionMode = useUIStore((state) => state.permissionMode);
-  const thinkingMode = useUIStore((state) => state.thinkingMode);
   const clearAttachedFiles = onAttach;
 
   const { previewUrls } = useFileHandling({
@@ -183,14 +180,17 @@ export function InputProvider({
     }
 
     if (isStreaming && hasMessage && chatId) {
-      void queueMessage(
-        chatId,
-        message.trim(),
-        selectedModelId,
-        permissionMode,
-        thinkingMode,
-        attachedFiles ?? undefined,
-      );
+      const { permissionMode, thinkingMode } = useUIStore.getState();
+      void useMessageQueueStore
+        .getState()
+        .queueMessage(
+          chatId,
+          message.trim(),
+          selectedModelId,
+          permissionMode,
+          thinkingMode,
+          attachedFiles ?? undefined,
+        );
       setMessage('');
       clearAttachedFiles?.([]);
       setPreviewDismissed(true);
@@ -226,12 +226,9 @@ export function InputProvider({
     chatId,
     message,
     attachedFiles,
-    queueMessage,
     setMessage,
     clearAttachedFiles,
     selectedModelId,
-    permissionMode,
-    thinkingMode,
   ]);
 
   const handleKeyDown = useCallback(

--- a/frontend/src/components/chat/permission-mode-selector/PermissionModeSelector.tsx
+++ b/frontend/src/components/chat/permission-mode-selector/PermissionModeSelector.tsx
@@ -25,7 +25,6 @@ export const PermissionModeSelector = memo(function PermissionModeSelector({
   disabled = false,
 }: PermissionModeSelectorProps) {
   const permissionMode = useUIStore((state) => state.permissionMode);
-  const setPermissionMode = useUIStore((state) => state.setPermissionMode);
   const isSplitMode = useUIStore((state) => state.isSplitMode);
 
   const selectedMode =
@@ -37,7 +36,7 @@ export const PermissionModeSelector = memo(function PermissionModeSelector({
       items={PERMISSION_MODES}
       getItemKey={(mode) => mode.value}
       getItemLabel={(mode) => mode.label}
-      onSelect={(mode) => setPermissionMode(mode.value)}
+      onSelect={(mode) => useUIStore.getState().setPermissionMode(mode.value)}
       leftIcon={Shield}
       width="w-48"
       itemClassName="flex flex-col gap-0.5"

--- a/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
+++ b/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
@@ -27,7 +27,6 @@ export const ThinkingModeSelector = memo(function ThinkingModeSelector({
   disabled = false,
 }: ThinkingModeSelectorProps) {
   const thinkingMode = useUIStore((state) => state.thinkingMode);
-  const setThinkingMode = useUIStore((state) => state.setThinkingMode);
   const isSplitMode = useUIStore((state) => state.isSplitMode);
 
   const selectedMode = THINKING_MODES.find((m) => m.value === thinkingMode) || THINKING_MODES[0];
@@ -38,7 +37,7 @@ export const ThinkingModeSelector = memo(function ThinkingModeSelector({
       items={THINKING_MODES}
       getItemKey={(mode) => mode.value || 'off'}
       getItemLabel={(mode) => mode.label}
-      onSelect={(mode) => setThinkingMode(mode.value)}
+      onSelect={(mode) => useUIStore.getState().setThinkingMode(mode.value)}
       leftIcon={Brain}
       width="w-32"
       dropdownPosition={dropdownPosition}

--- a/frontend/src/components/editor/file-preview/XlsxPreview.tsx
+++ b/frontend/src/components/editor/file-preview/XlsxPreview.tsx
@@ -56,8 +56,10 @@ export const XlsxPreview = memo(function XlsxPreview({
           const worksheet = workbook.Sheets[sheetName];
           const jsonData = XLSX.utils.sheet_to_json(worksheet, { header: 1, defval: '' });
 
-          const rowLengths = (jsonData as unknown[][]).map((row) => row.length);
-          const maxCols = rowLengths.length > 0 ? Math.max(...rowLengths) : 0;
+          let maxCols = 0;
+          for (const row of jsonData as unknown[][]) {
+            if (row.length > maxCols) maxCols = row.length;
+          }
 
           const data: SpreadsheetData = (jsonData as unknown[][])
             .filter(
@@ -203,10 +205,7 @@ export const XlsxPreview = memo(function XlsxPreview({
         <div className="h-16 shrink-0 border-t border-border bg-surface-secondary p-4 dark:border-border-dark dark:bg-surface-dark-secondary">
           <div className="text-sm text-text-secondary dark:text-text-dark-secondary">
             {currentSheet.data.length} rows ×{' '}
-            {currentSheet.data.length > 0
-              ? Math.max(...currentSheet.data.map((row) => row.length))
-              : 0}{' '}
-            columns
+            {currentSheet.data.reduce((max, row) => Math.max(max, row.length), 0)} columns
           </div>
         </div>
       </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -262,11 +262,8 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
   const isLandingPage = useMatch('/');
   const showSidebar = isChatPage || isLandingPage;
   const theme = useUIStore((state) => state.theme);
-  const toggleTheme = useUIStore((state) => state.toggleTheme);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
-  const setSidebarOpen = useUIStore((state) => state.setSidebarOpen);
 
   const { data: user } = useCurrentUserQuery({
     enabled: isAuthenticated && !isAuthPage,
@@ -278,7 +275,7 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
 
   const logoutMutation = useLogoutMutation({
     onSuccess: () => {
-      setAuthenticated(false);
+      useAuthStore.getState().setAuthenticated(false);
       navigate('/login');
     },
   });
@@ -328,7 +325,7 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
             <>
               <ToggleButton
                 isOpen={sidebarOpen}
-                onClick={() => setSidebarOpen(!sidebarOpen)}
+                onClick={() => useUIStore.getState().setSidebarOpen(!sidebarOpen)}
                 position="left"
                 className="mr-1"
               />
@@ -353,13 +350,15 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
         </div>
 
         <div className="flex items-center gap-1.5">
-          {showStandaloneThemeToggle && <ThemeToggleButton theme={theme} onToggle={toggleTheme} />}
+          {showStandaloneThemeToggle && (
+            <ThemeToggleButton theme={theme} onToggle={() => useUIStore.getState().toggleTheme()} />
+          )}
           {isAuthPage ? null : isAuthenticated ? (
             <UserMenu
               displayName={displayName}
               usage={usage}
               theme={theme}
-              onToggleTheme={toggleTheme}
+              onToggleTheme={() => useUIStore.getState().toggleTheme()}
               onSettings={() => {
                 prefetchSettingsPage();
                 handleNavigate('/settings');

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -8,14 +8,13 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 
 function MobileSidebarOverlay() {
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
-  const setSidebarOpen = useUIStore((state) => state.setSidebarOpen);
 
   if (!sidebarOpen) return null;
 
   return (
     <div
       className="fixed inset-0 z-30 bg-black/50 md:hidden"
-      onClick={() => setSidebarOpen(false)}
+      onClick={() => useUIStore.getState().setSidebarOpen(false)}
       aria-hidden="true"
     />
   );
@@ -39,13 +38,12 @@ export function Layout({
 }: LayoutProps) {
   const [sidebarContent, setSidebarContent] = useState<ReactNode | null>(null);
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
-  const setSidebarOpen = useUIStore((state) => state.setSidebarOpen);
   const isMobile = useIsMobile();
   const shouldPushContent = !!sidebarContent && sidebarOpen && !isMobile;
 
   useSwipeGesture({
-    onSwipeRight: () => setSidebarOpen(true),
-    onSwipeLeft: () => sidebarOpen && setSidebarOpen(false),
+    onSwipeRight: () => useUIStore.getState().setSidebarOpen(true),
+    onSwipeLeft: () => sidebarOpen && useUIStore.getState().setSidebarOpen(false),
     enabled: isMobile && !!sidebarContent,
   });
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -110,7 +110,6 @@ export function Sidebar({
 }: SidebarProps) {
   const navigate = useNavigate();
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
-  const setSidebarOpen = useUIStore((state) => state.setSidebarOpen);
   const isMobile = useIsMobile();
   const activeStreamMetadata = useStreamStore((state) => state.activeStreamMetadata);
   const streamingChatIdSet = useMemo(
@@ -194,10 +193,10 @@ export function Sidebar({
       onChatSelect(chatId);
       setHoveredChatId(null);
       if (isMobile) {
-        setSidebarOpen(false);
+        useUIStore.getState().setSidebarOpen(false);
       }
     },
-    [onChatSelect, isMobile, setSidebarOpen],
+    [onChatSelect, isMobile],
   );
 
   const handleDeleteChat = useCallback((chatId: string) => {
@@ -237,7 +236,7 @@ export function Sidebar({
   const handleNewChat = () => {
     navigate('/');
     if (isMobile) {
-      setSidebarOpen(false);
+      useUIStore.getState().setSidebarOpen(false);
     }
   };
 

--- a/frontend/src/components/views/index.ts
+++ b/frontend/src/components/views/index.ts
@@ -1,6 +1,0 @@
-export { BrowserView } from './BrowserView';
-export { IDEView } from './IDEView';
-export { MobilePreviewView } from './MobilePreviewView';
-export { SecretsView } from './SecretsView';
-export { TerminalView } from './TerminalView';
-export { WebPreviewView } from './WebPreviewView';

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -104,8 +104,6 @@ export function useChatStreaming({
     | null
   >(null);
 
-  const updateStreamCallbacks = useStreamStore((state) => state.updateStreamCallbacks);
-
   const isLoading = streamState === 'loading';
   const isStreaming = streamState === 'streaming';
 
@@ -149,7 +147,7 @@ export function useChatStreaming({
 
       if (existingStream && lastConnectedStreamRef.current !== existingStream.id) {
         lastConnectedStreamRef.current = existingStream.id;
-        updateStreamCallbacks(chatId, existingStream.messageId, {
+        useStreamStore.getState().updateStreamCallbacks(chatId, existingStream.messageId, {
           onEnvelope,
           onComplete,
           onError,
@@ -164,7 +162,7 @@ export function useChatStreaming({
 
     const unsubscribe = useStreamStore.subscribe(checkAndUpdateCallbacks);
     return () => unsubscribe();
-  }, [chatId, updateStreamCallbacks, onEnvelope, onComplete, onError, onQueueProcess]);
+  }, [chatId, onEnvelope, onComplete, onError, onQueueProcess]);
 
   useEffect(() => {
     if (prevChatIdRef.current !== chatId) {

--- a/frontend/src/hooks/useExitPlanMode.ts
+++ b/frontend/src/hooks/useExitPlanMode.ts
@@ -15,8 +15,6 @@ export function useExitPlanMode(chatId: string | undefined) {
   const [error, setError] = useState<string | null>(null);
 
   const pendingRequests = usePermissionStore((state) => state.pendingRequests);
-  const clearPermissionRequest = usePermissionStore((state) => state.clearPermissionRequest);
-  const setPermissionMode = useUIStore((state) => state.setPermissionMode);
 
   const pendingRequest = chatId ? (pendingRequests.get(chatId) ?? null) : null;
   const isExitPlanModeRequest = pendingRequest?.tool_name === 'ExitPlanMode';
@@ -31,19 +29,19 @@ export function useExitPlanMode(chatId: string | undefined) {
     try {
       await permissionService.respondToPermission(chatId, pendingRequest.request_id, true);
       addResolvedRequestId(pendingRequest.request_id);
-      clearPermissionRequest(chatId);
-      setPermissionMode('auto');
+      usePermissionStore.getState().clearPermissionRequest(chatId);
+      useUIStore.getState().setPermissionMode('auto');
     } catch (err) {
       if (isExpiredRequestError(err)) {
         addResolvedRequestId(pendingRequest.request_id);
-        clearPermissionRequest(chatId);
+        usePermissionStore.getState().clearPermissionRequest(chatId);
       } else {
         setError('Failed to approve plan');
       }
     } finally {
       setIsLoading(false);
     }
-  }, [chatId, pendingRequest, isExitPlanModeRequest, clearPermissionRequest, setPermissionMode]);
+  }, [chatId, pendingRequest, isExitPlanModeRequest]);
 
   const handleReject = useCallback(
     async (alternativeInstruction?: string) => {
@@ -61,11 +59,11 @@ export function useExitPlanMode(chatId: string | undefined) {
           alternativeInstruction,
         );
         addResolvedRequestId(pendingRequest.request_id);
-        clearPermissionRequest(chatId);
+        usePermissionStore.getState().clearPermissionRequest(chatId);
       } catch (err) {
         if (isExpiredRequestError(err)) {
           addResolvedRequestId(pendingRequest.request_id);
-          clearPermissionRequest(chatId);
+          usePermissionStore.getState().clearPermissionRequest(chatId);
         } else {
           setError('Failed to reject plan');
         }
@@ -73,7 +71,7 @@ export function useExitPlanMode(chatId: string | undefined) {
         setIsLoading(false);
       }
     },
-    [chatId, pendingRequest, isExitPlanModeRequest, clearPermissionRequest],
+    [chatId, pendingRequest, isExitPlanModeRequest],
   );
 
   return {

--- a/frontend/src/hooks/useGlobalStream.ts
+++ b/frontend/src/hooks/useGlobalStream.ts
@@ -9,7 +9,6 @@ interface UseGlobalStreamOptions {
 }
 
 export function useGlobalStream(options?: UseGlobalStreamOptions) {
-  const removeStreamMetadata = useStreamStore((state) => state.removeStreamMetadata);
   const hasValidatedRef = useRef(false);
 
   useEffect(() => {
@@ -26,11 +25,11 @@ export function useGlobalStream(options?: UseGlobalStreamOptions) {
           const status = await chatService.checkChatStatus(streamMeta.chatId);
 
           if (!status?.has_active_task) {
-            removeStreamMetadata(streamMeta.chatId);
+            useStreamStore.getState().removeStreamMetadata(streamMeta.chatId);
           }
         } catch (error) {
           logger.error('Stream validation failed', 'useGlobalStream', error);
-          removeStreamMetadata(streamMeta.chatId);
+          useStreamStore.getState().removeStreamMetadata(streamMeta.chatId);
         }
       });
 
@@ -41,7 +40,7 @@ export function useGlobalStream(options?: UseGlobalStreamOptions) {
     const timeoutId = setTimeout(validateStreams, 500);
 
     return () => clearTimeout(timeoutId);
-  }, [removeStreamMetadata, options]);
+  }, [options]);
 
   const stopAllStreams = useCallback(async () => {
     await streamService.stopAllStreams();

--- a/frontend/src/hooks/useStreamRestoration.ts
+++ b/frontend/src/hooks/useStreamRestoration.ts
@@ -17,7 +17,6 @@ export function useStreamRestoration({
   enabled = true,
 }: UseStreamRestorationOptions) {
   const hasRestoredRef = useRef(false);
-  const addStreamMetadata = useStreamStore((state) => state.addStreamMetadata);
 
   useEffect(() => {
     if (!enabled || hasRestoredRef.current || isLoading || !chats || chats.length === 0) {
@@ -47,7 +46,7 @@ export function useStreamRestoration({
               startTime: Date.now(),
             };
 
-            addStreamMetadata(metadata);
+            useStreamStore.getState().addStreamMetadata(metadata);
           }
         } catch (error) {
           logger.error('Failed to check chat status', 'useStreamRestoration', {
@@ -64,7 +63,7 @@ export function useStreamRestoration({
     restoreStreamMetadata().catch((error) => {
       logger.error('Stream restoration failed', 'useStreamRestoration', error);
     });
-  }, [chats, isLoading, enabled, addStreamMetadata]);
+  }, [chats, isLoading, enabled]);
 
   return { hasRestored: hasRestoredRef.current };
 }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -52,16 +52,13 @@ export function ChatPage() {
   const { chatId } = useParams();
   const navigate = useNavigate();
 
-  const setCurrentChat = useChatStore((state) => state.setCurrentChat);
-
   const { selectedModelId } = useModelSelection();
   useCommandMenu();
 
-  const { currentView, secondaryView, setCurrentView } = useUIStore(
+  const { currentView, secondaryView } = useUIStore(
     useShallow((state) => ({
       currentView: state.currentView,
       secondaryView: state.secondaryView,
-      setCurrentView: state.setCurrentView,
     })),
   );
 
@@ -123,13 +120,13 @@ export function ChatPage() {
     useEditorState(refetchFilesMetadata);
 
   useEffect(() => {
-    setCurrentChat(currentChat || null);
-  }, [currentChat, setCurrentChat]);
+    useChatStore.getState().setCurrentChat(currentChat || null);
+  }, [currentChat]);
 
   useEffect(() => {
     setSelectedFile(null);
-    setCurrentView('agent');
-  }, [chatId, setSelectedFile, setCurrentView]);
+    useUIStore.getState().setCurrentView('agent');
+  }, [chatId, setSelectedFile]);
 
   const handleChatSelect = useCallback(
     (selectedChatId: string) => {

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -46,8 +46,6 @@ const useExamplePrompts = () =>
 export function LandingPage() {
   const navigate = useNavigate();
   const attachedFiles = useChatStore((state) => state.attachedFiles);
-  const setAttachedFiles = useChatStore((state) => state.setAttachedFiles);
-  const setCurrentChat = useChatStore((state) => state.setCurrentChat);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { selectedModelId, selectModel } = useModelSelection({ enabled: isAuthenticated });
 
@@ -87,15 +85,12 @@ export function LandingPage() {
   }, [settings?.custom_prompts]);
 
   useEffect(() => {
-    setCurrentChat(null);
-  }, [setCurrentChat]);
+    useChatStore.getState().setCurrentChat(null);
+  }, []);
 
-  const handleFileAttach = useCallback(
-    (files: File[]) => {
-      setAttachedFiles(files);
-    },
-    [setAttachedFiles],
-  );
+  const handleFileAttach = useCallback((files: File[]) => {
+    useChatStore.getState().setAttachedFiles(files);
+  }, []);
 
   const handleNewChat = useCallback(
     async (e: React.FormEvent) => {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -95,14 +95,13 @@ const getFieldConfigs = (
 ];
 
 export function LoginPage() {
-  const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
   const navigate = useNavigate();
   const [values, setValues] = useState<LoginFormData>({ email: '', password: '' });
   const [errors, setErrors] = useState<LoginFormErrors | null>(null);
 
   const loginMutation = useLoginMutation({
     onSuccess: () => {
-      setAuthenticated(true);
+      useAuthStore.getState().setAuthenticated(true);
       navigate('/');
     },
   });

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -86,7 +86,6 @@ const validateForm = (values: SignupFormData): SignupFormErrors | null => {
 
 export function SignupPage() {
   const navigate = useNavigate();
-  const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
   const [values, setValues] = useState<SignupFormData>({
     email: '',
     username: '',
@@ -99,7 +98,7 @@ export function SignupPage() {
     onSuccess: (user) => {
       const needsVerification = user.email_verification_required && !user.is_verified;
       if (!needsVerification && authService.isAuthenticated()) {
-        setAuthenticated(true);
+        useAuthStore.getState().setAuthenticated(true);
         navigate('/');
       } else {
         navigate(`/verify-email?email=${encodeURIComponent(user.email)}`);


### PR DESCRIPTION
## Summary
- Replace 18+ Zustand selector-based subscriptions for action/setter functions with `getState()` calls at the call site across 15 files — prevents unnecessary selector evaluations on every store update
- Remove unnecessary `useMemo` wrappers for trivial derived values in `ContextUsageIndicator`
- Fix `Math.max(...spread)` on potentially large arrays in `XlsxPreview` (could hit stack limits)
- Delete unused barrel file `components/views/index.ts`

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Vite build succeeds
- [x] ESLint and Prettier pass (pre-commit hooks)
- [ ] Verify theme toggle, sidebar open/close, and logout still work in Header
- [ ] Verify sidebar swipe gestures work on mobile in Layout
- [ ] Verify chat creation and navigation from LandingPage
- [ ] Verify permission mode and thinking mode selectors update correctly
- [ ] Verify message queuing during active streams in InputProvider
- [ ] Verify stream restoration on page load
- [ ] Verify plan mode exit approval/rejection flow
- [ ] Verify XLSX file preview renders correctly with multi-sheet files