### PR TITLE
Fix React performance issues from Vercel best practices review

### DIFF
--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -7,6 +7,7 @@ import React, {
   useMemo,
   type ReactNode,
 } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { isBrowserObjectUrl } from '@/utils/attachmentUrl';
 import { UserMessage, AssistantMessage } from '@/components/chat/message-bubble/Message';
@@ -21,12 +22,46 @@ import { useStreamStore } from '@/store/streamStore';
 import { useMessageQueueStore, EMPTY_QUEUE } from '@/store/messageQueueStore';
 import { ToolPermissionInline } from '@/components/chat/tools/ToolPermissionInline';
 import { useChatContext } from '@/hooks/useChatContext';
-import { useChatSessionContext } from '@/hooks/useChatSessionContext';
+import {
+  useChatSessionContext,
+  useChatSessionState,
+  useChatSessionActions,
+} from '@/hooks/useChatSessionContext';
 import { useChatInputMessageContext } from '@/hooks/useChatInputMessageContext';
 
 const AT_BOTTOM_THRESHOLD_PX = 200;
 const INITIAL_FIRST_ITEM_INDEX = 1_000_000;
 const TOP_PAGINATION_ARM_VIEWPORT_MULTIPLIER = 1.5;
+
+const MessageInlinePermission = memo(function MessageInlinePermission() {
+  const state = useChatSessionState();
+  const actions = useChatSessionActions();
+
+  if (
+    !state.pendingPermissionRequest ||
+    state.pendingPermissionRequest.tool_name === 'AskUserQuestion' ||
+    state.pendingPermissionRequest.tool_name === 'ExitPlanMode'
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="px-4 sm:px-6">
+      <div className="flex items-start gap-3 sm:gap-4">
+        <div className="h-8 w-8 flex-shrink-0" />
+        <div className="mb-3 mt-1 min-w-0 flex-1">
+          <ToolPermissionInline
+            request={state.pendingPermissionRequest}
+            onApprove={actions.onPermissionApprove}
+            onReject={actions.onPermissionReject}
+            isLoading={state.isPermissionLoading}
+            error={state.permissionError}
+          />
+        </div>
+      </div>
+    </div>
+  );
+});
 
 interface VirtuosoContextValue {
   header: ReactNode;
@@ -50,25 +85,19 @@ export const Chat = memo(function Chat() {
     hasNextPage,
     isFetchingNextPage,
     pendingPermissionRequest,
-    isPermissionLoading,
-    permissionError,
   } = state;
 
-  const {
-    onSubmit,
-    onStopStream,
-    onAttach,
-    onModelChange,
-    onDismissError,
-    fetchNextPage,
-    onPermissionApprove,
-    onPermissionReject,
-  } = actions;
+  const { onSubmit, onStopStream, onAttach, onModelChange, onDismissError, fetchNextPage } =
+    actions;
 
   const { inputMessage, setInputMessage } = useChatInputMessageContext();
 
-  const activeStreams = useStreamStore((streamState) => streamState.activeStreams);
-  const streamIdByChatMessage = useStreamStore((streamState) => streamState.streamIdByChatMessage);
+  const { activeStreams, streamIdByChatMessage } = useStreamStore(
+    useShallow((s) => ({
+      activeStreams: s.activeStreams,
+      streamIdByChatMessage: s.streamIdByChatMessage,
+    })),
+  );
   const streamingMessageIdSet = useMemo(() => {
     const ids = new Set<string>();
     if (!chatId) return ids;
@@ -288,8 +317,6 @@ export const Chat = memo(function Chat() {
       const messageIsStreaming = streamingMessageIdSet.has(msg.id);
       const isBotMessage = msg.is_bot ?? msg.role === 'assistant';
       const isLastBotMessage = isBotMessage && msg.id === lastBotMessageId;
-      const showPermissionAfterThis =
-        isLastBotMessage && !messageIsStreaming && canShowPermissionInline;
       const localAttachmentIds =
         msg.attachments?.reduce<string[]>((acc, attachment) => {
           if (isBrowserObjectUrl(attachment.file_url)) acc.push(attachment.id);
@@ -324,38 +351,11 @@ export const Chat = memo(function Chat() {
               isStreaming={messageIsStreaming}
             />
           )}
-          {showPermissionAfterThis && pendingPermissionRequest && (
-            <div className="px-4 sm:px-6">
-              <div className="flex items-start gap-3 sm:gap-4">
-                <div className="h-8 w-8 flex-shrink-0" />
-                <div className="mb-3 mt-1 min-w-0 flex-1">
-                  <ToolPermissionInline
-                    request={pendingPermissionRequest}
-                    onApprove={onPermissionApprove}
-                    onReject={onPermissionReject}
-                    isLoading={isPermissionLoading}
-                    error={permissionError}
-                  />
-                </div>
-              </div>
-            </div>
-          )}
+          {isLastBotMessage && !messageIsStreaming && <MessageInlinePermission />}
         </div>
       );
     },
-    [
-      canShowPermissionInline,
-      isLoading,
-      isPermissionLoading,
-      lastBotMessageId,
-      latestUserMessageId,
-      onPermissionApprove,
-      onPermissionReject,
-      pendingPermissionRequest,
-      pendingUserMessageId,
-      permissionError,
-      streamingMessageIdSet,
-    ],
+    [isLoading, lastBotMessageId, latestUserMessageId, pendingUserMessageId, streamingMessageIdSet],
   );
 
   const listHeader = useMemo(() => {
@@ -387,22 +387,7 @@ export const Chat = memo(function Chat() {
     return (
       <div className="w-full lg:mx-auto lg:max-w-3xl">
         {showThinking && <ThinkingIndicator />}
-        {showPermissionAtEnd && pendingPermissionRequest && (
-          <div className="px-4 sm:px-6">
-            <div className="flex items-start gap-3 sm:gap-4">
-              <div className="h-8 w-8 flex-shrink-0" />
-              <div className="mb-3 mt-1 min-w-0 flex-1">
-                <ToolPermissionInline
-                  request={pendingPermissionRequest}
-                  onApprove={onPermissionApprove}
-                  onReject={onPermissionReject}
-                  isLoading={isPermissionLoading}
-                  error={permissionError}
-                />
-              </div>
-            </div>
-          </div>
-        )}
+        {showPermissionAtEnd && <MessageInlinePermission />}
         {pendingMessages.map((pending) => (
           <PendingMessage
             key={pending.id}
@@ -418,13 +403,8 @@ export const Chat = memo(function Chat() {
     error,
     handleCancelPending,
     handleEditPending,
-    isPermissionLoading,
     onDismissError,
-    onPermissionApprove,
-    onPermissionReject,
     pendingMessages,
-    pendingPermissionRequest,
-    permissionError,
     showPermissionAtEnd,
     showThinking,
   ]);

--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from 'react';
 import { UserMessageContent, AssistantMessageContent } from './MessageContent';
 import { MessageActions } from './MessageActions';
-import { useModelsQuery } from '@/hooks/queries/useModelQueries';
+import { useModelMap } from '@/hooks/queries/useModelQueries';
 import type { AssistantStreamEvent, MessageAttachment } from '@/types/chat.types';
 import { Tooltip } from '@/components/ui/Tooltip';
 import { formatRelativeTime, formatFullTimestamp } from '@/utils/date';
@@ -72,16 +72,16 @@ export const AssistantMessage = memo(function AssistantMessage({
   const { chatId } = useChatContext();
   const { setInputMessage } = useChatInputMessageContext();
   const onSuggestionSelect = isLastBotMessage ? setInputMessage : undefined;
-  const { data: models = [] } = useModelsQuery();
+  const modelMap = useModelMap();
 
   const relativeTime = createdAt ? formatRelativeTime(createdAt) : '';
   const fullTimestamp = createdAt ? formatFullTimestamp(createdAt) : '';
   const modelName = useMemo(() => {
     if (!modelId) return null;
-    const model = models.find((m) => m.model_id === modelId);
+    const model = modelMap.get(modelId);
     if (model?.name) return model.name;
     return modelId.includes(':') ? modelId.split(':').pop()! : modelId;
-  }, [modelId, models]);
+  }, [modelId, modelMap]);
 
   return (
     <div className="group px-4 py-1.5 sm:px-6 sm:py-2">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -217,7 +217,7 @@ export function Sidebar({
     setHoveredChatId(null);
   }, []);
 
-  const confirmDeleteChat = async () => {
+  const confirmDeleteChat = useCallback(async () => {
     if (chatToDelete) {
       try {
         await deleteChat.mutateAsync(chatToDelete);
@@ -227,23 +227,21 @@ export function Sidebar({
           navigate('/');
         }
 
-        if (onDeleteChat) {
-          onDeleteChat(chatToDelete);
-        }
+        onDeleteChat?.(chatToDelete);
       } catch (error) {
         toast.error(error instanceof Error ? error.message : 'Failed to delete chat');
       } finally {
         setChatToDelete(null);
       }
     }
-  };
+  }, [chatToDelete, deleteChat, selectedChatId, navigate, onDeleteChat]);
 
-  const handleNewChat = () => {
+  const handleNewChat = useCallback(() => {
     navigate('/');
     if (isMobile) {
       useUIStore.getState().setSidebarOpen(false);
     }
-  };
+  }, [navigate, isMobile]);
 
   const handleDropdownClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>, chatId: string) => {
@@ -264,26 +262,29 @@ export function Sidebar({
     [],
   );
 
-  const handleRenameClick = (chat: Chat) => {
+  const handleRenameClick = useCallback((chat: Chat) => {
     setChatToRename(chat);
     setDropdown(null);
-  };
+  }, []);
 
-  const handleSaveRename = async (newTitle: string) => {
-    if (!chatToRename) return;
+  const handleSaveRename = useCallback(
+    async (newTitle: string) => {
+      if (!chatToRename) return;
 
-    try {
-      await updateChat.mutateAsync({
-        chatId: chatToRename.id,
-        updateData: { title: newTitle },
-      });
-      toast.success('Chat renamed successfully');
-      setChatToRename(null);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to rename chat');
-      throw error;
-    }
-  };
+      try {
+        await updateChat.mutateAsync({
+          chatId: chatToRename.id,
+          updateData: { title: newTitle },
+        });
+        toast.success('Chat renamed successfully');
+        setChatToRename(null);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to rename chat');
+        throw error;
+      }
+    },
+    [chatToRename, updateChat],
+  );
 
   const handleTogglePin = useCallback(
     async (chat: Chat) => {

--- a/frontend/src/hooks/queries/useModelQueries.ts
+++ b/frontend/src/hooks/queries/useModelQueries.ts
@@ -6,6 +6,8 @@ import type { Model } from '@/types/chat.types';
 import { useModelStore } from '@/store/modelStore';
 import { queryKeys } from './queryKeys';
 
+const EMPTY_MODEL_MAP = new Map<string, Model>();
+
 export const useModelsQuery = (options?: Partial<UseQueryOptions<Model[]>>) => {
   return useQuery({
     queryKey: [queryKeys.models],
@@ -36,3 +38,11 @@ export const useModelSelection = (options?: { enabled?: boolean }) => {
 
   return { models, selectedModelId, selectedModel, selectModel, isLoading };
 };
+
+export function useModelMap(): Map<string, Model> {
+  const { data: models } = useModelsQuery();
+  return useMemo(
+    () => (models ? new Map(models.map((m) => [m.model_id, m])) : EMPTY_MODEL_MAP),
+    [models],
+  );
+}

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -6,6 +6,7 @@ import { useStreamStore } from '@/store/streamStore';
 import type { Chat, ContextUsage, Message, PermissionRequest } from '@/types/chat.types';
 import type { StreamState } from '@/types/stream.types';
 import { cleanupExpiredPdfBlobs, storePdfBlobUrl } from '@/hooks/usePdfBlobCache';
+import { chatStorage } from '@/utils/storage';
 import { useMessageActions } from '@/hooks/useMessageActions';
 import { useInputState } from '@/hooks/useInputState';
 import { useClipboard } from '@/hooks/useClipboard';
@@ -296,6 +297,7 @@ export function useChatStreaming({
 
   useEffect(() => {
     cleanupExpiredPdfBlobs();
+    chatStorage.pruneStaleEntries();
     const interval = setInterval(cleanupExpiredPdfBlobs, 1000 * 60 * 30);
     return () => clearInterval(interval);
   }, []);

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -295,14 +295,15 @@ class StreamService {
 
     this.store.abortAllStreams();
 
+    const chatIdArr = Array.from(chatIds);
     const results = await Promise.allSettled(
-      Array.from(chatIds).map((chatId) => chatService.stopStream(chatId)),
+      chatIdArr.map((chatId) => chatService.stopStream(chatId)),
     );
 
     results.forEach((result, index) => {
       if (result.status === 'rejected') {
         logger.error('Batch stream stop failed', 'streamService', {
-          chatId: Array.from(chatIds)[index],
+          chatId: chatIdArr[index],
           error: result.reason,
         });
       }

--- a/frontend/src/store/streamStore.ts
+++ b/frontend/src/store/streamStore.ts
@@ -153,13 +153,16 @@ export const useStreamStore = create<StreamState>((set, get) => ({
       const stream = state.activeStreams.get(streamId);
       if (!stream) return state;
 
-      stream.messageId = newMessageId;
+      const updatedStream = { ...stream, messageId: newMessageId };
+      const nextStreams = new Map(state.activeStreams);
+      nextStreams.set(streamId, updatedStream);
 
       const nextIndex = new Map(state.streamIdByChatMessage);
       nextIndex.delete(getChatMessageKey(chatId, oldMessageId));
       nextIndex.set(getChatMessageKey(chatId, newMessageId), streamId);
 
       return {
+        activeStreams: nextStreams,
         streamIdByChatMessage: nextIndex,
         activeStreamMetadata: upsertStreamMetadata(state.activeStreamMetadata, {
           chatId: stream.chatId,

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -93,9 +93,35 @@ export const authStorage = {
   },
 };
 
+const CHAT_EVENT_ID_PREFIX = 'chat:';
+const CHAT_EVENT_ID_SUFFIX = ':lastEventId';
+const MAX_CHAT_EVENT_ID_ENTRIES = 500;
+
 export const chatStorage = {
-  getEventId: (chatId: string): string | null => safeGetItem(`chat:${chatId}:lastEventId`),
+  getEventId: (chatId: string): string | null =>
+    safeGetItem(`${CHAT_EVENT_ID_PREFIX}${chatId}${CHAT_EVENT_ID_SUFFIX}`),
   setEventId: (chatId: string, eventId: string): void =>
-    safeSetItem(`chat:${chatId}:lastEventId`, eventId),
-  removeEventId: (chatId: string): void => safeRemoveItem(`chat:${chatId}:lastEventId`),
+    safeSetItem(`${CHAT_EVENT_ID_PREFIX}${chatId}${CHAT_EVENT_ID_SUFFIX}`, eventId),
+  removeEventId: (chatId: string): void =>
+    safeRemoveItem(`${CHAT_EVENT_ID_PREFIX}${chatId}${CHAT_EVENT_ID_SUFFIX}`),
+  pruneStaleEntries: (): void => {
+    const storage = getStorage();
+    if (!storage) return;
+
+    const entries: { key: string; seq: number }[] = [];
+    for (let i = 0; i < storage.length; i++) {
+      const key = storage.key(i);
+      if (key?.startsWith(CHAT_EVENT_ID_PREFIX) && key.endsWith(CHAT_EVENT_ID_SUFFIX)) {
+        const val = storage.getItem(key);
+        entries.push({ key, seq: Number(val) || 0 });
+      }
+    }
+
+    if (entries.length <= MAX_CHAT_EVENT_ID_ENTRIES) return;
+
+    entries.sort((a, b) => b.seq - a.seq);
+    for (let i = MAX_CHAT_EVENT_ID_ENTRIES; i < entries.length; i++) {
+      storage.removeItem(entries[i].key);
+    }
+  },
 };


### PR DESCRIPTION
## Summary

- **Chat.tsx: Double zustand subscription** — Combined two `useStreamStore` selectors into a single `useShallow` selector, halving re-renders per stream state change in the most expensive component
- **Chat.tsx: renderMessage instability** — Extracted `MessageInlinePermission` component that reads permission state from context, reducing `renderMessage` deps from 11 to 5 and `listFooter` deps from 12 to 7 for better Virtuoso `itemContent` stability
- **storage.ts: Unbounded localStorage growth** — Added `chatStorage.pruneStaleEntries()` to cap `chat:*:lastEventId` entries at 500, evicting oldest by sequence number; called on mount alongside existing blob cleanup
- **streamStore.ts: Zustand immutability** — Fixed `updateStreamMessageId` to create a new stream object via spread instead of mutating in place, properly returning a new `activeStreams` Map through `set()`
- **streamService.ts: Redundant Array.from()** — Cached `Array.from(chatIds)` in a local variable, eliminating duplicate conversion in `stopAllStreams`
- **Sidebar.tsx: Unstable callbacks** — Wrapped `confirmDeleteChat`, `handleNewChat`, `handleRenameClick`, `handleSaveRename` in `useCallback`
- **Message.tsx: Linear model lookup** — Added `useModelMap()` hook returning a `Map<string, Model>` (with stable `EMPTY_MODEL_MAP` for loading state), replacing O(N) `models.find()` with O(1) `modelMap.get()` per `AssistantMessage` render

## Test plan

- [ ] Open an existing chat — messages render correctly, streaming works
- [ ] Send a message — streaming content appears, thinking indicator shows, completion fires notification
- [ ] Verify permission request UI renders inline after last bot message and in footer during streaming
- [ ] Pin/unpin, rename, delete chats via sidebar — actions complete successfully
- [ ] Model name displays correctly in assistant message metadata
- [ ] Open 500+ chats over time — localStorage does not grow unbounded (pruned on mount)
- [ ] TypeScript (`tsc --noEmit`) and ESLint pass cleanly