### PR TITLE
Add GitHub repository browser to workspace selector

### DIFF
--- a/backend/app/api/endpoints/github.py
+++ b/backend/app/api/endpoints/github.py
@@ -1,0 +1,95 @@
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.core.deps import get_github_token
+from app.core.security import get_current_user
+from app.models.db_models.user import User
+from app.models.schemas.github import GitHubRepo, GitHubReposResponse
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+GITHUB_API_BASE = "https://api.github.com"
+
+
+@router.get("/repositories", response_model=GitHubReposResponse)
+async def list_repositories(
+    q: str = Query(default="", max_length=256),
+    page: int = Query(default=1, ge=1),
+    per_page: int = Query(default=20, ge=1, le=100),
+    _current_user: User = Depends(get_current_user),
+    github_token: str | None = Depends(get_github_token),
+) -> GitHubReposResponse:
+    if not github_token:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="GitHub personal access token not configured",
+        )
+
+    headers = {
+        "Authorization": f"Bearer {github_token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        if q.strip():
+            response = await client.get(
+                f"{GITHUB_API_BASE}/search/repositories",
+                params={
+                    "q": q.strip(),
+                    "sort": "updated",
+                    "order": "desc",
+                    "per_page": per_page,
+                    "page": page,
+                },
+                headers=headers,
+            )
+        else:
+            response = await client.get(
+                f"{GITHUB_API_BASE}/user/repos",
+                params={
+                    "sort": "pushed",
+                    "direction": "desc",
+                    "per_page": per_page,
+                    "page": page,
+                    "affiliation": "owner,collaborator,organization_member",
+                },
+                headers=headers,
+            )
+
+    if response.status_code == 401:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="GitHub token is invalid or expired",
+        )
+    if response.status_code != 200:
+        logger.warning(
+            "GitHub API returned %d: %s", response.status_code, response.text[:200]
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="GitHub API request failed",
+        )
+
+    data = response.json()
+    raw_repos = data.get("items", data) if isinstance(data, dict) else data
+
+    repos = [
+        GitHubRepo(
+            name=r["name"],
+            full_name=r["full_name"],
+            description=r.get("description"),
+            language=r.get("language"),
+            html_url=r["html_url"],
+            clone_url=r["clone_url"],
+            private=r.get("private", False),
+            pushed_at=r.get("pushed_at"),
+            stargazers_count=r.get("stargazers_count", 0),
+        )
+        for r in raw_repos
+    ]
+
+    return GitHubReposResponse(items=repos, has_more=len(raw_repos) == per_page)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from app.api.endpoints import (
     auth,
     chat,
     commands,
+    github,
     integrations,
     marketplace,
     mcps,
@@ -187,6 +188,11 @@ def create_application() -> FastAPI:
         integrations.router,
         prefix=f"{settings.API_V1_STR}/integrations",
         tags=["Integrations"],
+    )
+    application.include_router(
+        github.router,
+        prefix=f"{settings.API_V1_STR}/github",
+        tags=["GitHub"],
     )
     application.openapi = partial(custom_openapi, application)
 

--- a/backend/app/models/schemas/github.py
+++ b/backend/app/models/schemas/github.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class GitHubRepo(BaseModel):
+    name: str
+    full_name: str
+    description: str | None
+    language: str | None
+    html_url: str
+    clone_url: str
+    private: bool
+    pushed_at: str | None
+    stargazers_count: int
+
+
+class GitHubReposResponse(BaseModel):
+    items: list[GitHubRepo]
+    has_more: bool

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -1,7 +1,10 @@
 import asyncio
+import contextlib
 import logging
 import math
+import os
 import shutil
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
@@ -58,7 +61,9 @@ class WorkspaceService(BaseDbService[Workspace]):
                 )
             normalized_url = self._normalize_git_url(data.git_url)
             workspace_path = await self._clone_git_workspace(
-                user_workspace_dir, normalized_url
+                user_workspace_dir,
+                normalized_url,
+                github_token=user_settings.github_personal_access_token,
             )
             source_url = normalized_url
         elif data.source_type == "local":
@@ -248,9 +253,37 @@ class WorkspaceService(BaseDbService[Workspace]):
                     sandbox_service.delete_sandbox(workspace.sandbox_id)
                 )
 
