### PR TITLE
Remove messages count from profile dropdown

### DIFF
--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import get_settings
-from app.core.deps import get_refresh_token_service, get_user_service
+from app.core.deps import get_refresh_token_service
 from app.core.security import verify_password
 from app.core.user_manager import (
     UserDatabase,
@@ -29,12 +29,10 @@ from app.models.schemas.auth import (
     UserCreate,
     UserOut,
     UserRead,
-    UserUsage,
 )
 from app.services.email import email_service
 from app.services.exceptions import AuthException
 from app.services.refresh_token import RefreshTokenService
-from app.services.user import UserService
 
 settings = get_settings()
 router = APIRouter()
@@ -139,18 +137,6 @@ router.include_router(
 @router.get("/me", response_model=UserOut)
 async def get_me(current_user: User = Depends(current_active_user)) -> User:
     return current_user
-
-
-@router.get("/usage", response_model=UserUsage)
-async def get_user_usage(
-    current_user: User = Depends(current_active_user),
-    user_service: UserService = Depends(get_user_service),
-) -> UserUsage:
-    messages_used = await user_service.get_user_daily_message_count(current_user.id)
-
-    return UserUsage(
-        messages_used_today=messages_used,
-    )
 
 
 @router.post("/jwt/refresh", response_model=Token)

--- a/backend/app/models/schemas/auth.py
+++ b/backend/app/models/schemas/auth.py
@@ -71,7 +71,3 @@ class RefreshTokenRequest(BaseModel):
 
 class LogoutRequest(BaseModel):
     refresh_token: str
-
-
-class UserUsage(BaseModel):
-    messages_used_today: int

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
 from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.constants import REDIS_KEY_USER_SETTINGS
 from app.core.config import get_settings
-from app.models.db_models.chat import Chat, Message
-from app.models.db_models.enums import MessageRole
 from app.models.db_models.user import UserSettings
 from app.models.schemas.settings import UserSettingsResponse
 from app.models.types import InstalledPluginDict
@@ -161,22 +158,3 @@ class UserService(BaseDbService[UserSettings]):
         if modified:
             user_settings.installed_plugins = updated_plugins
         return modified
-
-    async def get_user_daily_message_count(self, user_id: UUID) -> int:
-        today = date.today()
-        start_of_day = datetime.combine(today, datetime.min.time()).replace(
-            tzinfo=timezone.utc
-        )
-        end_of_day = datetime.combine(today, datetime.max.time()).replace(
-            tzinfo=timezone.utc
-        )
-
-        async with self.session_factory() as db:
-            query = select(func.count(Message.id)).filter(
-                Message.role == MessageRole.USER,
-                Message.created_at >= start_of_day,
-                Message.created_at <= end_of_day,
-                Message.chat_id.in_(select(Chat.id).filter(Chat.user_id == user_id)),
-            )
-            result = await db.execute(query)
-            return result.scalar() or 0

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -240,30 +240,11 @@ class TestCurrentUser:
         assert data["id"] == str(integration_user_fixture.id)
 
 
-class TestUserUsage:
-    async def test_get_user_usage(
-        self,
-        async_client: AsyncClient,
-        integration_user_fixture: User,
-        auth_headers: dict[str, str],
-    ) -> None:
-        response = await async_client.get(
-            "/api/v1/auth/usage",
-            headers=auth_headers,
-        )
-
-        assert response.status_code == 200
-        data = response.json()
-        assert "messages_used_today" in data
-        assert isinstance(data["messages_used_today"], int)
-
-
 class TestUnauthorizedAccess:
     @pytest.mark.parametrize(
         "endpoint",
         [
             "/api/v1/auth/me",
-            "/api/v1/auth/usage",
         ],
     )
     async def test_unauthorized_access(

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,18 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowLeft, Command, LogOut, Moon, Settings, Sun } from 'lucide-react';
 import { useNavigate, useMatch } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
-import {
-  useCurrentUserQuery,
-  useLogoutMutation,
-  useUserUsageQuery,
-} from '@/hooks/queries/useAuthQueries';
+import { useCurrentUserQuery, useLogoutMutation } from '@/hooks/queries/useAuthQueries';
 import { Button } from '@/components/ui/primitives/Button';
 import { ToggleButton } from '@/components/ui/ToggleButton';
 import { cn } from '@/utils/cn';
 import { UserAvatarCircle } from '@/components/chat/message-bubble/MessageAvatars';
-import type { UserUsage } from '@/types/user.types';
 
 export interface HeaderProps {
   onLogout?: () => void;
@@ -44,13 +39,6 @@ function useClickOutside<T extends HTMLElement>(
     document.addEventListener('mousedown', handle);
     return () => document.removeEventListener('mousedown', handle);
   }, [handler, ref]);
-}
-
-function buildUsageMeta(usage?: UserUsage) {
-  if (!usage) return null;
-
-  const emphasisClass = 'text-text-tertiary dark:text-text-dark-tertiary font-medium';
-  return { emphasisClass };
 }
 
 function ThemeToggleButton({ theme, onToggle }: { theme: string; onToggle: () => void }) {
@@ -107,7 +95,6 @@ function AuthButtons({ onLogin, onSignup }: { onLogin: () => void; onSignup: () 
 
 function UserMenu({
   displayName,
-  usage,
   theme,
   onToggleTheme,
   onSettings,
@@ -115,7 +102,6 @@ function UserMenu({
   onLogout,
 }: {
   displayName: string;
-  usage?: UserUsage;
   theme: string;
   onToggleTheme: () => void;
   onSettings: () => void;
@@ -129,8 +115,6 @@ function UserMenu({
   const toggleMenu = useCallback(() => setIsOpen((prev) => !prev), []);
 
   useClickOutside(dropdownRef, closeMenu);
-
-  const usageMeta = useMemo(() => buildUsageMeta(usage), [usage]);
 
   return (
     <div className="relative" ref={dropdownRef}>
@@ -167,16 +151,6 @@ function UserMenu({
                 </p>
               </div>
             </div>
-            {usageMeta && usage && (
-              <div className="mt-2.5 space-y-1">
-                <div className="flex items-center justify-between">
-                  <span className={cn('text-2xs', usageMeta.emphasisClass)}>Messages</span>
-                  <span className={cn('text-2xs tabular-nums', usageMeta.emphasisClass)}>
-                    {usage.messages_used_today}
-                  </span>
-                </div>
-              </div>
-            )}
           </div>
 
           <div className="p-1">
@@ -230,10 +204,6 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
 
   const { data: user } = useCurrentUserQuery({
-    enabled: isAuthenticated && !isAuthPage,
-  });
-
-  const { data: usage } = useUserUsageQuery({
     enabled: isAuthenticated && !isAuthPage,
   });
 
@@ -321,7 +291,6 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
           {isAuthPage ? null : isAuthenticated ? (
             <UserMenu
               displayName={displayName}
-              usage={usage}
               theme={theme}
               onToggleTheme={() => useUIStore.getState().toggleTheme()}
               onSettings={() => {

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -5,7 +5,6 @@ export const queryKeys = {
   contextUsage: (chatId: string) => ['chat', chatId, 'context-usage'] as const,
   auth: {
     user: 'auth-user',
-    usage: 'auth-usage',
   },
   settings: 'settings',
   sandbox: {

--- a/frontend/src/hooks/queries/useAuthQueries.ts
+++ b/frontend/src/hooks/queries/useAuthQueries.ts
@@ -1,22 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { UseMutationOptions, UseQueryOptions } from '@tanstack/react-query';
 import { authService } from '@/services/authService';
-import type { AuthResponse, User, UserUsage } from '@/types/user.types';
+import type { AuthResponse, User } from '@/types/user.types';
 import { queryKeys } from './queryKeys';
 
 export const useCurrentUserQuery = (options?: Partial<UseQueryOptions<User>>) => {
   return useQuery({
     queryKey: [queryKeys.auth.user],
     queryFn: () => authService.getCurrentUser(),
-    retry: false,
-    ...options,
-  });
-};
-
-export const useUserUsageQuery = (options?: Partial<UseQueryOptions<UserUsage>>) => {
-  return useQuery({
-    queryKey: [queryKeys.auth.usage],
-    queryFn: () => authService.getUserUsage(),
     retry: false,
     ...options,
   });

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '@/lib/api';
 import { ensureResponse, serviceCall, withAuth } from '@/services/base/BaseService';
 import { ValidationError } from '@/services/base/ServiceError';
-import type { AuthResponse, User, UserUsage } from '@/types/user.types';
+import type { AuthResponse, User } from '@/types/user.types';
 import { authStorage } from '@/utils/storage';
 import {
   validateRequired,
@@ -104,13 +104,6 @@ async function getCurrentUser(): Promise<User> {
   });
 }
 
-async function getUserUsage(): Promise<UserUsage> {
-  return withAuth(async () => {
-    const response = await apiClient.get<UserUsage>('/auth/usage');
-    return ensureResponse(response, 'Invalid response from server');
-  });
-}
-
 async function logout(): Promise<void> {
   const currentRefreshToken = authStorage.getRefreshToken();
   try {
@@ -163,7 +156,6 @@ export const authService = {
   signup,
   login,
   getCurrentUser,
-  getUserUsage,
   logout,
   getToken,
   isAuthenticated,

--- a/frontend/src/types/user.types.ts
+++ b/frontend/src/types/user.types.ts
@@ -6,10 +6,6 @@ export interface User {
   email_verification_required: boolean;
 }
 
-export interface UserUsage {
-  messages_used_today: number;
-}
-
 export interface AuthResponse {
   access_token: string;
   refresh_token: string;


### PR DESCRIPTION
## Summary
- Removes the "Messages" daily usage count from the user profile dropdown menu
- Removes the `GET /auth/usage` backend endpoint, `UserUsage` schema, and `get_user_daily_message_count` service method
- Cleans up all related frontend code: query hook, service function, type, query key, and component props
- Removes associated tests

## Test plan
- [ ] Verify profile dropdown renders without the messages count row
- [ ] Verify no console errors or type errors in the frontend
- [ ] Verify backend starts without import errors