### PR TITLE
Fix skill deletion TypeError

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -365,9 +365,7 @@ class ChatService(BaseDbService[Chat]):
                         workspace_path=ws.workspace_path,
                     )
                     sandbox_service = SandboxService(provider)
-                    asyncio.create_task(
-                        sandbox_service.delete_sandbox(ws.sandbox_id)
-                    )
+                    asyncio.create_task(sandbox_service.delete_sandbox(ws.sandbox_id))
 
             return len(chat_ids)
 

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -56,7 +56,9 @@ class SkillService:
 
         return name
 
-    find_item_index_by_name = BaseMarkdownResourceService.find_item_index_by_name
+    find_item_index_by_name = staticmethod(
+        BaseMarkdownResourceService.find_item_index_by_name
+    )
 
     def validate_exact_sanitized_name(self, name: str) -> None:
         if self.sanitize_name(name) != name:


### PR DESCRIPTION
## Summary
- Fix `TypeError: BaseMarkdownResourceService.find_item_index_by_name() takes 2 positional arguments but 3 were given` when deleting a skill
- `SkillService` copies `find_item_index_by_name` from `BaseMarkdownResourceService` but doesn't inherit from it — without `staticmethod()`, Python passes `self` as an extra argument

## Test plan
- [ ] Delete a skill and verify it succeeds without errors