### PR TITLE
Support gitignore negation patterns in file listing

### DIFF
--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import fnmatch
 import logging
 import posixpath
 import shlex
@@ -132,33 +133,87 @@ class SandboxProvider(ABC):
             logger.error("Error cleaning up PTY session %s", session_id)
 
     @staticmethod
-    def _build_gitignore_patterns(gitignore_content: str) -> list[str]:
-        patterns: list[str] = []
+    def _build_gitignore_patterns(
+        gitignore_content: str,
+    ) -> tuple[list[str], list[str]]:
+        # Gitignore-like (not strict Git) negation handling: we allow
+        # negations to re-include children of excluded parent directories
+        # (e.g. ".claude/" + "!.claude/plans/" shows plans/), which real
+        # Git does not support without first un-ignoring the parent.
+        # Directory-only semantics (trailing /) are also not enforced.
+        rules: list[tuple[bool, str]] = []
         for raw_line in gitignore_content.splitlines():
             line = raw_line.strip()
-            if not line or line.startswith("#") or line.startswith("!"):
+            if not line or line.startswith("#"):
                 continue
+            if line.startswith("!"):
+                neg = line[1:].strip().lstrip("/").rstrip("/")
+                if neg:
+                    rules.append((True, neg))
+            else:
+                normalized = line.lstrip("/")
+                if normalized:
+                    rules.append((False, normalized))
 
-            normalized = line.lstrip("/")
-            if not normalized:
+        patterns = SandboxProvider._expand_ignore_rules(rules)
+        exceptions = SandboxProvider._build_negation_exceptions(rules)
+        return patterns, exceptions
+
+    @staticmethod
+    def _expand_ignore_rules(rules: list[tuple[bool, str]]) -> list[str]:
+        patterns: list[str] = []
+        for is_neg, rule in rules:
+            if is_neg:
                 continue
-
-            if normalized.startswith("*."):
-                patterns.append(normalized)
+            if rule.startswith("*."):
+                patterns.append(rule)
                 continue
-
-            if normalized.endswith("/"):
-                folder = normalized.rstrip("/")
+            if rule.endswith("/"):
+                folder = rule.rstrip("/")
                 if not folder:
                     continue
                 patterns.extend([folder, f"{folder}/*", f"*/{folder}", f"*/{folder}/*"])
                 continue
-
-            patterns.extend(
-                [normalized, f"{normalized}/*", f"*/{normalized}", f"*/{normalized}/*"]
-            )
-
+            patterns.extend([rule, f"{rule}/*", f"*/{rule}", f"*/{rule}/*"])
         return list(dict.fromkeys(patterns))
+
+    @staticmethod
+    def _build_negation_exceptions(rules: list[tuple[bool, str]]) -> list[str]:
+        # A negation is only active if no later ignore rule
+        # re-matches the negated path (last rule wins).
+        active: list[str] = []
+        for idx, (is_neg, rule) in enumerate(rules):
+            if not is_neg:
+                continue
+            neg_basename = rule.rsplit("/", 1)[-1]
+            overridden = False
+            for later_is_neg, later in rules[idx + 1 :]:
+                if later_is_neg:
+                    continue
+                later_norm = later.rstrip("/")
+                if (
+                    fnmatch.fnmatch(rule, later_norm)
+                    or fnmatch.fnmatch(neg_basename, later_norm)
+                    or rule.startswith(f"{later_norm}/")
+                ):
+                    overridden = True
+                    break
+            if not overridden:
+                active.append(rule)
+
+        exceptions: list[str] = []
+        for neg in active:
+            if "/" in neg:
+                # Path negation: include ancestors so find can descend
+                # into parent dirs before reaching the negated subtree.
+                parts = neg.split("/")
+                for i in range(len(parts)):
+                    exceptions.append("/".join(parts[: i + 1]))
+                exceptions.append(f"{neg}/*")
+            else:
+                # Basename negation: match in any subdirectory.
+                exceptions.extend([neg, f"*/{neg}", f"{neg}/*", f"*/{neg}/*"])
+        return exceptions
 
     @staticmethod
     def _read_global_gitignore() -> str:
