### PR TITLE
Scope Docker file metadata listing to mounted workspace

### DIFF
--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -36,7 +36,7 @@ T = TypeVar("T")
 LISTENING_PORTS_COMMAND = "ss -tuln | grep LISTEN | awk '{print $5}' | sed 's/.*://g' | grep -E '^[0-9]+$' | sort -u"
 GITIGNORE_CMD = (
     '{ base_home="${HOST_HOME:-$HOME}";'
-    ' [ -f .gitignore ] && cat .gitignore && echo;'
+    " [ -f .gitignore ] && cat .gitignore && echo;"
     ' p=$(HOME="$base_home" git config --global core.excludesFile 2>/dev/null);'
     ' [ -z "$p" ] && p="${XDG_CONFIG_HOME:-$base_home/.config}/git/ignore";'
     ' [ -n "$p" ] && p="${p/#~/$base_home}"'

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -27,6 +27,7 @@ from app.services.sandbox_providers.types import (
     CommandResult,
     DockerConfig,
     FileContent,
+    FileMetadata,
     PreviewLink,
     PtyDataCallbackType,
     PtySession,
@@ -278,6 +279,22 @@ class LocalDockerProvider(SandboxProvider):
         self._port_mappings.pop(sandbox_id, None)
 
         logger.info("Successfully deleted Docker sandbox %s", sandbox_id)
+
+    async def list_files(
+        self,
+        sandbox_id: str,
+        path: str = SANDBOX_HOME_DIR,
+        excluded_patterns: list[str] | None = None,
+    ) -> list[FileMetadata]:
+        target_path = path
+        if path == SANDBOX_HOME_DIR:
+            container = await self._get_container(sandbox_id)
+            workspace_mount_dir = f"{self.config.user_home}/workspace"
+            info = await container.show()
+            mounts = info.get("Mounts", []) or []
+            if any(mount.get("Destination") == workspace_mount_dir for mount in mounts):
+                target_path = workspace_mount_dir
+        return await super().list_files(sandbox_id, target_path, excluded_patterns)
 
     async def is_running(self, sandbox_id: str) -> bool:
         await self._get_docker()


### PR DESCRIPTION
## Summary
- override Docker provider `list_files` to adjust the default listing root
- when the default path is `/home/user`, detect whether a workspace is bind-mounted at `/home/user/workspace`
- if present, list files from the mounted workspace root instead of the sandbox home root

## Problem
For git-cloned workspaces in Docker mode, file metadata listing started at `/home/user`, which surfaced host-home/system artifacts (for example `.cache`, `.claude`) unrelated to the cloned repository.

## Result
Workspace-backed Docker sandboxes now show the mounted repo tree by default, while non-workspace sandboxes keep existing behavior.
