### PR TITLE
fix(frontend): add success toasts for task schedule operations

### DIFF
--- a/frontend/src/components/settings/tabs/TasksSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/TasksSettingsTab.tsx
@@ -56,7 +56,8 @@ export const TasksSettingsTab: React.FC<TasksSettingsTabProps> = ({ onAddTask, o
     async (task: ScheduledTask) => {
       setTogglingTaskId(task.id);
       try {
-        await toggleTask.mutateAsync(task.id);
+        const result = await toggleTask.mutateAsync(task.id);
+        toast.success(`Task ${result.enabled ? 'resumed' : 'paused'}`);
       } catch (error) {
         logger.error('Failed to toggle task', 'TasksSettingsTab', error);
         toast.error('Failed to toggle task status');
@@ -81,6 +82,7 @@ export const TasksSettingsTab: React.FC<TasksSettingsTabProps> = ({ onAddTask, o
     setDeletingTaskId(targetTask.id);
     try {
       await deleteTask.mutateAsync(targetTask.id);
+      toast.success('Task deleted');
       setTaskPendingDelete(null);
     } catch (error) {
       logger.error('Failed to delete task', 'TasksSettingsTab', error);

--- a/frontend/src/hooks/useTaskManagement.ts
+++ b/frontend/src/hooks/useTaskManagement.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { Dayjs } from 'dayjs';
 import dayjs from 'dayjs';
+import toast from 'react-hot-toast';
 import type { RecurrenceType, ScheduledTask } from '@/types/scheduler.types';
 import {
   useCreateScheduledTaskMutation,
@@ -119,8 +120,10 @@ export const useTaskManagement = (defaultModelId: string) => {
           taskId: editingTaskId,
           data: taskData,
         });
+        toast.success('Task updated');
       } else {
         await createTask.mutateAsync(taskData);
+        toast.success('Task created');
       }
       handleTaskDialogClose();
     } catch (error) {


### PR DESCRIPTION
## Summary
- Added success toast notifications for task create, update, delete, and toggle (pause/resume) operations
- Previously only error toasts were shown, leaving users without feedback on successful actions

## Test plan
- [ ] Create a new scheduled task → verify "Task created" toast appears
- [ ] Edit an existing task → verify "Task updated" toast appears
- [ ] Delete a task → verify "Task deleted" toast appears
- [ ] Pause/resume a task → verify "Task paused"/"Task resumed" toast appears
- [ ] Verify error toasts still appear on failure