### PR TITLE
Fix skeleton flash when switching between streaming chats

### DIFF
--- a/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
+++ b/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
@@ -103,7 +103,6 @@ export function ChatSessionOrchestrator({
     fetchedMessages,
     chatId,
     selectedModelId,
-    hasMessages: messages.length > 0,
     initialPromptFromRoute,
     initialPromptSent,
     wasAborted,

--- a/frontend/src/hooks/useMessageInitialization.ts
+++ b/frontend/src/hooks/useMessageInitialization.ts
@@ -8,7 +8,6 @@ interface UseMessageInitializationParams {
   fetchedMessages: Message[];
   chatId: string | undefined;
   selectedModelId: string | null | undefined;
-  hasMessages: boolean;
   initialPromptFromRoute: string | null;
   initialPromptSent: boolean;
   wasAborted: boolean;
@@ -23,7 +22,6 @@ export function useMessageInitialization({
   fetchedMessages,
   chatId,
   selectedModelId,
-  hasMessages,
   initialPromptFromRoute,
   initialPromptSent,
   wasAborted,
@@ -33,14 +31,14 @@ export function useMessageInitialization({
   setMessages,
   setInitialPrompt,
 }: UseMessageInitializationParams) {
-  const hasMessagesRef = useRef(hasMessages);
-  hasMessagesRef.current = hasMessages;
+  const initializedChatRef = useRef<string | undefined>();
 
   useEffect(() => {
     if (!fetchedMessages || !chatId || isLoading || wasAborted) return;
 
-    // Skip reprocessing during streaming to preserve attachment references and prevent image flashing
-    if (isStreaming && hasMessagesRef.current) return;
+    // Skip reprocessing during streaming to preserve attachment references and prevent image flashing,
+    // but always allow initialization when switching to a different chat
+    if (isStreaming && initializedChatRef.current === chatId) return;
 
     const formattedMessages = fetchedMessages.map((msg: Message) => {
       const processedAttachments = msg.attachments?.map((attachment) => {
@@ -75,6 +73,8 @@ export function useMessageInitialization({
     if (latestKnownSeq > 0) {
       chatStorage.setEventId(chatId, String(latestKnownSeq));
     }
+
+    initializedChatRef.current = chatId;
 
     if (
       initialPromptFromRoute &&


### PR DESCRIPTION
## Summary
- Fixed `useMessageInitialization` skipping message population when switching between two streaming chats, causing the skeleton to persist until a React Query refetch
- Replaced `hasMessagesRef` (which carried stale state from the previous chat) with `initializedChatRef` that tracks which chatId was last initialized
- Removed the now-unused `hasMessages` prop from the hook interface

## Root cause
When switching from streaming Chat A to streaming Chat B, the guard `isStreaming && hasMessagesRef.current` evaluated to `true && true` using stale values from Chat A. This skipped initialization for Chat B. Then `setMessages([])` fired, leaving messages empty. On the next render, no effect deps had meaningfully changed (`isStreaming` was true before and still true), so the effect never re-fired — the skeleton persisted.

## How it works now
The guard `isStreaming && initializedChatRef.current === chatId` only skips reprocessing for the **same** chat (preserving the original purpose of preventing attachment reference churn and image flashing during streaming). On chat switch, the ref doesn't match the new chatId, so initialization always proceeds.

The ref is set unconditionally on every successful pass through the effect (not just when messages are populated), so empty chats also mark themselves as initialized correctly.

## Test plan
- [ ] Start streams in Chat A and Chat B, switch between them rapidly — no skeleton flash
- [ ] Open a chat not yet cached — skeleton appears during initial fetch as expected
- [ ] Open a new empty chat — no stuck skeleton
- [ ] Switch between completed (non-streaming) chats — no regression
- [ ] During active stream with image attachments — no image flashing on refetch