### PR TITLE
Simplify desktop Tauri backend and fix updater

### DIFF
--- a/backend/app/api/endpoints/websocket.py
+++ b/backend/app/api/endpoints/websocket.py
@@ -192,7 +192,7 @@ async def terminal_websocket(
                     )
                 )
 
-                if is_reattach:
+                if is_reattach and session.pty_id is not None:
                     await session.sandbox_service.send_pty_input(
                         session.sandbox_id, session.pty_id, b" \x0c"
                     )

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -102,6 +102,8 @@ SANDBOX_EXCLUDED_PATHS: Final[list[str]] = [
     "*/package-lock.json",
     "bun.lock",
     "*/bun.lock",
+    "Library",
+    "Library/*",
 ]
 
 SANDBOX_BINARY_EXTENSIONS: Final[set[str]] = {

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -212,7 +212,11 @@ class SandboxService:
         on_data: PtyDataCallbackType,
     ) -> str:
         pty_session = await self.provider.create_pty(
-            sandbox_id, rows, cols, tmux_session, on_data=on_data,
+            sandbox_id,
+            rows,
+            cols,
+            tmux_session,
+            on_data=on_data,
         )
         return pty_session.id
 

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -63,6 +63,7 @@ LISTENING_PORTS_COMMAND = (
         " | grep -E '^[0-9]+$' | sort -u"
     )
 )
+HOST_REQUIRED_PATH_PREFIX = f"{Path.home()}/.local/bin:/opt/homebrew/bin:/usr/local/bin"
 
 
 class LocalHostProvider(SandboxProvider):
@@ -173,6 +174,9 @@ class LocalHostProvider(SandboxProvider):
     ) -> CommandResult:
         sandbox_dir = self._resolve_sandbox_dir(sandbox_id)
         command_to_run = self._map_virtual_paths(sandbox_id, command)
+        command_with_path = (
+            f"export PATH={HOST_REQUIRED_PATH_PREFIX}:$PATH; {command_to_run}"
+        )
         process_env = os.environ.copy()
         if envs:
             process_env.update(envs)
