### PR TITLE
Add git branch selector to workspace modal

### DIFF
--- a/backend/app/api/endpoints/sandbox.py
+++ b/backend/app/api/endpoints/sandbox.py
@@ -1,3 +1,5 @@
+import asyncio
+import re
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
@@ -10,6 +12,9 @@ from app.models.schemas.sandbox import (
     BrowserStatusResponse,
     FileContentResponse,
     FileMetadata,
+    GitBranchesResponse,
+    GitCheckoutRequest,
+    GitCheckoutResponse,
     GitDiffResponse,
     IDEUrlResponse,
     SandboxFilesMetadataResponse,
@@ -30,6 +35,9 @@ from app.services.sandbox import SandboxService
 
 
 router = APIRouter()
+
+GIT_CD_PREFIX = f"cd {SANDBOX_WORKSPACE_DIR} 2>/dev/null || cd {SANDBOX_HOME_DIR}; "
+BRANCH_NAME_RE = re.compile(r"^[\w./-]+$")
 
 
 @router.get("/{sandbox_id}/preview-links", response_model=PreviewLinksResponse)
@@ -260,11 +268,10 @@ async def get_git_diff(
 ) -> GitDiffResponse:
     # Workspace is mounted at /home/user/workspace in Docker containers;
     # cd there first, falling back to /home/user for non-Docker sandboxes.
-    cd_prefix = f"cd {SANDBOX_WORKSPACE_DIR} 2>/dev/null || cd {SANDBOX_HOME_DIR}; "
     try:
         check = await sandbox_service.execute_command(
             sandbox_id,
-            f"{cd_prefix}git rev-parse --is-inside-work-tree 2>/dev/null",
+            f"{GIT_CD_PREFIX}git rev-parse --is-inside-work-tree 2>/dev/null",
         )
         if check.exit_code != 0:
             return GitDiffResponse(diff="", has_changes=False, is_git_repo=False)
@@ -297,7 +304,9 @@ async def get_git_diff(
                 f"{untracked_diff}"
             )
 
-        result = await sandbox_service.execute_command(sandbox_id, f"{cd_prefix}{cmd}")
+        result = await sandbox_service.execute_command(
+            sandbox_id, f"{GIT_CD_PREFIX}{cmd}"
+        )
         if mode == "branch" and result.exit_code == 2:
             return GitDiffResponse(
                 diff="",
@@ -310,6 +319,128 @@ async def get_git_diff(
             diff=diff_output,
             has_changes=bool(diff_output.strip()),
             is_git_repo=True,
+        )
+    except SandboxException as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.get("/{sandbox_id}/git/branches", response_model=GitBranchesResponse)
+async def get_git_branches(
+    sandbox_id: str = Depends(validate_sandbox_ownership),
+    sandbox_service: SandboxService = Depends(get_sandbox_service),
+) -> GitBranchesResponse:
+    try:
+        check = await sandbox_service.execute_command(
+            sandbox_id,
+            f"{GIT_CD_PREFIX}git rev-parse --is-inside-work-tree 2>/dev/null",
+        )
+        if check.exit_code != 0:
+            return GitBranchesResponse(
+                branches=[], current_branch="", is_git_repo=False
+            )
+
+        head_result, local_result, remote_result = await asyncio.gather(
+            sandbox_service.execute_command(
+                sandbox_id,
+                f"{GIT_CD_PREFIX}git rev-parse --abbrev-ref HEAD 2>/dev/null",
+            ),
+            sandbox_service.execute_command(
+                sandbox_id,
+                f"{GIT_CD_PREFIX}git branch --no-color 2>/dev/null",
+            ),
+            sandbox_service.execute_command(
+                sandbox_id,
+                f"{GIT_CD_PREFIX}git branch -r --no-color 2>/dev/null",
+            ),
+        )
+        current_branch = head_result.stdout.strip()
+
+        local_branches: set[str] = set()
+        for line in local_result.stdout.splitlines():
+            name = line.removeprefix("* ").strip()
+            if name:
+                local_branches.add(name)
+
+        all_branches = set(local_branches)
+        for line in remote_result.stdout.splitlines():
+            name = line.strip()
+            if not name or " -> " in name or not name.startswith("origin/"):
+                continue
+            short = name.removeprefix("origin/")
+            if short not in all_branches:
+                all_branches.add(short)
+
+        sorted_branches = sorted(all_branches)
+        return GitBranchesResponse(
+            branches=sorted_branches,
+            current_branch=current_branch,
+            is_git_repo=True,
+        )
+    except SandboxException as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.post("/{sandbox_id}/git/checkout", response_model=GitCheckoutResponse)
+async def checkout_git_branch(
+    request: GitCheckoutRequest,
+    sandbox_id: str = Depends(validate_sandbox_ownership),
+    sandbox_service: SandboxService = Depends(get_sandbox_service),
+) -> GitCheckoutResponse:
+    if (
+        not BRANCH_NAME_RE.match(request.branch)
+        or ".." in request.branch
+        or request.branch.strip(".") == ""
+        or request.branch.startswith("-")
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid branch name",
+        )
+
+    try:
+        result = await sandbox_service.execute_command(
+            sandbox_id,
+            f"{GIT_CD_PREFIX}git checkout '{request.branch}' 2>&1",
+        )
+        if result.exit_code != 0:
+            # Branch might only exist as a remote tracking branch
+            result = await sandbox_service.execute_command(
+                sandbox_id,
+                f"{GIT_CD_PREFIX}git checkout -b '{request.branch}' 'origin/{request.branch}' 2>&1",
+            )
+
+        if result.exit_code != 0:
+            return GitCheckoutResponse(
+                success=False,
+                current_branch="",
+                error=result.stdout.strip() or result.stderr.strip(),
+            )
+
+        head_result = await sandbox_service.execute_command(
+            sandbox_id,
+            f"{GIT_CD_PREFIX}git rev-parse --abbrev-ref HEAD 2>/dev/null",
+        )
+        current = head_result.stdout.strip()
+        if current == "HEAD":
+            # Detached HEAD — revert to previous state
+            await sandbox_service.execute_command(
+                sandbox_id,
+                f"{GIT_CD_PREFIX}git checkout - 2>/dev/null",
+            )
+            return GitCheckoutResponse(
+                success=False,
+                current_branch="",
+                error="Cannot checkout: would result in detached HEAD",
+            )
+        return GitCheckoutResponse(
+            success=True,
+            current_branch=current,
         )
     except SandboxException as e:
         raise HTTPException(

--- a/backend/app/models/schemas/sandbox.py
+++ b/backend/app/models/schemas/sandbox.py
@@ -74,3 +74,19 @@ class GitDiffResponse(BaseModel):
     has_changes: bool
     is_git_repo: bool
     error: str | None = None
+
+
+class GitBranchesResponse(BaseModel):
+    branches: list[str]
+    current_branch: str
+    is_git_repo: bool
+
+
+class GitCheckoutRequest(BaseModel):
+    branch: str = Field(..., min_length=1, max_length=256)
+
+
+class GitCheckoutResponse(BaseModel):
+    success: bool
+    current_branch: str
+    error: str | None = None

--- a/frontend/src/components/chat/WorkspaceSelector.tsx
+++ b/frontend/src/components/chat/WorkspaceSelector.tsx
@@ -1,6 +1,18 @@
 import { useState, useCallback, useEffect, useMemo, memo } from 'react';
 import toast from 'react-hot-toast';
-import { FolderOpen, Search, GitBranch, Plus, Box, HardDrive, Lock, Loader2 } from 'lucide-react';
+import {
+  FolderOpen,
+  Search,
+  GitBranch,
+  Plus,
+  Box,
+  HardDrive,
+  Lock,
+  Loader2,
+  ChevronDown,
+  ChevronRight,
+  Check,
+} from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { ModalHeader } from '@/components/ui/shared/ModalHeader';
@@ -10,6 +22,7 @@ import {
 } from '@/hooks/queries/useWorkspaceQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
 import { useGitHubReposQuery } from '@/hooks/queries/useGitHubQueries';
+import { useGitBranchesQuery, useCheckoutBranchMutation } from '@/hooks/queries/useSandboxQueries';
 import type { Workspace } from '@/types/workspace.types';
 import type { GitHubRepo } from '@/types/github.types';
 import { formatRelativeTime } from '@/utils/date';
@@ -64,6 +77,191 @@ function sourceIcon(sourceType: string | null | undefined) {
     default:
       return <Box className={cls} />;
   }
+}
+
+function WorkspaceItem({
+  ws,
+  isSelected,
+  chatCount,
+  isModalOpen,
+  onSelect,
+}: {
+  ws: Workspace;
+  isSelected: boolean;
+  chatCount: number;
+  isModalOpen: boolean;
+  onSelect: (ws: Workspace) => void;
+}) {
+  const [branchesExpanded, setBranchesExpanded] = useState(false);
+  const [branchSearch, setBranchSearch] = useState('');
+  const hasSandbox = !!ws.sandbox_id;
+
+  const { data: branchesData, isLoading: branchesLoading } = useGitBranchesQuery(
+    ws.sandbox_id ?? '',
+    isModalOpen && hasSandbox,
+  );
+  const checkoutBranch = useCheckoutBranchMutation();
+
+  const showBranchSelector = branchesData?.is_git_repo === true;
+  const branches = branchesData?.branches ?? [];
+  const filteredBranches = branchSearch
+    ? branches.filter((b) => b.toLowerCase().includes(branchSearch.toLowerCase()))
+    : branches;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => {
+          setBranchesExpanded(false);
+          setBranchSearch('');
+          onSelect(ws);
+        }}
+        className={cn(
+          'flex w-full items-start gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors duration-200',
+          isSelected
+            ? 'bg-surface-active dark:bg-surface-dark-active'
+            : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+        )}
+      >
+        {sourceIcon(ws.source_type)}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate text-xs text-text-primary dark:text-text-dark-primary">
+              {ws.name}
+            </span>
+            <span className="shrink-0 rounded-full bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-tertiary dark:bg-surface-dark-tertiary dark:text-text-dark-tertiary">
+              {ws.source_type ?? 'empty'}
+            </span>
+            <span className="shrink-0 rounded-full bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-tertiary dark:bg-surface-dark-tertiary dark:text-text-dark-tertiary">
+              {ws.sandbox_provider === 'host' ? 'host' : 'docker'}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+            <span>{formatRelativeTime(ws.updated_at)}</span>
+            {chatCount > 0 && (
+              <>
+                <span>·</span>
+                <span>
+                  {chatCount} {chatCount === 1 ? 'chat' : 'chats'}
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+      </button>
+      {showBranchSelector && (
+        <div className="ml-6 mt-0.5">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              if (branchesExpanded) setBranchSearch('');
+              setBranchesExpanded(!branchesExpanded);
+            }}
+            className="flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-left transition-colors duration-200 hover:bg-surface-hover dark:hover:bg-surface-dark-hover"
+          >
+            {branchesExpanded ? (
+              <ChevronDown className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+            ) : (
+              <ChevronRight className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+            )}
+            <GitBranch className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+            <span className="truncate font-mono text-2xs text-text-secondary dark:text-text-dark-secondary">
+              {branchesData?.current_branch || '…'}
+            </span>
+          </button>
+          {branchesExpanded && (
+            <div className="mt-0.5 overflow-hidden rounded-md border border-border/50 dark:border-border-dark/50">
+              {branchesLoading ? (
+                <div className="flex items-center justify-center gap-1.5 px-2 py-3">
+                  <Loader2 className="h-3 w-3 animate-spin text-text-quaternary dark:text-text-dark-quaternary" />
+                  <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                    Loading branches…
+                  </span>
+                </div>
+              ) : !branches.length ? (
+                <p className="px-2 py-3 text-center text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                  No branches found
+                </p>
+              ) : (
+                <>
+                  {branches.length >= 6 && (
+                    <div className="border-b border-border/50 px-2 py-1 dark:border-border-dark/50">
+                      <input
+                        type="text"
+                        value={branchSearch}
+                        onChange={(e) => setBranchSearch(e.target.value)}
+                        onClick={(e) => e.stopPropagation()}
+                        placeholder="Search branches…"
+                        className="w-full bg-transparent text-2xs text-text-primary outline-none placeholder:text-text-quaternary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary"
+                      />
+                    </div>
+                  )}
+                  <div className="max-h-[10rem] overflow-y-auto">
+                    {filteredBranches.length === 0 ? (
+                      <p className="px-2 py-2 text-center text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                        No matching branches
+                      </p>
+                    ) : (
+                      <div className="flex flex-col py-0.5">
+                        {filteredBranches.map((branch) => {
+                          const isCurrent = branch === branchesData.current_branch;
+                          return (
+                            <button
+                              key={branch}
+                              type="button"
+                              disabled={checkoutBranch.isPending}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (isCurrent) return;
+                                checkoutBranch.mutate(
+                                  { sandboxId: ws.sandbox_id, branch },
+                                  {
+                                    onSuccess: (data) => {
+                                      if (data.success) {
+                                        toast.success(`Switched to ${branch}`);
+                                      } else {
+                                        toast.error(data.error ?? 'Failed to switch branch');
+                                      }
+                                    },
+                                    onError: (err) => {
+                                      toast.error(
+                                        err instanceof Error
+                                          ? err.message
+                                          : 'Failed to switch branch',
+                                      );
+                                    },
+                                  },
+                                );
+                              }}
+                              className={cn(
+                                'flex w-full items-center gap-1.5 px-2 py-1 text-left text-2xs transition-colors duration-200 disabled:opacity-50',
+                                isCurrent
+                                  ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
+                                  : 'text-text-secondary hover:bg-surface-hover dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover',
+                              )}
+                            >
+                              {isCurrent ? (
+                                <Check className="h-3 w-3 shrink-0" />
+                              ) : (
+                                <span className="h-3 w-3 shrink-0" />
+                              )}
+                              <span className="truncate font-mono">{branch}</span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
 }
 
 const GitHubRepoItem = memo(function GitHubRepoItem({
@@ -162,7 +360,6 @@ export function WorkspaceSelector({
   const [repoSearchQuery, setRepoSearchQuery] = useState('');
   const [debouncedRepoQuery, setDebouncedRepoQuery] = useState('');
   const [showUrlInput, setShowUrlInput] = useState(false);
-
   useEffect(() => {
     setSandboxProvider(defaultProvider);
   }, [defaultProvider]);
@@ -323,48 +520,16 @@ export function WorkspaceSelector({
               </p>
             ) : (
               <div className="flex flex-col gap-0.5">
-                {visibleWorkspaces.map((ws) => {
-                  const chatCount = chatCountByWorkspace?.get(ws.id) ?? 0;
-                  return (
-                    <button
-                      key={ws.id}
-                      type="button"
-                      onClick={() => selectWorkspace(ws)}
-                      className={cn(
-                        'flex w-full items-start gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors duration-200',
-                        ws.id === selectedWorkspaceId
-                          ? 'bg-surface-active dark:bg-surface-dark-active'
-                          : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-                      )}
-                    >
-                      {sourceIcon(ws.source_type)}
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-1.5">
-                          <span className="truncate text-xs text-text-primary dark:text-text-dark-primary">
-                            {ws.name}
-                          </span>
-                          <span className="shrink-0 rounded-full bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-tertiary dark:bg-surface-dark-tertiary dark:text-text-dark-tertiary">
-                            {ws.source_type ?? 'empty'}
-                          </span>
-                          <span className="shrink-0 rounded-full bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-tertiary dark:bg-surface-dark-tertiary dark:text-text-dark-tertiary">
-                            {ws.sandbox_provider === 'host' ? 'host' : 'docker'}
-                          </span>
-                        </div>
-                        <div className="flex items-center gap-1.5 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-                          <span>{formatRelativeTime(ws.updated_at)}</span>
-                          {chatCount > 0 && (
-                            <>
-                              <span>·</span>
-                              <span>
-                                {chatCount} {chatCount === 1 ? 'chat' : 'chats'}
-                              </span>
-                            </>
-                          )}
-                        </div>
-                      </div>
-                    </button>
-                  );
-                })}
+                {visibleWorkspaces.map((ws) => (
+                  <WorkspaceItem
+                    key={ws.id}
+                    ws={ws}
+                    isSelected={ws.id === selectedWorkspaceId}
+                    chatCount={chatCountByWorkspace?.get(ws.id) ?? 0}
+                    isModalOpen={isModalOpen}
+                    onSelect={selectWorkspace}
+                  />
+                ))}
               </div>
             )}
           </div>

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -20,6 +20,8 @@ export const queryKeys = {
     browserStatus: (sandboxId: string) => ['sandbox', sandboxId, 'browser-status'] as const,
     gitDiff: (sandboxId: string, mode: DiffMode) =>
       ['sandbox', sandboxId, 'git-diff', mode] as const,
+    gitDiffAll: (sandboxId: string) => ['sandbox', sandboxId, 'git-diff'] as const,
+    gitBranches: (sandboxId: string) => ['sandbox', sandboxId, 'git-branches'] as const,
   },
   workspaces: ['workspaces'] as const,
   models: 'models',

--- a/frontend/src/hooks/queries/useSandboxQueries.ts
+++ b/frontend/src/hooks/queries/useSandboxQueries.ts
@@ -148,6 +148,37 @@ export const useDeleteSecretMutation = (
 ) =>
   useSecretMutation(({ sandboxId, key }) => sandboxService.deleteSecret(sandboxId, key), options);
 
+export const useGitBranchesQuery = (sandboxId: string, enabled: boolean) => {
+  return useQuery({
+    queryKey: queryKeys.sandbox.gitBranches(sandboxId),
+    queryFn: () => sandboxService.getGitBranches(sandboxId),
+    enabled: !!sandboxId && enabled,
+    staleTime: 30_000,
+  });
+};
+
+export const useCheckoutBranchMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ sandboxId, branch }: { sandboxId: string; branch: string }) =>
+      sandboxService.checkoutGitBranch(sandboxId, branch),
+    onSuccess: (data, variables) => {
+      if (!data.success) return;
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.sandbox.gitBranches(variables.sandboxId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.sandbox.filesMetadata(variables.sandboxId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.sandbox.gitDiffAll(variables.sandboxId),
+        }),
+      ]);
+    },
+  });
+};
+
 export const useGitDiffQuery = (
   sandboxId: string,
   mode: DiffMode = 'all',

--- a/frontend/src/services/sandboxService.ts
+++ b/frontend/src/services/sandboxService.ts
@@ -6,6 +6,8 @@ import type {
   DiffMode,
   FileContent,
   FileMetadata,
+  GitBranchesData,
+  GitCheckoutData,
   GitDiffData,
   PortInfo,
   Secret,
@@ -227,6 +229,27 @@ async function getGitDiff(sandboxId: string, mode: DiffMode = 'all'): Promise<Gi
   });
 }
 
+async function getGitBranches(sandboxId: string): Promise<GitBranchesData> {
+  validateRequired(sandboxId, 'Sandbox ID');
+
+  return serviceCall(async () => {
+    const response = await apiClient.get<GitBranchesData>(`/sandbox/${sandboxId}/git/branches`);
+    return response ?? { branches: [], current_branch: '', is_git_repo: false };
+  });
+}
+
+async function checkoutGitBranch(sandboxId: string, branch: string): Promise<GitCheckoutData> {
+  validateRequired(sandboxId, 'Sandbox ID');
+  validateRequired(branch, 'Branch name');
+
+  return serviceCall(async () => {
+    const response = await apiClient.post<GitCheckoutData>(`/sandbox/${sandboxId}/git/checkout`, {
+      branch,
+    });
+    return ensureResponse(response, 'Checkout failed');
+  });
+}
+
 export const sandboxService = {
   getPreviewLinks,
   getSandboxFilesMetadata,
@@ -244,4 +267,6 @@ export const sandboxService = {
   stopBrowser,
   getBrowserStatus,
   getGitDiff,
+  getGitBranches,
+  checkoutGitBranch,
 };

--- a/frontend/src/types/sandbox.types.ts
+++ b/frontend/src/types/sandbox.types.ts
@@ -46,3 +46,15 @@ export interface GitDiffData {
   is_git_repo: boolean;
   error?: string;
 }
+
+export interface GitBranchesData {
+  branches: string[];
+  current_branch: string;
+  is_git_repo: boolean;
+}
+
+export interface GitCheckoutData {
+  success: boolean;
+  current_branch: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
- Add branch list and checkout endpoints to the sandbox API (`GET /git/branches`, `POST /git/checkout`)
- Show an expandable branch selector inside the workspace modal for git-sourced workspaces
- Lazy-load branches only when the user expands the selector, with 30s stale time
- Validate branch names server-side (regex allowlist, reject `..`, `.`-only names, and leading `-`)
- Gate success toast on actual checkout result to avoid false confirmation on failure

## Test plan
- [ ] Open workspace selector, select a git workspace — verify branch expander appears
- [ ] Expand branches — verify current branch is highlighted with a checkmark
- [ ] Click a different branch — verify toast shows success and branch updates
- [ ] Trigger a checkout failure (e.g. uncommitted changes) — verify error toast, not success
- [ ] Collapse and re-expand — verify branches load from cache (no spinner if within 30s)
- [ ] Switch to a non-git workspace — verify no branch selector shown