### PR TITLE
Fix refresh button spinning forever when IDE/browser not available

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@
 
 ## Code Style
 
+- Always choose the smallest, simplest fix that solves the problem — do not refactor, restructure, or add abstractions as part of a bug fix; if a one-line guard or a single conditional handles it, prefer that over reworking control flow
 - Do not optimize for no regressions or long-term resilience unless explicitly requested — favor simple, direct changes over defensive scaffolding
 - Do not build elaborate rollback/state-restoration logic for failure paths — in a single-user app, a simple log + best-effort recovery (e.g., re-queue the item) is sufficient; do not save/restore every field, delete orphaned rows, or revert intermediate state changes
 - Do not add pre-flight compatibility checks that gate an operation when a natural fallback already exists — if the operation can't proceed, let it fall through to the existing path (e.g., normal queue processing) instead of adding branching to detect and re-route

--- a/frontend/src/components/views/BrowserView.tsx
+++ b/frontend/src/components/views/BrowserView.tsx
@@ -85,11 +85,13 @@ export const BrowserView = memo(function BrowserView({
   }, []);
 
   const handleReconnect = useCallback(() => {
-    setIsConnecting(true);
     setConnectionError(null);
-    setVncInstanceKey((prev) => prev + 1);
+    if (vncUrl) {
+      setIsConnecting(true);
+      setVncInstanceKey((prev) => prev + 1);
+    }
     refetchVncUrl();
-  }, [refetchVncUrl]);
+  }, [vncUrl, refetchVncUrl]);
 
   const isBrowserRunning = browserStatus?.running;
 

--- a/frontend/src/components/views/IDEView.tsx
+++ b/frontend/src/components/views/IDEView.tsx
@@ -19,7 +19,7 @@ export const IDEView = memo(function IDEView({ sandboxId, isActive = false }: ID
   const prevThemeRef = useRef(theme);
   const hasLoadedRef = useRef(false);
 
-  const { data: ideUrl, isError, isFetched } = useIDEUrlQuery(sandboxId || '');
+  const { data: ideUrl, isError, isFetched, isFetching, refetch } = useIDEUrlQuery(sandboxId || '');
 
   const iframeKey = useMemo(() => {
     if (!ideUrl) return 'no-ide';
@@ -32,9 +32,12 @@ export const IDEView = memo(function IDEView({ sandboxId, isActive = false }: ID
   }, []);
 
   const handleReload = useCallback(() => {
-    setIsLoading(true);
-    setReloadToken((t) => t + 1);
-  }, []);
+    if (ideUrl) {
+      setIsLoading(true);
+      setReloadToken((t) => t + 1);
+    }
+    refetch();
+  }, [ideUrl, refetch]);
 
   const handleOpenInNewTab = useCallback(() => {
     if (ideUrl) {
@@ -110,7 +113,7 @@ export const IDEView = memo(function IDEView({ sandboxId, isActive = false }: ID
             title="Reload IDE"
             aria-label="Reload IDE"
           >
-            <RotateCcw className={`h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`} />
+            <RotateCcw className={`h-3.5 w-3.5 ${isLoading || isFetching ? 'animate-spin' : ''}`} />
           </Button>
 
           <span className="text-xs font-medium text-text-secondary dark:text-text-dark-secondary">


### PR DESCRIPTION
## Summary
- **IDEView**: Refresh button set `isLoading=true` and incremented the iframe reload token, but when the IDE isn't installed no iframe renders so `onLoad` never fires — spinner spun forever. Now only enters loading state when there's an actual URL, and always calls `refetch()` to check for availability. Refresh icon spins via query's `isFetching` state.
- **BrowserView**: Refresh button set `isConnecting=true` which hid the "Browser is not available" message, and no VNC callbacks fire to reset it. Now only enters connecting state when there's an actual VNC URL.

## Test plan
- [ ] Open IDE view when OpenVSCode Server is not installed → shows "not installed" message
- [ ] Click refresh → icon spins briefly during refetch, "not installed" message stays visible
- [ ] Open Browser view when browser is not available → shows "not available" message
- [ ] Click refresh → icon spins briefly during refetch, "not available" message stays visible
- [ ] When IDE/browser IS available, refresh still reloads correctly