### PR TITLE
Fix context usage counting subagent tokens

### DIFF
--- a/backend/app/services/streaming/processor.py
+++ b/backend/app/services/streaming/processor.py
@@ -57,7 +57,8 @@ class StreamProcessor:
             return
 
         if isinstance(message, AssistantMessage):
-            if message.usage is not None:
+            is_subagent = getattr(message, "parent_tool_use_id", None) is not None
+            if message.usage is not None and not is_subagent:
                 self.usage = message.usage
             yield from self._emit_assistant_events(message)
             return


### PR DESCRIPTION
## Summary
- Subagent `AssistantMessage`s were overwriting the processor's `usage` field, causing the context usage indicator to jump to the subagent's token count and then drop back when the main agent resumed
- Skip usage updates for messages with a non-null `parent_tool_use_id` so only the main agent's context tokens are tracked and displayed

## Test plan
- [ ] Start a chat and observe context usage growing steadily
- [ ] Trigger a subagent call (e.g., Task tool) and verify the context percentage does not spike to the subagent's usage
- [ ] After the subagent completes, verify the percentage continues from where the main agent left off without dropping