### PR TITLE
Remove leftover api_key parameter from terminal session

### DIFF
--- a/backend/app/api/endpoints/websocket.py
+++ b/backend/app/api/endpoints/websocket.py
@@ -138,7 +138,6 @@ async def terminal_websocket(
         sandbox_id=sandbox_id,
         terminal_id=terminal_id,
         provider_type=provider_type,
-        api_key=None,
         workspace_path=workspace_path,
     )
 

--- a/backend/app/services/terminal.py
+++ b/backend/app/services/terminal.py
@@ -172,7 +172,6 @@ class TerminalSessionRegistry:
         sandbox_id: str,
         terminal_id: str,
         provider_type: SandboxProviderType,
-        api_key: str | None,
         workspace_path: str | None,
     ) -> TerminalSessionRecord:
         key = self.build_session_key(user_id, sandbox_id, terminal_id)
@@ -181,7 +180,7 @@ class TerminalSessionRegistry:
             if existing:
                 return existing
 
-            provider = SandboxProviderFactory.create(provider_type, api_key)
+            provider = SandboxProviderFactory.create(provider_type)
             if provider_type == SandboxProviderType.HOST and workspace_path:
                 host_provider = cast(LocalHostProvider, provider)
                 host_provider.bind_workspace(


### PR DESCRIPTION
## Summary
- Removes the `api_key` parameter from `TerminalSessionRegistry.get_or_create` and its caller in `websocket.py`, left behind after removing Modal and E2B sandbox providers in 434516a
- Fixes mypy `call-arg` error: `Too many arguments for "create" of "SandboxProviderFactory"`

## Test plan
- [ ] Verify `mypy` passes on `app/services/terminal.py`
- [ ] Verify terminal WebSocket connections still work