### PR TITLE
Add collapsible file tree panel in editor

### DIFF
--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -1,5 +1,6 @@
-import { memo, useState, useCallback } from 'react';
+import { memo, useState, useCallback, useRef } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import type { ImperativePanelHandle } from 'react-resizable-panels';
 import { Tree } from '../file-tree/Tree';
 import { View } from '../editor-view/View';
 import type { FileStructure } from '@/types/file-system.types';
@@ -40,6 +41,18 @@ export const CodeView = memo(function CodeView({
   const backgroundClass = theme === 'light' ? 'bg-surface-secondary' : 'bg-surface-dark-secondary';
   const isMobile = useIsMobile();
   const [showMobileTree, setShowMobileTree] = useState(false);
+  const fileTreePanelRef = useRef<ImperativePanelHandle>(null);
+  const [isFileTreeCollapsed, setIsFileTreeCollapsed] = useState(false);
+
+  const handleToggleFileTree = useCallback(() => {
+    const panel = fileTreePanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) {
+      panel.expand();
+    } else {
+      panel.collapse();
+    }
+  }, []);
 
   const handleMobileFileSelect = useCallback(
     (file: FileStructure | null) => {
@@ -104,7 +117,16 @@ export const CodeView = memo(function CodeView({
   return (
     <div className="flex min-h-0 flex-1 overflow-hidden">
       <PanelGroup direction="horizontal" autoSaveId="code-view-layout">
-        <Panel defaultSize={20} minSize={15} maxSize={40}>
+        <Panel
+          ref={fileTreePanelRef}
+          defaultSize={20}
+          minSize={15}
+          maxSize={40}
+          collapsible
+          collapsedSize={0}
+          onCollapse={() => setIsFileTreeCollapsed(true)}
+          onExpand={() => setIsFileTreeCollapsed(false)}
+        >
           <div
             className={`h-full overflow-hidden border-r border-border dark:border-border-dark ${backgroundClass}`}
           >
@@ -119,6 +141,7 @@ export const CodeView = memo(function CodeView({
               isSandboxSyncing={isSandboxSyncing}
               onRefresh={onRefresh}
               isRefreshing={isRefreshing}
+              onClose={handleToggleFileTree}
             />
           </div>
         </Panel>
@@ -141,6 +164,7 @@ export const CodeView = memo(function CodeView({
               fileStructure={files}
               sandboxId={sandboxId}
               chatId={chatId}
+              onToggleFileTree={isFileTreeCollapsed ? handleToggleFileTree : undefined}
             />
           </div>
         </Panel>

--- a/frontend/src/components/editor/file-tree/Header.tsx
+++ b/frontend/src/components/editor/file-tree/Header.tsx
@@ -1,4 +1,4 @@
-import { Download, Loader2, RefreshCw, X } from 'lucide-react';
+import { Download, Loader2, PanelLeftClose, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { SearchInput } from './SearchInput';
 
@@ -70,10 +70,10 @@ export function Header({
               onClick={onClose}
               variant="unstyled"
               className="rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
-              title="Close"
+              title="Close file tree"
               aria-label="Close file tree"
             >
-              <X className="h-3 w-3" />
+              <PanelLeftClose className="h-3 w-3" />
             </Button>
           )}
         </div>

--- a/frontend/src/components/editor/file-tree/Item.tsx
+++ b/frontend/src/components/editor/file-tree/Item.tsx
@@ -22,7 +22,7 @@ export const Item = memo(function Item({ item, level, searchQuery = '', matchedP
   const isExpanded = isFolder && !!expandedFolders[item.path];
   const isSelected = selectedFile?.path === item.path;
 
-  const indentStyle = useMemo(() => ({ paddingLeft: `${level * 10 + 6}px` }), [level]);
+  const indentStyle = useMemo(() => ({ paddingLeft: `${level * 8 + 4}px` }), [level]);
 
   const handleClick = useCallback(() => {
     if (isFolder) {
@@ -39,7 +39,7 @@ export const Item = memo(function Item({ item, level, searchQuery = '', matchedP
         onClick={handleClick}
         variant="unstyled"
         className={cn(
-          'flex w-full items-center gap-1.5 px-1.5 py-[3px] text-left',
+          'flex w-full items-center gap-1 px-1.5 py-[3px] text-left',
           'rounded-md transition-colors duration-150',
           'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
           isSelected &&


### PR DESCRIPTION
## Summary
- Make the desktop editor file tree panel collapsible using `react-resizable-panels` imperative API
- Add a `PanelLeftClose` button in the file tree header to collapse it; a `PanelLeft` button appears in the editor header to re-open when collapsed
- Tighten file tree indentation (10→8 px/level) and item gap (6→4 px) to reduce truncation on deeply nested files

## Test plan
- [ ] Open the editor with a file tree visible
- [ ] Click the collapse button in the file tree header — tree should collapse fully
- [ ] Verify the PanelLeft re-open button appears in the editor header
- [ ] Click the re-open button — tree should expand back to previous size
- [ ] Drag the resize handle all the way left — should also collapse the panel
- [ ] Verify deeply nested files show more of their names than before
- [ ] Verify mobile file tree overlay still works as before