### PR TITLE
Replace Granian with uvicorn to fix ~40% idle CPU usage

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from fastapi import FastAPI, Response, status
 from fastapi.staticfiles import StaticFiles
-from granian.utils.proxies import wrap_asgi_with_proxy_headers
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from sqlalchemy import text
 
 from app.api.docs import custom_openapi
@@ -244,4 +244,4 @@ if not settings.DESKTOP_MODE and _instrumentator_available:
     Instrumentator().instrument(app).expose(app)
 
 if not settings.DISABLE_PROXY_HEADERS:
-    app = wrap_asgi_with_proxy_headers(app, trusted_hosts=settings.TRUSTED_PROXY_HOSTS)
+    app = ProxyHeadersMiddleware(app, trusted_hosts=settings.TRUSTED_PROXY_HOSTS)

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -23,7 +23,7 @@ start-vnc.sh &
 echo "Starting API server..."
 if [ -S /var/run/docker.sock ]; then
     echo "Docker socket detected, running as current user for Docker access..."
-    exec sh -c "ulimit -s 65536 && exec granian --interface asgi app.main:app --host 0.0.0.0 --port ${PORT:-8080}"
+    exec sh -c "ulimit -s 65536 && exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080} --workers 1 --log-level info --no-proxy-headers"
 else
-    exec gosu appuser sh -c "ulimit -s 65536 && exec granian --interface asgi app.main:app --host 0.0.0.0 --port ${PORT:-8080}"
+    exec gosu appuser sh -c "ulimit -s 65536 && exec uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8080} --workers 1 --log-level info --no-proxy-headers"
 fi

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -97,7 +97,7 @@ module = [
     "sqladmin.*",
     "sse_starlette.*",
     "prometheus_fastapi_instrumentator.*",
-    "granian.*",
+    "uvicorn.*",
     "claude_agent_sdk.*",
     "yaml",
     "fastapi_users.*",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ alembic
 python-jose[cryptography]
 cryptography
 bcrypt
-granian
+uvicorn[standard]
 jinja2>=3.1.3,<4.0
 markupsafe
 python-multipart

--- a/desktop/entry.py
+++ b/desktop/entry.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from urllib.parse import urlparse
 
-from granian import Granian
+import uvicorn
 from migrate import check_and_run_migrations
 
 
@@ -15,14 +15,14 @@ def main() -> None:
     parsed = urlparse(base_url)
     port = parsed.port or 8081
 
-    server = Granian(
-        target="app.main:app",
-        address="127.0.0.1",
+    uvicorn.run(
+        "app.main:app",
+        host="127.0.0.1",
         port=port,
-        interface="asgi",
         workers=1,
+        log_level="info",
+        proxy_headers=False,
     )
-    server.serve()
 
 
 if __name__ == "__main__":

--- a/desktop/requirements.txt
+++ b/desktop/requirements.txt
@@ -8,7 +8,7 @@ aiosqlite
 python-jose[cryptography]
 cryptography
 bcrypt
-granian
+uvicorn[standard]
 jinja2>=3.1.3,<4.0
 markupsafe
 python-multipart


### PR DESCRIPTION
## Summary

- Granian's Rust tokio runtime continuously wakes Python's asyncio event loop even with zero connections, causing the sidecar worker process to burn ~40% CPU when fully idle (confirmed via `sample`/`ps -M` profiling on macOS)
- Replace Granian with uvicorn across all entry points — uvicorn's idle CPU is typically <1%
- `uvicorn[standard]` includes uvloop for further performance gains
- Disable uvicorn's built-in proxy header parsing (`--no-proxy-headers` / `proxy_headers=False`) so `ProxyHeadersMiddleware` in `app.main` remains the single source of truth for `TRUSTED_PROXY_HOSTS` / `DISABLE_PROXY_HEADERS`

## Test plan

- [ ] Start the desktop app and verify the sidecar starts and responds to API requests
- [ ] Confirm idle CPU usage drops to <1% (was ~40%)
- [ ] Build and start Docker backend, verify API starts and health check passes
- [ ] Verify proxy header behavior: `X-Forwarded-For` is respected when `DISABLE_PROXY_HEADERS` is unset, and ignored when set to any truthy value (`true`, `1`, `yes`, `True`)
- [ ] Regenerate lock files (`requirements.lock`, `requirements-test.lock`)