### PR TITLE
Fix file tree not respecting .gitignore and global gitignore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,12 @@
 - Narrow `except` clauses to specific exception types — never `except Exception` when the actual failure modes are known (e.g., `except (KeyError, SomeLibError)` not `except Exception`)
 - Do not translate exceptions across boundaries just to change the type — if an upstream function already raises a meaningful error, let it propagate; only catch-and-wrap when the caller genuinely needs a different status code or error shape that the original doesn't provide
 - Do not handle hypothetical input shapes — if you have evidence of the actual data format (logs, tests, type definitions), write code for that format only; do not add branches for types or structures you have not observed
-- Don't add comments or docstrings for self-explanatory code
+- Don't add comments or docstrings for self-explanatory code — but do add inline comments for non-obvious logic, implicit conventions, or design decisions that aren't clear from the code alone
+- Do not delete existing comments without asking first — they may capture context that isn't obvious from the code
 - Let the code speak for itself - use clear variable/function names instead of comments
 - Do not use decorative section comments (e.g., `# ── Section ──────`) — code structure should be self-evident from class/method organization
+- Example — no comment needed (self-explanatory): `user_dir.mkdir(parents=True, exist_ok=True)`
+- Example — comment needed (non-obvious why): `# Read from the API host, not the sandbox — sandbox containers don't have the user's global git config`
 - Avoid no-op pass-through wrappers (e.g., a function that only calls another function with identical args/return)
 - If a wrapper exists, it must add concrete value (validation, transformation, error handling, compatibility boundary, or stable public API surface)
 - Prefer direct imports/calls over indirection when behavior is unchanged

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -3,6 +3,7 @@ import base64
 import logging
 import posixpath
 import shlex
+import subprocess
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path, PurePosixPath
@@ -34,15 +35,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 LISTENING_PORTS_COMMAND = "ss -tuln | grep LISTEN | awk '{print $5}' | sed 's/.*://g' | grep -E '^[0-9]+$' | sort -u"
-GITIGNORE_CMD = (
-    '{ base_home="${HOST_HOME:-$HOME}";'
-    " [ -f .gitignore ] && cat .gitignore && echo;"
-    ' p=$(HOME="$base_home" git config --global core.excludesFile 2>/dev/null);'
-    ' [ -z "$p" ] && p="${XDG_CONFIG_HOME:-$base_home/.config}/git/ignore";'
-    ' [ -n "$p" ] && p="${p/#~/$base_home}"'
-    ' && case "$p" in /*) ;; *) p="$base_home/$p" ;; esac'
-    ' && [ -f "$p" ] && cat "$p"; } 2>/dev/null'
-)
+GITIGNORE_CMD = "cat .gitignore 2>/dev/null"
 
 
 class SandboxProvider(ABC):
@@ -167,15 +160,49 @@ class SandboxProvider(ABC):
 
         return list(dict.fromkeys(patterns))
 
-    async def _get_gitignore_patterns(self, sandbox_id: str) -> list[str]:
+    @staticmethod
+    def _read_global_gitignore() -> str:
+        # Read from the API host, not the sandbox — sandbox containers
+        # don't have the user's global git config, so this is the only
+        # way to pick up global excludes like ~/.gitignore_global.
+        try:
+            result = subprocess.run(
+                ["git", "config", "--global", "core.excludesFile"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            p = result.stdout.strip()
+        except (OSError, subprocess.TimeoutExpired):
+            p = ""
+        # Fall back to XDG default location when core.excludesFile is not set
+        if not p:
+            p = str(Path.home() / ".config" / "git" / "ignore")
+        # Expand ~ and resolve relative paths against $HOME (matching git behavior)
+        path = Path(p).expanduser()
+        if not path.is_absolute():
+            path = Path.home() / path
+        try:
+            return path.read_text() if path.is_file() else ""
+        except (OSError, UnicodeDecodeError):
+            return ""
+
+    async def _get_gitignore_patterns(
+        self, sandbox_id: str, path: str = SANDBOX_HOME_DIR
+    ) -> list[str]:
+        cmd = f"cd {shlex.quote(path)} && {GITIGNORE_CMD}"
         result = await self.execute_command(
             sandbox_id,
-            GITIGNORE_CMD,
+            cmd,
             timeout=5,
         )
-        if not result.stdout:
+        parts = result.stdout or ""
+        global_ignore = await asyncio.to_thread(self._read_global_gitignore)
+        if global_ignore:
+            parts = f"{parts}\n{global_ignore}"
+        if not parts.strip():
             return []
-        return self._build_gitignore_patterns(result.stdout)
+        return self._build_gitignore_patterns(parts)
 
     @abstractmethod
     async def create_sandbox(self, workspace_path: str | None = None) -> str:
@@ -235,7 +262,7 @@ class SandboxProvider(ABC):
         excluded_patterns: list[str] | None = None,
     ) -> list[FileMetadata]:
         patterns = list(excluded_patterns or [])
-        patterns.extend(await self._get_gitignore_patterns(sandbox_id))
+        patterns.extend(await self._get_gitignore_patterns(sandbox_id, path))
         patterns = list(dict.fromkeys(patterns))
 
         if patterns:

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -340,7 +340,7 @@ class LocalHostProvider(SandboxProvider):
     ) -> list[FileMetadata]:
         sandbox_dir = self._resolve_sandbox_dir(sandbox_id)
         patterns = list(excluded_patterns or [])
-        patterns.extend(await self._get_gitignore_patterns(sandbox_id))
+        patterns.extend(await self._get_gitignore_patterns(sandbox_id, str(sandbox_dir)))
         patterns = list(dict.fromkeys(patterns))
         return await asyncio.to_thread(self._walk_files, sandbox_dir, patterns)
 


### PR DESCRIPTION
## Summary
- Fixed project `.gitignore` not being read by `cd`ing into the workspace directory before running the gitignore command
- Fixed global gitignore (`~/.gitignore_global`) being missed by reading it from the API host in Python, since sandbox containers don't have the user's global git config
- Simplified `GITIGNORE_CMD` from a complex shell script to `cat .gitignore 2>/dev/null`
- Passed workspace path to `_get_gitignore_patterns` in both Docker and host providers

## Test plan
- [ ] Start a chat with a local folder workspace that has a `.gitignore`
- [ ] Verify folders like `__pycache__`, `.ruff_cache`, `.pytest_cache` are hidden in the file tree
- [ ] Verify entries from `~/.gitignore_global` (or `core.excludesFile`) are also respected
- [ ] Verify file tree still works when no `.gitignore` or global gitignore exists