### PR TITLE
feat(desktop): use Tauri native store for auth tokens

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@tanstack/react-query": "^5.62.11",
         "@tanstack/react-query-devtools": "^5.62.11",
         "@tauri-apps/api": "2.10.1",
+        "@tauri-apps/plugin-store": "^2.4.0",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "@types/jszip": "^3.4.1",
         "@types/node": "^22.10.5",
@@ -1530,6 +1531,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-store": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-store/-/plugin-store-2.4.0.tgz",
+      "integrity": "sha512-PjBnlnH6jyI71MGhrPaxUUCsOzc7WO1mbc4gRhME0m2oxLgCqbksw6JyeKQimuzv4ysdpNO3YbmaY2haf82a3A==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-updater": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-query": "^5.62.11",
     "@tanstack/react-query-devtools": "^5.62.11",
     "@tauri-apps/api": "2.10.1",
+    "@tauri-apps/plugin-store": "^2.4.0",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@types/jszip": "^3.4.1",
     "@types/node": "^22.10.5",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -318,6 +318,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-store",
  "tauri-plugin-updater",
  "tokio",
 ]
@@ -3777,6 +3778,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-store"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca1a8ff83c269b115e98726ffc13f9e548a10161544a92ad121d6d0a96e16ea"
+dependencies = [
+ "dunce",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4026,7 +4043,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4210,7 +4239,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ rand = "0.9"
 dirs = "5"
 reqwest = "0.12"
 tokio = { version = "1", features = ["time"] }
+tauri-plugin-store = "2.4.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"

--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "main-capability",
   "description": "Desktop capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "updater:default"]
+  "permissions": ["core:default", "store:default", "updater:default"]
 }

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -111,6 +111,7 @@ fn main() {
     let backend_for_exit = backend_process.clone();
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(move |app| {
             let app_handle = app.handle().clone();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { toasterConfig } from '@/config/toaster';
 import { AuthRoute } from '@/components/routes/AuthRoute';
 import { API_BASE_URL } from '@/lib/api';
 import { check } from '@tauri-apps/plugin-updater';
+import { authStorage } from '@/utils/storage';
 
 const LandingPage = lazy(() =>
   import('@/pages/LandingPage').then((m) => ({ default: m.LandingPage })),
@@ -175,8 +176,28 @@ function AppContent() {
 export default function App() {
   const theme = useUIStore((state) => state.theme);
   const [backendReady, setBackendReady] = useState<boolean | null>(null);
+  const [authHydrated, setAuthHydrated] = useState(false);
 
-  useGlobalStream();
+  useGlobalStream({ enabled: authHydrated });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    authStorage
+      .hydrate()
+      .catch((error) => {
+        console.error('Auth storage hydration failed:', error);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        useAuthStore.getState().setAuthenticated(!!authStorage.getToken());
+        setAuthHydrated(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     document.body.classList.remove('light', 'dark');
@@ -227,6 +248,10 @@ export default function App() {
       console.error('Desktop updater check failed:', error);
     });
   }, []);
+
+  if (!authHydrated) {
+    return <LoadingScreen />;
+  }
 
   return (
     <BrowserRouter>

--- a/frontend/src/hooks/useGlobalStream.ts
+++ b/frontend/src/hooks/useGlobalStream.ts
@@ -5,13 +5,17 @@ import { streamService } from '@/services/streamService';
 import { chatService } from '@/services/chatService';
 
 interface UseGlobalStreamOptions {
+  enabled?: boolean;
   onValidationComplete?: () => void;
 }
 
 export function useGlobalStream(options?: UseGlobalStreamOptions) {
   const hasValidatedRef = useRef(false);
+  const enabled = options?.enabled ?? true;
+  const onValidationComplete = options?.onValidationComplete;
 
   useEffect(() => {
+    if (!enabled) return;
     if (hasValidatedRef.current) return;
     hasValidatedRef.current = true;
 
@@ -34,13 +38,13 @@ export function useGlobalStream(options?: UseGlobalStreamOptions) {
       });
 
       await Promise.allSettled(validationPromises);
-      options?.onValidationComplete?.();
+      onValidationComplete?.();
     };
 
     const timeoutId = setTimeout(validateStreams, 500);
 
     return () => clearTimeout(timeoutId);
-  }, [options]);
+  }, [enabled, onValidationComplete]);
 
   const stopAllStreams = useCallback(async () => {
     await streamService.stopAllStreams();

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,5 +1,19 @@
 import { logger } from '@/utils/logger';
 
+const AUTH_TOKEN_KEY = 'auth_token';
+const REFRESH_TOKEN_KEY = 'refresh_token';
+const AUTH_STORE_PATH = 'auth.store.json';
+const CHAT_EVENT_ID_PREFIX = 'chat:';
+const CHAT_EVENT_ID_SUFFIX = ':lastEventId';
+const MAX_CHAT_EVENT_ID_ENTRIES = 500;
+
+interface AuthStoreBackend {
+  get<T>(key: string): Promise<T | undefined>;
+  set(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<boolean>;
+  save(): Promise<void>;
+}
+
 const getStorage = (): Storage | null => {
   if (typeof window === 'undefined') {
     return null;
@@ -12,6 +26,9 @@ const getStorage = (): Storage | null => {
     return null;
   }
 };
+
+const isTauriRuntime = (): boolean =>
+  typeof window !== 'undefined' && ('__TAURI__' in window || window.location.protocol === 'tauri:');
 
 export const safeGetItem = (key: string): string | null => {
   const storageInstance = getStorage();
@@ -53,49 +70,162 @@ const safeRemoveItem = (key: string): void => {
   }
 };
 
+let desktopStorePromise: Promise<AuthStoreBackend | null> | null = null;
+
+async function getDesktopAuthStore(): Promise<AuthStoreBackend | null> {
+  if (!isTauriRuntime()) {
+    return null;
+  }
+  if (desktopStorePromise) {
+    try {
+      return await desktopStorePromise;
+    } catch (error) {
+      desktopStorePromise = null;
+      logger.error('Desktop auth store init failed', 'storage.getDesktopAuthStore', error);
+      return null;
+    }
+  }
+
+  desktopStorePromise = (async () => {
+    const { load } = await import('@tauri-apps/plugin-store');
+    return await load(AUTH_STORE_PATH, { defaults: {}, autoSave: false });
+  })();
+
+  try {
+    return await desktopStorePromise;
+  } catch (error) {
+    desktopStorePromise = null;
+    logger.error('Desktop auth store init failed', 'storage.getDesktopAuthStore', error);
+    return null;
+  }
+}
+
 let cachedToken: string | null = null;
 let cachedRefreshToken: string | null = null;
 let tokenCacheInitialized = false;
 
-function initTokenCache(): void {
+async function persistDesktopAuthState(): Promise<void> {
+  const store = await getDesktopAuthStore();
+  if (!store) {
+    return;
+  }
+
+  try {
+    if (cachedToken) {
+      await store.set(AUTH_TOKEN_KEY, cachedToken);
+    } else {
+      await store.delete(AUTH_TOKEN_KEY);
+    }
+
+    if (cachedRefreshToken) {
+      await store.set(REFRESH_TOKEN_KEY, cachedRefreshToken);
+    } else {
+      await store.delete(REFRESH_TOKEN_KEY);
+    }
+
+    await store.save();
+  } catch (error) {
+    logger.error('Desktop auth store persist failed', 'storage.persistDesktopAuthState', error);
+  }
+}
+
+function initTokenCacheFromLocalStorage(): void {
   if (tokenCacheInitialized) return;
-  cachedToken = safeGetItem('auth_token');
-  cachedRefreshToken = safeGetItem('refresh_token');
+  cachedToken = safeGetItem(AUTH_TOKEN_KEY);
+  cachedRefreshToken = safeGetItem(REFRESH_TOKEN_KEY);
   tokenCacheInitialized = true;
 }
 
 export const authStorage = {
+  hydrate: async (): Promise<void> => {
+    if (tokenCacheInitialized) {
+      return;
+    }
+
+    if (!isTauriRuntime()) {
+      initTokenCacheFromLocalStorage();
+      return;
+    }
+
+    const store = await getDesktopAuthStore();
+    if (store) {
+      try {
+        const persistedToken = await store.get<string>(AUTH_TOKEN_KEY);
+        const persistedRefreshToken = await store.get<string>(REFRESH_TOKEN_KEY);
+
+        cachedToken = persistedToken ?? null;
+        cachedRefreshToken = persistedRefreshToken ?? null;
+      } catch (error) {
+        logger.error('Desktop auth store read failed', 'storage.authStorage.hydrate', error);
+      }
+    }
+
+    tokenCacheInitialized = true;
+  },
   getToken: (): string | null => {
-    initTokenCache();
+    if (!tokenCacheInitialized && !isTauriRuntime()) {
+      initTokenCacheFromLocalStorage();
+    }
     return cachedToken;
   },
   setToken: (token: string): void => {
     cachedToken = token;
-    safeSetItem('auth_token', token);
+    tokenCacheInitialized = true;
+
+    if (isTauriRuntime()) {
+      void persistDesktopAuthState();
+      safeRemoveItem(AUTH_TOKEN_KEY);
+      return;
+    }
+
+    safeSetItem(AUTH_TOKEN_KEY, token);
   },
   getRefreshToken: (): string | null => {
-    initTokenCache();
+    if (!tokenCacheInitialized && !isTauriRuntime()) {
+      initTokenCacheFromLocalStorage();
+    }
     return cachedRefreshToken;
   },
   setRefreshToken: (token: string): void => {
     cachedRefreshToken = token;
-    safeSetItem('refresh_token', token);
+    tokenCacheInitialized = true;
+
+    if (isTauriRuntime()) {
+      void persistDesktopAuthState();
+      safeRemoveItem(REFRESH_TOKEN_KEY);
+      return;
+    }
+
+    safeSetItem(REFRESH_TOKEN_KEY, token);
   },
   removeRefreshToken: (): void => {
     cachedRefreshToken = null;
-    safeRemoveItem('refresh_token');
+    tokenCacheInitialized = true;
+
+    if (isTauriRuntime()) {
+      void persistDesktopAuthState();
+      safeRemoveItem(REFRESH_TOKEN_KEY);
+      return;
+    }
+
+    safeRemoveItem(REFRESH_TOKEN_KEY);
   },
   clearAuth: (): void => {
     cachedToken = null;
     cachedRefreshToken = null;
-    safeRemoveItem('auth_token');
-    safeRemoveItem('refresh_token');
+    tokenCacheInitialized = true;
+
+    if (isTauriRuntime()) {
+      void persistDesktopAuthState();
+      safeRemoveItem(AUTH_TOKEN_KEY);
+      safeRemoveItem(REFRESH_TOKEN_KEY);
+      return;
+    }
+
+    safeRemoveItem(AUTH_TOKEN_KEY);
+    safeRemoveItem(REFRESH_TOKEN_KEY);
   },
 };
-
-const CHAT_EVENT_ID_PREFIX = 'chat:';
-const CHAT_EVENT_ID_SUFFIX = ':lastEventId';
-const MAX_CHAT_EVENT_ID_ENTRIES = 500;
 
 export const chatStorage = {
   getEventId: (chatId: string): string | null =>


### PR DESCRIPTION
## Summary
- add Tauri Store plugin on desktop (@tauri-apps/plugin-store and Rust plugin wiring)
- persist access/refresh tokens in native desktop store instead of localStorage in Tauri runtime
- hydrate auth state before app bootstrap and defer global stream validation until hydration completes
- remove desktop legacy localStorage token fallback in authStorage.hydrate()

## Notes
- branch includes frontend + Tauri dependency/capability updates required for native store support
