### PR TITLE
Fix Zustand snapshot loop in chat and add guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@
 
 ### Re-render Optimization
 - Zustand selectors for action functions (used only in callbacks, not in JSX) must use `useStore.getState().action()` at the call site instead of subscribing with `useStore((s) => s.action)` — subscriptions cause re-renders when the store updates
+- Do not wrap Zustand store `set(...)` calls in `startTransition` inside store definitions/actions; use normal synchronous `set` in stores, and only use `startTransition` from React components/hooks when needed
+- Zustand selectors passed to `useStore(...)` must return stable references; never create new objects/arrays/`Set`/`Map` inside the selector. Subscribe to stable slices and derive new collections with `useMemo`
 - Use `Set` instead of arrays for membership checks in render loops — wrap with `useMemo(() => new Set(arr), [arr])` and use `.has()` instead of `.includes()`
 - Do not wrap trivial expressions in `useMemo` (e.g., `useMemo(() => x || [], [x])`) — use direct expressions (`x ?? []`)
 - Hoist regex patterns to module-level constants — never create RegExp inside loops or frequently-called functions

--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -27,14 +27,6 @@ import { useChatInputMessageContext } from '@/hooks/useChatInputMessageContext';
 
 const SCROLL_THRESHOLD_PERCENT = 20;
 
-function setsAreEqual(a: Set<string>, b: Set<string>): boolean {
-  if (a.size !== b.size) return false;
-  for (const id of a) {
-    if (!b.has(id)) return false;
-  }
-  return true;
-}
-
 export const Chat = memo(function Chat() {
   const { chatId } = useChatContext();
   const { state, actions } = useChatSessionContext();
@@ -69,23 +61,21 @@ export const Chat = memo(function Chat() {
 
   const { inputMessage, setInputMessage } = useChatInputMessageContext();
 
-  const streamingMessageIdSet = useStreamStore(
-    useCallback(
-      (s: {
-        activeStreams: Map<string, { chatId: string; isActive: boolean; messageId: string }>;
-      }) => {
-        const ids = new Set<string>();
-        s.activeStreams.forEach((stream) => {
-          if (stream.chatId === chatId && stream.isActive) {
-            ids.add(stream.messageId);
-          }
-        });
-        return ids;
-      },
-      [chatId],
-    ),
-    setsAreEqual,
-  );
+  const activeStreams = useStreamStore((state) => state.activeStreams);
+  const streamIdByChatMessage = useStreamStore((state) => state.streamIdByChatMessage);
+  const streamingMessageIdSet = useMemo(() => {
+    const ids = new Set<string>();
+    if (!chatId) return ids;
+
+    for (const streamId of streamIdByChatMessage.values()) {
+      const stream = activeStreams.get(streamId);
+      if (stream?.chatId === chatId && stream.isActive) {
+        ids.add(stream.messageId);
+      }
+    }
+
+    return ids;
+  }, [activeStreams, chatId, streamIdByChatMessage]);
 
   const pendingMessages = useMessageQueueStore((s) =>
     chatId ? (s.queues.get(chatId) ?? EMPTY_QUEUE) : EMPTY_QUEUE,


### PR DESCRIPTION
## Summary
- fix React/Zustand infinite update loop in chat by avoiding non-cached selector snapshots
- replace useStreamStore selector allocation pattern in Chat.tsx with stable slice subscriptions plus useMemo derivation
- add CLAUDE.md guardrails to prevent reintroducing the issue:
  - do not wrap Zustand store set(...) in startTransition inside store definitions/actions
  - do not return newly allocated objects/arrays/Set/Map from Zustand selectors

## Changed Files
- frontend/src/components/chat/chat-window/Chat.tsx
- CLAUDE.md

## Validation
- docker compose exec frontend npx eslint src/components/chat/chat-window/Chat.tsx
- docker compose exec frontend npx tsc --noEmit