### PR TITLE
Fix uvicorn WebSocket support in lock file

### DIFF
--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -310,7 +310,7 @@ typing-inspection==0.4.2
     #   pydantic-settings
 urllib3==2.6.3
     # via requests
-uvicorn==0.40.0
+uvicorn[standard]==0.40.0
     # via
     #   anthropic-bridge
     #   mcp


### PR DESCRIPTION
## Summary
- The `requirements.lock` had bare `uvicorn==0.40.0` without the `[standard]` extra, so `websockets` was never installed in the container
- This caused `WARNING: No supported WebSocket library detected` errors at runtime
- Changed to `uvicorn[standard]==0.40.0` to include WebSocket dependencies

## Test plan
- [ ] Rebuild API container (`docker compose build api`)
- [ ] Verify `websockets` is installed (`docker compose exec api pip list | grep websockets`)
- [ ] Confirm WebSocket warning is gone on startup