### PR TITLE
Fix title generation exceeding VARCHAR(255) limit

### DIFF
--- a/backend/app/services/claude_agent.py
+++ b/backend/app/services/claude_agent.py
@@ -296,8 +296,9 @@ class ClaudeAgentService:
 
         options = ClaudeAgentOptions(
             system_prompt=(
-                "Generate a short conversation title (3-8 words) for the "
-                "user's message. Reply with ONLY the title, nothing else."
+                "Generate a short conversation title (3-8 words, max 255 characters) for the "
+                "user's message. Reply with ONLY the title, nothing else. "
+                "Do not explain, analyze, or comment on the message."
             ),
             permission_mode="default",
             model=actual_model_id,

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -713,6 +713,7 @@ class ChatStreamRuntime:
         title = await ai_service.generate_title(self.prompt, user)
         if not title:
             return
+        title = title[:255]
 
         async with self.session_factory() as db:
             await db.execute(


### PR DESCRIPTION
## Summary
- Truncate generated chat title to 255 characters before saving to prevent `StringDataRightTruncationError`
- Tighten the title generation prompt to explicitly cap length and prevent the LLM from returning explanations instead of a title

## Test plan
- [ ] Send a message that triggers title generation and verify it saves without error
- [ ] Confirm titles remain short and descriptive