### PR TITLE
Fix git authentication failure in host provider

### DIFF
--- a/backend/app/services/transports/host.py
+++ b/backend/app/services/transports/host.py
@@ -43,6 +43,14 @@ class HostSandboxTransport(BaseSandboxTransport):
         else:
             self._workspace_dir = self._home_dir
 
+    def _resolve_virtual_env_paths(self, envs: dict[str, str]) -> dict[str, str]:
+        return {
+            key: str(self._resolve_cwd(value))
+            if value.startswith(SANDBOX_HOME_DIR)
+            else value
+            for key, value in envs.items()
+        }
+
     def _resolve_cwd(self, cwd: str) -> Path:
         if cwd == SANDBOX_HOME_DIR:
             return self._home_dir
@@ -91,6 +99,7 @@ class HostSandboxTransport(BaseSandboxTransport):
 
         command_args = shlex.split(self._build_command())
         envs, cwd, requested_user = self._prepare_environment()
+        envs = self._resolve_virtual_env_paths(envs)
         current_path = os.environ.get("PATH", "")
         env = {
             **os.environ,


### PR DESCRIPTION
## Summary
- Fix `GIT_ASKPASS` pointing to non-existent virtual path (`/home/user/.git-askpass.sh`) when using the host sandbox provider
- Resolve virtual sandbox paths in environment variable values to real host paths before passing them to the Claude CLI process
- Reuse existing `_resolve_cwd` method to avoid duplicating path-mapping logic

## Test plan
- [ ] Configure a GitHub PAT in settings and use the host provider
- [ ] Verify git clone/push/pull operations work without `fatal: cannot run /home/user/.git-askpass.sh` errors