### PR TITLE
Replace ChatException with WorkspaceException in workspace module

### DIFF
--- a/backend/app/api/endpoints/workspace.py
+++ b/backend/app/api/endpoints/workspace.py
@@ -14,14 +14,14 @@ from app.models.schemas.workspace import (
     WorkspaceCreate,
     WorkspaceUpdate,
 )
-from app.services.exceptions import ChatException
+from app.services.exceptions import WorkspaceException
 from app.services.workspace import WorkspaceService
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-def _raise_workspace_http_exception(exc: ChatException) -> NoReturn:
+def _raise_workspace_http_exception(exc: WorkspaceException) -> NoReturn:
     raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
@@ -37,7 +37,7 @@ async def create_workspace(
 ) -> WorkspaceSchema:
     try:
         return await workspace_service.create_workspace(current_user, data)
-    except ChatException as e:
+    except WorkspaceException as e:
         _raise_workspace_http_exception(e)
     except SQLAlchemyError as e:
         logger.error("Database error creating workspace: %s", e, exc_info=True)
@@ -63,7 +63,7 @@ async def get_workspace(
 ) -> WorkspaceSchema:
     try:
         return await workspace_service.get_workspace(workspace_id, current_user)
-    except ChatException as e:
+    except WorkspaceException as e:
         _raise_workspace_http_exception(e)
 
 
@@ -78,7 +78,7 @@ async def update_workspace(
         return await workspace_service.update_workspace(
             workspace_id, current_user, data
         )
-    except ChatException as e:
+    except WorkspaceException as e:
         _raise_workspace_http_exception(e)
 
 
@@ -90,5 +90,5 @@ async def delete_workspace(
 ) -> None:
     try:
         await workspace_service.delete_workspace(workspace_id, current_user)
-    except ChatException as e:
+    except WorkspaceException as e:
         _raise_workspace_http_exception(e)

--- a/backend/app/services/exceptions.py
+++ b/backend/app/services/exceptions.py
@@ -203,3 +203,14 @@ class MarketplaceException(ServiceException):
         status_code: int = 400,
     ):
         super().__init__(message, error_code, details, status_code)
+
+
+class WorkspaceException(ServiceException):
+    def __init__(
+        self,
+        message: str,
+        error_code: ErrorCode = ErrorCode.WORKSPACE_NOT_FOUND,
+        details: dict[str, str] | None = None,
+        status_code: int = 400,
+    ):
+        super().__init__(message, error_code, details, status_code)

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -17,7 +17,7 @@ from app.models.schemas.workspace import WorkspaceCreate, WorkspaceUpdate
 from app.models.schemas.workspace import Workspace as WorkspaceSchema
 from app.models.schemas.pagination import PaginatedResponse, PaginationParams
 from app.services.db import BaseDbService, SessionFactoryType
-from app.services.exceptions import ChatException, ErrorCode
+from app.services.exceptions import ErrorCode, WorkspaceException
 from app.services.sandbox import SandboxService
 from app.services.sandbox_providers.factory import SandboxProviderFactory
 from app.services.sandbox_providers.types import SandboxProviderType
@@ -51,7 +51,7 @@ class WorkspaceService(BaseDbService[Workspace]):
 
         if data.source_type == "git":
             if not data.git_url:
-                raise ChatException(
+                raise WorkspaceException(
                     "git_url is required for git workspace",
                     error_code=ErrorCode.VALIDATION_ERROR,
                     status_code=400,
@@ -63,14 +63,14 @@ class WorkspaceService(BaseDbService[Workspace]):
             source_url = normalized_url
         elif data.source_type == "local":
             if not data.workspace_path:
-                raise ChatException(
+                raise WorkspaceException(
                     "workspace_path is required for local workspace",
                     error_code=ErrorCode.VALIDATION_ERROR,
                     status_code=400,
                 )
             resolved = Path(data.workspace_path).expanduser().resolve()
             if not resolved.exists() or not resolved.is_dir():
-                raise ChatException(
+                raise WorkspaceException(
                     "workspace_path must be an existing directory",
                     error_code=ErrorCode.VALIDATION_ERROR,
                     status_code=400,
@@ -180,7 +180,7 @@ class WorkspaceService(BaseDbService[Workspace]):
             )
             workspace: Workspace | None = result.scalar_one_or_none()
             if not workspace:
-                raise ChatException(
+                raise WorkspaceException(
                     "Workspace not found",
                     error_code=ErrorCode.WORKSPACE_NOT_FOUND,
                     details={"workspace_id": str(workspace_id)},
@@ -271,7 +271,7 @@ class WorkspaceService(BaseDbService[Workspace]):
             process.kill()
             await process.wait()
             await asyncio.to_thread(shutil.rmtree, workspace_dir, True)
-            raise ChatException(
+            raise WorkspaceException(
                 "Git clone timed out",
                 error_code=ErrorCode.VALIDATION_ERROR,
                 status_code=400,
@@ -284,7 +284,7 @@ class WorkspaceService(BaseDbService[Workspace]):
                 or stdout.decode("utf-8", errors="replace").strip()
                 or "Failed to clone repository"
             )
-            raise ChatException(
+            raise WorkspaceException(
                 error_output,
                 error_code=ErrorCode.VALIDATION_ERROR,
                 status_code=400,
@@ -296,7 +296,7 @@ class WorkspaceService(BaseDbService[Workspace]):
     def _normalize_git_url(git_url: str) -> str:
         candidate = git_url.strip()
         if not candidate:
-            raise ChatException(
+            raise WorkspaceException(
                 "git_url is required for git workspace",
                 error_code=ErrorCode.VALIDATION_ERROR,
                 status_code=400,
@@ -307,13 +307,13 @@ class WorkspaceService(BaseDbService[Workspace]):
 
         parsed = urlparse(candidate)
         if parsed.scheme != "https":
-            raise ChatException(
+            raise WorkspaceException(
                 "git_url must be an HTTPS or git@... SSH URL",
                 error_code=ErrorCode.VALIDATION_ERROR,
                 status_code=400,
             )
         if parsed.username or parsed.password:
-            raise ChatException(
+            raise WorkspaceException(
                 "git_url must not contain embedded credentials",
                 error_code=ErrorCode.VALIDATION_ERROR,
                 status_code=400,


### PR DESCRIPTION
## Summary
- Added `WorkspaceException` to the service exceptions module, following the existing one-exception-per-domain pattern
- Replaced all `ChatException` usage in `WorkspaceService` and the workspace API endpoint with `WorkspaceException`
- Leftover from when workspaces were extracted into first-class entities in #304

## Test plan
- [ ] Verify workspace creation with invalid inputs returns proper error responses
- [ ] Verify workspace not-found returns 404 with `WORKSPACE_NOT_FOUND` error code
- [ ] Verify git clone timeout/failure errors surface correctly