-    async def _clone_git_workspace(self, user_workspace_dir: Path, git_url: str) -> str:
+    async def _clone_git_workspace(
+        self,
+        user_workspace_dir: Path,
+        git_url: str,
+        github_token: str | None = None,
+    ) -> str:
         repo_name = self._extract_repo_name(git_url)
         workspace_dir = user_workspace_dir / f"{repo_name}-{uuid4().hex[:8]}"
+
+        env = None
+        askpass_path = None
+        if github_token and git_url.startswith("https://"):
+            parsed = urlparse(git_url)
+            if parsed.hostname in ("github.com", "www.github.com"):
+                fd, askpass_path = tempfile.mkstemp(prefix="git-askpass-", suffix=".sh")
+                script = (
+                    "#!/bin/sh\n"
+                    'case "$1" in\n'
+                    '*Username*) echo "x-access-token" ;;\n'
+                    '*Password*) echo "$GIT_PASSWORD" ;;\n'
+                    "esac\n"
+                )
+                os.write(fd, script.encode())
+                os.close(fd)
+                os.chmod(askpass_path, 0o700)
+                env = {
+                    **os.environ,
+                    "GIT_ASKPASS": askpass_path,
+                    "GIT_TERMINAL_PROMPT": "0",
+                    "GIT_PASSWORD": github_token,
+                }
 
         process = await asyncio.create_subprocess_exec(
             "git",
@@ -261,6 +294,7 @@ class WorkspaceService(BaseDbService[Workspace]):
             str(workspace_dir),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=env,
         )
 
         try:
@@ -276,6 +310,10 @@ class WorkspaceService(BaseDbService[Workspace]):
                 error_code=ErrorCode.VALIDATION_ERROR,
                 status_code=400,
             ) from exc
+        finally:
+            if askpass_path:
+                with contextlib.suppress(OSError):
+                    os.unlink(askpass_path)
 
         if process.returncode != 0:
             await asyncio.to_thread(shutil.rmtree, workspace_dir, True)
@@ -284,6 +322,8 @@ class WorkspaceService(BaseDbService[Workspace]):
                 or stdout.decode("utf-8", errors="replace").strip()
                 or "Failed to clone repository"
             )
+            if github_token:
+                error_output = error_output.replace(github_token, "***")
             raise WorkspaceException(
                 error_output,
                 error_code=ErrorCode.VALIDATION_ERROR,

--- a/frontend/src/components/chat/WorkspaceSelector.tsx
+++ b/frontend/src/components/chat/WorkspaceSelector.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, memo } from 'react';
 import toast from 'react-hot-toast';
-import { FolderOpen, Search, GitBranch, Plus, Box, HardDrive } from 'lucide-react';
+import { FolderOpen, Search, GitBranch, Plus, Box, HardDrive, Lock, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { ModalHeader } from '@/components/ui/shared/ModalHeader';
@@ -9,7 +9,9 @@ import {
   useCreateWorkspaceMutation,
 } from '@/hooks/queries/useWorkspaceQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
+import { useGitHubReposQuery } from '@/hooks/queries/useGitHubQueries';
 import type { Workspace } from '@/types/workspace.types';
+import type { GitHubRepo } from '@/types/github.types';
 import { formatRelativeTime } from '@/utils/date';
 import { cn } from '@/utils/cn';
 import { isTauri } from '@tauri-apps/api/core';
@@ -64,6 +66,72 @@ function sourceIcon(sourceType: string | null | undefined) {
   }
 }
 
