### PR TITLE
Fix no-workspace crash, enable host provider on web, add registration guard

### DIFF
--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -92,6 +92,12 @@ async def register(
     user_create: UserCreate,
     user_manager: UserManager = Depends(get_user_manager),
 ) -> User:
+    if settings.REGISTRATION_DISABLED:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Registration is disabled",
+        )
+
     if settings.BLOCK_DISPOSABLE_EMAILS:
         if await email_service.is_disposable_email(user_create.email):
             raise HTTPException(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     API_V1_STR: str = "/api/v1"
     ENVIRONMENT: str = "development"  # "development" or "production"
     REQUIRE_EMAIL_VERIFICATION: bool = False
+    REGISTRATION_DISABLED: bool = False
 
     DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/claudex"
     REDIS_URL: str = "redis://localhost:6379/0"

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -241,7 +241,7 @@ class SandboxProvider(ABC):
         if patterns:
             prune_conditions = [
                 f"-name {shlex.quote(p)}"
-                if p.startswith("*.")
+                if p.startswith("*.") or p.startswith(".")
                 else f"-path {shlex.quote(p)}"
                 for p in patterns
             ]

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -294,6 +294,9 @@ class LocalDockerProvider(SandboxProvider):
             mounts = info.get("Mounts", []) or []
             if any(mount.get("Destination") == workspace_mount_dir for mount in mounts):
                 target_path = workspace_mount_dir
+            else:
+                excluded_patterns = list(excluded_patterns or [])
+                excluded_patterns.append(".*")
         return await super().list_files(sandbox_id, target_path, excluded_patterns)
 
     async def is_running(self, sandbox_id: str) -> bool:

--- a/backend/app/services/sandbox_providers/factory.py
+++ b/backend/app/services/sandbox_providers/factory.py
@@ -1,5 +1,4 @@
 from app.core.config import get_settings
-from app.services.exceptions import SandboxException
 from app.services.sandbox_providers.base import SandboxProvider
 from app.services.sandbox_providers.docker_provider import LocalDockerProvider
 from app.services.sandbox_providers.host_provider import LocalHostProvider
@@ -38,10 +37,6 @@ class SandboxProviderFactory:
             )
 
         if provider_type == SandboxProviderType.HOST:
-            if not settings.DESKTOP_MODE:
-                raise SandboxException(
-                    "Host provider is only available in the desktop app"
-                )
             host_base_dir = settings.get_host_sandbox_base_dir()
             return LocalHostProvider(
                 base_dir=host_base_dir,

--- a/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
@@ -8,7 +8,6 @@ import type { Theme } from '@/types/ui.types';
 import { useUIStore } from '@/store/uiStore';
 import { SecretInput } from '@/components/settings/inputs/SecretInput';
 import { cn } from '@/utils/cn';
-import { isTauri } from '@tauri-apps/api/core';
 
 interface GeneralSettingsTabProps {
   fields: GeneralSecretFieldConfig[];
@@ -110,7 +109,7 @@ export const GeneralSettingsTab: React.FC<GeneralSettingsTabProps> = ({
           value={settings.sandbox_provider ?? 'docker'}
           onChange={(val) => onSandboxProviderChange(val as SandboxProviderType)}
           options={[
-            ...(isTauri() ? [{ value: 'host', label: 'Host (Local)', disabled: false }] : []),
+            { value: 'host', label: 'Host (Local)', disabled: false },
             { value: 'docker', label: 'Docker (Local)', disabled: false },
           ]}
         />


### PR DESCRIPTION
## Summary
- Exclude hidden files (`.*`) from file listing when no workspace is mounted in Docker provider, preventing Monaco editor crash from loading thousands of dotfiles
- Fix `find` pattern matching so dot-prefixed patterns (`.cache`, `.checkpoints`, `.*`) use `-name` instead of `-path`
- Remove `DESKTOP_MODE` gate on host sandbox provider, making it available in web deployments
- Add `REGISTRATION_DISABLED` env var to block new account registration via 403

## Test plan
- [ ] Start a chat with no workspace selected in Docker provider, open Monaco editor — should not crash, no hidden files shown
- [ ] Select host provider in settings on web (non-Tauri) — should work
- [ ] Set `REGISTRATION_DISABLED=true` and attempt to register — should get 403