### PR TITLE
Fix terminal labels to stay sequential after create/close

### DIFF
--- a/frontend/src/components/sandbox/terminal/Container.tsx
+++ b/frontend/src/components/sandbox/terminal/Container.tsx
@@ -79,7 +79,7 @@ export const Container: FC<ContainerProps> = ({ sandboxId, chatId, isVisible, pa
 
       const newTerminal: TerminalInstance = {
         id: `terminal-${panelKey}-${nextNumber}`,
-        label: `Terminal ${nextNumber}`,
+        label: `Terminal ${prev.length + 1}`,
       };
 
       setActiveTerminalId(newTerminal.id);
@@ -113,7 +113,7 @@ export const Container: FC<ContainerProps> = ({ sandboxId, chatId, isVisible, pa
           return current;
         });
 
-        return filtered;
+        return filtered.map((t, i) => ({ ...t, label: `Terminal ${i + 1}` }));
       });
       setClosingTerminalIds((prev) => {
         const next = new Set(prev);


### PR DESCRIPTION
## Summary
- New terminals now use `prev.length + 1` for their label instead of tracking `nextNumber`, ensuring sequential numbering
- Closing a terminal re-labels remaining terminals sequentially (`Terminal 1`, `Terminal 2`, ...) instead of leaving gaps

## Test plan
- [ ] Open multiple terminals, verify labels are `Terminal 1`, `Terminal 2`, etc.
- [ ] Close a middle terminal, verify remaining terminals renumber sequentially
- [ ] Create new terminals after closing, verify numbering stays correct