### PR TITLE
Fix resource deployment to use direct writes instead of shell extraction

### DIFF
--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -375,10 +375,10 @@ class SandboxService:
                 for entry in skill_zip.namelist():
                     if entry.endswith("/"):
                         continue
-                    content = skill_zip.read(entry)
+                    file_bytes = skill_zip.read(entry)
                     rel = entry[len(prefix) :] if entry.startswith(prefix) else entry
                     remote_path = f"{SANDBOX_CLAUDE_DIR}/skills/{skill_name}/{rel}"
-                    writes.append((remote_path, content))
+                    writes.append((remote_path, file_bytes))
 
         for command in enabled_commands:
             command_name = command["name"]


### PR DESCRIPTION
## Summary
- Replace the zip → base64-encode → shell `base64 -d | unzip` pipeline in `_deploy_resources` with direct `provider.write_file()` calls, fixing silent deployment failures on Host provider
- Parallelize all file writes with `asyncio.TaskGroup` to avoid N+1 sequential round-trips
- Strip skill-name prefix from zip entries to fix double-nested folder structure (`skills/pptx/pptx/...`)

## Test plan
- [ ] Host provider: create new workspace with an uploaded skill — verify files exist under `.claude/skills/<name>/` without double-nesting
- [ ] Host provider: create new workspace with an uploaded command — verify `.claude/commands/<name>.md` exists
- [ ] Host provider: create new workspace with an uploaded agent — verify `.claude/agents/<name>.md` exists
- [ ] Mixed resources (skill + command + agent) — verify all present after workspace creation
- [ ] Manually remove a stored artifact before init — confirm warning logged, remaining resources still deploy
- [ ] Verify deployment failure surfaces as a visible error instead of silent success