### PR TITLE
Fix refresh token expiry check for naive datetime comparison

### DIFF
--- a/backend/app/models/db_models/refresh_token.py
+++ b/backend/app/models/db_models/refresh_token.py
@@ -36,7 +36,10 @@ class RefreshToken(Base):
 
     @property
     def is_expired(self) -> bool:
-        return bool(datetime.now(timezone.utc) > self.expires_at)
+        expires_at = self.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        return bool(datetime.now(timezone.utc) > expires_at)
 
     @property
     def is_revoked(self) -> bool:


### PR DESCRIPTION
## Summary
- Fix `RefreshToken.is_expired` to handle naive (timezone-unaware) `expires_at` datetimes by assuming UTC before comparing with `datetime.now(timezone.utc)`
- Prevents `TypeError` when the database returns a naive datetime

## Test plan
- [ ] Verify refresh token expiry works correctly with timezone-aware datetimes
- [ ] Verify refresh token expiry works correctly with naive datetimes from the database