### PR TITLE
Fix React performance: lazy imports, Zustand selectors, hoisted regex

### DIFF
--- a/frontend/src/components/settings/dialogs/PluginDetailModal.tsx
+++ b/frontend/src/components/settings/dialogs/PluginDetailModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { Button } from '@/components/ui/primitives/Button';
 import { Spinner } from '@/components/ui/primitives/Spinner';
-import MarkDown from '@/components/ui/MarkDown';
+import { LazyMarkDown } from '@/components/ui/LazyMarkDown';
 import { Bot, Terminal, Zap, Plug, ExternalLink, X, AlertCircle } from 'lucide-react';
 import {
   usePluginDetailsQuery,
@@ -390,7 +390,7 @@ export const PluginDetailModal: React.FC<PluginDetailModalProps> = ({
                     Documentation
                   </h3>
                   <div className="max-h-64 overflow-y-auto rounded-lg bg-surface-tertiary p-3 dark:bg-surface-dark-tertiary">
-                    <MarkDown content={details.readme} />
+                    <LazyMarkDown content={details.readme} />
                   </div>
                 </div>
               )}

--- a/frontend/src/components/ui/MarkDown.tsx
+++ b/frontend/src/components/ui/MarkDown.tsx
@@ -23,6 +23,8 @@ type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement>;
 
 type ImageProps = ImgHTMLAttributes<HTMLImageElement>;
 
+const MATH_PATTERN = /(^|[^\\])(\$[^$\n]+\$|\$\$[\s\S]*?\$\$|\\\(|\\\[)/;
+
 const createImageAttachment = (url: string, alt?: string): MessageAttachment => {
   return {
     id: url,
@@ -39,10 +41,7 @@ function MarkDownInner({ content, className = '' }: { content: string; className
   const [remarkMathPlugin, setRemarkMathPlugin] = useState<unknown>(null);
   const [rehypeKatexPlugin, setRehypeKatexPlugin] = useState<unknown>(null);
 
-  const needsMath = useMemo(
-    () => /(^|[^\\])(\$[^$\n]+\$|\$\$[\s\S]*?\$\$|\\\(|\\\[)/.test(content),
-    [content],
-  );
+  const needsMath = useMemo(() => MATH_PATTERN.test(content), [content]);
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/src/hooks/queries/useModelQueries.ts
+++ b/frontend/src/hooks/queries/useModelQueries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import type { UseQueryOptions } from '@tanstack/react-query';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { modelService } from '@/services/modelService';
 import type { Model } from '@/types/chat.types';
 import { useModelStore } from '@/store/modelStore';
@@ -21,19 +21,23 @@ export const useModelSelection = (options?: { enabled?: boolean }) => {
     enabled: options?.enabled,
   });
   const selectedModelId = useModelStore((state) => state.selectedModelId);
-  const selectModel = useModelStore((state) => state.selectModel);
 
   useEffect(() => {
     if (models.length === 0) return;
     const selectedExists = models.some((m) => m.model_id === selectedModelId);
     if (!selectedExists) {
-      selectModel(models[0].model_id);
+      useModelStore.getState().selectModel(models[0].model_id);
     }
-  }, [models, selectedModelId, selectModel]);
+  }, [models, selectedModelId]);
 
   const selectedModel = useMemo(
     () => models.find((m) => m.model_id === selectedModelId) ?? null,
     [models, selectedModelId],
+  );
+
+  const selectModel = useCallback(
+    (modelId: string) => useModelStore.getState().selectModel(modelId),
+    [],
   );
 
   return { models, selectedModelId, selectedModel, selectModel, isLoading };

--- a/frontend/src/hooks/usePermissionRequest.ts
+++ b/frontend/src/hooks/usePermissionRequest.ts
@@ -24,8 +24,6 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
   const [error, setError] = useState<string | null>(null);
 
   const pendingRequests = usePermissionStore((state) => state.pendingRequests);
-  const setPermissionRequest = usePermissionStore((state) => state.setPermissionRequest);
-  const clearPermissionRequest = usePermissionStore((state) => state.clearPermissionRequest);
 
   const pendingRequest = chatId ? (pendingRequests.get(chatId) ?? null) : null;
 
@@ -37,9 +35,9 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
     (request: PermissionRequest) => {
       if (!chatId) return;
       if (isRequestResolved(request.request_id)) return;
-      setPermissionRequest(chatId, request);
+      usePermissionStore.getState().setPermissionRequest(chatId, request);
     },
-    [chatId, setPermissionRequest],
+    [chatId],
   );
 
   const handleApprove = useCallback(async () => {
@@ -52,18 +50,18 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
     try {
       await permissionService.respondToPermission(chatId, pendingRequest.request_id, true);
       addResolvedRequestId(pendingRequest.request_id);
-      clearPermissionRequest(chatId);
+      usePermissionStore.getState().clearPermissionRequest(chatId);
     } catch (err) {
       if (isExpiredRequestError(err)) {
         addResolvedRequestId(pendingRequest.request_id);
-        clearPermissionRequest(chatId);
+        usePermissionStore.getState().clearPermissionRequest(chatId);
       } else {
         setError(err instanceof Error ? err.message : 'Failed to approve permission');
       }
     } finally {
       setIsLoading(false);
     }
-  }, [chatId, pendingRequest, clearPermissionRequest]);
+  }, [chatId, pendingRequest]);
 
   const handleReject = useCallback(
     async (alternativeInstruction?: string) => {
@@ -81,11 +79,11 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
           alternativeInstruction,
         );
         addResolvedRequestId(pendingRequest.request_id);
-        clearPermissionRequest(chatId);
+        usePermissionStore.getState().clearPermissionRequest(chatId);
       } catch (err) {
         if (isExpiredRequestError(err)) {
           addResolvedRequestId(pendingRequest.request_id);
-          clearPermissionRequest(chatId);
+          usePermissionStore.getState().clearPermissionRequest(chatId);
         } else {
           setError(err instanceof Error ? err.message : 'Failed to reject permission');
         }
@@ -93,7 +91,7 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
         setIsLoading(false);
       }
     },
-    [chatId, pendingRequest, clearPermissionRequest],
+    [chatId, pendingRequest],
   );
 
   return {


### PR DESCRIPTION
## Summary
- **PluginDetailModal**: Switch from direct `MarkDown` import to `LazyMarkDown` to avoid pulling `react-markdown`/`remark-gfm` into the chunk statically
- **useModelSelection**: Remove `selectModel` Zustand store subscription; use `getState()` at call sites via a stable `useCallback` wrapper
- **usePermissionRequest**: Remove `setPermissionRequest` and `clearPermissionRequest` store subscriptions; use `getState()` at call sites, trimming dependency arrays
- **MarkDown**: Hoist math detection regex to module-level `MATH_PATTERN` constant to avoid re-creation on every `useMemo` evaluation

## Test plan
- [ ] Verify plugin detail modal still renders markdown readme content correctly
- [ ] Verify model selection works (switching models, default selection on first load)
- [ ] Verify permission approve/reject flows work in chat
- [ ] Verify math rendering in markdown messages (e.g. `$x^2$`, `$$\sum$$`)
- [ ] Confirm `tsc --noEmit` and `eslint` pass cleanly