### PR TITLE
feat: support queuing multiple messages per chat

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -42,9 +42,9 @@ from app.models.schemas import (
     PaginatedChats,
     PaginationParams,
     PermissionRespondResponse,
+    QueueAddResponse,
     QueuedMessage,
     QueueMessageUpdate,
-    QueueUpsertResponse,
     RestoreRequest,
 )
 from app.services.chat import ChatService
@@ -491,7 +491,7 @@ async def respond_to_permission(
 
 @router.post(
     "/chats/{chat_id}/queue",
-    response_model=QueueUpsertResponse,
+    response_model=QueueAddResponse,
     status_code=status.HTTP_201_CREATED,
 )
 async def queue_message(
@@ -503,7 +503,7 @@ async def queue_message(
     attached_files: list[UploadFile] | None = File(None),
     current_user: User = Depends(get_current_user),
     chat_service: ChatService = Depends(get_chat_service),
-) -> QueueUpsertResponse:
+) -> QueueAddResponse:
     try:
         chat = await chat_service.get_chat(chat_id, current_user)
     except ChatException:
@@ -532,7 +532,7 @@ async def queue_message(
     try:
         async with cache_connection() as cache:
             queue_service = QueueService(cache)
-            return await queue_service.upsert_message(
+            return await queue_service.add_message(
                 str(chat_id),
                 content,
                 model_id,
@@ -550,19 +550,19 @@ async def queue_message(
 
 @router.get(
     "/chats/{chat_id}/queue",
-    response_model=QueuedMessage | None,
+    response_model=list[QueuedMessage],
 )
 async def get_queue(
     chat_id: UUID,
     current_user: User = Depends(get_current_user),
     chat_service: ChatService = Depends(get_chat_service),
-) -> QueuedMessage | None:
+) -> list[QueuedMessage]:
     await _ensure_chat_access(chat_id, chat_service, current_user)
 
     try:
         async with cache_connection() as cache:
             queue_service = QueueService(cache)
-            return await queue_service.get_message(str(chat_id))
+            return await queue_service.get_queue(str(chat_id))
     except CacheError as e:
         logger.error("Redis error getting queue: %s", e, exc_info=True)
         raise HTTPException(
@@ -572,11 +572,12 @@ async def get_queue(
 
 
 @router.patch(
-    "/chats/{chat_id}/queue",
+    "/chats/{chat_id}/queue/{message_id}",
     response_model=QueuedMessage,
 )
 async def update_queued_message(
     chat_id: UUID,
+    message_id: UUID,
     update: QueueMessageUpdate,
     current_user: User = Depends(get_current_user),
     chat_service: ChatService = Depends(get_chat_service),
@@ -586,15 +587,46 @@ async def update_queued_message(
     try:
         async with cache_connection() as cache:
             queue_service = QueueService(cache)
-            result = await queue_service.update_message(str(chat_id), update.content)
+            result = await queue_service.update_message(
+                str(chat_id), str(message_id), update.content
+            )
             if result is None:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
-                    detail="No queued message found",
+                    detail="Queued message not found",
                 )
             return result
     except CacheError as e:
         logger.error("Redis error updating queued message: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Service temporarily unavailable",
+        )
+
+
+@router.delete(
+    "/chats/{chat_id}/queue/{message_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_queued_message(
+    chat_id: UUID,
+    message_id: UUID,
+    current_user: User = Depends(get_current_user),
+    chat_service: ChatService = Depends(get_chat_service),
+) -> None:
+    await _ensure_chat_access(chat_id, chat_service, current_user)
+
+    try:
+        async with cache_connection() as cache:
+            queue_service = QueueService(cache)
+            found = await queue_service.delete_message(str(chat_id), str(message_id))
+            if not found:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Queued message not found",
+                )
+    except CacheError as e:
+        logger.error("Redis error deleting queued message: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Service temporarily unavailable",
@@ -615,12 +647,7 @@ async def clear_queue(
     try:
         async with cache_connection() as cache:
             queue_service = QueueService(cache)
-            success = await queue_service.clear_queue(str(chat_id))
-            if not success:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="No queued message found",
-                )
+            await queue_service.clear_queue(str(chat_id))
     except CacheError as e:
         logger.error("Redis error clearing queue: %s", e, exc_info=True)
         raise HTTPException(

--- a/backend/app/models/schemas/__init__.py
+++ b/backend/app/models/schemas/__init__.py
@@ -81,9 +81,9 @@ from .mcps import McpCreateRequest, McpDeleteResponse, McpResponse, McpUpdateReq
 from .ai_model import AIModelResponse
 from .errors import HTTPErrorResponse
 from .queue import (
+    QueueAddResponse,
     QueuedMessage,
     QueueMessageUpdate,
-    QueueUpsertResponse,
 )
 
 __all__ = [
@@ -182,5 +182,5 @@ __all__ = [
     # queue
     "QueuedMessage",
     "QueueMessageUpdate",
-    "QueueUpsertResponse",
+    "QueueAddResponse",
 ]

--- a/backend/app/models/schemas/queue.py
+++ b/backend/app/models/schemas/queue.py
@@ -22,8 +22,6 @@ class QueuedMessage(QueuedMessageBase):
     attachments: list[dict[str, Any]] | None = None
 
 
-class QueueUpsertResponse(BaseModel):
+class QueueAddResponse(BaseModel):
     id: UUID
-    created: bool
-    content: str
-    attachments: list[dict[str, Any]] | None = None
+    queued_at: datetime

--- a/backend/app/services/queue.py
+++ b/backend/app/services/queue.py
@@ -8,7 +8,7 @@ from app.constants import (
     QUEUE_MESSAGE_TTL_SECONDS,
     REDIS_KEY_CHAT_QUEUE,
 )
-from app.models.schemas.queue import QueuedMessage, QueueUpsertResponse
+from app.models.schemas.queue import QueueAddResponse, QueuedMessage
 
 from app.utils.cache import CacheStore
 
@@ -22,7 +22,22 @@ class QueueService:
     def _queue_key(self, chat_id: str) -> str:
         return REDIS_KEY_CHAT_QUEUE.format(chat_id=chat_id)
 
-    async def upsert_message(
+    async def _read_queue(self, key: str) -> list[dict[str, Any]]:
+        raw = await self.cache.get(key)
+        if not raw:
+            return []
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            return [parsed]
+        return cast(list[dict[str, Any]], parsed)
+
+    async def _write_queue(self, key: str, queue: list[dict[str, Any]]) -> None:
+        if not queue:
+            await self.cache.delete(key)
+        else:
+            await self.cache.set(key, json.dumps(queue), ex=QUEUE_MESSAGE_TTL_SECONDS)
+
+    async def add_message(
         self,
         chat_id: str,
         content: str,
@@ -30,103 +45,81 @@ class QueueService:
         permission_mode: str = "auto",
         thinking_mode: str | None = None,
         attachments: list[dict[str, Any]] | None = None,
-    ) -> QueueUpsertResponse:
+    ) -> QueueAddResponse:
         key = self._queue_key(chat_id)
-        raw = await self.cache.get(key)
-
-        if raw:
-            data = json.loads(raw)
-            data["content"] = data["content"] + "\n" + content
-            data["model_id"] = model_id
-            data["permission_mode"] = permission_mode
-            if thinking_mode is not None:
-                data["thinking_mode"] = thinking_mode
-
-            if attachments:
-                existing_attachments = data.get("attachments") or []
-                data["attachments"] = existing_attachments + attachments
-
-            await self.cache.set(key, json.dumps(data), ex=QUEUE_MESSAGE_TTL_SECONDS)
-
-            return QueueUpsertResponse(
-                id=UUID(data["id"]),
-                created=False,
-                content=data["content"],
-                attachments=data.get("attachments"),
-            )
+        queue = await self._read_queue(key)
 
         message_id = uuid4()
+        queued_at = datetime.now(timezone.utc)
         message_data: dict[str, Any] = {
             "id": str(message_id),
             "content": content,
             "model_id": model_id,
             "permission_mode": permission_mode,
             "thinking_mode": thinking_mode,
-            "queued_at": datetime.now(timezone.utc).isoformat(),
+            "queued_at": queued_at.isoformat(),
             "attachments": attachments,
         }
 
-        await self.cache.set(
-            key, json.dumps(message_data), ex=QUEUE_MESSAGE_TTL_SECONDS
-        )
+        queue.append(message_data)
+        await self._write_queue(key, queue)
 
-        return QueueUpsertResponse(
-            id=message_id,
-            created=True,
-            content=content,
-            attachments=attachments,
-        )
+        return QueueAddResponse(id=message_id, queued_at=queued_at)
 
-    async def get_message(self, chat_id: str) -> QueuedMessage | None:
-        key = self._queue_key(chat_id)
-        raw = await self.cache.get(key)
-
-        if not raw:
-            return None
-
-        data = json.loads(raw)
+    @staticmethod
+    def _to_queued_message(item: dict[str, Any]) -> QueuedMessage:
         return QueuedMessage(
-            id=UUID(data["id"]),
-            content=data["content"],
-            model_id=data["model_id"],
-            permission_mode=data.get("permission_mode", "auto"),
-            thinking_mode=data.get("thinking_mode"),
-            queued_at=datetime.fromisoformat(data["queued_at"]),
-            attachments=data.get("attachments"),
+            id=UUID(item["id"]),
+            content=item["content"],
+            model_id=item["model_id"],
+            permission_mode=item.get("permission_mode", "auto"),
+            thinking_mode=item.get("thinking_mode"),
+            queued_at=datetime.fromisoformat(item["queued_at"]),
+            attachments=item.get("attachments"),
         )
 
-    async def update_message(self, chat_id: str, content: str) -> QueuedMessage | None:
+    async def get_queue(self, chat_id: str) -> list[QueuedMessage]:
         key = self._queue_key(chat_id)
-        raw = await self.cache.get(key)
+        queue = await self._read_queue(key)
+        return [self._to_queued_message(item) for item in queue]
 
-        if not raw:
-            return None
-
-        data = json.loads(raw)
-        data["content"] = content
-
-        await self.cache.set(key, json.dumps(data), ex=QUEUE_MESSAGE_TTL_SECONDS)
-
-        return QueuedMessage(
-            id=UUID(data["id"]),
-            content=data["content"],
-            model_id=data["model_id"],
-            permission_mode=data.get("permission_mode", "auto"),
-            thinking_mode=data.get("thinking_mode"),
-            queued_at=datetime.fromisoformat(data["queued_at"]),
-            attachments=data.get("attachments"),
-        )
-
-    async def clear_queue(self, chat_id: str) -> bool:
+    async def update_message(
+        self, chat_id: str, message_id: str, content: str
+    ) -> QueuedMessage | None:
         key = self._queue_key(chat_id)
-        deleted = await self.cache.delete(key)
-        return deleted > 0
+        queue = await self._read_queue(key)
+
+        for item in queue:
+            if item["id"] == message_id:
+                item["content"] = content
+                await self._write_queue(key, queue)
+                return self._to_queued_message(item)
+
+        return None
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        key = self._queue_key(chat_id)
+        queue = await self._read_queue(key)
+        original_len = len(queue)
+        queue = [item for item in queue if item["id"] != message_id]
+
+        if len(queue) == original_len:
+            return False
+
+        await self._write_queue(key, queue)
+        return True
+
+    async def clear_queue(self, chat_id: str) -> None:
+        key = self._queue_key(chat_id)
+        await self.cache.delete(key)
 
     async def pop_next_message(self, chat_id: str) -> dict[str, Any] | None:
         key = self._queue_key(chat_id)
-        raw = await self.cache.getdel(key)
+        queue = await self._read_queue(key)
 
-        if not raw:
+        if not queue:
             return None
 
-        return cast(dict[str, Any], json.loads(raw))
+        next_msg = queue[0]
+        await self._write_queue(key, queue[1:])
+        return next_msg

--- a/backend/tests/test_queue.py
+++ b/backend/tests/test_queue.py
@@ -28,12 +28,11 @@ class TestQueueMessage:
 
         assert response.status_code == 201
         data = response.json()
-        assert data["created"] is True
-        assert data["content"] == "Test queued message"
         assert "id" in data
         assert uuid.UUID(data["id"])
+        assert "queued_at" in data
 
-    async def test_queue_message_appends(
+    async def test_queue_multiple_messages(
         self,
         async_client: AsyncClient,
         integration_chat_fixture: tuple[User, Chat, SandboxService],
@@ -41,7 +40,7 @@ class TestQueueMessage:
     ) -> None:
         _, chat, _ = integration_chat_fixture
 
-        await async_client.post(
+        resp1 = await async_client.post(
             f"/api/v1/chat/chats/{chat.id}/queue",
             data={
                 "content": "First message",
@@ -49,8 +48,10 @@ class TestQueueMessage:
             },
             headers=auth_headers,
         )
+        assert resp1.status_code == 201
+        id1 = resp1.json()["id"]
 
-        response = await async_client.post(
+        resp2 = await async_client.post(
             f"/api/v1/chat/chats/{chat.id}/queue",
             data={
                 "content": "Second message",
@@ -58,12 +59,18 @@ class TestQueueMessage:
             },
             headers=auth_headers,
         )
+        assert resp2.status_code == 201
+        id2 = resp2.json()["id"]
+        assert id1 != id2
 
-        assert response.status_code == 201
-        data = response.json()
-        assert data["created"] is False
-        assert "First message" in data["content"]
-        assert "Second message" in data["content"]
+        get_response = await async_client.get(
+            f"/api/v1/chat/chats/{chat.id}/queue",
+            headers=auth_headers,
+        )
+        queue = get_response.json()
+        assert len(queue) == 2
+        assert queue[0]["content"] == "First message"
+        assert queue[1]["content"] == "Second message"
 
     async def test_queue_message_with_options(
         self,
@@ -91,9 +98,10 @@ class TestQueueMessage:
             headers=auth_headers,
         )
 
-        data = get_response.json()
-        assert data["permission_mode"] == "plan"
-        assert data["thinking_mode"] == "extended"
+        queue = get_response.json()
+        assert len(queue) == 1
+        assert queue[0]["permission_mode"] == "plan"
+        assert queue[0]["thinking_mode"] == "extended"
 
     async def test_queue_message_chat_not_found(
         self,
@@ -157,12 +165,13 @@ class TestGetQueue:
         )
 
         assert response.status_code == 200
-        data = response.json()
-        assert data["content"] == "Queued content"
-        assert data["model_id"] == "claude-haiku-4-5"
-        assert data["permission_mode"] == "plan"
-        assert "id" in data
-        assert "queued_at" in data
+        queue = response.json()
+        assert len(queue) == 1
+        assert queue[0]["content"] == "Queued content"
+        assert queue[0]["model_id"] == "claude-haiku-4-5"
+        assert queue[0]["permission_mode"] == "plan"
+        assert "id" in queue[0]
+        assert "queued_at" in queue[0]
 
     async def test_get_queue_empty(
         self,
@@ -178,7 +187,7 @@ class TestGetQueue:
         )
 
         assert response.status_code == 200
-        assert response.json() is None
+        assert response.json() == []
 
     async def test_get_queue_unauthorized(
         self,
@@ -203,7 +212,7 @@ class TestUpdateQueuedMessage:
     ) -> None:
         _, chat, _ = integration_chat_fixture
 
-        await async_client.post(
+        post_response = await async_client.post(
             f"/api/v1/chat/chats/{chat.id}/queue",
             data={
                 "content": "Original content",
@@ -211,9 +220,10 @@ class TestUpdateQueuedMessage:
             },
             headers=auth_headers,
         )
+        message_id = post_response.json()["id"]
 
         response = await async_client.patch(
-            f"/api/v1/chat/chats/{chat.id}/queue",
+            f"/api/v1/chat/chats/{chat.id}/queue/{message_id}",
             json={"content": "Updated content"},
             headers=auth_headers,
         )
@@ -229,9 +239,10 @@ class TestUpdateQueuedMessage:
         auth_headers: dict[str, str],
     ) -> None:
         _, chat, _ = integration_chat_fixture
+        fake_id = uuid.uuid4()
 
         response = await async_client.patch(
-            f"/api/v1/chat/chats/{chat.id}/queue",
+            f"/api/v1/chat/chats/{chat.id}/queue/{fake_id}",
             json={"content": "Updated content"},
             headers=auth_headers,
         )
@@ -244,13 +255,96 @@ class TestUpdateQueuedMessage:
         integration_chat_fixture: tuple[User, Chat, SandboxService],
     ) -> None:
         _, chat, _ = integration_chat_fixture
+        fake_id = uuid.uuid4()
 
         response = await async_client.patch(
-            f"/api/v1/chat/chats/{chat.id}/queue",
+            f"/api/v1/chat/chats/{chat.id}/queue/{fake_id}",
             json={"content": "Updated content"},
         )
 
         assert response.status_code == 401
+
+
+class TestDeleteQueuedMessage:
+    async def test_delete_queued_message(
+        self,
+        async_client: AsyncClient,
+        integration_chat_fixture: tuple[User, Chat, SandboxService],
+        auth_headers: dict[str, str],
+    ) -> None:
+        _, chat, _ = integration_chat_fixture
+
+        post_response = await async_client.post(
+            f"/api/v1/chat/chats/{chat.id}/queue",
+            data={
+                "content": "To be deleted",
+                "model_id": "claude-haiku-4-5",
+            },
+            headers=auth_headers,
+        )
+        message_id = post_response.json()["id"]
+
+        response = await async_client.delete(
+            f"/api/v1/chat/chats/{chat.id}/queue/{message_id}",
+            headers=auth_headers,
+        )
+        assert response.status_code == 204
+
+        get_response = await async_client.get(
+            f"/api/v1/chat/chats/{chat.id}/queue",
+            headers=auth_headers,
+        )
+        assert get_response.json() == []
+
+    async def test_delete_queued_message_not_found(
+        self,
+        async_client: AsyncClient,
+        integration_chat_fixture: tuple[User, Chat, SandboxService],
+        auth_headers: dict[str, str],
+    ) -> None:
+        _, chat, _ = integration_chat_fixture
+        fake_id = uuid.uuid4()
+
+        response = await async_client.delete(
+            f"/api/v1/chat/chats/{chat.id}/queue/{fake_id}",
+            headers=auth_headers,
+        )
+        assert response.status_code == 404
+
+    async def test_delete_one_preserves_others(
+        self,
+        async_client: AsyncClient,
+        integration_chat_fixture: tuple[User, Chat, SandboxService],
+        auth_headers: dict[str, str],
+    ) -> None:
+        _, chat, _ = integration_chat_fixture
+
+        resp1 = await async_client.post(
+            f"/api/v1/chat/chats/{chat.id}/queue",
+            data={"content": "Keep me", "model_id": "claude-haiku-4-5"},
+            headers=auth_headers,
+        )
+        resp2 = await async_client.post(
+            f"/api/v1/chat/chats/{chat.id}/queue",
+            data={"content": "Delete me", "model_id": "claude-haiku-4-5"},
+            headers=auth_headers,
+        )
+        delete_id = resp2.json()["id"]
+        keep_id = resp1.json()["id"]
+
+        await async_client.delete(
+            f"/api/v1/chat/chats/{chat.id}/queue/{delete_id}",
+            headers=auth_headers,
+        )
+
+        get_response = await async_client.get(
+            f"/api/v1/chat/chats/{chat.id}/queue",
+            headers=auth_headers,
+        )
+        queue = get_response.json()
+        assert len(queue) == 1
+        assert queue[0]["id"] == keep_id
+        assert queue[0]["content"] == "Keep me"
 
 
 class TestClearQueue:
@@ -282,9 +376,9 @@ class TestClearQueue:
             f"/api/v1/chat/chats/{chat.id}/queue",
             headers=auth_headers,
         )
-        assert get_response.json() is None
+        assert get_response.json() == []
 
-    async def test_clear_queue_not_found(
+    async def test_clear_empty_queue(
         self,
         async_client: AsyncClient,
         integration_chat_fixture: tuple[User, Chat, SandboxService],
@@ -297,7 +391,7 @@ class TestClearQueue:
             headers=auth_headers,
         )
 
-        assert response.status_code == 404
+        assert response.status_code == 204
 
     async def test_clear_queue_unauthorized(
         self,

--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -122,16 +122,19 @@ export const Chat = memo(function Chat() {
     }
   }, [chatId]);
 
-  const handleCancelPending = useCallback(() => {
-    if (chatId) {
-      useMessageQueueStore.getState().clearAndSync(chatId);
-    }
-  }, [chatId]);
-
-  const handleEditPending = useCallback(
-    (newContent: string) => {
+  const handleCancelMessage = useCallback(
+    (messageId: string) => {
       if (chatId) {
-        useMessageQueueStore.getState().updateQueuedMessage(chatId, newContent);
+        void useMessageQueueStore.getState().removeMessage(chatId, messageId);
+      }
+    },
+    [chatId],
+  );
+
+  const handleEditMessage = useCallback(
+    (messageId: string, newContent: string) => {
+      if (chatId) {
+        void useMessageQueueStore.getState().updateQueuedMessage(chatId, messageId, newContent);
       }
     },
     [chatId],
@@ -443,8 +446,8 @@ export const Chat = memo(function Chat() {
                     <QueueMessageCard
                       key={pending.id}
                       message={pending}
-                      onCancel={handleCancelPending}
-                      onEdit={handleEditPending}
+                      onCancel={handleCancelMessage}
+                      onEdit={handleEditMessage}
                     />
                   ))}
                 </div>

--- a/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
+++ b/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
@@ -13,8 +13,8 @@ import type {
 
 interface QueueMessageCardProps {
   message: LocalQueuedMessage;
-  onCancel: () => void;
-  onEdit: (newContent: string) => void;
+  onCancel: (messageId: string) => void;
+  onEdit: (messageId: string, newContent: string) => void;
 }
 
 function UploadingOverlay() {
@@ -27,7 +27,7 @@ function UploadingOverlay() {
   );
 }
 
-function LocalUploadingPreview({ file }: { file: File }) {
+function LocalFilePreview({ file, uploading }: { file: File; uploading: boolean }) {
   const [imageSrc, setImageSrc] = useState<string | null>(null);
   const [fileType, setFileType] = useState<'image' | 'pdf' | 'xlsx' | 'unknown'>('unknown');
 
@@ -61,7 +61,7 @@ function LocalUploadingPreview({ file }: { file: File }) {
           alt={file.name || 'Attachment'}
           className="h-8 w-8 rounded-md object-cover"
         />
-        <UploadingOverlay />
+        {uploading && <UploadingOverlay />}
       </div>
     );
   }
@@ -70,7 +70,7 @@ function LocalUploadingPreview({ file }: { file: File }) {
     return (
       <div className="relative flex h-8 w-8 items-center justify-center rounded-md bg-surface-tertiary dark:bg-surface-dark-tertiary">
         <FileSpreadsheet className="h-4 w-4 text-success-600 dark:text-success-400" />
-        <UploadingOverlay />
+        {uploading && <UploadingOverlay />}
       </div>
     );
   }
@@ -79,7 +79,7 @@ function LocalUploadingPreview({ file }: { file: File }) {
     return (
       <div className="relative flex h-8 w-8 items-center justify-center rounded-md bg-surface-tertiary dark:bg-surface-dark-tertiary">
         <FileText className="h-4 w-4 text-error-500 dark:text-error-400" />
-        <UploadingOverlay />
+        {uploading && <UploadingOverlay />}
       </div>
     );
   }
@@ -87,7 +87,7 @@ function LocalUploadingPreview({ file }: { file: File }) {
   return (
     <div className="relative flex h-8 w-8 items-center justify-center rounded-md bg-surface-tertiary dark:bg-surface-dark-tertiary">
       <FileText className="h-4 w-4 text-text-tertiary dark:text-text-dark-tertiary" />
-      <UploadingOverlay />
+      {uploading && <UploadingOverlay />}
     </div>
   );
 }
@@ -206,12 +206,12 @@ export const QueueMessageCard = memo(function QueueMessageCard({
   const handleSaveEdit = useCallback(() => {
     const trimmed = editContent.trim();
     if (!trimmed) {
-      onCancel();
+      onCancel(message.id);
     } else {
-      onEdit(trimmed);
+      onEdit(message.id, trimmed);
     }
     setIsEditing(false);
-  }, [editContent, onCancel, onEdit]);
+  }, [editContent, message.id, onCancel, onEdit]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -233,9 +233,10 @@ export const QueueMessageCard = memo(function QueueMessageCard({
           {hasLocalFiles && !hasServerAttachments && (
             <div className="flex flex-wrap gap-1">
               {message.files!.map((file, idx) => (
-                <LocalUploadingPreview
+                <LocalFilePreview
                   key={`${file.name}-${file.lastModified}-${idx}`}
                   file={file}
+                  uploading={!message.synced}
                 />
               ))}
             </div>
@@ -292,7 +293,7 @@ export const QueueMessageCard = memo(function QueueMessageCard({
                 <Pencil className="h-3.5 w-3.5" />
               </Button>
               <Button
-                onClick={onCancel}
+                onClick={() => onCancel(message.id)}
                 variant="ghost"
                 className="h-6 rounded-md px-2 py-0 text-text-tertiary hover:bg-error-50 hover:text-error-600 dark:hover:bg-error-500/10 dark:hover:text-error-400"
                 aria-label="Cancel message"

--- a/frontend/src/services/queueService.ts
+++ b/frontend/src/services/queueService.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '@/lib/api';
 import { ensureResponse, serviceCall } from '@/services/base/BaseService';
 import { validateId, validateRequired } from '@/utils/validation';
-import type { QueuedMessage, QueueUpsertResponse } from '@/types/queue.types';
+import type { QueuedMessage, QueueAddResponse } from '@/types/queue.types';
 
 async function queueMessage(
   chatId: string,
@@ -10,7 +10,7 @@ async function queueMessage(
   permissionMode: string = 'auto',
   thinkingMode: string | null = null,
   files?: File[],
-): Promise<QueueUpsertResponse> {
+): Promise<QueueAddResponse> {
   validateId(chatId, 'Chat ID');
   validateRequired(content, 'Content');
   validateRequired(modelId, 'Model ID');
@@ -30,7 +30,7 @@ async function queueMessage(
       });
     }
 
-    const response = await apiClient.postForm<QueueUpsertResponse>(
+    const response = await apiClient.postForm<QueueAddResponse>(
       `/chat/chats/${chatId}/queue`,
       formData,
     );
@@ -38,24 +38,39 @@ async function queueMessage(
   });
 }
 
-async function getQueue(chatId: string): Promise<QueuedMessage | null> {
+async function getQueue(chatId: string): Promise<QueuedMessage[]> {
   validateId(chatId, 'Chat ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.get<QueuedMessage | null>(`/chat/chats/${chatId}/queue`);
-    return response ?? null;
+    const response = await apiClient.get<QueuedMessage[]>(`/chat/chats/${chatId}/queue`);
+    return response ?? [];
   });
 }
 
-async function updateQueuedMessage(chatId: string, content: string): Promise<QueuedMessage> {
+async function updateQueuedMessage(
+  chatId: string,
+  messageId: string,
+  content: string,
+): Promise<QueuedMessage> {
   validateId(chatId, 'Chat ID');
+  validateId(messageId, 'Message ID');
   validateRequired(content, 'Content');
 
   return serviceCall(async () => {
-    const response = await apiClient.patch<QueuedMessage>(`/chat/chats/${chatId}/queue`, {
-      content,
-    });
+    const response = await apiClient.patch<QueuedMessage>(
+      `/chat/chats/${chatId}/queue/${messageId}`,
+      { content },
+    );
     return ensureResponse(response, 'Failed to update queued message');
+  });
+}
+
+async function deleteQueuedMessage(chatId: string, messageId: string): Promise<void> {
+  validateId(chatId, 'Chat ID');
+  validateId(messageId, 'Message ID');
+
+  await serviceCall(async () => {
+    await apiClient.delete(`/chat/chats/${chatId}/queue/${messageId}`);
   });
 }
 
@@ -71,5 +86,6 @@ export const queueService = {
   queueMessage,
   getQueue,
   updateQueuedMessage,
+  deleteQueuedMessage,
   clearQueue,
 };

--- a/frontend/src/store/messageQueueStore.ts
+++ b/frontend/src/store/messageQueueStore.ts
@@ -16,12 +16,13 @@ interface MessageQueueState {
     thinkingMode?: string | null,
     files?: File[],
   ) => Promise<string>;
-  updateQueuedMessage: (chatId: string, content: string) => Promise<void>;
+  updateQueuedMessage: (chatId: string, messageId: string, content: string) => Promise<void>;
+  removeMessage: (chatId: string, messageId: string) => Promise<void>;
   clearAndSync: (chatId: string) => Promise<void>;
   getQueue: (chatId: string) => LocalQueuedMessage[];
   clearQueue: (chatId: string) => void;
   fetchQueue: (chatId: string) => Promise<void>;
-  syncPendingMessages: (chatId: string, modelId: string) => Promise<void>;
+  syncPendingMessages: (chatId: string) => Promise<void>;
   removeLocalOnly: (chatId: string, messageId: string) => void;
   cleanupChat: (chatId: string) => void;
 }
@@ -39,54 +40,6 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
     files?: File[],
   ): Promise<string> => {
     const currentQueue = get().queues.get(chatId) || [];
-    const existingMessage = currentQueue[0];
-
-    if (existingMessage) {
-      const appendedContent = existingMessage.content + '\n' + content;
-      const mergedFiles = [...(existingMessage.files || []), ...(files || [])];
-
-      set((state) => {
-        const nextQueues = new Map(state.queues);
-        nextQueues.set(chatId, [
-          {
-            ...existingMessage,
-            content: appendedContent,
-            files: mergedFiles.length > 0 ? mergedFiles : undefined,
-          },
-        ]);
-        return { queues: nextQueues };
-      });
-
-      if (existingMessage.synced) {
-        try {
-          const result = await queueService.queueMessage(
-            chatId,
-            content,
-            modelId,
-            permissionMode,
-            thinkingMode,
-            files,
-          );
-
-          set((state) => {
-            const nextQueues = new Map(state.queues);
-            const queue = nextQueues.get(chatId) || [];
-            const updatedQueue = queue.map((msg) =>
-              msg.id === existingMessage.id
-                ? { ...msg, content: result.content, attachments: result.attachments }
-                : msg,
-            );
-            nextQueues.set(chatId, updatedQueue);
-            return { queues: nextQueues };
-          });
-        } catch (error) {
-          console.error('Failed to append to queued message:', error);
-        }
-      }
-
-      return existingMessage.id;
-    }
-
     const tempId = crypto.randomUUID();
     const tempMessage: LocalQueuedMessage = {
       id: tempId,
@@ -99,7 +52,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
 
     set((state) => {
       const nextQueues = new Map(state.queues);
-      nextQueues.set(chatId, [tempMessage]);
+      nextQueues.set(chatId, [...currentQueue, tempMessage]);
       return { queues: nextQueues };
     });
 
@@ -117,9 +70,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
         const nextQueues = new Map(state.queues);
         const queue = nextQueues.get(chatId) || [];
         const updatedQueue = queue.map((msg) =>
-          msg.id === tempId
-            ? { ...msg, id: result.id, synced: true, attachments: result.attachments }
-            : msg,
+          msg.id === tempId ? { ...msg, id: result.id, synced: true } : msg,
         );
         nextQueues.set(chatId, updatedQueue);
         return { queues: nextQueues };
@@ -139,37 +90,67 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
     }
   },
 
-  updateQueuedMessage: async (chatId: string, content: string) => {
+  updateQueuedMessage: async (chatId: string, messageId: string, content: string) => {
     const trimmedContent = content.trim();
     const currentQueue = get().queues.get(chatId) || [];
-    const message = currentQueue[0];
+    const message = currentQueue.find((m) => m.id === messageId);
 
     if (!message) {
       return;
     }
 
     if (!trimmedContent) {
-      await get().clearAndSync(chatId);
+      await get().removeMessage(chatId, messageId);
       return;
     }
 
     set((state) => {
       const nextQueues = new Map(state.queues);
-      nextQueues.set(chatId, [{ ...message, content: trimmedContent }]);
+      const queue = nextQueues.get(chatId) || [];
+      const updatedQueue = queue.map((msg) =>
+        msg.id === messageId ? { ...msg, content: trimmedContent } : msg,
+      );
+      nextQueues.set(chatId, updatedQueue);
       return { queues: nextQueues };
     });
 
     if (message.synced) {
       try {
-        await queueService.updateQueuedMessage(chatId, trimmedContent);
+        await queueService.updateQueuedMessage(chatId, messageId, trimmedContent);
       } catch (error) {
         console.error('Failed to sync message update:', error);
       }
     }
   },
 
+  removeMessage: async (chatId: string, messageId: string) => {
+    const currentQueue = get().queues.get(chatId) || [];
+    const message = currentQueue.find((m) => m.id === messageId);
+
+    set((state) => {
+      const nextQueues = new Map(state.queues);
+      const queue = nextQueues.get(chatId) || [];
+      const filtered = queue.filter((msg) => msg.id !== messageId);
+      if (filtered.length === 0) {
+        nextQueues.delete(chatId);
+      } else {
+        nextQueues.set(chatId, filtered);
+      }
+      return { queues: nextQueues };
+    });
+
+    if (message?.synced) {
+      try {
+        await queueService.deleteQueuedMessage(chatId, messageId);
+      } catch (error) {
+        console.error('Failed to sync message delete:', error);
+      }
+    }
+  },
+
   clearAndSync: async (chatId: string) => {
-    const message = get().queues.get(chatId)?.[0];
+    const queue = get().queues.get(chatId) || [];
+    const hasSynced = queue.some((m) => m.synced);
 
     set((state) => {
       const nextQueues = new Map(state.queues);
@@ -177,7 +158,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
       return { queues: nextQueues };
     });
 
-    if (message?.synced) {
+    if (hasSynced) {
       try {
         await queueService.clearQueue(chatId);
       } catch (error) {
@@ -226,33 +207,29 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
 
   fetchQueue: async (chatId: string) => {
     try {
-      const serverMessage = await queueService.getQueue(chatId);
+      const serverMessages = await queueService.getQueue(chatId);
 
       set((state) => {
         const nextQueues = new Map(state.queues);
         const existingQueue = nextQueues.get(chatId) || [];
 
-        if (serverMessage) {
-          const localMessage: LocalQueuedMessage = {
-            id: serverMessage.id,
-            content: serverMessage.content,
-            model_id: serverMessage.model_id,
-            attachments: serverMessage.attachments,
-            queuedAt: new Date(serverMessage.queued_at).getTime(),
-            synced: true,
-          };
+        const serverIds = new Set(serverMessages.map((m) => m.id));
+        const pendingMessages = existingQueue.filter((m) => !m.synced && !serverIds.has(m.id));
 
-          const pendingMessages = existingQueue.filter(
-            (m) => !m.synced && m.id !== serverMessage.id,
-          );
-          nextQueues.set(chatId, [localMessage, ...pendingMessages]);
+        const syncedMessages: LocalQueuedMessage[] = serverMessages.map((msg) => ({
+          id: msg.id,
+          content: msg.content,
+          model_id: msg.model_id,
+          attachments: msg.attachments,
+          queuedAt: new Date(msg.queued_at).getTime(),
+          synced: true,
+        }));
+
+        const merged = [...syncedMessages, ...pendingMessages];
+        if (merged.length > 0) {
+          nextQueues.set(chatId, merged);
         } else {
-          const pendingMessages = existingQueue.filter((m) => !m.synced);
-          if (pendingMessages.length > 0) {
-            nextQueues.set(chatId, pendingMessages);
-          } else {
-            nextQueues.delete(chatId);
-          }
+          nextQueues.delete(chatId);
         }
 
         return { queues: nextQueues };
@@ -262,7 +239,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
     }
   },
 
-  syncPendingMessages: async (chatId: string, modelId: string) => {
+  syncPendingMessages: async (chatId: string) => {
     const state = get();
     if (state.isSyncing.get(chatId)) {
       return;
@@ -283,7 +260,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
           const result = await queueService.queueMessage(
             chatId,
             msg.content,
-            modelId,
+            msg.model_id,
             'auto',
             null,
             msg.files,
@@ -293,9 +270,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
             const nextQueues = new Map(s.queues);
             const currentQueue = nextQueues.get(chatId) || [];
             const updatedQueue = currentQueue.map((m) =>
-              m.id === msg.id
-                ? { ...m, id: result.id, synced: true, attachments: result.attachments }
-                : m,
+              m.id === msg.id ? { ...m, id: result.id, synced: true } : m,
             );
             nextQueues.set(chatId, updatedQueue);
             return { queues: nextQueues };

--- a/frontend/src/types/queue.types.ts
+++ b/frontend/src/types/queue.types.ts
@@ -13,11 +13,8 @@ export interface QueuedMessage {
   attachments?: QueueMessageAttachment[];
 }
 
-export interface QueueUpsertResponse {
+export interface QueueAddResponse {
   id: string;
-  created: boolean;
-  content: string;
-  attachments?: QueueMessageAttachment[];
 }
 
 export interface LocalQueuedMessage {


### PR DESCRIPTION
## Summary
- Changes the message queue from single-message-per-chat to multi-message support
- Each queued message is now an independent entry with its own edit/cancel actions, processed in FIFO order
- Redis storage migrated from a single JSON object to a JSON array, with backward compatibility for legacy single-object payloads
- New per-message API endpoints: `PATCH /queue/{message_id}` and `DELETE /queue/{message_id}`
- Frontend store, service, types, and UI updated to manage multiple queue entries independently

## Test plan
- [ ] Queue 2+ messages while a stream is active — verify each appears as a separate card
- [ ] Cancel one queued message — verify the others remain
- [ ] Edit a specific queued message — verify only that message changes
- [ ] Let stream complete — verify first queued message processes, then second
- [ ] Queue a message with file attachments — verify preview shows uploading spinner, then static preview after sync
- [ ] Run backend tests: `docker compose exec api pytest tests/test_queue.py`
- [ ] Run frontend type checks: `docker compose exec frontend npx tsc --noEmit`