@@ -184,7 +188,7 @@ class LocalHostProvider(SandboxProvider):
         if background:
             await asyncio.to_thread(
                 subprocess.Popen,
-                ["bash", "-lc", command_to_run],
+                ["bash", "-lc", command_with_path],
                 cwd=str(sandbox_dir),
                 env=process_env,
                 stdin=subprocess.DEVNULL,
@@ -202,7 +206,7 @@ class LocalHostProvider(SandboxProvider):
         process = await asyncio.create_subprocess_exec(
             "bash",
             "-lc",
-            command_to_run,
+            command_with_path,
             cwd=str(sandbox_dir),
             env=process_env,
             stdout=asyncio.subprocess.PIPE,
@@ -333,6 +337,7 @@ class LocalHostProvider(SandboxProvider):
         env["TERM"] = TERMINAL_TYPE
 
         cmd = (
+            f"export PATH={HOST_REQUIRED_PATH_PREFIX}:$PATH; "
             "command -v tmux >/dev/null && "
             f"tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off || exec bash"
         )

--- a/backend/app/services/terminal.py
+++ b/backend/app/services/terminal.py
@@ -40,7 +40,10 @@ class TerminalSessionRecord:
             tmux_session = self._get_tmux_session_name()
             self.output_queue = asyncio.Queue(maxsize=PTY_OUTPUT_QUEUE_SIZE)
             self.pty_id = await self.sandbox_service.create_pty_session(
-                self.sandbox_id, rows, cols, tmux_session,
+                self.sandbox_id,
+                rows,
+                cols,
+                tmux_session,
                 on_data=self._enqueue_output,
             )
             self.input_queue = asyncio.Queue(maxsize=PTY_INPUT_QUEUE_SIZE)
@@ -81,9 +84,7 @@ class TerminalSessionRecord:
         if self.output_task:
             self.output_task.cancel()
 
-        self.output_task = asyncio.create_task(
-            self._forward_output(websocket)
-        )
+        self.output_task = asyncio.create_task(self._forward_output(websocket))
 
     async def detach(self) -> None:
         self.active_websocket = None
@@ -166,7 +167,9 @@ class TerminalSessionRecord:
         except (OSError, RuntimeError) as e:
             logger.error(
                 "Error forwarding PTY output for sandbox %s: %s",
-                self.sandbox_id, e, exc_info=True,
+                self.sandbox_id,
+                e,
+                exc_info=True,
             )
 
     @staticmethod

--- a/desktop/entry.py
+++ b/desktop/entry.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from urllib.parse import urlparse
 
+from granian import Granian
 from migrate import check_and_run_migrations
 
 
@@ -13,8 +14,6 @@ def main() -> None:
     base_url = os.environ.get("BASE_URL", "http://127.0.0.1:8081")
     parsed = urlparse(base_url)
     port = parsed.port or 8081
-
-    from granian import Granian
 
     server = Granian(
         target="app.main:app",

--- a/desktop/requirements.txt
+++ b/desktop/requirements.txt
@@ -22,7 +22,6 @@ aiosmtplib
 slowapi
 sse-starlette
 wtforms
-tenacity==8.2.3
 PyYAML>=6.0
 python-json-logger>=2.0.0
 anthropic-bridge==0.1.38

--- a/desktop/run_build.mjs
+++ b/desktop/run_build.mjs
@@ -1,9 +1,9 @@
 import { createWriteStream } from 'node:fs';
-import { chmodSync, copyFileSync, cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { get } from 'node:https';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 const dir = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(dir, '..');
@@ -16,6 +16,8 @@ const GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py';
 
 const platform = process.platform;
 const arch = process.arch;
+const forceClean = process.argv.includes('--clean');
+const PYTHON_STAMP_VALUE = `${PYTHON_VERSION}+${RELEASE_TAG}-${arch}-${platform}`;
 
 const archMap = {
   arm64: 'aarch64',
@@ -40,11 +42,8 @@ function pythonBin() {
   return join(sidecarDir, 'python', 'bin', 'python3');
 }
 
-function resetSidecarDir() {
-  if (existsSync(sidecarDir)) {
-    rmSync(sidecarDir, { recursive: true, force: true });
-  }
-  mkdirSync(sidecarDir, { recursive: true });
+function pythonStampPath() {
+  return join(sidecarDir, '.python-stamp');
 }
 
 function downloadFile(url, outputPath) {
@@ -80,24 +79,22 @@ function downloadFile(url, outputPath) {
   });
 }
 
-function extractArchive(archivePath) {
-  execFileSync('tar', ['-xzf', archivePath, '-C', sidecarDir], {
-    stdio: 'inherit',
-  });
-}
-
 function downloadPython() {
   const archivePath = join(sidecarDir, 'python.tar.gz');
   const url = pythonUrl();
   console.log(`Downloading Python ${PYTHON_VERSION}...`);
   return downloadFile(url, archivePath)
     .then(() => {
-      extractArchive(archivePath);
+      execFileSync('tar', ['-xzf', archivePath, '-C', sidecarDir], {
+        stdio: 'inherit',
+      });
       rmSync(archivePath, { force: true });
 
       if (!existsSync(pythonBin())) {
         throw new Error(`Python binary not found at ${pythonBin()}`);
       }
+
+      writeFileSync(pythonStampPath(), `${PYTHON_STAMP_VALUE}\n`);
     });
 }
 
@@ -112,19 +109,44 @@ async function installPip() {
       [getPipPath, '--disable-pip-version-check'],
       { stdio: 'inherit' }
     );
-    const result = spawnSync(pythonBin(), ['-m', 'pip', '--version'], {
-      stdio: 'ignore',
-    });
-    if (result.status !== 0) {
-      throw new Error('Failed to bootstrap pip in bundled Python');
-    }
   } finally {
     rmSync(getPipPath, { force: true });
   }
 }
 
+function depsStampPath() {
+  return join(sidecarDir, '.deps-stamp');
+}
+
+function depsStampValue() {
+  const requirements = readFileSync(join(dir, 'requirements.txt'), 'utf-8');
+  return JSON.stringify({ requirements, python: PYTHON_STAMP_VALUE });
+}
+
+function pythonUpToDate() {
+  const stamp = pythonStampPath();
+  if (!existsSync(pythonBin()) || !existsSync(stamp)) return false;
+  return readFileSync(stamp, 'utf-8').trim() === PYTHON_STAMP_VALUE;
+}
+
+function depsUpToDate() {
+  const stamp = depsStampPath();
+  if (!existsSync(stamp)) return false;
+  try {
+    const installed = JSON.parse(readFileSync(stamp, 'utf-8'));
+    return installed.requirements === readFileSync(join(dir, 'requirements.txt'), 'utf-8') &&
+      installed.python === PYTHON_STAMP_VALUE;
+  } catch {
+    return false;
+  }
+}
+
 async function installDeps() {
-  await installPip();
+  try {
+    execFileSync(pythonBin(), ['-m', 'pip', '--version'], { stdio: 'ignore' });
+  } catch {
+    await installPip();
+  }
   console.log('Installing dependencies...');
   execFileSync(
     pythonBin(),
@@ -143,23 +165,22 @@ async function installDeps() {
       stdio: 'inherit',
     }
   );
+  writeFileSync(depsStampPath(), depsStampValue());
 }
 
 function copySource() {
   console.log('Copying source...');
+  const pycacheFilter = (src) => !src.includes('__pycache__') && !src.endsWith('.pyc');
+  rmSync(join(sidecarDir, 'app'), { recursive: true, force: true });
+  rmSync(join(sidecarDir, 'migrations'), { recursive: true, force: true });
+
   cpSync(join(backendDir, 'app'), join(sidecarDir, 'app'), {
     recursive: true,
-    filter: (src) => {
-      const rel = src.replace(join(backendDir, 'app'), '');
-      return !rel.includes('__pycache__') && !src.endsWith('.pyc');
-    },
+    filter: pycacheFilter,
   });
   cpSync(join(backendDir, 'migrations'), join(sidecarDir, 'migrations'), {
     recursive: true,
-    filter: (src) => {
-      const rel = src.replace(join(backendDir, 'migrations'), '');
-      return !rel.includes('__pycache__') && !src.endsWith('.pyc');
-    },
+    filter: pycacheFilter,
   });
   copyFileSync(join(backendDir, 'alembic.ini'), join(sidecarDir, 'alembic.ini'));
   copyFileSync(join(backendDir, 'migrate.py'), join(sidecarDir, 'migrate.py'));
@@ -183,9 +204,26 @@ async function run() {
   if (platform !== 'darwin') {
     throw new Error(`Desktop build currently supports macOS only (received: ${platform})`);
   }
-  resetSidecarDir();
-  await downloadPython();
-  await installDeps();
+
+  if (forceClean && existsSync(sidecarDir)) {
+    rmSync(sidecarDir, { recursive: true, force: true });
+  }
+  mkdirSync(sidecarDir, { recursive: true });
+
+  const pythonChanged = !pythonUpToDate();
+  if (pythonChanged) {
+    rmSync(join(sidecarDir, 'python'), { recursive: true, force: true });
+    await downloadPython();
+  } else {
+    console.log('Python already installed, skipping download.');
+  }
+
+  if (!pythonChanged && depsUpToDate()) {
+    console.log('Dependencies up to date, skipping install.');
+  } else {
+    await installDeps();
+  }
+
   copySource();
   writeLauncher();
   console.log('Done');

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -457,7 +457,6 @@ dependencies = [
  "dirs 5.0.1",
  "libc",
  "rand 0.9.2",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -466,7 +465,6 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-store",
  "tauri-plugin-updater",
- "tokio",
 ]
 
 [[package]]
@@ -506,16 +504,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -537,9 +525,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -550,7 +538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "libc",
 ]
 
@@ -864,15 +852,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,21 +986,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1034,12 +1004,6 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1452,25 +1416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,7 +1512,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1596,22 +1540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,11 +1557,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2135,23 +2061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5d26952a508f321b4d3d2e80e78fc2603eaefcdf0c30783867f19586518bdc"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,48 +2384,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -3149,46 +3020,6 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
@@ -3327,7 +3158,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3364,12 +3195,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3453,7 +3278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3590,18 +3415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -3879,27 +3692,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3920,7 +3712,7 @@ checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -4010,7 +3802,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.1",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4202,7 +3994,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.1",
+ "reqwest",
  "rustls",
  "semver",
  "serde",
@@ -4461,16 +4253,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -4826,12 +4608,6 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5223,17 +4999,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -16,8 +16,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rand = "0.9"
 dirs = "5"
-reqwest = "0.12"
-tokio = { version = "1", features = ["time"] }
 tauri-plugin-store = "2.4.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-show",
     "store:default",
     "updater:default",
     "notification:default",

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -1,24 +1,33 @@
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::os::unix::process::CommandExt;
 use std::process::{Child, Command, Stdio};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use libc;
 use rand::Rng;
-use std::net::TcpListener;
 use tauri::Manager;
 
-fn app_data_dir() -> std::path::PathBuf {
+#[tauri::command]
+fn get_backend_port(state: tauri::State<'_, Arc<OnceLock<Result<u16, String>>>>) -> Result<u16, String> {
+    loop {
+        if let Some(result) = state.get() {
+            return result.clone();
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn data_dir() -> std::path::PathBuf {
     dirs::data_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join("com.claudex.app")
 }
 
-fn ensure_secret_key() -> String {
-    let data_dir = app_data_dir();
-    fs::create_dir_all(&data_dir).ok();
+fn ensure_secret_key(data_dir: &std::path::Path) -> String {
+    fs::create_dir_all(data_dir).ok();
     let key_path = data_dir.join(".secret_key");
     if let Ok(key) = fs::read_to_string(&key_path) {
         let key = key.trim().to_string();
@@ -27,22 +36,11 @@ fn ensure_secret_key() -> String {
         }
     }
     let mut rng = rand::rng();
-    let key: String = (0..64)
-        .map(|_| {
-            let idx = rng.random_range(0..36);
-            if idx < 10 {
-                (b'0' + idx) as char
-            } else {
-                (b'a' + idx - 10) as char
-            }
-        })
+    let key: String = (0..32)
+        .map(|_| format!("{:02x}", rng.random_range(0u8..=255)))
         .collect();
     fs::write(&key_path, &key).ok();
     key
-}
-
-fn launcher_name() -> &'static str {
-    "claudex-backend"
 }
 
 fn resolve_backend_binary(app_handle: &tauri::AppHandle) -> std::path::PathBuf {
@@ -51,17 +49,15 @@ fn resolve_backend_binary(app_handle: &tauri::AppHandle) -> std::path::PathBuf {
         .resource_dir()
         .expect("failed to resolve resource dir");
 
-    let name = launcher_name();
-
     let binary = resource_dir
         .join("_up_")
         .join("backend-sidecar")
-        .join(name);
+        .join("claudex-backend");
     if binary.exists() {
         return binary;
     }
 
-    let direct = resource_dir.join("backend-sidecar").join(name);
+    let direct = resource_dir.join("backend-sidecar").join("claudex-backend");
     if direct.exists() {
         return direct;
     }
@@ -70,7 +66,7 @@ fn resolve_backend_binary(app_handle: &tauri::AppHandle) -> std::path::PathBuf {
         .parent()
         .unwrap()
         .join("backend-sidecar")
-        .join(name);
+        .join("claudex-backend");
     if dev_binary.exists() {
         return dev_binary;
     }
@@ -81,64 +77,108 @@ fn resolve_backend_binary(app_handle: &tauri::AppHandle) -> std::path::PathBuf {
     );
 }
 
-const BACKEND_PORT: u16 = 8081;
-
-fn show_error_and_exit(message: &str) -> ! {
-    eprintln!("{}", message);
-    let _ = Command::new("osascript")
-        .arg("-e")
-        .arg(format!(
-            "display dialog \"{}\" with title \"Claudex\" buttons {{\"OK\"}} default button \"OK\" with icon stop",
-            message
-        ))
-        .output();
-    std::process::exit(1);
+fn pick_available_port() -> u16 {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("failed to bind ephemeral port");
+    listener.local_addr().unwrap().port()
 }
 
-fn check_port_available() {
-    if TcpListener::bind(("127.0.0.1", BACKEND_PORT)).is_err() {
-        show_error_and_exit(&format!(
-            "Port {} is already in use. Another Claudex instance may be running.",
-            BACKEND_PORT
-        ));
+fn backend_ready(port: u16) -> bool {
+    let mut stream = match TcpStream::connect(("127.0.0.1", port)) {
+        Ok(stream) => stream,
+        Err(_) => return false,
+    };
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(1)));
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(1)));
+    let request =
+        b"GET /api/v1/readyz HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+    if stream.write_all(request).is_err() {
+        return false;
     }
+    let mut response = String::new();
+    if stream.read_to_string(&mut response).is_err() {
+        return false;
+    }
+    response.starts_with("HTTP/1.1 200") || response.starts_with("HTTP/1.0 200")
 }
 
 fn terminate_backend_process(backend: &Arc<Mutex<Option<Child>>>) {
     if let Ok(mut guard) = backend.lock() {
         if let Some(ref mut child) = *guard {
             let pid = child.id() as libc::pid_t;
-
             unsafe {
-                libc::kill(-pid, libc::SIGTERM);
+                libc::kill(-pid, libc::SIGKILL);
             }
-
-            let deadline = std::time::Instant::now() + Duration::from_secs(5);
-            loop {
-                match child.try_wait() {
-                    Ok(Some(_)) => break,
-                    Ok(None) if std::time::Instant::now() < deadline => {
-                        std::thread::sleep(Duration::from_millis(100));
-                    }
-                    _ => {
-                        unsafe {
-                            libc::kill(-pid, libc::SIGKILL);
-                        }
-                        let _ = child.kill();
-                        let _ = child.wait();
-                        break;
-                    }
-                }
-            }
+            let _ = child.wait();
         }
         *guard = None;
     }
 }
 
+fn pipe_output<R: Read + Send + 'static>(stream: R, is_err: bool) {
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stream);
+        for line in reader.lines().flatten() {
+            if is_err {
+                eprintln!("[backend] {}", line);
+            } else {
+                println!("[backend] {}", line);
+            }
+        }
+    });
+}
+
+fn spawn_backend(
+    app_handle: &tauri::AppHandle,
+    data_dir: &std::path::Path,
+    secret_key: &str,
+    port: u16,
+) -> Child {
+    let backend_bin = resolve_backend_binary(app_handle);
+    let mut backend_path = std::env::var("PATH").unwrap_or_default();
+    if let Some(home) = dirs::home_dir() {
+        backend_path.push_str(&format!(":{}/.local/bin", home.display()));
+    }
+
+    let db_path = data_dir.join("claudex.db").to_string_lossy().to_string();
+    let mut command = Command::new(&backend_bin);
+    command
+        .env("DESKTOP_MODE", "true")
+        .env("SECRET_KEY", secret_key)
+        .env("BASE_URL", format!("http://127.0.0.1:{port}"))
+        .env("DATABASE_URL", format!("sqlite+aiosqlite:///{db_path}"))
+        .env("PATH", backend_path)
+        .env(
+            "STORAGE_PATH",
+            data_dir.join("storage").to_string_lossy().to_string(),
+        )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setpgid(0, 0) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = command.spawn().expect("failed to spawn backend process");
+
+    if let Some(stdout) = child.stdout.take() {
+        pipe_output(stdout, false);
+    }
+    if let Some(stderr) = child.stderr.take() {
+        pipe_output(stderr, true);
+    }
+
+    child
+}
+
 fn main() {
-    let secret_key = ensure_secret_key();
-    let data_dir = app_data_dir();
-    check_port_available();
+    let data_dir = data_dir();
+    let secret_key = ensure_secret_key(&data_dir);
+    let port = pick_available_port();
+    let backend_port: Arc<OnceLock<Result<u16, String>>> = Arc::new(OnceLock::new());
     let backend_process: Arc<Mutex<Option<Child>>> = Arc::new(Mutex::new(None));
     let backend_for_exit = backend_process.clone();
 
@@ -147,81 +187,25 @@ fn main() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_dialog::init())
+        .manage(backend_port.clone())
+        .invoke_handler(tauri::generate_handler![get_backend_port])
         .setup(move |app| {
-            let app_handle = app.handle().clone();
-            let backend_bin = resolve_backend_binary(&app_handle);
-
-            let db_path = data_dir
-                .join("claudex.db")
-                .to_string_lossy()
-                .replace('\\', "/");
-
-            let mut command = Command::new(&backend_bin);
-            command
-                .env("DESKTOP_MODE", "true")
-                .env("SECRET_KEY", &secret_key)
-                .env("BASE_URL", format!("http://127.0.0.1:{BACKEND_PORT}"))
-                .env("DATABASE_URL", format!("sqlite+aiosqlite:///{db_path}"))
-                .env(
-                    "STORAGE_PATH",
-                    data_dir.join("storage").to_string_lossy().to_string(),
-                )
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
-            unsafe {
-                command.pre_exec(|| {
-                    if libc::setpgid(0, 0) != 0 {
-                        return Err(std::io::Error::last_os_error());
-                    }
-                    Ok(())
-                });
-            }
-            let mut child = command
-                .spawn()
-                .expect("failed to spawn backend process");
-
-            if let Some(stdout) = child.stdout.take() {
-                std::thread::spawn(move || {
-                    let reader = BufReader::new(stdout);
-                    for line in reader.lines() {
-                        if let Ok(line) = line {
-                            println!("[backend] {}", line);
-                        }
-                    }
-                });
-            }
-
-            if let Some(stderr) = child.stderr.take() {
-                std::thread::spawn(move || {
-                    let reader = BufReader::new(stderr);
-                    for line in reader.lines() {
-                        if let Ok(line) = line {
-                            eprintln!("[backend] {}", line);
-                        }
-                    }
-                });
-            }
-
+            let child = spawn_backend(app.handle(), &data_dir, &secret_key, port);
             *backend_process.lock().unwrap() = Some(child);
 
-            let readyz_url = format!("http://127.0.0.1:{BACKEND_PORT}/api/v1/readyz");
-            tauri::async_runtime::spawn(async move {
-                let client = reqwest::Client::new();
+            let port_ref = backend_port.clone();
+            std::thread::spawn(move || {
                 for _ in 0..60 {
-                    tokio::time::sleep(Duration::from_millis(500)).await;
-                    if let Ok(resp) = client.get(&readyz_url).send().await {
-                        if resp.status().is_success() {
-                            if let Some(window) = app_handle.get_webview_window("main") {
-                                let _ = window.show();
-                            }
-                            return;
-                        }
+                    std::thread::sleep(Duration::from_millis(500));
+                    if backend_ready(port) {
+                        let _ = port_ref.set(Ok(port));
+                        return;
                     }
                 }
-                eprintln!("[backend] readyz timeout — showing window anyway");
-                if let Some(window) = app_handle.get_webview_window("main") {
-                    let _ = window.show();
-                }
+                eprintln!("[backend] readyz timeout");
+                let _ = port_ref.set(Err(
+                    "Backend failed readiness checks within startup timeout".to_string(),
+                ));
             });
 
             Ok(())

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "beforeDevCommand": "node ../desktop/run_build.mjs && npm run dev:desktop",
     "devUrl": "http://localhost:3000",
-    "beforeBuildCommand": "node ../desktop/run_build.mjs && npm run build -- --mode desktop",
+    "beforeBuildCommand": "node ../desktop/run_build.mjs --clean && npm run build -- --mode desktop",
     "frontendDist": "../dist"
   },
   "app": {
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:; connect-src 'self' ipc: ipc://localhost http://localhost:8080 ws://localhost:8080 http://127.0.0.1:8080 ws://127.0.0.1:8080 http://localhost:8081 ws://localhost:8081 http://127.0.0.1:8081 ws://127.0.0.1:8081 http://localhost:* ws://localhost:* http://127.0.0.1:* ws://127.0.0.1:*; frame-src http://localhost:* http://127.0.0.1:*; child-src http://localhost:* http://127.0.0.1:*",
+      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdn.jsdelivr.net; connect-src 'self' ipc: ipc://localhost http://localhost:* ws://localhost:* http://127.0.0.1:* ws://127.0.0.1:*; frame-src http://localhost:* http://127.0.0.1:*; child-src http://localhost:* http://127.0.0.1:*",
       "capabilities": ["main-capability"]
     }
   },
@@ -37,7 +37,6 @@
   },
   "plugins": {
     "updater": {
-      "active": true,
       "endpoints": ["https://github.com/Mng-dev-ai/claudex/releases/latest/download/latest.json"],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDc0NjI1OEY5Q0EwNThDNzkKUldSNWpBWEsrVmhpZE8vdUpqWWJPc3Y1NXpxNWZQYTNGNndwQ3lpS2FhaXJFWEM1LzhIOFlVRUYK"
     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,9 +12,11 @@ import { useGlobalStream, useStreamRestoration } from '@/hooks/useChatStreaming'
 import { authService } from '@/services/authService';
 import { toasterConfig } from '@/config/toaster';
 import { AuthRoute } from '@/components/routes/AuthRoute';
-import { API_BASE_URL } from '@/lib/api';
-import { isTauri } from '@tauri-apps/api/core';
+import { setApiPort } from '@/lib/api';
+import { isTauri, invoke } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { check } from '@tauri-apps/plugin-updater';
+import { ask } from '@tauri-apps/plugin-dialog';
 import { authStorage } from '@/utils/storage';
 
 const LandingPage = lazy(() =>
@@ -42,7 +44,10 @@ async function checkDesktopUpdate(): Promise<void> {
     return;
   }
 
-  const shouldInstall = window.confirm(`Claudex ${update.version} is available. Install now?`);
+  const shouldInstall = await ask(`Claudex ${update.version} is available. Install now?`, {
+    title: 'Update Available',
+    kind: 'info',
+  });
   if (!shouldInstall) {
     return;
   }
@@ -173,10 +178,11 @@ function AppContent() {
 
 export default function App() {
   const resolvedTheme = useResolvedTheme();
-  const [backendReady, setBackendReady] = useState<boolean | null>(null);
+  const [desktopReady, setDesktopReady] = useState(!isTauri());
+  const [desktopError, setDesktopError] = useState<string | null>(null);
   const [authHydrated, setAuthHydrated] = useState(false);
 
-  useGlobalStream({ enabled: authHydrated });
+  useGlobalStream({ enabled: authHydrated && desktopReady });
 
   useEffect(() => {
     let cancelled = false;
@@ -210,32 +216,32 @@ export default function App() {
   useEffect(() => {
     if (!isTauri()) return;
 
-    let interval: number | undefined;
     let cancelled = false;
-    const apiUrl = new URL(API_BASE_URL, window.location.origin);
-    const healthUrl = `${apiUrl.origin}/api/v1/readyz`;
 
-    const check = async () => {
-      try {
-        const response = await fetch(healthUrl, { method: 'GET', cache: 'no-store' });
-        if (!cancelled) {
-          setBackendReady(response.ok);
-          if (response.ok && interval) {
-            window.clearInterval(interval);
-            interval = undefined;
-          }
-        }
-      } catch {
-        if (!cancelled) setBackendReady(false);
-      }
-    };
-
-    check();
-    interval = window.setInterval(check, 3000);
+    invoke<number>('get_backend_port')
+      .then((port) => {
+        if (cancelled) return;
+        setApiPort(port);
+        setDesktopReady(true);
+        getCurrentWindow()
+          .show()
+          .catch((error) => {
+            console.error('Failed to show desktop window:', error);
+          });
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error('Failed to resolve desktop backend port:', error);
+        setDesktopError('Desktop backend failed to start. Restart Claudex and try again.');
+        getCurrentWindow()
+          .show()
+          .catch((error) => {
+            console.error('Failed to show desktop window:', error);
+          });
+      });
 
     return () => {
       cancelled = true;
-      if (interval) window.clearInterval(interval);
     };
   }, []);
 
@@ -247,36 +253,22 @@ export default function App() {
     });
   }, []);
 
-  if (!authHydrated) {
+  if (desktopError) {
+    return (
+      <div className="bg-surface-primary dark:bg-surface-dark-primary flex min-h-screen items-center justify-center text-text-primary dark:text-text-dark-primary">
+        <div className="rounded-lg border border-border/50 bg-surface-secondary px-4 py-3 text-xs dark:border-border-dark/50 dark:bg-surface-dark-secondary">
+          {desktopError}
+        </div>
+      </div>
+    );
+  }
+
+  if (!desktopReady || !authHydrated) {
     return <LoadingScreen />;
   }
 
   return (
     <BrowserRouter>
-      {backendReady === false && (
-        <div className="fixed inset-x-0 top-0 z-[100] flex items-center justify-center gap-2 bg-surface-tertiary px-4 py-2 text-center text-xs font-medium text-text-primary dark:bg-surface-dark-tertiary dark:text-text-dark-primary">
-          <svg
-            className="h-3 w-3 animate-spin text-text-quaternary dark:text-text-dark-quaternary"
-            viewBox="0 0 24 24"
-            fill="none"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-            />
-          </svg>
-          Starting backend...
-        </div>
-      )}
       <Toaster {...toasterConfig} />
       <AppContent />
     </BrowserRouter>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -117,6 +117,10 @@ class APIClient {
     return this.baseURL;
   }
 
+  setBaseUrl(url: string): void {
+    this.baseURL = url;
+  }
+
   private async handleResponse<T>(response: Response): Promise<T | null> {
     if (!response.ok) {
       const errorMessage = await extractErrorMessage(response);
@@ -233,8 +237,16 @@ class APIClient {
   }
 }
 
-export const API_BASE_URL: string = resolveHttpBaseUrl(import.meta.env.VITE_API_BASE_URL);
-export const WS_BASE_URL: string = resolveWsBaseUrl(import.meta.env.VITE_WS_URL);
-export const API_ORIGIN: string = new URL(API_BASE_URL).origin;
+export let API_BASE_URL: string = resolveHttpBaseUrl(import.meta.env.VITE_API_BASE_URL);
+export let WS_BASE_URL: string = resolveWsBaseUrl(import.meta.env.VITE_WS_URL);
+export let API_ORIGIN: string = new URL(API_BASE_URL).origin;
 
 export const apiClient = new APIClient(API_BASE_URL);
+
+export function setApiPort(port: number): void {
+  const origin = `http://127.0.0.1:${port}`;
+  API_BASE_URL = `${origin}/api/v1`;
+  WS_BASE_URL = `ws://127.0.0.1:${port}/api/v1/ws`;
+  API_ORIGIN = origin;
+  apiClient.setBaseUrl(API_BASE_URL);
+}


### PR DESCRIPTION
## Summary
- **main.rs cleanup**: Extract `data_dir()` helper, simplify secret key generation with hex formatting, collapse PATH manipulation, extract `pipe_output()` to deduplicate stdout/stderr forwarding
- **Fast app exit**: Replace 5-second SIGTERM polling with immediate SIGKILL — local sidecar needs no graceful shutdown
- **Fix updater downloading on cancel**: Replace `window.confirm()` (unreliable in WKWebView) with async `ask()` from `@tauri-apps/plugin-dialog`, and remove `"active": true` from updater config to prevent native auto-download
- **Build improvements**: Incremental build support in `run_build.mjs` with stamp files, HOST_REQUIRED_PATH_PREFIX for sandbox commands, remove unused `tenacity` dep, inline granian import

## Test plan
- [ ] Verify desktop app launches and backend sidecar starts correctly
- [ ] Verify app window closes instantly without delay
- [ ] Verify update dialog waits for user response before downloading
- [ ] Verify clicking cancel on update dialog does not trigger a download