### PR TITLE
Fix host provider terminal prompt in desktop app

### DIFF
--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -91,7 +91,11 @@ class LocalHostProvider(SandboxProvider):
         sandbox_id = str(uuid.uuid4())[:12]
         sandbox_dir = (self._base_dir / sandbox_id).resolve()
         sandbox_dir.mkdir(parents=True, exist_ok=True)
-        (sandbox_dir / ".bashrc").touch(exist_ok=True)
+        bashrc_content = f'export PS1="user@{sandbox_id}:\\w$ "\n'
+        (sandbox_dir / ".bashrc").write_text(bashrc_content)
+        (sandbox_dir / ".bash_profile").write_text(
+            "[ -f ~/.bashrc ] && source ~/.bashrc\n"
+        )
         self._sandboxes[sandbox_id] = sandbox_dir
         return sandbox_id
 
@@ -138,7 +142,8 @@ class LocalHostProvider(SandboxProvider):
         if envs:
             process_env.update(envs)
         process_env["HOME"] = str(sandbox_dir)
-        process_env["USER"] = process_env.get("USER", "user")
+        process_env["USER"] = "user"
+        process_env["HOSTNAME"] = sandbox_id
         process_env["TERM"] = process_env.get("TERM", TERMINAL_TYPE)
 
         if background:
@@ -237,7 +242,8 @@ class LocalHostProvider(SandboxProvider):
 
         env = os.environ.copy()
         env["HOME"] = str(sandbox_dir)
-        env["USER"] = env.get("USER", "user")
+        env["USER"] = "user"
+        env["HOSTNAME"] = sandbox_id
         env["TERM"] = TERMINAL_TYPE
 
         cmd = (


### PR DESCRIPTION
## Summary
- Configure sandbox `.bashrc` with custom PS1 (`user@sandbox-id:\w$`) and `.bash_profile` to source it on macOS login shells
- Set `USER=user` and `HOSTNAME=sandbox-id` in PTY and command environments instead of leaking host macOS username
- Desktop terminal now shows `user@a79f63d6:~$` instead of bare `bash-3.2$`

## Test plan
- [ ] Launch desktop app, create a chat with host provider
- [ ] Open terminal — verify prompt shows `user@<id>:~$`
- [ ] Run `whoami` — should show `user`
- [ ] Run `pwd` — should show `~` or the sandbox home
- [ ] Verify web app host provider terminal still works as before