### PR TITLE
Fix permission requests failing in desktop mode

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -187,6 +187,15 @@ class Settings(BaseSettings):
     # URL the permission server in host mode uses to reach the API
     HOST_PERMISSION_API_URL: str = "http://localhost:8080"
 
+    @field_validator("HOST_PERMISSION_API_URL", mode="before")
+    @classmethod
+    def set_host_permission_api_url(cls, v: str, info: ValidationInfo) -> str:
+        if v != "http://localhost:8080":
+            return v
+        if info.data.get("DESKTOP_MODE"):
+            return info.data.get("BASE_URL", v)
+        return v
+
     @field_validator("HOST_SANDBOX_BASE_DIR", mode="before")
     @classmethod
     def set_host_sandbox_base_dir(


### PR DESCRIPTION
## Summary
- In desktop mode, Tauri picks an ephemeral port for the backend sidecar, but `HOST_PERMISSION_API_URL` defaults to `http://localhost:8080`
- The permission server subprocess connects to port 8080 where nothing is listening, causing **every** permission request (plan mode, AskUserQuestion, etc.) to fail with "Network error"
- Added a `field_validator` on `HOST_PERMISSION_API_URL` that derives the URL from `BASE_URL` (which has the actual dynamic port) when `DESKTOP_MODE` is true and no explicit override is set

## Test plan
- [ ] Launch the desktop app
- [ ] Start a chat with host sandbox provider
- [ ] Trigger a permission request (e.g., plan mode or ask mode)
- [ ] Confirm the permission dialog appears and approve/reject works
- [ ] Verify web mode (non-desktop) is unaffected