### PR TITLE
Clear active workspace when removing it from recents

### DIFF
--- a/frontend/src/components/chat/WorkspaceSelector.tsx
+++ b/frontend/src/components/chat/WorkspaceSelector.tsx
@@ -113,13 +113,20 @@ export function WorkspaceSelector({
     setIsPopoverOpen(false);
   }, [onWorkspaceChange]);
 
-  const removeRecentWorkspace = useCallback((pathToRemove: string) => {
-    setRecentWorkspaces((prev) => {
-      const next = prev.filter((p) => p !== pathToRemove);
-      localStorage.setItem(RECENT_WORKSPACES_KEY, JSON.stringify(next));
-      return next;
-    });
-  }, []);
+  const removeRecentWorkspace = useCallback(
+    (pathToRemove: string) => {
+      if (pathToRemove === workspacePath) {
+        onWorkspaceChange('');
+        localStorage.setItem(ACTIVE_WORKSPACE_KEY, '');
+      }
+      setRecentWorkspaces((prev) => {
+        const next = prev.filter((p) => p !== pathToRemove);
+        localStorage.setItem(RECENT_WORKSPACES_KEY, JSON.stringify(next));
+        return next;
+      });
+    },
+    [workspacePath, onWorkspaceChange],
+  );
 
   const handleChooseWorkspace = useCallback(async () => {
     const selected = await open({


### PR DESCRIPTION
## Summary
- When the currently active workspace is removed from the recent list via the X button, the active workspace is now cleared (shows "No workspace")
- Previously, removing the current workspace from recents left it displayed as active

## Test plan
- [ ] Set a workspace as active
- [ ] Open the dropdown and remove the active workspace via the X button
- [ ] Verify the selector resets to "No workspace" state
- [ ] Verify removing a non-active recent workspace does not affect the current selection