### PR TITLE
Stabilize chat virtualization with bidirectional first-item anchoring

### DIFF
--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -6,6 +6,7 @@ import React, {
   useLayoutEffect,
   memo,
   useMemo,
+  type ReactNode,
 } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { isBrowserObjectUrl } from '@/utils/attachmentUrl';
@@ -115,6 +116,8 @@ export const Chat = memo(function Chat() {
   const [firstItemIndex, setFirstItemIndex] = useState(INITIAL_FIRST_ITEM_INDEX);
   const [showScrollButton, setShowScrollButton] = useState(false);
   const [scrollerElement, setScrollerElement] = useState<HTMLElement | null>(null);
+  const listHeaderRef = useRef<ReactNode>(null);
+  const listFooterRef = useRef<ReactNode>(null);
 
   useEffect(() => {
     hasScrolledToBottom.current = false;
@@ -185,6 +188,12 @@ export const Chat = memo(function Chat() {
     if (!container) return;
 
     const { scrollTop, scrollHeight, clientHeight } = container;
+
+    if (!hasScrolledToBottom.current) {
+      lastScrollTopRef.current = scrollTop;
+      return;
+    }
+
     const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
     const thresholdPixels = (clientHeight * SCROLL_THRESHOLD_PERCENT) / 100;
     const isAtBottom = distanceFromBottom <= thresholdPixels;
@@ -458,13 +467,13 @@ export const Chat = memo(function Chat() {
     showThinking,
   ]);
 
-  const virtuosoComponents = useMemo(
-    () => ({
-      Header: () => listHeader,
-      Footer: () => listFooter,
-    }),
-    [listFooter, listHeader],
-  );
+  listHeaderRef.current = listHeader;
+  listFooterRef.current = listFooter;
+
+  const virtuosoComponents = useRef({
+    Header: () => <>{listHeaderRef.current}</>,
+    Footer: () => <>{listFooterRef.current}</>,
+  }).current;
 
   return (
     <div className="relative flex min-w-0 flex-1 flex-col">

--- a/frontend/src/hooks/useMessageInitialization.ts
+++ b/frontend/src/hooks/useMessageInitialization.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { detectFileType } from '@/utils/fileTypes';
 import { createInitialMessage } from '@/utils/message';
 import { chatStorage } from '@/utils/storage';
@@ -33,11 +33,14 @@ export function useMessageInitialization({
   setMessages,
   setInitialPrompt,
 }: UseMessageInitializationParams) {
+  const hasMessagesRef = useRef(hasMessages);
+  hasMessagesRef.current = hasMessages;
+
   useEffect(() => {
     if (!fetchedMessages || !chatId || isLoading || wasAborted) return;
 
     // Skip reprocessing during streaming to preserve attachment references and prevent image flashing
-    if (isStreaming && hasMessages) return;
+    if (isStreaming && hasMessagesRef.current) return;
 
     const formattedMessages = fetchedMessages.map((msg: Message) => {
       const processedAttachments = msg.attachments?.map((attachment) => {
@@ -96,7 +99,6 @@ export function useMessageInitialization({
     selectedModelId,
     initialPromptSent,
     wasAborted,
-    hasMessages,
     initialPromptFromRoute,
     attachedFiles,
     isLoading,


### PR DESCRIPTION
## Summary
- replace length-based firstItemIndex adjustment with id-based bidirectional anchoring
- handle both prepends and top-removals by computing index deltas from message ids
- keep existing pagination arming/dedupe guards and streaming follow behavior

## Why
The previous length-delta logic only handled simple prepends and can drift when message array shape changes during refresh.

## Validation
- docker compose exec frontend npx tsc --noEmit
- docker compose exec frontend npx eslint src/components/chat/chat-window/Chat.tsx