### PR TITLE
Fix suggestion panels overlapping workspace selector

### DIFF
--- a/frontend/src/components/chat/message-input/MentionSuggestionsPanel.tsx
+++ b/frontend/src/components/chat/message-input/MentionSuggestionsPanel.tsx
@@ -36,7 +36,7 @@ export const MentionSuggestionsPanel = memo(function MentionSuggestionsPanel({
   if (!hasSuggestions) return null;
 
   return (
-    <div className="absolute bottom-full left-0 right-0 z-20 mb-2">
+    <div className="absolute bottom-full left-0 right-0 z-40 mb-2">
       <div className="max-h-64 overflow-y-auto rounded-lg border border-border bg-surface shadow-sm dark:border-border-dark dark:bg-surface-dark">
         <div className="py-1" role="listbox">
           {hasFiles && (

--- a/frontend/src/components/chat/message-input/SlashCommandsPanel.tsx
+++ b/frontend/src/components/chat/message-input/SlashCommandsPanel.tsx
@@ -16,8 +16,8 @@ export const SlashCommandsPanel = memo(function SlashCommandsPanel({
   if (suggestions.length === 0) return null;
 
   return (
-    <div className="absolute bottom-full left-0 right-0 z-20 mb-2">
-      <div className="rounded-lg border border-border bg-surface shadow-sm dark:border-border-dark dark:bg-surface-dark">
+    <div className="absolute bottom-full left-0 right-0 z-40 mb-2">
+      <div className="max-h-64 overflow-y-auto rounded-lg border border-border bg-surface shadow-sm dark:border-border-dark dark:bg-surface-dark">
         <div className="py-1" role="listbox">
           {suggestions.map((command, index) => {
             const isActive = index === highlightedIndex;


### PR DESCRIPTION
## Summary
- Bump z-index from `z-20` to `z-40` on `SlashCommandsPanel` and `MentionSuggestionsPanel` so they render above the workspace selector (`z-30`) on the landing page
- Add `max-h-64 overflow-y-auto` to `SlashCommandsPanel` to match `MentionSuggestionsPanel` and prevent unbounded list growth

## Test plan
- [ ] Type `/` in the landing page input — slash command menu should render above the workspace selector
- [ ] Type `@` in the landing page input — mention suggestions should render above the workspace selector
- [ ] Verify both panels still render correctly on the chat page