@@ -189,7 +244,7 @@ class SandboxProvider(ABC):
 
     async def _get_gitignore_patterns(
         self, sandbox_id: str, path: str = SANDBOX_HOME_DIR
-    ) -> list[str]:
+    ) -> tuple[list[str], list[str]]:
         cmd = f"cd {shlex.quote(path)} && {GITIGNORE_CMD}"
         result = await self.execute_command(
             sandbox_id,
@@ -201,7 +256,7 @@ class SandboxProvider(ABC):
         if global_ignore:
             parts = f"{parts}\n{global_ignore}"
         if not parts.strip():
-            return []
+            return [], []
         return self._build_gitignore_patterns(parts)
 
     @abstractmethod
@@ -255,27 +310,47 @@ class SandboxProvider(ABC):
     ) -> FileContent:
         pass
 
+    @staticmethod
+    def _find_prune_condition(p: str) -> str:
+        if p.startswith("*.") or p.startswith("."):
+            return f"-name {shlex.quote(p)}"
+        return f"-path {shlex.quote(p)}"
+
     async def list_files(
         self,
         sandbox_id: str,
         path: str = SANDBOX_HOME_DIR,
         excluded_patterns: list[str] | None = None,
     ) -> list[FileMetadata]:
-        patterns = list(excluded_patterns or [])
-        patterns.extend(await self._get_gitignore_patterns(sandbox_id, path))
-        patterns = list(dict.fromkeys(patterns))
+        caller_patterns = list(dict.fromkeys(excluded_patterns or []))
+        gitignore_patterns, exceptions = await self._get_gitignore_patterns(
+            sandbox_id, path
+        )
 
-        if patterns:
-            prune_conditions = [
-                f"-name {shlex.quote(p)}"
-                if p.startswith("*.") or p.startswith(".")
-                else f"-path {shlex.quote(p)}"
-                for p in patterns
-            ]
-            prune_expr = " -o ".join(prune_conditions)
+        prune_parts: list[str] = []
+        if caller_patterns:
+            caller_expr = " -o ".join(
+                self._find_prune_condition(p) for p in caller_patterns
+            )
+            prune_parts.append(f"\\( {caller_expr} \\)")
+        if gitignore_patterns:
+            gi_expr = " -o ".join(
+                self._find_prune_condition(p) for p in gitignore_patterns
+            )
+            exception_expr = ""
+            if exceptions:
+                exception_parts = [
+                    f"! -path {shlex.quote(f'{path}/{e}')}" for e in exceptions
+                ]
+                exception_expr = " " + " ".join(exception_parts)
+            prune_parts.append(f"\\( {gi_expr} \\){exception_expr}")
+
+        if prune_parts:
+            combined = " -o ".join(prune_parts)
             find_command = (
                 f"find {shlex.quote(path)} "
-                f"\\( {prune_expr} \\) -prune -o -printf '%p\\t%y\\t%s\\t%T@\\n'"
+                f"\\( {combined} \\) "
+                f"-prune -o -printf '%p\\t%y\\t%s\\t%T@\\n'"
             )
         else:
             find_command = f"find {shlex.quote(path)} -printf '%p\\t%y\\t%s\\t%T@\\n'"

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -267,17 +267,37 @@ class LocalHostProvider(SandboxProvider):
         return FileContent(path=path, content=content, type="file", is_binary=is_binary)
 
     @staticmethod
-    def _is_excluded_path(rel_path: str, name: str, patterns: list[str]) -> bool:
+    def _is_excluded_path(
+        rel_path: str,
+        name: str,
+        caller_patterns: list[str],
+        gitignore_patterns: list[str],
+        exceptions: list[str],
+    ) -> bool:
         full_path = f"{SANDBOX_HOME_DIR}/{rel_path}"
