### PR TITLE
Fix admin panel proxy routing and session auth

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -111,6 +111,8 @@ def create_application() -> FastAPI:
             "Failed to create storage directory at %s: %s", settings.STORAGE_PATH, e
         )
 
+    _mount_admin(application)
+
     setup_middleware(application)
 
     application.include_router(
@@ -181,8 +183,6 @@ def create_application() -> FastAPI:
         tags=["Integrations"],
     )
     application.openapi = partial(custom_openapi, application)
-
-    _mount_admin(application)
 
     application.add_api_route("/health", health_check, methods=["GET"])
     application.add_api_route(f"{settings.API_V1_STR}/readyz", readyz, methods=["GET"])

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -44,6 +44,12 @@ export default defineConfig({
         ws: true,
         secure: false,
       },
+      '/admin': {
+        target: 'http://api:8080',
+        changeOrigin: false,
+        secure: false,
+        autoRewrite: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- Add `/admin` proxy rule in Vite config so the frontend forwards admin panel requests to the backend, fixing blank page on deployed environments
- Mount admin routes before middleware setup so `SessionMiddleware` wraps them, fixing auth bypass that allowed unauthenticated access to admin data

## Test plan
- [ ] Visit `/admin/` through the frontend — should show sqladmin login page (not blank page)
- [ ] Verify unauthenticated users cannot access admin data
- [ ] Verify only superusers can log in