### PR TITLE
fix(desktop): use isTauri() for updater and auth hydration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { authService } from '@/services/authService';
 import { toasterConfig } from '@/config/toaster';
 import { AuthRoute } from '@/components/routes/AuthRoute';
 import { API_BASE_URL } from '@/lib/api';
+import { isTauri } from '@tauri-apps/api/core';
 import { check } from '@tauri-apps/plugin-updater';
 import { authStorage } from '@/utils/storage';
 
@@ -34,9 +35,6 @@ const ResetPasswordPage = lazy(() =>
   import('@/pages/ResetPasswordPage').then((m) => ({ default: m.ResetPasswordPage })),
 );
 const SettingsPage = lazy(() => import('@/pages/SettingsPage'));
-
-const isTauriRuntime = (): boolean =>
-  typeof window !== 'undefined' && ('__TAURI__' in window || window.location.protocol === 'tauri:');
 
 async function checkDesktopUpdate(): Promise<void> {
   const update = await check();
@@ -210,7 +208,7 @@ export default function App() {
   }, [theme]);
 
   useEffect(() => {
-    if (!isTauriRuntime()) return;
+    if (!isTauri()) return;
 
     let interval: number | undefined;
     let cancelled = false;
@@ -242,7 +240,7 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    if (import.meta.env.DEV || !isTauriRuntime()) return;
+    if (import.meta.env.DEV || !isTauri()) return;
 
     checkDesktopUpdate().catch((error) => {
       console.error('Desktop updater check failed:', error);

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/utils/logger';
+import { isTauri } from '@tauri-apps/api/core';
 
 const AUTH_TOKEN_KEY = 'auth_token';
 const REFRESH_TOKEN_KEY = 'refresh_token';
@@ -26,9 +27,6 @@ const getStorage = (): Storage | null => {
     return null;
   }
 };
-
-const isTauriRuntime = (): boolean =>
-  typeof window !== 'undefined' && ('__TAURI__' in window || window.location.protocol === 'tauri:');
 
 export const safeGetItem = (key: string): string | null => {
   const storageInstance = getStorage();
@@ -73,7 +71,7 @@ const safeRemoveItem = (key: string): void => {
 let desktopStorePromise: Promise<AuthStoreBackend | null> | null = null;
 
 async function getDesktopAuthStore(): Promise<AuthStoreBackend | null> {
-  if (!isTauriRuntime()) {
+  if (!isTauri()) {
     return null;
   }
   if (desktopStorePromise) {
@@ -142,7 +140,7 @@ export const authStorage = {
       return;
     }
 
-    if (!isTauriRuntime()) {
+    if (!isTauri()) {
       initTokenCacheFromLocalStorage();
       return;
     }
@@ -163,7 +161,7 @@ export const authStorage = {
     tokenCacheInitialized = true;
   },
   getToken: (): string | null => {
-    if (!tokenCacheInitialized && !isTauriRuntime()) {
+    if (!tokenCacheInitialized && !isTauri()) {
       initTokenCacheFromLocalStorage();
     }
     return cachedToken;
@@ -172,7 +170,7 @@ export const authStorage = {
     cachedToken = token;
     tokenCacheInitialized = true;
 
-    if (isTauriRuntime()) {
+    if (isTauri()) {
       void persistDesktopAuthState();
       safeRemoveItem(AUTH_TOKEN_KEY);
       return;
@@ -181,7 +179,7 @@ export const authStorage = {
     safeSetItem(AUTH_TOKEN_KEY, token);
   },
   getRefreshToken: (): string | null => {
-    if (!tokenCacheInitialized && !isTauriRuntime()) {
+    if (!tokenCacheInitialized && !isTauri()) {
       initTokenCacheFromLocalStorage();
     }
     return cachedRefreshToken;
@@ -190,7 +188,7 @@ export const authStorage = {
     cachedRefreshToken = token;
     tokenCacheInitialized = true;
 
-    if (isTauriRuntime()) {
+    if (isTauri()) {
       void persistDesktopAuthState();
       safeRemoveItem(REFRESH_TOKEN_KEY);
       return;
@@ -202,7 +200,7 @@ export const authStorage = {
     cachedRefreshToken = null;
     tokenCacheInitialized = true;
 
-    if (isTauriRuntime()) {
+    if (isTauri()) {
       void persistDesktopAuthState();
       safeRemoveItem(REFRESH_TOKEN_KEY);
       return;
@@ -215,7 +213,7 @@ export const authStorage = {
     cachedRefreshToken = null;
     tokenCacheInitialized = true;
 
-    if (isTauriRuntime()) {
+    if (isTauri()) {
       void persistDesktopAuthState();
       safeRemoveItem(AUTH_TOKEN_KEY);
       safeRemoveItem(REFRESH_TOKEN_KEY);


### PR DESCRIPTION
## Summary
- replace custom desktop detection (`__TAURI__` / `tauri:`) with `isTauri()` from `@tauri-apps/api/core`
- ensure updater startup check actually runs in Tauri v2 production builds
- ensure native auth store hydration path correctly runs in desktop builds

## Why
`v0.1.9` -> `v0.1.10` did not show update prompt despite newer `latest.json`.
The prior runtime detection could evaluate false in production, skipping the updater check.

## Files
- frontend/src/App.tsx
- frontend/src/utils/storage.ts
