### PR TITLE
Fix missing PATH in host transport for CLI commands

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -1,4 +1,9 @@
+from pathlib import Path
 from typing import Final
+
+HOST_REQUIRED_PATH_PREFIX: Final[str] = (
+    f"{Path.home()}/.local/bin:/opt/homebrew/bin:/usr/local/bin"
+)
 
 MAX_RESOURCE_NAME_LENGTH: Final[int] = 50
 MIN_RESOURCE_NAME_LENGTH: Final[int] = 2

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -22,6 +22,7 @@ from app.constants import (
     CHECKPOINT_BASE_DIR,
     DOCKER_AVAILABLE_PORTS,
     EXCLUDED_PREVIEW_PORTS,
+    HOST_REQUIRED_PATH_PREFIX,
     OPENVSCODE_PORT,
     SANDBOX_BASHRC_PATH,
     SANDBOX_BINARY_EXTENSIONS,
@@ -66,7 +67,6 @@ LISTENING_PORTS_COMMAND = (
         " | grep -E '^[0-9]+$' | sort -u"
     )
 )
-HOST_REQUIRED_PATH_PREFIX = f"{Path.home()}/.local/bin:/opt/homebrew/bin:/usr/local/bin"
 
 
 class LocalHostProvider(SandboxProvider):

--- a/backend/app/services/transports/host.py
+++ b/backend/app/services/transports/host.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from claude_agent_sdk._errors import CLIConnectionError, ProcessError
 from claude_agent_sdk.types import ClaudeAgentOptions
 
-from app.constants import SANDBOX_HOME_DIR
+from app.constants import HOST_REQUIRED_PATH_PREFIX, SANDBOX_HOME_DIR
 from app.core.config import get_settings
 from app.services.transports.base import BaseSandboxTransport
 
@@ -80,11 +80,13 @@ class HostSandboxTransport(BaseSandboxTransport):
 
         command_args = shlex.split(self._build_command())
         envs, cwd, requested_user = self._prepare_environment()
+        current_path = os.environ.get("PATH", "")
         env = {
             **os.environ,
             **envs,
             "HOME": str(self._sandbox_dir),
             "USER": requested_user,
+            "PATH": f"{HOST_REQUIRED_PATH_PREFIX}:{current_path}",
         }
         run_user = self._resolve_run_user(requested_user)
 


### PR DESCRIPTION
## Summary
- Host transport spawns the Claude CLI subprocess without prepending standard host paths to `PATH`, causing commands like `docker`, `git`, etc. to fail with "command not found"
- Moved `HOST_REQUIRED_PATH_PREFIX` (`~/.local/bin:/opt/homebrew/bin:/usr/local/bin`) from `host_provider.py` to `constants.py` since it's now shared
- Prepend the path prefix to `PATH` in the host transport environment, matching what `execute_command` and `create_pty` already do

## Test plan
- [ ] Use host provider, verify Claude can run `git`, `docker`, and other `/usr/local/bin` commands without "command not found"