### PR TITLE
feat: add send-now button to inject queued messages mid-stream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@
 ## Code Style
 
 - Do not optimize for no regressions or long-term resilience unless explicitly requested — favor simple, direct changes over defensive scaffolding
+- Do not build elaborate rollback/state-restoration logic for failure paths — in a single-user app, a simple log + best-effort recovery (e.g., re-queue the item) is sufficient; do not save/restore every field, delete orphaned rows, or revert intermediate state changes
+- Do not add pre-flight compatibility checks that gate an operation when a natural fallback already exists — if the operation can't proceed, let it fall through to the existing path (e.g., normal queue processing) instead of adding branching to detect and re-route
+- Prefer the simplest collection operation that achieves the goal — use `list.insert(0, item)` instead of a sorted-insertion loop when ordering doesn't meaningfully matter
+- Keep `try/except` blocks narrow — only wrap the code that needs the specific recovery action (e.g., requeue after a pop), not the entire function body; code that can safely propagate exceptions should stay outside the `try`
 - Do not handle hypothetical input shapes — if you have evidence of the actual data format (logs, tests, type definitions), write code for that format only; do not add branches for types or structures you have not observed
 - Don't add comments or docstrings for self-explanatory code
 - Let the code speak for itself - use clear variable/function names instead of comments
@@ -185,6 +189,23 @@
 - Loading states: `animate-spin` for spinners, `animate-pulse` for skeletons, `animate-bounce` with staggered `animationDelay` for dot loaders
 - Expandable content: `transition-all duration-200` with `max-h-*` and `opacity` toggling
 - Dropdowns: `animate-fadeIn` for entry — no scale transforms on buttons
+
+## Code Review Guidelines
+
+### What to fix
+- Bugs that break user-visible behavior (wrong event ordering, dropped messages, stale UI state)
+- Correctness issues where the code silently continues into a broken state (e.g., swallowing an error that leaves client/server out of sync)
+- Missing TTLs or expiry on Redis keys that can leak forever
+- Dead code left behind by the change (unused imports, unreachable branches, orphaned constants)
+
+### What to skip
+- Orphaned DB rows from unlikely failure paths — in a single-user app, a stray empty message row is harmless; do not add delete-rollback logic
+- Concurrency edge cases (double-submit, multi-tab races, overlapping requests) — unless the task explicitly asks for concurrency hardening
+- Hypothetical compatibility mismatches — if a natural fallback already handles the case (e.g., normal queue processing), do not add pre-flight checks to detect and re-route
+- State-restoration rollback for failure paths — a simple log + best-effort recovery (re-queue) is sufficient; do not save/restore every field or revert intermediate changes
+
+### Complexity test
+Before flagging or fixing an issue, ask: "If this fails, does the user lose data or get stuck?" If the answer is no (e.g., an orphaned row, a briefly stale UI element), skip it. If the answer is yes (e.g., a queued message is silently dropped, the stream appears frozen), fix it.
 
 ## Completion Quality Gate
 

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -633,6 +633,47 @@ async def delete_queued_message(
         )
 
 
