### PR TITLE
Restrict host sandbox provider to desktop app only

### DIFF
--- a/backend/app/services/sandbox_providers/factory.py
+++ b/backend/app/services/sandbox_providers/factory.py
@@ -51,6 +51,10 @@ class SandboxProviderFactory:
             return ModalSandboxProvider(api_key=api_key)
 
         if provider_type == SandboxProviderType.HOST:
+            if not settings.DESKTOP_MODE:
+                raise SandboxException(
+                    "Host provider is only available in the desktop app"
+                )
             host_base_dir = settings.get_host_sandbox_base_dir()
             return LocalHostProvider(
                 base_dir=host_base_dir,

--- a/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
@@ -8,6 +8,7 @@ import type { Theme } from '@/types/ui.types';
 import { useUIStore } from '@/store/uiStore';
 import { SecretInput } from '@/components/settings/inputs/SecretInput';
 import { cn } from '@/utils/cn';
+import { isTauri } from '@tauri-apps/api/core';
 
 interface GeneralSettingsTabProps {
   fields: GeneralSecretFieldConfig[];
@@ -111,7 +112,9 @@ export const GeneralSettingsTab: React.FC<GeneralSettingsTabProps> = ({
           value={settings.sandbox_provider ?? 'docker'}
           onChange={(val) => onSandboxProviderChange(val as SandboxProviderType)}
           options={[
-            { value: 'host', label: 'Host (Local)', disabled: false },
+            ...(isTauri()
+              ? [{ value: 'host', label: 'Host (Local)', disabled: false }]
+              : []),
             { value: 'docker', label: 'Docker (Local)', disabled: false },
             { value: 'e2b', label: 'E2B (Cloud)', disabled: !savedSettings?.e2b_api_key },
             { value: 'modal', label: 'Modal (Cloud)', disabled: !savedSettings?.modal_api_key },


### PR DESCRIPTION
## Summary
- Hide the "Host (Local)" sandbox provider option in settings when running in the web browser (only show it in the Tauri desktop app via `isTauri()` check)
- Add a backend guard in `SandboxProviderFactory.create()` that rejects host provider creation when `DESKTOP_MODE` is false, returning a clear error message

## Test plan
- [ ] Open the web app and verify the "Host (Local)" option is not visible in Settings > Sandbox Provider
- [ ] Open the desktop (Tauri) app and verify the "Host (Local)" option is visible and selectable
- [ ] Attempt to create a host sandbox via API without `DESKTOP_MODE=true` and confirm it returns a `SandboxException`