+const GitHubRepoItem = memo(function GitHubRepoItem({
+  repo,
+  onSelect,
+  isCloning,
+}: {
+  repo: GitHubRepo;
+  onSelect: (cloneUrl: string, name: string) => void | Promise<void>;
+  isCloning: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={isCloning}
+      onClick={() => onSelect(repo.clone_url, repo.name)}
+      className="flex w-full items-start gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors duration-200 hover:bg-surface-hover disabled:opacity-50 dark:hover:bg-surface-dark-hover"
+    >
+      <GitBranch className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate text-xs text-text-primary dark:text-text-dark-primary">
+            {repo.full_name}
+          </span>
+          {repo.private && (
+            <span className="flex shrink-0 items-center gap-0.5 rounded-full bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-tertiary dark:bg-surface-dark-tertiary dark:text-text-dark-tertiary">
+              <Lock className="h-2.5 w-2.5" />
+              private
+            </span>
+          )}
+        </div>
+        {repo.description && (
+          <p className="truncate text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+            {repo.description}
+          </p>
+        )}
+        <div className="flex items-center gap-1.5 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+          {repo.language && <span>{repo.language}</span>}
+          {repo.pushed_at && (
+            <>
+              {repo.language && <span>·</span>}
+              <span>{formatRelativeTime(repo.pushed_at)}</span>
+            </>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+});
+
+const SKELETON_ITEMS = [0, 1, 2];
+
+function RepoListSkeleton() {
+  return (
+    <div className="flex flex-col gap-2">
+      {SKELETON_ITEMS.map((i) => (
+        <div key={i} className="flex items-start gap-2.5 px-2.5 py-2">
+          <div className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-pulse rounded bg-surface-tertiary dark:bg-surface-dark-tertiary" />
+          <div className="flex-1 space-y-1.5">
+            <div className="h-3 w-2/3 animate-pulse rounded bg-surface-tertiary dark:bg-surface-dark-tertiary" />
+            <div className="h-2.5 w-full animate-pulse rounded bg-surface-tertiary dark:bg-surface-dark-tertiary" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 interface WorkspaceSelectorProps {
   selectedWorkspaceId: string | null;
   onWorkspaceChange: (workspaceId: string | null) => void;
@@ -83,6 +151,7 @@ export function WorkspaceSelector({
   const createWorkspace = useCreateWorkspaceMutation();
 
   const defaultProvider = settings?.sandbox_provider ?? 'docker';
+  const hasGitHubToken = Boolean(settings?.github_personal_access_token);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -90,10 +159,23 @@ export function WorkspaceSelector({
   const [emptyName, setEmptyName] = useState('');
   const [gitUrl, setGitUrl] = useState('');
   const [sandboxProvider, setSandboxProvider] = useState<'docker' | 'host'>(defaultProvider);
+  const [repoSearchQuery, setRepoSearchQuery] = useState('');
+  const [debouncedRepoQuery, setDebouncedRepoQuery] = useState('');
+  const [showUrlInput, setShowUrlInput] = useState(false);
 
   useEffect(() => {
     setSandboxProvider(defaultProvider);
   }, [defaultProvider]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedRepoQuery(repoSearchQuery), 300);
+    return () => clearTimeout(timer);
+  }, [repoSearchQuery]);
+
+  const { data: reposData, isLoading: reposLoading } = useGitHubReposQuery(
+    debouncedRepoQuery,
+    creationMode === 'git' && hasGitHubToken && !showUrlInput,
+  );
 
   const workspaces = workspacesData?.items ?? [];
   const selectedWorkspace = workspaces.find((ws) => ws.id === selectedWorkspaceId);
@@ -112,6 +194,9 @@ export function WorkspaceSelector({
     setEmptyName('');
     setGitUrl('');
     setSandboxProvider(defaultProvider);
+    setRepoSearchQuery('');
+    setDebouncedRepoQuery('');
+    setShowUrlInput(false);
   }, [defaultProvider]);
 
   const selectWorkspace = useCallback(
@@ -161,26 +246,34 @@ export function WorkspaceSelector({
     }
   }, [createWorkspace, sandboxProvider, onWorkspaceChange, closeModal]);
 
+  const cloneRepo = useCallback(
+    async (url: string, name: string) => {
+      try {
+        const workspace = await createWorkspace.mutateAsync({
+          name,
+          source_type: 'git',
+          git_url: url,
+          sandbox_provider: sandboxProvider,
+        });
+        onWorkspaceChange(workspace.id);
+        closeModal();
+        toast.success('Repository cloned');
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to clone repository');
+      }
+    },
+    [createWorkspace, sandboxProvider, onWorkspaceChange, closeModal],
+  );
+
   const handleCloneGit = useCallback(async () => {
     const normalizedGitUrl = gitUrl.trim();
     if (!normalizedGitUrl) {
       toast.error('Enter a Git repository URL');
       return;
     }
-    try {
-      const workspace = await createWorkspace.mutateAsync({
-        name: normalizedGitUrl.split('/').pop()?.replace('.git', '') || 'Git Project',
-        source_type: 'git',
-        git_url: normalizedGitUrl,
-        sandbox_provider: sandboxProvider,
-      });
-      onWorkspaceChange(workspace.id);
-      closeModal();
-      toast.success('Repository cloned');
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to clone repository');
-    }
-  }, [createWorkspace, gitUrl, sandboxProvider, onWorkspaceChange, closeModal]);
+    const name = normalizedGitUrl.split('/').pop()?.replace('.git', '') || 'Git Project';
+    await cloneRepo(normalizedGitUrl, name);
+  }, [gitUrl, cloneRepo]);
 
   const label = selectedWorkspace?.name || 'Select workspace';
 
@@ -327,20 +420,87 @@ export function WorkspaceSelector({
               </div>
             ) : creationMode === 'git' ? (
               <div className="flex flex-col gap-2">
-                <div className="flex items-center gap-2 text-xs text-text-secondary dark:text-text-dark-secondary">
-                  <GitBranch className="h-3.5 w-3.5 text-text-quaternary dark:text-text-dark-quaternary" />
-                  Clone Git repo
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2 text-xs text-text-secondary dark:text-text-dark-secondary">
+                    <GitBranch className="h-3.5 w-3.5 text-text-quaternary dark:text-text-dark-quaternary" />
+                    Clone Git repo
+                  </div>
+                  {hasGitHubToken && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setShowUrlInput(!showUrlInput);
+                        setRepoSearchQuery('');
+                        setGitUrl('');
+                      }}
+                      className="text-2xs text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+                    >
+                      {showUrlInput ? 'Browse repos' : 'Paste URL'}
+                    </button>
+                  )}
                 </div>
-                <input
-                  value={gitUrl}
-                  onChange={(e) => setGitUrl(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') void handleCloneGit();
-                  }}
-                  placeholder="https://github.com/org/repo.git"
-                  autoFocus
-                  className="bg-surface-primary dark:bg-surface-dark-primary h-8 w-full rounded-lg border border-border/50 px-3 font-mono text-xs text-text-primary outline-none placeholder:text-text-quaternary focus-visible:border-border-hover dark:border-border-dark/50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus-visible:border-border-dark-hover"
-                />
+
+                {hasGitHubToken && !showUrlInput ? (
+                  <>
+                    <div className="relative">
+                      <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-quaternary dark:text-text-dark-quaternary" />
+                      <input
+                        value={repoSearchQuery}
+                        onChange={(e) => setRepoSearchQuery(e.target.value)}
+                        placeholder="Search repositories…"
+                        autoFocus
+                        className="bg-surface-primary dark:bg-surface-dark-primary h-8 w-full rounded-lg border border-border/50 pl-8 pr-3 text-xs text-text-primary outline-none placeholder:text-text-quaternary focus-visible:border-border-hover dark:border-border-dark/50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus-visible:border-border-dark-hover"
+                      />
+                    </div>
+                    <div className="max-h-[12rem] overflow-y-auto">
+                      {createWorkspace.isPending ? (
+                        <div className="flex items-center justify-center gap-2 px-2.5 py-6">
+                          <Loader2 className="h-3.5 w-3.5 animate-spin text-text-quaternary dark:text-text-dark-quaternary" />
+                          <span className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
+                            Cloning repository…
+                          </span>
+                        </div>
+                      ) : reposLoading ? (
+                        <RepoListSkeleton />
+                      ) : !reposData?.items.length ? (
+                        <p className="px-2.5 py-4 text-center text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                          {debouncedRepoQuery ? 'No repositories found' : 'No repositories'}
+                        </p>
+                      ) : (
+                        <div className="flex flex-col gap-0.5">
+                          {reposData.items.map((repo) => (
+                            <GitHubRepoItem
+                              key={repo.full_name}
+                              repo={repo}
+                              onSelect={cloneRepo}
+                              isCloning={createWorkspace.isPending}
+                            />
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <input
+                      value={gitUrl}
+                      onChange={(e) => setGitUrl(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') void handleCloneGit();
+                      }}
+                      placeholder="https://github.com/org/repo.git"
+                      autoFocus
+                      disabled={createWorkspace.isPending}
+                      className="bg-surface-primary dark:bg-surface-dark-primary h-8 w-full rounded-lg border border-border/50 px-3 font-mono text-xs text-text-primary outline-none placeholder:text-text-quaternary focus-visible:border-border-hover disabled:opacity-50 dark:border-border-dark/50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus-visible:border-border-dark-hover"
+                    />
+                    {!hasGitHubToken && (
+                      <p className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                        Add a GitHub token in Settings to browse repos
+                      </p>
+                    )}
+                  </>
+                )}
+
                 <ProviderToggle value={sandboxProvider} onChange={setSandboxProvider} />
                 <div className="flex items-center justify-end gap-2">
                   <Button
@@ -350,18 +510,22 @@ export function WorkspaceSelector({
                     onClick={() => {
                       setCreationMode('menu');
                       setGitUrl('');
+                      setRepoSearchQuery('');
+                      setShowUrlInput(false);
                     }}
                   >
                     Cancel
                   </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    onClick={() => void handleCloneGit()}
-                    isLoading={createWorkspace.isPending}
-                  >
-                    Clone
-                  </Button>
+                  {(showUrlInput || !hasGitHubToken) && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => void handleCloneGit()}
+                      isLoading={createWorkspace.isPending}
+                    >
+                      Clone
+                    </Button>
+                  )}
                 </div>
               </div>
             ) : (

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -29,4 +29,7 @@ export const queryKeys = {
     pluginDetails: (pluginName: string) => ['marketplace', 'plugin', pluginName] as const,
     installed: ['marketplace', 'installed'] as const,
   },
+  github: {
+    repos: (query: string) => ['github-repos', query] as const,
+  },
 } as const;

--- a/frontend/src/hooks/queries/useGitHubQueries.ts
+++ b/frontend/src/hooks/queries/useGitHubQueries.ts
@@ -1,0 +1,13 @@
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { githubService } from '@/services/githubService';
+import { queryKeys } from '@/hooks/queries/queryKeys';
+
+export function useGitHubReposQuery(query: string, enabled: boolean) {
+  return useQuery({
+    queryKey: queryKeys.github.repos(query),
+    queryFn: () => githubService.searchRepositories(query, 1, 20),
+    enabled,
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/services/githubService.ts
+++ b/frontend/src/services/githubService.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '@/lib/api';
+import { ensureResponse, withAuth, buildQueryString } from '@/services/base/BaseService';
+import type { GitHubReposResponse } from '@/types/github.types';
+
+async function searchRepositories(
+  query: string,
+  page: number,
+  perPage: number,
+): Promise<GitHubReposResponse> {
+  return withAuth(async () => {
+    const qs = buildQueryString({ q: query, page, per_page: perPage });
+    const response = await apiClient.get<GitHubReposResponse>(`/github/repositories${qs}`);
+    return ensureResponse(response, 'Failed to fetch GitHub repositories');
+  });
+}
+
+export const githubService = {
+  searchRepositories,
+};

--- a/frontend/src/types/github.types.ts
+++ b/frontend/src/types/github.types.ts
@@ -1,0 +1,16 @@
+export interface GitHubRepo {
+  name: string;
+  full_name: string;
+  description: string | null;
+  language: string | null;
+  html_url: string;
+  clone_url: string;
+  private: boolean;
+  pushed_at: string | null;
+  stargazers_count: number;
+}
+
+export interface GitHubReposResponse {
+  items: GitHubRepo[];
+  has_more: boolean;
+}


### PR DESCRIPTION
## Summary

- Adds a searchable GitHub repo browser when creating a git workspace, replacing the plain URL input for users with a configured PAT
- Backend proxy endpoint (`GET /api/v1/github/repositories`) queries GitHub API using the stored token — lists user repos by default, searches on query
- Authenticated `git clone` for private repos via `GIT_ASKPASS` temp script (token never in argv, redacted from errors, restricted to `github.com` hosts)
- Falls back to plain URL input for non-GitHub repos or when no token is configured

## Test plan

- [ ] Configure a GitHub PAT in Settings
- [ ] Open workspace selector → Clone Git repo → verify repo list loads with user's repos
- [ ] Type in search → verify debounced search returns results
- [ ] Click a private repo → verify clone succeeds with "Cloning repository…" indicator
- [ ] Click "Paste URL" → verify toggle to plain URL input works
- [ ] Click "Browse repos" → verify toggle back to repo list
- [ ] Remove GitHub PAT → verify fallback to plain URL input with hint text
- [ ] Clone a non-GitHub HTTPS repo → verify no token injection