+@router.post(
+    "/chats/{chat_id}/queue/{message_id}/send-now",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def send_now_queued_message(
+    chat_id: UUID,
+    message_id: UUID,
+    current_user: User = Depends(get_current_user),
+    chat_service: ChatService = Depends(get_chat_service),
+) -> None:
+    await _ensure_chat_access(chat_id, chat_service, current_user)
+
+    try:
+        async with cache_connection() as cache:
+            queue_service = QueueService(cache)
+            found = await queue_service.mark_send_now(str(chat_id), str(message_id))
+            if not found:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Queued message not found",
+                )
+    except CacheError as e:
+        logger.error("Redis error marking send-now: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Service temporarily unavailable",
+        )
+
+    if not ChatStreamRuntime.is_chat_streaming(str(chat_id)):
+        try:
+            await ChatStreamRuntime.process_send_now_idle(
+                str(chat_id), chat_service.session_factory
+            )
+        except Exception as e:
+            logger.error("Failed to start idle send-now for chat %s: %s", chat_id, e)
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Failed to start send-now execution",
+            )
+
+
 @router.delete(
     "/chats/{chat_id}/queue",
     status_code=status.HTTP_204_NO_CONTENT,

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -10,6 +10,7 @@ REDIS_KEY_CHAT_STREAM_LIVE: Final[str] = "chat:{chat_id}:stream:live"
 REDIS_KEY_USER_SETTINGS: Final[str] = "user_settings:{user_id}"
 REDIS_KEY_CHAT_CONTEXT_USAGE: Final[str] = "chat:{chat_id}:context_usage"
 REDIS_KEY_CHAT_QUEUE: Final[str] = "chat:{chat_id}:queue"
+REDIS_KEY_CHAT_QUEUE_SEND_NOW: Final[str] = "chat:{chat_id}:queue:send_now"
 
 QUEUE_MESSAGE_TTL_SECONDS: Final[int] = 3600
 

--- a/backend/app/services/claude_session_registry.py
+++ b/backend/app/services/claude_session_registry.py
@@ -85,6 +85,9 @@ class SessionRegistry:
             session.last_used_at = time.monotonic()
             return session
 
+    def get_session(self, chat_id: str) -> ChatSession | None:
+        return self._sessions.get(chat_id)
+
     async def cancel_generation(self, chat_id: str) -> None:
         self._pending_cancels.add(chat_id)
         session = self._sessions.get(chat_id)

--- a/backend/app/services/queue.py
+++ b/backend/app/services/queue.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 from app.constants import (
     QUEUE_MESSAGE_TTL_SECONDS,
     REDIS_KEY_CHAT_QUEUE,
+    REDIS_KEY_CHAT_QUEUE_SEND_NOW,
 )
 from app.models.schemas.queue import QueueAddResponse, QueuedMessage
 
@@ -123,3 +124,47 @@ class QueueService:
         next_msg = queue[0]
         await self._write_queue(key, queue[1:])
         return next_msg
+
+    async def mark_send_now(self, chat_id: str, message_id: str) -> bool:
+        key = self._queue_key(chat_id)
+        queue = await self._read_queue(key)
+        if not any(item["id"] == message_id for item in queue):
+            return False
+
+        send_now_key = REDIS_KEY_CHAT_QUEUE_SEND_NOW.format(chat_id=chat_id)
+        await self.cache.set(send_now_key, message_id, ex=QUEUE_MESSAGE_TTL_SECONDS)
+        return True
+
+    async def pop_send_now_message(self, chat_id: str) -> dict[str, Any] | None:
+        send_now_key = REDIS_KEY_CHAT_QUEUE_SEND_NOW.format(chat_id=chat_id)
+        message_id = await self.cache.get(send_now_key)
+        if not message_id:
+            return None
+
+        await self.cache.delete(send_now_key)
+
+        key = self._queue_key(chat_id)
+        queue = await self._read_queue(key)
+        target = None
+        remaining = []
+        for item in queue:
+            if item["id"] == message_id and target is None:
+                target = item
+            else:
+                remaining.append(item)
+
+        if target is None:
+            return None
+
+        await self._write_queue(key, remaining)
+        return target
+
+    async def requeue_message(self, chat_id: str, message_data: dict[str, Any]) -> None:
+        key = self._queue_key(chat_id)
+        queue = await self._read_queue(key)
+        queue.insert(0, message_data)
+        await self._write_queue(key, queue)
+
+    async def clear_send_now(self, chat_id: str) -> None:
+        send_now_key = REDIS_KEY_CHAT_QUEUE_SEND_NOW.format(chat_id=chat_id)
+        await self.cache.delete(send_now_key)

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -11,7 +11,13 @@ from uuid import UUID, uuid4
 
 from sqlalchemy import select
 
-from app.constants import REDIS_KEY_CHAT_CONTEXT_USAGE, REDIS_KEY_CHAT_STREAM_LIVE
+from app.constants import (
+    REDIS_KEY_CHAT_CONTEXT_USAGE,
+    REDIS_KEY_CHAT_STREAM_LIVE,
+)
+from claude_agent_sdk import ClaudeSDKClient
+
+from app.services.transports import SandboxTransport
 from app.core.config import get_settings
 from app.utils.cache import CacheStore, cache_connection
 from app.db.session import SessionLocal
@@ -24,7 +30,11 @@ from app.models.db_models import (
 )
 from app.prompts.system_prompt import build_system_prompt_for_chat
 from claude_agent_sdk import CLIConnectionError, CLIJSONDecodeError
-from app.services.claude_agent import ClaudeAgentService, SessionParams
+from app.services.claude_agent import (
+    ClaudeAgentService,
+    SDK_PERMISSION_MODE_MAP,
+    SessionParams,
+)
 from app.services.db import SessionFactoryType
 from app.services.exceptions import ClaudeAgentException
 from app.services.message import MessageService
@@ -137,6 +147,7 @@ class ChatStreamRuntime:
         self.assistant_message_id = request.assistant_message_id
         self.user_id = str(chat.user_id)
         self.model_id = request.model_id
+        self.custom_instructions = request.custom_instructions
         self.sandbox_service = sandbox_service
         self.session_factory = session_factory
 
@@ -148,9 +159,12 @@ class ChatStreamRuntime:
         self.message_service = MessageService(session_factory=session_factory)
         self._event_buffer: list[tuple[str, dict[str, Any], dict[str, Any] | None]] = []
 
+        self.transport: SandboxTransport | None = None
+        self.client: ClaudeSDKClient | None = None
         self.cache: CacheStore | None = None
         self._cancel_event: asyncio.Event | None = None
         self._cancelled: bool = False
+        self._send_now_pending: bool = False
 
     async def run(
         self, ai_service: ClaudeAgentService, stream: AsyncIterator[StreamEvent]
@@ -204,13 +218,22 @@ class ChatStreamRuntime:
             while True:
                 event = await self._next_or_cancel(stream_iter)
                 if event is None:
+                    self._send_now_pending = False
                     break
+
+                if self._send_now_pending and self._is_assistant_turn_start(event):
+                    self._send_now_pending = False
+                    if await self._write_send_now(ai_service):
+                        continue
 
                 self.event_count += 1
                 kind = str(event.get("type") or "system")
                 payload = {k: v for k, v in event.items() if k != "type"}
                 await self.emit_event(kind, payload)
                 await self._flush_snapshot(force=False)
+
+                if not self._send_now_pending and self._is_send_now_eligible(event):
+                    self._send_now_pending = True
 
                 current_usage = ai_service.get_usage()
                 if current_usage is not None and current_usage is not last_usage:
@@ -220,6 +243,7 @@ class ChatStreamRuntime:
             if not (self._cancel_event and self._cancel_event.is_set()):
                 raise
             self._cancelled = True
+            self._send_now_pending = False
 
     @staticmethod
     def _cancel_task_if_running(
@@ -366,6 +390,13 @@ class ChatStreamRuntime:
         await self._save_final_snapshot(ai_service, status)
         final_content = self.snapshot.content_text
 
+        if status != MessageStreamStatus.COMPLETED and self.cache:
+            try:
+                queue_service = QueueService(self.cache)
+                await queue_service.clear_send_now(self.chat_id)
+            except Exception as exc:
+                logger.debug("Failed to clear send-now flag: %s", exc)
+
         if status == MessageStreamStatus.COMPLETED:
             await self._create_checkpoint()
             queue_processed = await self._process_next_queued()
@@ -388,6 +419,139 @@ class ChatStreamRuntime:
             )
 
         return final_content
+
+    @staticmethod
+    def _is_send_now_eligible(event: StreamEvent) -> bool:
+        if event.get("type") != "tool_completed":
+            return False
+        tool = event.get("tool", {})
+        if tool.get("parent_id"):
+            return False
+        return True
+
+    @staticmethod
+    def _is_assistant_turn_start(event: StreamEvent) -> bool:
+        event_type = event.get("type")
+        if event_type in ("assistant_text", "assistant_thinking"):
+            return True
+        if event_type == "tool_started":
+            tool = event.get("tool", {})
+            return not tool.get("parent_id")
+        return False
+
+    async def _write_send_now(self, ai_service: ClaudeAgentService) -> bool:
+        if not self.cache or not self.transport:
+            return False
+
+        queue_service = QueueService(self.cache)
+        queued_msg = await queue_service.pop_send_now_message(self.chat_id)
+        if not queued_msg:
+            return False
+
+        try:
+            await self._flush_event_buffer()
+
+            user_message = await self.message_service.create_message(
+                UUID(self.chat_id),
+                queued_msg["content"],
+                MessageRole.USER,
+                attachments=queued_msg.get("attachments"),
+            )
+            assistant_message = await self.message_service.create_message(
+                UUID(self.chat_id),
+                "",
+                MessageRole.ASSISTANT,
+                model_id=queued_msg["model_id"],
+                stream_status=MessageStreamStatus.IN_PROGRESS,
+            )
+
+            if self.client:
+                queued_model = queued_msg.get("model_id")
+                if queued_model:
+                    resolved_model = queued_model.split(":", 1)[-1]
+                    if resolved_model != self.model_id:
+                        await self.client.set_model(resolved_model)
+                        self.model_id = resolved_model
+                queued_permission = queued_msg.get("permission_mode")
+                if queued_permission:
+                    sdk_permission = SDK_PERMISSION_MODE_MAP.get(
+                        queued_permission, "bypassPermissions"
+                    )
+                    await self.client.set_permission_mode(sdk_permission)
+
+            prompt = ai_service.prepare_user_prompt(
+                queued_msg["content"],
+                self.custom_instructions,
+                queued_msg.get("attachments"),
+            )
+            injection = {
+                "type": "user",
+                "message": {"role": "user", "content": prompt},
+                "parent_tool_use_id": None,
+                "session_id": self.session_container.get("session_id"),
+            }
+            await self.transport.write(json.dumps(injection) + "\n")
+
+            await self.message_service.update_message_snapshot(
+                UUID(self.assistant_message_id),
+                content_text=self.snapshot.content_text,
+                content_render=self.snapshot.to_render(),
+                last_seq=self.last_seq,
+                active_stream_id=None,
+                stream_status=MessageStreamStatus.COMPLETED,
+            )
+            await self._create_checkpoint()
+
+            await self.emit_event(
+                "queue_processing",
+                {
+                    "queued_message_id": queued_msg["id"],
+                    "user_message_id": str(user_message.id),
+                    "assistant_message_id": str(assistant_message.id),
+                    "content": queued_msg["content"],
+                    "model_id": queued_msg["model_id"],
+                    "attachments": MessageService.serialize_attachments(
+                        queued_msg, user_message
+                    ),
+                    "send_now": True,
+                },
+                apply_snapshot=False,
+            )
+
+            self.assistant_message_id = str(assistant_message.id)
+            self.stream_id = uuid4()
+            self.snapshot = StreamSnapshotAccumulator()
+            self.pending_since_flush = 0
+            self.last_flush_at = time.monotonic()
+            self._event_buffer = []
+            self.last_seq = 0
+
+            start_seq = await self.emit_event(
+                "stream_started",
+                {"status": "started"},
+                apply_snapshot=False,
+            )
+            await self.message_service.update_message_snapshot(
+                UUID(self.assistant_message_id),
+                content_text="",
+                content_render=self.snapshot.to_render(),
+                last_seq=start_seq,
+                active_stream_id=self.stream_id,
+            )
+        except Exception as exc:
+            logger.error("Failed to process send-now message: %s", exc)
+            try:
+                await queue_service.requeue_message(self.chat_id, queued_msg)
+            except Exception as requeue_exc:
+                logger.error("Failed to re-queue message: %s", requeue_exc)
+            return False
+
+        logger.info(
+            "Send-now message %s written for chat %s",
+            queued_msg["id"],
+            self.chat_id,
+        )
+        return True
 
     async def _create_checkpoint(self) -> None:
         if not (
@@ -418,7 +582,9 @@ class ChatStreamRuntime:
         try:
             async with cache_connection() as cache:
                 queue_service = QueueService(cache)
-                next_msg = await queue_service.pop_next_message(self.chat_id)
+                next_msg = await queue_service.pop_send_now_message(self.chat_id)
+                if not next_msg:
+                    next_msg = await queue_service.pop_next_message(self.chat_id)
             if not next_msg:
                 return False
 
@@ -645,6 +811,104 @@ class ChatStreamRuntime:
         )
         return resolved_task_id
 
+    @classmethod
+    def is_chat_streaming(cls, chat_id: str) -> bool:
+        return any(
+            cid == chat_id
+            for task, cid in cls._background_task_chat_ids.items()
+            if not task.done()
+        )
+
+    @classmethod
+    async def process_send_now_idle(
+        cls,
+        chat_id: str,
+        session_factory: SessionFactoryType,
+    ) -> bool:
+        if cls.is_chat_streaming(chat_id):
+            return False
+
+        async with cache_connection() as cache:
+            queue_service = QueueService(cache)
+            queued_msg = await queue_service.pop_send_now_message(chat_id)
+            if not queued_msg:
+                return False
+
+        try:
+            message_service = MessageService(session_factory=session_factory)
+            await message_service.create_message(
+                UUID(chat_id),
+                queued_msg["content"],
+                MessageRole.USER,
+                attachments=queued_msg.get("attachments"),
+            )
+            assistant_message = await message_service.create_message(
+                UUID(chat_id),
+                "",
+                MessageRole.ASSISTANT,
+                model_id=queued_msg["model_id"],
+                stream_status=MessageStreamStatus.IN_PROGRESS,
+            )
+
+            async with session_factory() as db:
+                chat = await db.get(Chat, UUID(chat_id))
+                if not chat:
+                    raise ClaudeAgentException(
+                        f"Chat {chat_id} not found for idle send-now"
+                    )
+
+            user_service = UserService(session_factory=session_factory)
+            user_settings = await user_service.get_user_settings(chat.user_id, db=None)
+
+            system_prompt = build_system_prompt_for_chat(
+                chat.sandbox_id or "",
+                user_settings,
+            )
+
+            cls.start_background_chat(
+                ChatStreamRequest(
+                    prompt=queued_msg["content"],
+                    system_prompt=system_prompt,
+                    custom_instructions=(
+                        user_settings.custom_instructions if user_settings else None
+                    ),
+                    chat_data={
+                        "id": chat_id,
+                        "user_id": str(chat.user_id),
+                        "title": chat.title,
+                        "sandbox_id": chat.sandbox_id,
+                        "session_id": chat.session_id,
+                    },
+                    permission_mode=queued_msg.get("permission_mode", "auto"),
+                    model_id=queued_msg["model_id"],
+                    session_id=chat.session_id,
+                    assistant_message_id=str(assistant_message.id),
+                    thinking_mode=queued_msg.get("thinking_mode"),
+                    attachments=queued_msg.get("attachments"),
+                    is_custom_prompt=False,
+                )
+            )
+
+            logger.info(
+                "Idle send-now: message %s started for chat %s",
+                queued_msg["id"],
+                chat_id,
+            )
+            return True
+
+        except Exception:
+            try:
+                async with cache_connection() as cache:
+                    queue_service = QueueService(cache)
+                    await queue_service.requeue_message(chat_id, queued_msg)
+                    logger.info(
+                        "Re-queued message %s after idle send-now failure",
+                        queued_msg["id"],
+                    )
+            except Exception as requeue_exc:
+                logger.error("Failed to re-queue message: %s", requeue_exc)
+            raise
+
     @staticmethod
     async def _mark_message_failed(
         *,
@@ -734,6 +998,8 @@ class ChatStreamRuntime:
                         session.cancel_event.set()
                     runtime._cancel_event = session.cancel_event
                     session.active_generation_task = asyncio.current_task()
+                    runtime.transport = session.transport
+                    runtime.client = session.client
                     stream: AsyncIterator[StreamEvent] | None = None
                     try:
                         if params.options.model:

--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -7,6 +7,7 @@ import React, {
   useMemo,
   type ReactNode,
 } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useShallow } from 'zustand/react/shallow';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { isBrowserObjectUrl } from '@/utils/attachmentUrl';
@@ -28,6 +29,7 @@ import {
   useChatSessionActions,
 } from '@/hooks/useChatSessionContext';
 import { useChatInputMessageContext } from '@/hooks/useChatInputMessageContext';
+import { queryKeys } from '@/hooks/queries/queryKeys';
 
 const AT_BOTTOM_THRESHOLD_PX = 200;
 const INITIAL_FIRST_ITEM_INDEX = 1_000_000;
@@ -71,6 +73,7 @@ interface VirtuosoContextValue {
 export const Chat = memo(function Chat() {
   const { chatId } = useChatContext();
   const { state, actions } = useChatSessionContext();
+  const queryClient = useQueryClient();
 
   const {
     messages,
@@ -138,6 +141,18 @@ export const Chat = memo(function Chat() {
       }
     },
     [chatId],
+  );
+
+  const handleSendNow = useCallback(
+    async (messageId: string) => {
+      if (!chatId) return;
+      const success = await useMessageQueueStore.getState().sendNow(chatId, messageId);
+      if (success && !isStreaming) {
+        useMessageQueueStore.getState().removeLocalOnly(chatId, messageId);
+        await queryClient.invalidateQueries({ queryKey: queryKeys.messages(chatId) });
+      }
+    },
+    [chatId, isStreaming, queryClient],
   );
 
   const virtuosoRef = useRef<VirtuosoHandle | null>(null);
@@ -448,6 +463,7 @@ export const Chat = memo(function Chat() {
                       message={pending}
                       onCancel={handleCancelMessage}
                       onEdit={handleEditMessage}
+                      onSendNow={handleSendNow}
                     />
                   ))}
                 </div>

--- a/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
+++ b/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useCallback, useRef, useEffect } from 'react';
-import { X, Pencil, CornerDownRight, FileText, FileSpreadsheet } from 'lucide-react';
+import { X, Pencil, CornerDownRight, FileText, FileSpreadsheet, Send } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { Spinner } from '@/components/ui/primitives/Spinner';
 import { apiClient } from '@/lib/api';
@@ -15,6 +15,7 @@ interface QueueMessageCardProps {
   message: LocalQueuedMessage;
   onCancel: (messageId: string) => void;
   onEdit: (messageId: string, newContent: string) => void;
+  onSendNow: (messageId: string) => void;
 }
 
 function UploadingOverlay() {
@@ -179,6 +180,7 @@ export const QueueMessageCard = memo(function QueueMessageCard({
   message,
   onCancel,
   onEdit,
+  onSendNow,
 }: QueueMessageCardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(message.content);
@@ -265,7 +267,12 @@ export const QueueMessageCard = memo(function QueueMessageCard({
           )}
         </div>
         <div className="flex flex-shrink-0 items-center gap-1">
-          {isEditing ? (
+          {message.sendingNow ? (
+            <span className="flex items-center gap-1.5 px-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+              <Spinner size="xs" />
+              Sending...
+            </span>
+          ) : isEditing ? (
             <>
               <Button
                 onClick={handleSaveEdit}
@@ -284,6 +291,16 @@ export const QueueMessageCard = memo(function QueueMessageCard({
             </>
           ) : (
             <>
+              {message.synced && (
+                <Button
+                  onClick={() => onSendNow(message.id)}
+                  variant="ghost"
+                  className="h-6 rounded-md px-2 py-0 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+                  aria-label="Send now"
+                >
+                  <Send className="h-3.5 w-3.5" />
+                </Button>
+              )}
               <Button
                 onClick={handleStartEdit}
                 variant="ghost"

--- a/frontend/src/services/queueService.ts
+++ b/frontend/src/services/queueService.ts
@@ -74,6 +74,15 @@ async function deleteQueuedMessage(chatId: string, messageId: string): Promise<v
   });
 }
 
+async function sendNow(chatId: string, messageId: string): Promise<void> {
+  validateId(chatId, 'Chat ID');
+  validateId(messageId, 'Message ID');
+
+  await serviceCall(async () => {
+    await apiClient.post(`/chat/chats/${chatId}/queue/${messageId}/send-now`);
+  });
+}
+
 async function clearQueue(chatId: string): Promise<void> {
   validateId(chatId, 'Chat ID');
 
@@ -87,5 +96,6 @@ export const queueService = {
   getQueue,
   updateQueuedMessage,
   deleteQueuedMessage,
+  sendNow,
   clearQueue,
 };

--- a/frontend/src/store/messageQueueStore.ts
+++ b/frontend/src/store/messageQueueStore.ts
@@ -20,6 +20,7 @@ interface MessageQueueState {
   removeMessage: (chatId: string, messageId: string) => Promise<void>;
   clearAndSync: (chatId: string) => Promise<void>;
   getQueue: (chatId: string) => LocalQueuedMessage[];
+  sendNow: (chatId: string, messageId: string) => Promise<boolean>;
   clearQueue: (chatId: string) => void;
   fetchQueue: (chatId: string) => Promise<void>;
   syncPendingMessages: (chatId: string) => Promise<void>;
@@ -48,6 +49,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
       files,
       queuedAt: Date.now(),
       synced: false,
+      sendingNow: false,
     };
 
     set((state) => {
@@ -167,6 +169,48 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
     }
   },
 
+  sendNow: async (chatId: string, messageId: string): Promise<boolean> => {
+    const queue = get().queues.get(chatId) || [];
+    const message = queue.find((m) => m.id === messageId);
+    if (!message?.synced) return false;
+
+    const resetSendingNow = () => {
+      set((state) => {
+        const nextQueues = new Map(state.queues);
+        const currentQueue = nextQueues.get(chatId) || [];
+        nextQueues.set(
+          chatId,
+          currentQueue.map((msg) => (msg.id === messageId ? { ...msg, sendingNow: false } : msg)),
+        );
+        return { queues: nextQueues };
+      });
+    };
+
+    set((state) => {
+      const nextQueues = new Map(state.queues);
+      const currentQueue = nextQueues.get(chatId) || [];
+      nextQueues.set(
+        chatId,
+        currentQueue.map((msg) => (msg.id === messageId ? { ...msg, sendingNow: true } : msg)),
+      );
+      return { queues: nextQueues };
+    });
+
+    const timeout = window.setTimeout(resetSendingNow, 30_000);
+
+    try {
+      await queueService.sendNow(chatId, messageId);
+      clearTimeout(timeout);
+      resetSendingNow();
+      return true;
+    } catch (error) {
+      console.error('Failed to send now:', error);
+      clearTimeout(timeout);
+      resetSendingNow();
+      return false;
+    }
+  },
+
   removeLocalOnly: (chatId: string, messageId: string) => {
     set((state) => {
       const nextQueues = new Map(state.queues);
@@ -223,6 +267,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
           attachments: msg.attachments,
           queuedAt: new Date(msg.queued_at).getTime(),
           synced: true,
+          sendingNow: false,
         }));
 
         const merged = [...syncedMessages, ...pendingMessages];

--- a/frontend/src/types/queue.types.ts
+++ b/frontend/src/types/queue.types.ts
@@ -25,4 +25,5 @@ export interface LocalQueuedMessage {
   attachments?: QueueMessageAttachment[];
   queuedAt: number;
   synced: boolean;
+  sendingNow: boolean;
 }


### PR DESCRIPTION
## Summary
- Add a "Send Now" button (Send icon) to queue message cards that injects the message into the active stream after the next top-level tool completion via `transport.write`, bypassing the normal end-of-stream queue processing
- Backend marks the message for immediate delivery in Redis; the runtime checks for it after each top-level `tool_completed` event, finalizes the current assistant message, creates new user/assistant messages, and writes the injection to the transport
- Card stays visible with a spinner + "Sending..." indicator until the SSE `queue_processing` event confirms the message was processed, then gets removed automatically

## Test plan
- [ ] Queue multiple messages while a stream is active
- [ ] Click "Send Now" on a queued message — verify the card shows "Sending..." spinner
- [ ] Verify the message gets injected after the next tool completion and the card disappears
- [ ] Verify remaining queued messages continue processing normally after the injected message completes
- [ ] Click "Send Now" and verify rollback if the API call fails (spinner disappears, buttons return)
- [ ] Verify "Send Now" button only appears on synced messages (not local-only/uploading)