### PR TITLE
Add preview fullscreen, fix host attachment paths, clean up dead props

### DIFF
--- a/backend/app/services/claude_agent.py
+++ b/backend/app/services/claude_agent.py
@@ -173,10 +173,13 @@ class ClaudeAgentService:
         result: StreamResult,
         session_callback: Callable[[str], None] | None = None,
         attachments: list[dict[str, Any]] | None = None,
+        attachment_base_dir: str = SANDBOX_HOME_DIR,
     ) -> AsyncIterator[StreamEvent]:
         # Send a prompt to the Claude SDK client and yield processed stream
         # events, handling plan mode transitions on tool success/failure.
-        user_prompt = self.prepare_user_prompt(prompt, custom_instructions, attachments)
+        user_prompt = self.prepare_user_prompt(
+            prompt, custom_instructions, attachments, attachment_base_dir
+        )
 
         prompt_message = {
             "type": "user",
@@ -527,6 +530,7 @@ class ClaudeAgentService:
         prompt: str,
         custom_instructions: str | None,
         attachments: list[dict[str, Any]] | None = None,
+        attachment_base_dir: str = SANDBOX_HOME_DIR,
     ) -> str:
         # Wrap the raw user prompt with XML-tagged context (instructions,
         # attachments) so the SDK can distinguish each section.
@@ -545,9 +549,11 @@ class ClaudeAgentService:
 
         if attachments:
             # Uploaded files are copied to the sandbox home dir with their
-            # original filename — reference that path so Claude can find them.
+            # UUID-based filename — reference the correct base path so Claude
+            # can find them (host mode uses the real workspace path, Docker
+            # uses /home/user).
             files_list = "\n".join(
-                f"- {SANDBOX_HOME_DIR}/{attachment['file_path'].split('/')[-1]}"
+                f"- {attachment_base_dir}/{attachment['file_path'].split('/')[-1]}"
                 for attachment in attachments
             )
             parts.append(

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -14,7 +14,12 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import selectinload
 
-from app.constants import REDIS_KEY_CHAT_CONTEXT_USAGE, REDIS_KEY_CHAT_STREAM_LIVE
+from app.constants import (
+    REDIS_KEY_CHAT_CONTEXT_USAGE,
+    REDIS_KEY_CHAT_STREAM_LIVE,
+    SANDBOX_HOME_DIR,
+)
+from app.services.sandbox_providers import SandboxProviderType
 from app.core.config import get_settings
 from app.db.session import SessionLocal
 from app.models.db_models.chat import Chat, Message
@@ -1041,6 +1046,11 @@ class ChatStreamRuntime:
                             params.options.permission_mode
                         )
                     stream_result = StreamResult()
