### PR TITLE
Fix transport lifecycle leaks causing CPU spin

### DIFF
--- a/backend/app/services/claude_agent.py
+++ b/backend/app/services/claude_agent.py
@@ -51,6 +51,9 @@ ALLOWED_SLASH_COMMANDS = [
     "/pr-comments",
     "/review",
     "/init",
+    "/debug",
+    "/security-review",
+    "/insights",
 ]
 SDK_PERMISSION_MODE_MAP: dict[
     str, Literal["default", "acceptEdits", "plan", "bypassPermissions"]

--- a/backend/app/services/claude_session_registry.py
+++ b/backend/app/services/claude_session_registry.py
@@ -58,6 +58,13 @@ class SessionRegistry:
         session = self._sessions.get(chat_id)
         fingerprint = self._compute_fingerprint(options)
 
+        # Transport may be dead if the underlying container vanished
+        # (e.g. removed externally). Reuse would leave stale callbacks
+        # spinning in the event loop — tear down and recreate instead.
+        if session is not None and not session.transport.is_ready():
+            await self._close_session(session)
+            session = None
+
         if session is not None and session.fingerprint != fingerprint:
             await self._close_session(session)
             session = None

--- a/backend/app/services/transports/docker.py
+++ b/backend/app/services/transports/docker.py
@@ -199,3 +199,4 @@ class DockerSandboxTransport(BaseSandboxTransport):
             )
         finally:
             self._ready = False
+            await self._put_sentinel()

--- a/frontend/src/hooks/useSlashCommandSuggestions.ts
+++ b/frontend/src/hooks/useSlashCommandSuggestions.ts
@@ -30,6 +30,21 @@ const SLASH_COMMANDS: SlashCommand[] = [
     label: 'Init',
     description: 'Initialize a new CLAUDE.md file with codebase documentation',
   },
+  {
+    value: '/debug',
+    label: 'Debug',
+    description: 'Debug you current Claude code session',
+  },
+  {
+    value: '/security-review',
+    label: 'Security Review',
+    description: 'Complete a security review of the pending changes on the current branch',
+  },
+  {
+    value: '/insights',
+    label: 'Insights',
+    description: 'Generate a report analyzing your Claude code sessions',
+  },
 ];
 
 interface UseSlashCommandOptions {


### PR DESCRIPTION
## Summary
- **Stale transport detection**: Session registry now checks `transport.is_ready()` before reusing a cached session — if the underlying container vanished (e.g. removed externally via `docker rm`), the dead session is torn down and recreated instead of being reused with orphaned callbacks
- **Missing sentinel in Docker monitor**: Docker transport's `_monitor_process` was missing `_put_sentinel()` in its finally block (host transport had it). Without the sentinel, when a container dies the reader task and `_parse_cli_output` stay blocked on `queue.get()` forever, leaking asyncio tasks that spin the event loop
- **New slash commands**: Added `/debug`, `/security-review`, `/insights` to allowed commands list and frontend suggestions

## Context
Diagnosed ~40% sustained CPU usage on the desktop sidecar after prolonged use with many sandbox containers. Root cause: when containers are removed externally, the Docker transport monitor sets `_ready = False` but never signals the stdout queue, leaving reader tasks alive indefinitely. These orphaned callbacks accumulate in uvloop's idle handler, creating a self-sustaining `call_soon` spin loop.

## Test plan
- [ ] Create a sandbox, start a chat, then force-remove the container (`docker rm -f`) — verify the next message recreates the session cleanly instead of hanging
- [ ] Run the app for an extended session with sandbox creation/deletion — verify CPU stays low after cleanup
- [ ] Verify new slash commands appear in the input suggestions