### PR TITLE
Fix toolbar selectors showing icons only on desktop

### DIFF
--- a/frontend/src/components/ui/primitives/Dropdown.tsx
+++ b/frontend/src/components/ui/primitives/Dropdown.tsx
@@ -125,12 +125,12 @@ function DropdownInner<T>({
   const labelClasses = showIconOnly
     ? forceCompact
       ? 'hidden whitespace-nowrap text-2xs font-medium text-text-primary dark:text-text-dark-secondary'
-      : 'hidden lg:inline whitespace-nowrap text-2xs font-medium text-text-primary dark:text-text-dark-secondary'
+      : 'hidden sm:inline whitespace-nowrap text-2xs font-medium text-text-primary dark:text-text-dark-secondary'
     : 'whitespace-nowrap text-2xs font-medium text-text-primary dark:text-text-dark-secondary';
   const chevronClasses = showIconOnly
     ? forceCompact
       ? 'hidden'
-      : 'hidden lg:block h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary transition-transform duration-200'
+      : 'hidden sm:block h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary transition-transform duration-200'
     : 'h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary transition-transform duration-200';
 
   return (
@@ -146,7 +146,7 @@ function DropdownInner<T>({
       >
         {LeftIcon && (
           <LeftIcon
-            className={`h-3 w-3 text-text-tertiary dark:text-text-dark-tertiary${forceCompact ? '' : 'lg:hidden'}`}
+            className={`h-3 w-3 text-text-tertiary dark:text-text-dark-tertiary${forceCompact ? '' : 'sm:hidden'}`}
           />
         )}
         <span className={labelClasses}>

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -86,18 +86,21 @@ export const useUIStore = create<UIStoreState>()(
     }),
     {
       name: 'ui-storage',
-      version: 1,
+      version: 2,
       partialize: (state) => ({
         theme: state.theme,
         permissionMode: state.permissionMode,
         thinkingMode: state.thinkingMode,
         currentView: state.currentView,
-        secondaryView: state.secondaryView,
-        isSplitMode: state.isSplitMode,
         splitDirection: state.splitDirection,
         sidebarOpen: state.sidebarOpen,
       }),
-      migrate: (persisted) => persisted as Record<string, unknown>,
+      migrate: (persisted) => {
+        const state = persisted as Record<string, unknown>;
+        delete state.isSplitMode;
+        delete state.secondaryView;
+        return state;
+      },
       merge: (persisted, current) => ({
         ...current,
         ...(persisted || {}),


### PR DESCRIPTION
## Summary
- **Root cause:** `isSplitMode` was persisted to localStorage — once a user entered split mode, `forceCompact` stayed `true` permanently, hiding selector labels even on desktop
- Removed `isSplitMode` and `secondaryView` from persisted UI state (transient, not preferences) and added a migration to strip stale values
- Lowered the responsive breakpoint from `lg` (1024px) to `sm` (640px) so labels appear on all non-mobile screens

## Test plan
- [ ] Open the app on a desktop browser — toolbar selectors should show text labels + chevrons, not just icons
- [ ] Resize to mobile width (< 640px) — selectors should collapse to icon-only
- [ ] Enter split mode, then exit — selectors should still show labels
- [ ] Clear localStorage and reload — verify preferences (theme, model, etc.) are preserved