### PR TITLE
Fix context usage showing cumulative tokens instead of actual context size

### DIFF
--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -340,7 +340,9 @@ class LocalHostProvider(SandboxProvider):
     ) -> list[FileMetadata]:
         sandbox_dir = self._resolve_sandbox_dir(sandbox_id)
         patterns = list(excluded_patterns or [])
-        patterns.extend(await self._get_gitignore_patterns(sandbox_id, str(sandbox_dir)))
+        patterns.extend(
+            await self._get_gitignore_patterns(sandbox_id, str(sandbox_dir))
+        )
         patterns = list(dict.fromkeys(patterns))
         return await asyncio.to_thread(self._walk_files, sandbox_dir, patterns)
 

--- a/backend/app/services/streaming/processor.py
+++ b/backend/app/services/streaming/processor.py
@@ -74,7 +74,10 @@ class StreamProcessor:
         if isinstance(message, ResultMessage):
             if message.total_cost_usd is not None:
                 self.total_cost_usd = message.total_cost_usd
-            if message.usage is not None:
+            # Only use ResultMessage usage if we have no per-turn usage from
+            # AssistantMessage. ResultMessage.usage contains cumulative totals
+            # across all API calls, not the current context window size.
+            if message.usage is not None and self.usage is None:
                 self.usage = message.usage
 
     @staticmethod


### PR DESCRIPTION
## Summary
- `ResultMessage.usage` from the Claude Agent SDK contains cumulative input tokens across all API calls in a multi-turn conversation (including subagent turns), not the current context window size
- This caused the context usage indicator to show inflated numbers (e.g., 14.8M/200k) after conversations with multiple turns or subagents
- Fixed by preserving the last per-turn `AssistantMessage.usage` (which reflects the actual context size) and only falling back to `ResultMessage.usage` when no `AssistantMessage` was received

## Test plan
- [ ] Start a multi-turn chat that triggers tool use (multiple turns)
- [ ] Verify context usage indicator shows a reasonable number (under 200k) after stream completes
- [ ] Start a chat that spawns subagents and verify the context usage doesn't include subagent tokens
- [ ] Verify single-turn chats still show correct context usage