### PR TITLE
fix(docker-provider): create parent dir as root before put_archive

### DIFF
--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -343,8 +343,15 @@ class LocalDockerProvider(SandboxProvider):
         tar_stream.seek(0)
 
         parent_dir = str(Path(normalized_path).parent)
-        mkdir_exec = await container.exec(cmd=["mkdir", "-p", parent_dir])
-        await self._collect_exec_output(mkdir_exec)
+        mkdir_exec = await container.exec(
+            cmd=["mkdir", "-p", parent_dir],
+            user="root",
+        )
+        mkdir_exit_code, mkdir_output = await self._collect_exec_output(mkdir_exec)
+        if mkdir_exit_code != 0:
+            raise SandboxException(
+                f"Failed to create directory {parent_dir}: {mkdir_output}"
+            )
         await container.put_archive(parent_dir, tar_stream.read())
 
     async def read_file(


### PR DESCRIPTION
## Summary
- run parent directory creation as root before `put_archive`
- check mkdir exit code and raise `SandboxException` on failure
- prevent silent mkdir failures that surfaced later as `DockerError(404, 'Could not find the file /home/user ...')`

## Validation
- docker compose -f docker-compose.test.yml run --rm backend-test mypy app/services/sandbox_providers/docker_provider.py