### PR TITLE
Fix host sandbox global gitignore resolution

### DIFF
--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -35,11 +35,12 @@ T = TypeVar("T")
 
 LISTENING_PORTS_COMMAND = "ss -tuln | grep LISTEN | awk '{print $5}' | sed 's/.*://g' | grep -E '^[0-9]+$' | sort -u"
 GITIGNORE_CMD = (
-    '{ [ -f .gitignore ] && cat .gitignore && echo;'
-    ' p=$(git config --global core.excludesFile 2>/dev/null);'
-    ' [ -z "$p" ] && p="${XDG_CONFIG_HOME:-$HOME/.config}/git/ignore";'
-    ' [ -n "$p" ] && p="${p/#~/$HOME}"'
-    ' && case "$p" in /*) ;; *) p="$HOME/$p" ;; esac'
+    '{ base_home="${HOST_HOME:-$HOME}";'
+    ' [ -f .gitignore ] && cat .gitignore && echo;'
+    ' p=$(HOME="$base_home" git config --global core.excludesFile 2>/dev/null);'
+    ' [ -z "$p" ] && p="${XDG_CONFIG_HOME:-$base_home/.config}/git/ignore";'
+    ' [ -n "$p" ] && p="${p/#~/$base_home}"'
+    ' && case "$p" in /*) ;; *) p="$base_home/$p" ;; esac'
     ' && [ -f "$p" ] && cat "$p"; } 2>/dev/null'
 )
 

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -183,6 +183,7 @@ class LocalHostProvider(SandboxProvider):
         process_env = os.environ.copy()
         if envs:
             process_env.update(envs)
+        process_env["HOST_HOME"] = os.environ.get("HOME", "")
         process_env["HOME"] = str(sandbox_dir)
         process_env["USER"] = "user"
         process_env["HOSTNAME"] = sandbox_id


### PR DESCRIPTION
## Summary
- preserve the host home directory in command env as `HOST_HOME` before overriding `HOME` to sandbox path
- resolve global git excludes from `HOST_HOME` when building gitignore patterns
- run `git config --global core.excludesFile` with `HOME` set to host home so global config is read correctly

## Problem
`GITIGNORE_CMD` was executed in an environment where `HOME` points to the sandbox directory. That made `git config --global` read sandbox-local config instead of the real user config, so `~/.gitignore_global` was not respected.

## Result
Host-provider file listing now correctly includes global ignore patterns from the user’s Git config/excludes file.
