### PR TITLE
Enable ad-hoc code signing for macOS desktop builds

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -29,6 +29,9 @@
     "active": true,
     "targets": ["dmg", "app"],
     "icon": ["icons/icon.icns", "icons/icon.png"],
-    "resources": ["../backend-sidecar/"]
+    "resources": ["../backend-sidecar/"],
+    "macOS": {
+      "signingIdentity": "-"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add `signingIdentity: "-"` to Tauri macOS bundle config for ad-hoc code signing
- Eliminates the need to run `xattr -cr /Applications/Claudex.app` after every install
- Users will see a one-time "unidentified developer" prompt instead of "damaged and can't be opened", bypassable via System Settings > Privacy & Security > Open Anyway

## Test plan
- [ ] Build desktop app and verify the DMG installs without needing `xattr -cr`
- [ ] Verify the "Open Anyway" prompt appears in Privacy & Security on first launch