### PR TITLE
fix(ci): force npx tauri in desktop release workflow

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -44,6 +44,7 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         with:
           projectPath: frontend
+          tauriScript: npx tauri
           tagName: ${{ github.ref_name }}
           releaseName: Claudex Desktop ${{ github.ref_name }}
           releaseBody: Desktop release for ${{ github.ref_name }}.


### PR DESCRIPTION
## Summary
- force `tauri-action` to run `npx tauri` via `tauriScript`
- avoid package manager auto-detection selecting `bun` because `frontend/bun.lockb` exists

## Why
Release workflow was invoking:
- `running bun [ 'tauri', 'build' ]`

This change pins the Tauri CLI invocation path to npm-based execution.
