### PR TITLE
Add dynamic system theme option

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import { Layout } from '@/components/layout/Layout';
 import { Toaster } from 'react-hot-toast';
 import toast from 'react-hot-toast';
 import { useAuthStore } from '@/store/authStore';
-import { useUIStore } from '@/store/uiStore';
+import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { useCurrentUserQuery } from '@/hooks/queries/useAuthQueries';
 import { useInfiniteChatsQuery } from '@/hooks/queries/useChatQueries';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
@@ -172,7 +172,7 @@ function AppContent() {
 }
 
 export default function App() {
-  const theme = useUIStore((state) => state.theme);
+  const resolvedTheme = useResolvedTheme();
   const [backendReady, setBackendReady] = useState<boolean | null>(null);
   const [authHydrated, setAuthHydrated] = useState(false);
 
@@ -199,13 +199,13 @@ export default function App() {
 
   useEffect(() => {
     document.body.classList.remove('light', 'dark');
-    document.body.classList.add(theme);
-    document.documentElement.setAttribute('data-theme', theme);
+    document.body.classList.add(resolvedTheme);
+    document.documentElement.setAttribute('data-theme', resolvedTheme);
     const metaThemeColor = document.querySelector('meta[name="theme-color"]');
     if (metaThemeColor) {
-      metaThemeColor.setAttribute('content', theme === 'dark' ? '#0a0a0a' : '#ffffff');
+      metaThemeColor.setAttribute('content', resolvedTheme === 'dark' ? '#0a0a0a' : '#ffffff');
     }
-  }, [theme]);
+  }, [resolvedTheme]);
 
   useEffect(() => {
     if (!isTauri()) return;

--- a/frontend/src/components/editor/editor-core/Editor.tsx
+++ b/frontend/src/components/editor/editor-core/Editor.tsx
@@ -3,7 +3,7 @@ import { logger } from '@/utils/logger';
 import { CodeView } from '../code-view/CodeView';
 import type { FileStructure } from '@/types/file-system.types';
 import type { Chat } from '@/types/chat.types';
-import { useUIStore } from '@/store/uiStore';
+import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { sandboxService } from '@/services/sandboxService';
 
 const collectFolderPaths = (items: FileStructure[], validPaths: Set<string>) => {
@@ -38,7 +38,7 @@ export const Editor = memo(function Editor({
   onRefresh,
   isRefreshing = false,
 }: EditorProps) {
-  const theme = useUIStore((state) => state.theme);
+  const theme = useResolvedTheme();
   const [expandedFolders, setExpandedFolders] = useState<Record<string, boolean>>({});
 
   const validFolderPaths = useMemo(() => {

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -5,7 +5,7 @@ import { Content } from './Content';
 import { EmptyState } from './EmptyState';
 import { FilePreview } from '../file-preview/FilePreview';
 import { useEditorTheme } from '@/hooks/useEditorTheme';
-import { useUIStore } from '@/store/uiStore';
+import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import type { FileStructure } from '@/types/file-system.types';
 import { detectLanguage, findFileInStructure } from '@/utils/file';
 import { useUpdateFileMutation, useFileContentQuery } from '@/hooks/queries/useSandboxQueries';
@@ -26,7 +26,7 @@ export const View = memo(function View({
   chatId,
   onToggleFileTree,
 }: ViewProps) {
-  const theme = useUIStore((state) => state.theme);
+  const theme = useResolvedTheme();
   const previousFileRef = useRef<FileStructure | null>(null);
   const [showPreview, setShowPreview] = useState(false);
   const [currentContent, setCurrentContent] = useState('');

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ArrowLeft, Command, LogOut, Moon, Settings, Sun } from 'lucide-react';
+import { ArrowLeft, Command, LogOut, Monitor, Moon, Settings, Sun } from 'lucide-react';
 import { useNavigate, useMatch } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
@@ -41,7 +41,21 @@ function useClickOutside<T extends HTMLElement>(
   }, [handler, ref]);
 }
 
+const THEME_ICON_MAP = {
+  dark: Sun,
+  light: Moon,
+  system: Monitor,
+} as const;
+
+const THEME_NEXT_LABEL = {
+  dark: 'light',
+  light: 'system',
+  system: 'dark',
+} as const;
+
 function ThemeToggleButton({ theme, onToggle }: { theme: string; onToggle: () => void }) {
+  const Icon = THEME_ICON_MAP[theme as keyof typeof THEME_ICON_MAP] ?? Monitor;
+  const nextLabel = THEME_NEXT_LABEL[theme as keyof typeof THEME_NEXT_LABEL] ?? 'dark';
   return (
     <Button
       onClick={onToggle}
@@ -54,9 +68,9 @@ function ThemeToggleButton({ theme, onToggle }: { theme: string; onToggle: () =>
         'transition-colors duration-200',
       )}
       aria-label="Toggle theme"
-      title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      title={`Switch to ${nextLabel} mode`}
     >
-      {theme === 'dark' ? <Sun className="h-3.5 w-3.5" /> : <Moon className="h-3.5 w-3.5" />}
+      <Icon className="h-3.5 w-3.5" />
     </Button>
   );
 }
@@ -95,15 +109,11 @@ function AuthButtons({ onLogin, onSignup }: { onLogin: () => void; onSignup: () 
 
 function UserMenu({
   displayName,
-  theme,
-  onToggleTheme,
   onSettings,
   onPrefetchSettings,
   onLogout,
 }: {
   displayName: string;
-  theme: string;
-  onToggleTheme: () => void;
   onSettings: () => void;
   onPrefetchSettings: () => void;
   onLogout: () => void;
@@ -154,14 +164,6 @@ function UserMenu({
           </div>
 
           <div className="p-1">
-            <Button onClick={onToggleTheme} variant="unstyled" className={menuItemClasses}>
-              {theme === 'dark' ? (
-                <Sun className="h-3.5 w-3.5" />
-              ) : (
-                <Moon className="h-3.5 w-3.5" />
-              )}
-              <span className="flex-1">{theme === 'dark' ? 'Light mode' : 'Dark mode'}</span>
-            </Button>
             <Button
               onClick={() => {
                 onSettings();
@@ -291,8 +293,6 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
           {isAuthPage ? null : isAuthenticated ? (
             <UserMenu
               displayName={displayName}
-              theme={theme}
-              onToggleTheme={() => useUIStore.getState().toggleTheme()}
               onSettings={() => {
                 prefetchSettingsPage();
                 handleNavigate('/settings');

--- a/frontend/src/components/sandbox/terminal/TerminalTab.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab.tsx
@@ -3,7 +3,7 @@ import { logger } from '@/utils/logger';
 import type { FC } from 'react';
 import 'xterm/css/xterm.css';
 
-import { useUIStore } from '@/store/uiStore';
+import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { authService } from '@/services/authService';
 import { WS_BASE_URL } from '@/lib/api';
 
@@ -30,7 +30,7 @@ export const TerminalTab: FC<TerminalTabProps> = ({
   shouldClose = false,
   onClosed,
 }) => {
-  const theme = useUIStore((state) => state.theme);
+  const theme = useResolvedTheme();
   const [sessionState, setSessionState] = useState<SessionState>('idle');
 
   const lastSentSizeRef = useRef<TerminalSize | null>(null);

--- a/frontend/src/components/settings/dialogs/AgentEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/AgentEditDialog.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, lazy, Suspense } from 'react';
 const Editor = lazy(() => import('@monaco-editor/react'));
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { Button } from '@/components/ui/primitives/Button';
-import { useUIStore } from '@/store/uiStore';
+import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import type { CustomAgent } from '@/types/user.types';
 
 interface AgentEditDialogProps {
@@ -24,7 +24,7 @@ export const AgentEditDialog: React.FC<AgentEditDialogProps> = ({
   onSave,
 }) => {
   const [editedContent, setEditedContent] = useState('');
-  const theme = useUIStore((state) => state.theme);
+  const theme = useResolvedTheme();
 
   useEffect(() => {
     if (agent) {

--- a/frontend/src/components/settings/dialogs/CommandEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/CommandEditDialog.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, lazy, Suspense } from 'react';
 const Editor = lazy(() => import('@monaco-editor/react'));
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { Button } from '@/components/ui/primitives/Button';
-import { useUIStore } from '@/store/uiStore';
+import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import type { CustomCommand } from '@/types/user.types';
 
 interface CommandEditDialogProps {
@@ -24,7 +24,7 @@ export const CommandEditDialog: React.FC<CommandEditDialogProps> = ({
   onSave,
 }) => {
   const [editedContent, setEditedContent] = useState('');
-  const theme = useUIStore((state) => state.theme);
+  const theme = useResolvedTheme();
 
   useEffect(() => {
     if (command) {

--- a/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
@@ -4,6 +4,8 @@ import { Switch } from '@/components/ui/primitives/Switch';
 import { SegmentedControl } from '@/components/ui/primitives/SegmentedControl';
 import type { ApiFieldKey, GeneralSecretFieldConfig } from '@/types/settings.types';
 import type { UserSettings, SandboxProviderType } from '@/types/user.types';
+import type { Theme } from '@/types/ui.types';
+import { useUIStore } from '@/store/uiStore';
 import { SecretInput } from '@/components/settings/inputs/SecretInput';
 import { cn } from '@/utils/cn';
 
@@ -38,6 +40,23 @@ function SectionCard({
       </h2>
       {children}
     </div>
+  );
+}
+
+const THEME_OPTIONS = [
+  { value: 'light', label: 'Light', disabled: false },
+  { value: 'dark', label: 'Dark', disabled: false },
+  { value: 'system', label: 'System', disabled: false },
+];
+
+function ThemeControl() {
+  const theme = useUIStore((state) => state.theme);
+  return (
+    <SegmentedControl
+      value={theme}
+      onChange={(val) => useUIStore.getState().setTheme(val as Theme)}
+      options={THEME_OPTIONS}
+    />
   );
 }
 
@@ -116,7 +135,13 @@ export const GeneralSettingsTab: React.FC<GeneralSettingsTabProps> = ({
 
     <SectionCard title="Preferences">
       <div className="divide-y divide-border dark:divide-border-dark">
-        <div className="flex items-start justify-between gap-4 py-3 first:pt-0 last:pb-0 sm:items-center">
+        <div className="flex items-center justify-between gap-4 py-3 first:pt-0">
+          <h3 className="text-sm font-medium text-text-primary dark:text-text-dark-primary">
+            Theme
+          </h3>
+          <ThemeControl />
+        </div>
+        <div className="flex items-start justify-between gap-4 py-3 sm:items-center">
           <div className="min-w-0 flex-1">
             <h3 className="text-sm font-medium text-text-primary dark:text-text-dark-primary">
               Sound Notification

--- a/frontend/src/components/ui/Mermaid.tsx
+++ b/frontend/src/components/ui/Mermaid.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { Eye, EyeOff, AlertCircle, RefreshCw } from 'lucide-react';
 import { Button } from './primitives/Button';
-import { useUIStore } from '@/store/uiStore';
+import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 
 interface MermaidProps {
   content: string;
@@ -27,7 +27,7 @@ const sanitizeSvg = async (svg: string): Promise<string> => {
 };
 
 export function Mermaid({ content }: MermaidProps) {
-  const theme = useUIStore((state) => state.theme);
+  const theme = useResolvedTheme();
   const [showPreview, setShowPreview] = useState(true);
   const [state, setState] = useState<RenderState>({ status: 'idle' });
   const renderIdRef = useRef(0);

--- a/frontend/src/components/views/IDEView.tsx
+++ b/frontend/src/components/views/IDEView.tsx
@@ -3,7 +3,7 @@ import { Download, ExternalLink, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { Spinner } from '@/components/ui/primitives/Spinner';
 import { useIDEUrlQuery } from '@/hooks/queries/useSandboxQueries';
-import { useUIStore } from '@/store/uiStore';
+import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { sandboxService } from '@/services/sandboxService';
 
 interface IDEViewProps {
@@ -12,7 +12,7 @@ interface IDEViewProps {
 }
 
 export const IDEView = memo(function IDEView({ sandboxId, isActive = false }: IDEViewProps) {
-  const theme = useUIStore((state) => state.theme);
+  const theme = useResolvedTheme();
   const [isLoading, setIsLoading] = useState(true);
   const [isDownloading, setIsDownloading] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);

--- a/frontend/src/hooks/useEditorTheme.ts
+++ b/frontend/src/hooks/useEditorTheme.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useUIStore } from '@/store/uiStore';
+import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import type * as monaco from 'monaco-editor';
 
 const LIGHT_THEME: monaco.editor.IStandaloneThemeData = {
@@ -77,7 +77,7 @@ const DARK_THEME: monaco.editor.IStandaloneThemeData = {
 };
 
 export function useEditorTheme() {
-  const theme = useUIStore((state) => state.theme);
+  const theme = useResolvedTheme();
 
   const setupEditorTheme = useCallback(
     (monaco: typeof import('monaco-editor')) => {

--- a/frontend/src/hooks/useResolvedTheme.ts
+++ b/frontend/src/hooks/useResolvedTheme.ts
@@ -1,0 +1,43 @@
+import { useSyncExternalStore } from 'react';
+import { useUIStore } from '@/store/uiStore';
+import type { ResolvedTheme } from '@/types/ui.types';
+
+function getMediaQuery(): MediaQueryList | null {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return null;
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)');
+}
+
+function subscribe(callback: () => void): () => void {
+  const mediaQuery = getMediaQuery();
+  if (!mediaQuery) {
+    return () => {};
+  }
+
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', callback);
+    return () => mediaQuery.removeEventListener('change', callback);
+  }
+
+  mediaQuery.addListener(callback);
+  return () => mediaQuery.removeListener(callback);
+}
+
+function getSnapshot(): boolean {
+  return getMediaQuery()?.matches ?? true;
+}
+
+function getServerSnapshot(): boolean {
+  return true;
+}
+
+export function useResolvedTheme(): ResolvedTheme {
+  const theme = useUIStore((state) => state.theme);
+  const prefersDark = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  if (theme === 'system') {
+    return prefersDark ? 'dark' : 'light';
+  }
+  return theme;
+}

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -32,9 +32,12 @@ export const useUIStore = create<UIStoreState>()(
     (set, get) => ({
       theme: 'dark',
       toggleTheme: () =>
-        set((state) => ({
-          theme: state.theme === 'dark' ? 'light' : 'dark',
-        })),
+        set((state) => {
+          const next =
+            state.theme === 'dark' ? 'light' : state.theme === 'light' ? 'system' : 'dark';
+          return { theme: next };
+        }),
+      setTheme: (theme) => set({ theme }),
       permissionMode: 'auto',
       setPermissionMode: (mode) => set({ permissionMode: mode }),
       thinkingMode: null,

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -3,7 +3,8 @@ import type { ToolAggregate } from './tools.types';
 
 export type ToolComponent = React.FC<{ tool: ToolAggregate; chatId?: string }>;
 
-export type Theme = 'light' | 'dark';
+export type Theme = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
 
 type MentionType = 'file' | 'agent' | 'prompt';
 
@@ -17,6 +18,7 @@ export interface MentionItem {
 export interface ThemeState {
   theme: Theme;
   toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
 }
 
 export interface ModelSelectionState {


### PR DESCRIPTION
## Summary
- Add a **System** theme option that dynamically follows the OS light/dark appearance via `prefers-color-scheme`
- Theme is now selectable via a **segmented control** (Light / Dark / System) in Settings > Preferences
- New `useResolvedTheme` hook resolves `'system'` to the actual `'light'` or `'dark'` value reactively using `useSyncExternalStore`
- All theme consumers (terminal, editor, IDE view, Mermaid, dialogs) updated to use the resolved theme
- Removed theme toggle from the user menu (now controlled from settings)

## Test plan
- [ ] Open Settings > Preferences, verify the segmented control shows Light / Dark / System
- [ ] Select each option and confirm the UI updates immediately
- [ ] Select **System**, then toggle OS appearance — verify terminal, editor, and UI update in real-time
- [ ] Reload the page — verify the selected theme persists from localStorage
- [ ] On auth/landing pages, verify the standalone theme toggle still cycles correctly