### PR TITLE
Symlink .config in host sandbox to preserve CLI credentials

### DIFF
--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -100,6 +100,11 @@ class LocalHostProvider(SandboxProvider):
         bash_profile = home_dir / ".bash_profile"
         if not bash_profile.exists():
             bash_profile.write_text("[ -f ~/.bashrc ] && source ~/.bashrc\n")
+        # Symlink .config so CLI tools (gws, etc.) find host credentials despite HOME override
+        real_config = Path.home() / ".config"
+        sandbox_config = home_dir / ".config"
+        if real_config.is_dir() and not sandbox_config.exists():
+            sandbox_config.symlink_to(real_config)
 
     def bind_workspace(self, sandbox_id: str, workspace_path: str) -> None:
         home_dir = (self._base_dir / sandbox_id).resolve()


### PR DESCRIPTION
## Summary
- The host provider overrides `HOME` to the sandbox directory, which breaks CLI tools (gws, gcloud, docker, etc.) that resolve credentials via `~/.config/`
- Symlinks `.config` in the sandbox home to the real user's `~/.config/` so all config-based CLI tools work without tool-specific env var workarounds

## Test plan
- [ ] Verified `gws auth status` works with symlinked `.config` under overridden `HOME`
- [ ] Create a new workspace with host provider, confirm `.config` symlink exists in sandbox home
- [ ] Run a CLI tool that uses `~/.config/` credentials from within the sandbox