### PR TITLE
Bump claude-code to 2.1.50

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     apt-get install -y gh && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.44 @gongrzhe/server-gmail-autoauth-mcp @openai/codex @playwright/mcp@latest
+RUN npm install -g @anthropic-ai/claude-code@2.1.50 @gongrzhe/server-gmail-autoauth-mcp @openai/codex @playwright/mcp@latest
 
 # Install uv package manager
 RUN curl -LsSf https://astral.sh/uv/install.sh | bash

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.44 @openai/codex @gongrzhe/server-gmail-autoauth-mcp @playwright/mcp@latest
+    npm install -g @anthropic-ai/claude-code@2.1.50 @openai/codex @gongrzhe/server-gmail-autoauth-mcp @playwright/mcp@latest
 
 RUN python3 -m pip install --user --upgrade pip && \
     python3 -m pip install --user \

--- a/sandbox/e2b/e2b.Dockerfile
+++ b/sandbox/e2b/e2b.Dockerfile
@@ -51,7 +51,7 @@ RUN curl -fsSLO https://nodejs.org/dist/v20.19.0/node-v20.19.0-linux-x64.tar.xz 
     && echo '#!/bin/sh\nexec bun x "$@"' > /usr/local/bin/bunx \
     && chmod +x /usr/local/bin/bunx
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.44
+RUN npm install -g @anthropic-ai/claude-code@2.1.50
 
 RUN pip3 install anthropic-bridge==0.1.38
 


### PR DESCRIPTION
## Summary
- Bump `@anthropic-ai/claude-code` from 2.1.44 to 2.1.50 across all Dockerfiles (backend, docker sandbox, e2b sandbox)

## Test plan
- [ ] Verify backend container builds successfully
- [ ] Verify docker sandbox builds successfully
- [ ] Verify e2b sandbox builds successfully