+        if any(
+            fnmatch.fnmatch(full_path, p)
+            or fnmatch.fnmatch(rel_path, p)
+            or fnmatch.fnmatch(name, p)
+            for p in caller_patterns
+        ):
+            return True
+        if any(fnmatch.fnmatch(rel_path, exc) for exc in exceptions):
+            return False
         return any(
-            fnmatch.fnmatch(full_path, pattern)
-            or fnmatch.fnmatch(rel_path, pattern)
-            or fnmatch.fnmatch(name, pattern)
-            for pattern in patterns
+            fnmatch.fnmatch(full_path, p)
+            or fnmatch.fnmatch(rel_path, p)
+            or fnmatch.fnmatch(name, p)
+            for p in gitignore_patterns
         )
 
     @staticmethod
-    def _walk_files(sandbox_dir: Path, patterns: list[str]) -> list[FileMetadata]:
+    def _walk_files(
+        sandbox_dir: Path,
+        caller_patterns: list[str],
+        gitignore_patterns: list[str],
+        exceptions: list[str],
+    ) -> list[FileMetadata]:
         items: list[FileMetadata] = []
         for root, dirnames, filenames in os.walk(sandbox_dir, topdown=True):
             root_path = Path(root)
@@ -287,7 +307,9 @@ class LocalHostProvider(SandboxProvider):
             kept_dirnames: list[str] = []
             for dirname in dirnames:
                 rel = f"{root_rel}/{dirname}" if root_rel else dirname
-                if LocalHostProvider._is_excluded_path(rel, dirname, patterns):
+                if LocalHostProvider._is_excluded_path(
+                    rel, dirname, caller_patterns, gitignore_patterns, exceptions
+                ):
                     continue
 
                 dir_path = root_path / dirname
@@ -310,7 +332,9 @@ class LocalHostProvider(SandboxProvider):
 
             for filename in filenames:
                 rel = f"{root_rel}/{filename}" if root_rel else filename
-                if LocalHostProvider._is_excluded_path(rel, filename, patterns):
+                if LocalHostProvider._is_excluded_path(
+                    rel, filename, caller_patterns, gitignore_patterns, exceptions
+                ):
                     continue
 
                 file_path = root_path / filename
@@ -339,12 +363,17 @@ class LocalHostProvider(SandboxProvider):
         excluded_patterns: list[str] | None = None,
     ) -> list[FileMetadata]:
         sandbox_dir = self._resolve_sandbox_dir(sandbox_id)
-        patterns = list(excluded_patterns or [])
-        patterns.extend(
-            await self._get_gitignore_patterns(sandbox_id, str(sandbox_dir))
+        caller_patterns = list(dict.fromkeys(excluded_patterns or []))
+        gitignore_patterns, exceptions = await self._get_gitignore_patterns(
+            sandbox_id, str(sandbox_dir)
         )
-        patterns = list(dict.fromkeys(patterns))
-        return await asyncio.to_thread(self._walk_files, sandbox_dir, patterns)
+        return await asyncio.to_thread(
+            self._walk_files,
+            sandbox_dir,
+            caller_patterns,
+            gitignore_patterns,
+            exceptions,
+        )
 
     @staticmethod
     def _resize_fd(fd: int, rows: int, cols: int) -> None:


### PR DESCRIPTION
## Summary
- Parse `!` negation lines in `.gitignore` instead of skipping them, so patterns like `!.claude/plans/` with `.claude/` correctly show the plans directory in the file tree
- Preserve gitignore rule order ("last match wins") — a negation followed by a later ignore rule that re-matches the same path is correctly overridden
- Support both path-based negations (`!.claude/plans/`) and basename negations (`!important.txt`) matching in any subdirectory
- Scope negation exceptions to gitignore rules only — caller-provided `excluded_patterns` (e.g. `.*` in Docker fallback mode) are never overridden by negations
- Apply changes to both Docker (find-based) and host (os.walk-based) provider paths

## Test plan
- [ ] Verify `.claude/plans/` appears in file tree when `.gitignore` contains `.claude/` and `!.claude/plans/`
- [ ] Verify other `.claude/` contents (e.g. `settings.json`) remain hidden
- [ ] Verify file listing still works correctly with no negation patterns in `.gitignore`
- [ ] Verify dot-directories remain hidden in Docker fallback mode (caller `.*` pattern not overridden)