### PR TITLE
Fix git commit identity not linked to GitHub profile in host provider

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -162,6 +162,11 @@ class Settings(BaseSettings):
     # Git configuration
     GIT_AUTHOR_NAME: str = ""
     GIT_AUTHOR_EMAIL: str = ""
+    # Resolved once at startup so host-provider subprocesses (which override
+    # HOME to the sandbox dir) still read the real user's global git config
+    # and GPG keyring for commit signing.
+    GIT_CONFIG_GLOBAL: str = str(Path.home() / ".gitconfig")
+    GNUPGHOME: str = str(Path.home() / ".gnupg")
 
     # Docker Sandbox configuration
     DOCKER_IMAGE: str = "ghcr.io/mng-dev-ai/claudex-sandbox:latest"

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -31,6 +31,7 @@ from app.constants import (
     TERMINAL_TYPE,
     VNC_WEBSOCKET_PORT,
 )
+from app.core.config import get_settings
 from app.services.exceptions import SandboxException
 from app.services.sandbox_providers.base import SandboxProvider
 from app.services.sandbox_providers.types import (
@@ -44,6 +45,7 @@ from app.services.sandbox_providers.types import (
 )
 
 logger = logging.getLogger(__name__)
+settings = get_settings()
 
 HOST_ALLOWED_PREVIEW_PORTS: set[int] = (
     set(DOCKER_AVAILABLE_PORTS) - EXCLUDED_PREVIEW_PORTS
@@ -288,6 +290,8 @@ class LocalHostProvider(SandboxProvider):
         process_env["USER"] = "user"
         process_env["HOSTNAME"] = sandbox_id
         process_env["TERM"] = process_env.get("TERM", TERMINAL_TYPE)
+        process_env["GIT_CONFIG_GLOBAL"] = settings.GIT_CONFIG_GLOBAL
+        process_env["GNUPGHOME"] = settings.GNUPGHOME
 
         if background:
             await asyncio.to_thread(
@@ -506,6 +510,8 @@ class LocalHostProvider(SandboxProvider):
         env["HOSTNAME"] = sandbox_id
         env["SHELL"] = "/bin/bash"
         env["TERM"] = TERMINAL_TYPE
+        env["GIT_CONFIG_GLOBAL"] = settings.GIT_CONFIG_GLOBAL
+        env["GNUPGHOME"] = settings.GNUPGHOME
 
         cmd = (
             f"export PATH={HOST_REQUIRED_PATH_PREFIX}:$PATH; "

--- a/backend/app/services/transports/host.py
+++ b/backend/app/services/transports/host.py
@@ -108,6 +108,8 @@ class HostSandboxTransport(BaseSandboxTransport):
             "USER": requested_user,
             "PATH": f"{HOST_REQUIRED_PATH_PREFIX}:{current_path}",
         }
+        env["GIT_CONFIG_GLOBAL"] = settings.GIT_CONFIG_GLOBAL
+        env["GNUPGHOME"] = settings.GNUPGHOME
         run_user = self._resolve_run_user(requested_user)
 
         try:


### PR DESCRIPTION
## Summary
- Host provider overrides `HOME` to the sandbox directory, so git can't find the user's real `~/.gitconfig` — commits end up with an identity GitHub can't link to the user's profile
- Added `GIT_CONFIG_GLOBAL` setting in config.py (resolved once at startup from `Path.home()`) and set it in all three host-provider subprocess paths (Claude agent, shell commands, PTY sessions)
- Uses git's `GIT_CONFIG_GLOBAL` env var (git 2.32+) to point at the real global gitconfig even though `HOME` is overridden

## Test plan
- [ ] Create a workspace in host provider mode
- [ ] Have Claude create a commit and PR
- [ ] Verify the commit on GitHub shows the user's profile avatar and link