### PR TITLE
fix(ci): correct tauri-action updater input

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -49,7 +49,7 @@ jobs:
           releaseBody: Desktop release for ${{ github.ref_name }}.
           releaseDraft: false
           prerelease: false
-          uploadUpdaterJson: true
+          includeUpdaterJson: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- fix desktop release workflow input name for `tauri-apps/tauri-action`
- replace unsupported `uploadUpdaterJson` with supported `includeUpdaterJson`

## Why
GitHub Actions failed with:
- `Unexpected input(s) 'uploadUpdaterJson'`

This change uses the valid action input so updater metadata generation can proceed.