+                    attachment_base_dir = SANDBOX_HOME_DIR
+                    if runtime.chat.sandbox_provider == SandboxProviderType.HOST:
+                        attachment_base_dir = (
+                            runtime.chat.workspace_path or SANDBOX_HOME_DIR
+                        )
                     stream = ai_service.stream_response(
                         client=session.client,
                         prompt=request.prompt,
@@ -1049,6 +1059,7 @@ class ChatStreamRuntime:
                         result=stream_result,
                         session_callback=session_callback,
                         attachments=request.attachments,
+                        attachment_base_dir=attachment_base_dir,
                     )
                     return await runtime.run(ai_service, stream_result, stream)
                 except (

--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -99,7 +99,7 @@ export const AssistantMessage = memo(function AssistantMessage({
           </div>
 
           {contentText.trim() && !isStreaming && (
-            <div className="mt-2 flex items-center justify-between opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+            <div className="mt-2 flex items-center justify-between">
               <MessageActions
                 messageId={id}
                 contentText={contentText}

--- a/frontend/src/components/editor/editor-view/Header.tsx
+++ b/frontend/src/components/editor/editor-view/Header.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { AlertTriangle, Code, FileText, Save, Loader2, PanelLeft } from 'lucide-react';
+import { AlertTriangle, Code, FileText, Save, Loader2, PanelLeft, Maximize2 } from 'lucide-react';
 import type { FileStructure } from '@/types/file-system.types';
 import { Button } from '@/components/ui/primitives/Button';
 import { isPreviewableFile } from '@/utils/fileTypes';
@@ -15,6 +15,7 @@ export interface HeaderProps {
   isSaving?: boolean;
   onSave?: () => void;
   onToggleFileTree?: () => void;
+  onToggleFullscreen?: () => void;
 }
 
 export const Header = memo(function Header({
@@ -27,6 +28,7 @@ export const Header = memo(function Header({
   isSaving = false,
   onSave,
   onToggleFileTree,
+  onToggleFullscreen,
 }: HeaderProps) {
   const isPreviewable = selectedFile ? isPreviewableFile(selectedFile) : false;
 
@@ -97,7 +99,7 @@ export const Header = memo(function Header({
             {showPreview ? (
               <>
                 <Code className="h-3 w-3" />
-                Code
+                Raw
               </>
             ) : (
               <>
@@ -105,6 +107,18 @@ export const Header = memo(function Header({
                 Preview
               </>
             )}
+          </Button>
+        )}
+
+        {showPreview && onToggleFullscreen && (
+          <Button
+            onClick={onToggleFullscreen}
+            variant="unstyled"
+            className="rounded-md p-1 text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+            title="Enter fullscreen"
+            aria-label="Enter fullscreen"
+          >
+            <Maximize2 className="h-3 w-3" />
           </Button>
         )}
       </div>

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -154,6 +154,37 @@ export const View = memo(function View({
     [setupEditorTheme],
   );
 
+  const [isPreviewFullscreen, setIsPreviewFullscreen] = useState(false);
+
+  const handleTogglePreviewFullscreen = useCallback(() => {
+    setIsPreviewFullscreen((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    if (!showPreview) {
+      setIsPreviewFullscreen(false);
+    }
+  }, [showPreview]);
+
+  useEffect(() => {
+    setIsPreviewFullscreen(false);
+  }, [selectedFile?.path]);
+
+  useEffect(() => {
+    if (!isPreviewFullscreen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsPreviewFullscreen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isPreviewFullscreen]);
+
   const isValidFile =
     selectedFile && findFileInStructure(fileStructure, selectedFile.path) !== undefined;
 
@@ -186,6 +217,9 @@ export const View = memo(function View({
         isSaving={updateFileMutation.isPending}
         onSave={handleUpdateFile}
         onToggleFileTree={onToggleFileTree}
+        onToggleFullscreen={
+          isPreviewable && showPreview ? handleTogglePreviewFullscreen : undefined
+        }
       />
 
       <div className="relative flex-1 overflow-hidden">
@@ -210,7 +244,11 @@ export const View = memo(function View({
 
         {isPreviewable && showPreview && fileForPreview && (
           <div className="h-full">
-            <FilePreview file={fileForPreview} showPreview={showPreview} />
+            <FilePreview
+              file={fileForPreview}
+              isFullscreen={isPreviewFullscreen}
+              onToggleFullscreen={handleTogglePreviewFullscreen}
+            />
           </div>
         )}
       </div>

--- a/frontend/src/components/editor/file-preview/FilePreview.tsx
+++ b/frontend/src/components/editor/file-preview/FilePreview.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useEffect, useCallback, useMemo, lazy, Suspense } from 'react';
+import { memo, useMemo, lazy, Suspense } from 'react';
 import type { ComponentType } from 'react';
 import { createPortal } from 'react-dom';
 import type { FileStructure } from '@/types/file-system.types';
@@ -55,57 +55,29 @@ const previewRenderers: PreviewRenderer[] = [
 
 export interface FilePreviewProps {
   file: FileStructure;
-  showPreview: boolean;
+  isFullscreen?: boolean;
+  onToggleFullscreen?: () => void;
 }
 
-export const FilePreview = memo(function FilePreview({ file, showPreview }: FilePreviewProps) {
-  const [isFullscreen, setIsFullscreen] = useState(false);
-
+export const FilePreview = memo(function FilePreview({
+  file,
+  isFullscreen = false,
+  onToggleFullscreen,
+}: FilePreviewProps) {
   const matchedPreview = useMemo(() => previewRenderers.find(({ match }) => match(file)), [file]);
 
-  const PreviewComponent = matchedPreview?.Component;
+  const MatchedComponent = matchedPreview?.Component;
 
-  const handleToggleFullscreen = useCallback(() => {
-    setIsFullscreen((prev) => !prev);
-  }, []);
-
-  useEffect(() => {
-    if (typeof document === 'undefined' || !isFullscreen) {
-      return;
-    }
-
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setIsFullscreen(false);
-      }
-    };
-
-    document.addEventListener('keydown', handleEscape);
-    return () => {
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [isFullscreen]);
-
-  useEffect(() => {
-    if (!showPreview) {
-      setIsFullscreen(false);
-    }
-  }, [showPreview]);
-
-  useEffect(() => {
-    setIsFullscreen(false);
-  }, [file.path]);
-
-  if (!showPreview || !PreviewComponent) {
+  if (!MatchedComponent) {
     return null;
   }
 
   const previewContent = (
     <Suspense fallback={null}>
-      <PreviewComponent
+      <MatchedComponent
         file={file}
         isFullscreen={isFullscreen}
-        onToggleFullscreen={handleToggleFullscreen}
+        onToggleFullscreen={onToggleFullscreen}
       />
     </Suspense>
   );

--- a/frontend/src/components/editor/file-preview/PreviewContainer.tsx
+++ b/frontend/src/components/editor/file-preview/PreviewContainer.tsx
@@ -20,11 +20,13 @@ export const PreviewContainer = memo(function PreviewContainer({
 }: PreviewContainerProps) {
   return (
     <div className={`flex flex-col ${previewBackgroundClass} h-full ${className}`}>
-      <PreviewHeader
-        fileName={fileName}
-        isFullscreen={isFullscreen}
-        onToggleFullscreen={onToggleFullscreen}
-      />
+      {isFullscreen && (
+        <PreviewHeader
+          fileName={fileName}
+          isFullscreen={isFullscreen}
+          onToggleFullscreen={onToggleFullscreen}
+        />
+      )}
 
       {disableContentWrapper ? (
         children


### PR DESCRIPTION
## Summary
- **Preview fullscreen**: Lift fullscreen state from `FilePreview` to `View`, add fullscreen toggle button (Maximize2) to editor header when preview is active, show `PreviewHeader` only in fullscreen mode
- **Host attachment paths**: Fix attachment base dir to use workspace path in host sandbox mode instead of hardcoded `/home/user`
- **Message actions**: Make always visible instead of hover-to-show
- **Cleanup**: Remove dead `showPreview` prop from `FilePreview`, remove redundant `.value` on `SandboxProviderType` enum comparison, rename preview toggle label from "Code" to "Raw"

## Test plan
- [ ] Open a previewable file (markdown, CSV, etc.) and verify the fullscreen button appears in the editor header
- [ ] Click fullscreen — verify the preview fills the screen with a header bar; press Escape to exit
- [ ] Switch files while in fullscreen — verify it exits fullscreen
- [ ] Toggle preview off while in fullscreen — verify it exits fullscreen
- [ ] Send a message with attachments in host sandbox mode — verify the attachment path references the workspace path
- [ ] Verify message actions (copy, etc.) are visible without hovering