### PR TITLE
Fix drag-and-drop files not working in desktop app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ wheels/
 !.env
 
 .agents/
-.claude/
 **/.claude/settings.local.json
 
 # Celery beat artifacts

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "height": 800,
         "resizable": true,
         "visible": false,
-        "devtools": true
+        "devtools": true,
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
## Summary
- Tauri v2 defaults `dragDropEnabled` to `true` on windows, which intercepts file drop events at the native layer before they reach the webview's JavaScript
- This prevents the HTML5 `dataTransfer.files` API from receiving dropped files, breaking the existing `useDragAndDrop` hook in the desktop app
- Set `dragDropEnabled: false` in the Tauri window config to disable native interception and let the browser handle drag-drop normally

## Test plan
- [ ] Run the desktop app (`npm run desktop:dev`)
- [ ] Drag a file from Finder onto the chat input area — drop indicator should appear and file should attach
- [ ] Verify drag-and-drop also works in `FileUploadDialog` and `SettingsUploadModal`
- [ ] Confirm web app drag-and-drop is unaffected