### PR TITLE
Fix desktop release always producing v0.1.0 DMG

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -33,6 +33,12 @@ jobs:
           cd frontend
           npm ci --legacy-peer-deps
 
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cd frontend/src-tauri
+          jq --arg v "$VERSION" '.version = $v' tauri.conf.json > tmp.json && mv tmp.json tauri.conf.json
+
       - name: Build Tauri bundles
         run: |
           cd frontend

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Desktop mode uses Tauri with a bundled Python backend sidecar on `localhost:8081
 
 ### Download prebuilt app
 
-- Apple Silicon DMG: [Claudex_0.1.0_aarch64.dmg](https://github.com/Mng-dev-ai/claudex/releases/download/v0.1.1/Claudex_0.1.0_aarch64.dmg)
+- Apple Silicon DMG: [Latest Release](https://github.com/Mng-dev-ai/claudex/releases/latest)
 
 ### How it works
 


### PR DESCRIPTION
## Summary
- Inject the git tag version into `tauri.conf.json` before building so each release produces a correctly versioned DMG (e.g. `Claudex_0.1.3_aarch64.dmg` instead of always `Claudex_0.1.0_aarch64.dmg`)
- Update README download link to point to `/releases/latest` instead of a hardcoded filename that goes stale

## Test plan
- [ ] Push a new `v*` tag and verify the workflow sets the correct version in `tauri.conf.json`
- [ ] Confirm the resulting DMG filename matches the tag version
- [ ] Verify the README link redirects to the latest release page