### PR TITLE
Enable partial delta streaming for text and thinking blocks

### DIFF
--- a/backend/app/services/claude_agent.py
+++ b/backend/app/services/claude_agent.py
@@ -519,6 +519,7 @@ class ClaudeAgentService:
             setting_sources=["local", "user", "project"],
             # Route permission prompts through our MCP permission server
             permission_prompt_tool_name="mcp__permission__approval_prompt",
+            include_partial_messages=True,
         )
 
         if thinking_mode in THINKING_MODE_TOKENS:

--- a/backend/app/services/streaming/processor.py
+++ b/backend/app/services/streaming/processor.py
@@ -14,6 +14,8 @@ from claude_agent_sdk import (
     ThinkingBlock,
     SystemMessage,
 )
+from claude_agent_sdk.types import StreamEvent as SDKStreamEvent
+
 from app.services.tool_handler import ToolHandlerRegistry
 from app.services.streaming.types import StreamEvent, StreamEventType
 
@@ -40,6 +42,9 @@ class StreamProcessor:
         self._session_handler = session_handler
         self.total_cost_usd = 0.0
         self.usage: dict[str, Any] | None = None
+        # Tracks which block kinds have been streamed via partial deltas
+        # so we skip only those specific kinds from the complete AssistantMessage.
+        self._streamed_kinds: set[str] = set()
 
     def _process_session_init(self, message: SystemMessage) -> None:
         if message.subtype != "init" or not self._session_handler:
@@ -50,8 +55,17 @@ class StreamProcessor:
             self._session_handler(session_id)
 
     def emit_events_for_message(
-        self, message: AssistantMessage | UserMessage | ResultMessage | SystemMessage
+        self,
+        message: AssistantMessage
+        | UserMessage
+        | ResultMessage
+        | SystemMessage
+        | SDKStreamEvent,
     ) -> Iterable[StreamEvent]:
+        if isinstance(message, SDKStreamEvent):
+            yield from self._emit_partial_delta(message)
+            return
+
         if isinstance(message, SystemMessage):
             self._process_session_init(message)
             return
@@ -61,6 +75,7 @@ class StreamProcessor:
             if message.usage is not None and not is_subagent:
                 self.usage = message.usage
             yield from self._emit_assistant_events(message)
+            self._streamed_kinds.clear()
             return
 
         if isinstance(message, UserMessage):
@@ -94,15 +109,42 @@ class StreamProcessor:
         for block in message.content:
             yield from self._emit_block_events(block, parent_tool_use_id)
 
+    def _emit_partial_delta(self, message: SDKStreamEvent) -> Iterable[StreamEvent]:
+        raw = message.event
+        if raw.get("type") != "content_block_delta":
+            return
+
+        delta = raw.get("delta", {})
+        delta_type = delta.get("type")
+        if delta_type == "text_delta":
+            text = delta.get("text", "")
+            if text:
+                self._streamed_kinds.add("text")
+                yield {"type": "assistant_text", "text": text}
+        elif delta_type == "thinking_delta":
+            thinking = delta.get("thinking", "")
+            if thinking:
+                self._streamed_kinds.add("thinking")
+                yield {"type": "assistant_thinking", "thinking": thinking}
+
     def _emit_block_events(
         self, block: Any, parent_tool_use_id: str | None = None
     ) -> Iterable[StreamEvent]:
         if isinstance(block, TextBlock):
-            yield from self._emit_text_block(block.text, event_type="assistant_text")
+            if "text" in self._streamed_kinds:
+                # Text already streamed token-by-token via partial deltas,
+                # but we still need to extract prompt suggestions from the
+                # complete text since the tag spans multiple delta chunks.
+                yield from self._extract_prompt_suggestions(block.text)
+            else:
+                yield from self._emit_text_block(
+                    block.text, event_type="assistant_text"
+                )
             return
 
         if isinstance(block, ThinkingBlock):
-            yield from self._emit_thinking_block(block.thinking)
+            if "thinking" not in self._streamed_kinds:
+                yield from self._emit_thinking_block(block.thinking)
             return
 
         if isinstance(block, ToolUseBlock):
@@ -135,42 +177,40 @@ class StreamProcessor:
         if isinstance(item, ToolResultBlock):
             yield from self._emit_tool_result(item)
 
+    def _extract_prompt_suggestions(self, text: str) -> Iterable[StreamEvent]:
+        match = PROMPT_SUGGESTIONS_PATTERN.search(text)
+        if not match:
+            return
+        try:
+            parsed = json.loads(match.group(1))
+            if isinstance(parsed, list):
+                suggestions = [
+                    s.strip() for s in parsed if isinstance(s, str) and s.strip()
+                ]
+                if suggestions:
+                    yield {
+                        "type": "prompt_suggestions",
+                        "suggestions": suggestions,
+                    }
+            else:
+                logger.warning("Prompt suggestions is not a list")
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse prompt suggestions JSON")
+
     def _emit_text_block(
         self, text: str | None, *, event_type: StreamEventType
     ) -> Iterable[StreamEvent]:
         if not text:
             return
 
-        suggestions: list[str] | None = None
+        if event_type == "assistant_text" and PROMPT_SUGGESTIONS_PATTERN.search(text):
+            cleaned = PROMPT_SUGGESTIONS_PATTERN.sub("", text).strip()
+            if cleaned:
+                yield {"type": event_type, "text": cleaned}
+            yield from self._extract_prompt_suggestions(text)
+            return
 
-        if event_type == "assistant_text":
-            match = PROMPT_SUGGESTIONS_PATTERN.search(text)
-            if match:
-                try:
-                    parsed = json.loads(match.group(1))
-                    if isinstance(parsed, list):
-                        suggestions = [
-                            s.strip()
-                            for s in parsed
-                            if isinstance(s, str) and s.strip()
-                        ]
-                        if suggestions:
-                            text = PROMPT_SUGGESTIONS_PATTERN.sub("", text).strip()
-                    else:
-                        logger.warning("Prompt suggestions is not a list")
-                except json.JSONDecodeError:
-                    logger.warning("Failed to parse prompt suggestions JSON")
-
-        if text:
-            event: StreamEvent = {"type": event_type, "text": text}
-            yield event
-
-        if suggestions:
-            suggestions_event: StreamEvent = {
-                "type": "prompt_suggestions",
-                "suggestions": suggestions,
-            }
-            yield suggestions_event
+        yield {"type": event_type, "text": text}
 
     def _emit_thinking_block(self, thinking: str | None) -> Iterable[StreamEvent]:
         if thinking:

--- a/backend/app/services/streaming/types.py
+++ b/backend/app/services/streaming/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from hashlib import sha256
 from typing import Any, Literal, TypedDict
@@ -18,6 +19,10 @@ StreamEventType = Literal[
     "prompt_suggestions",
 ]
 MAX_AUDIT_STRING_LENGTH = 4096
+PROMPT_SUGGESTIONS_RE = re.compile(
+    r"<prompt_suggestions>\s*.*?\s*</prompt_suggestions>",
+    re.DOTALL,
+)
 SENSITIVE_KEY_PARTS = (
     "token",
     "api_key",
@@ -103,7 +108,10 @@ class StreamSnapshotAccumulator:
 
     @property
     def content_text(self) -> str:
-        return "".join(self.text_parts)
+        raw = "".join(self.text_parts)
+        if "<prompt_suggestions>" not in raw:
+            return raw
+        return PROMPT_SUGGESTIONS_RE.sub("", raw).strip()
 
 
 class StreamEnvelope:

--- a/backend/app/services/transports/base.py
+++ b/backend/app/services/transports/base.py
@@ -79,6 +79,12 @@ class BaseSandboxTransport(Transport, ABC):
             "TERM": TERMINAL_TYPE,
             **(self._options.env or {}),
         }
+        # Enable fine-grained tool streaming when partial messages are requested.
+        # --include-partial-messages emits stream_event messages, but tool input
+        # parameters are still buffered unless eager_input_streaming is also
+        # enabled at the per-tool level via this env var.
+        if self._options.include_partial_messages:
+            envs.setdefault("CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING", "1")
         return (
             envs,
             str(self._options.cwd or "/home/user"),

--- a/frontend/src/components/chat/message-bubble/segmentBuilder.ts
+++ b/frontend/src/components/chat/message-bubble/segmentBuilder.ts
@@ -1,5 +1,8 @@
 import type { AssistantStreamEvent } from '@/types/chat.types';
 import type { ToolAggregate, ToolEventStatus } from '@/types/tools.types';
+import { PROMPT_SUGGESTIONS_RE } from '@/utils/stream';
+
+const PARTIAL_PROMPT_SUGGESTIONS_RE = /<prompt_suggestions>[\s\S]*$/;
 
 export interface TextSegment {
   kind: 'text';
@@ -312,19 +315,44 @@ export const buildSegments = (events: AssistantStreamEvent[]): MessageSegment[] 
   const segmentIndexByToolId = new Map<string, number>();
   const pendingChildren = new Map<string, ToolAggregate[]>();
   let pendingText = '';
+  let pendingThinking = '';
+  let pendingThinkingIndex = -1;
   let textSegmentCount = 0;
   let thinkingSegmentCount = 0;
   let suggestionsSegmentCount = 0;
 
   const flushText = () => {
     if (!pendingText) return;
-    segments.push({
-      kind: 'text',
-      id: `text-${textSegmentCount}`,
-      text: pendingText,
-    });
-    textSegmentCount++;
+    // Strip prompt_suggestions tags that arrive as raw text via partial streaming
+    const hasTag = pendingText.includes('<prompt_suggestion');
+    const cleaned = hasTag
+      ? pendingText
+          .replace(PROMPT_SUGGESTIONS_RE, '')
+          .replace(PARTIAL_PROMPT_SUGGESTIONS_RE, '')
+          .trimEnd()
+      : pendingText;
+    if (cleaned) {
+      segments.push({
+        kind: 'text',
+        id: `text-${textSegmentCount}`,
+        text: cleaned,
+      });
+      textSegmentCount++;
+    }
     pendingText = '';
+  };
+
+  const flushThinking = () => {
+    if (!pendingThinking) return;
+    segments.push({
+      kind: 'thinking',
+      id: `thinking-${thinkingSegmentCount}`,
+      text: pendingThinking,
+      eventIndex: pendingThinkingIndex,
+    });
+    thinkingSegmentCount++;
+    pendingThinking = '';
+    pendingThinkingIndex = -1;
   };
 
   const context: ProcessToolEventContext = {
@@ -337,20 +365,17 @@ export const buildSegments = (events: AssistantStreamEvent[]): MessageSegment[] 
   events.forEach((event, index) => {
     switch (event.type) {
       case 'assistant_text':
+        flushThinking();
         pendingText += event.text;
         break;
       case 'assistant_thinking':
         flushText();
-        segments.push({
-          kind: 'thinking',
-          id: `thinking-${thinkingSegmentCount}`,
-          text: event.thinking,
-          eventIndex: index,
-        });
-        thinkingSegmentCount++;
+        pendingThinkingIndex = index;
+        pendingThinking += event.thinking;
         break;
       case 'prompt_suggestions':
         flushText();
+        flushThinking();
         segments.push({
           kind: 'suggestions',
           id: `suggestions-${suggestionsSegmentCount}`,
@@ -362,9 +387,11 @@ export const buildSegments = (events: AssistantStreamEvent[]): MessageSegment[] 
       case 'tool_completed':
       case 'tool_failed':
         flushText();
+        flushThinking();
         processToolEvent(event, context);
         break;
       case 'user_text':
+        flushThinking();
         pendingText += event.text;
         break;
       default:
@@ -373,5 +400,6 @@ export const buildSegments = (events: AssistantStreamEvent[]): MessageSegment[] 
   });
 
   flushText();
+  flushThinking();
   return segments;
 };

--- a/frontend/src/utils/stream.ts
+++ b/frontend/src/utils/stream.ts
@@ -133,10 +133,13 @@ export const appendEventToLog = (
   return JSON.stringify(events);
 };
 
+export const PROMPT_SUGGESTIONS_RE = /<prompt_suggestions>[\s\S]*?<\/prompt_suggestions>/g;
+
 export const extractAssistantText = (source: string | AssistantStreamEvent[]): string => {
   const events = Array.isArray(source) ? source : parseEventLog(source);
-  return events
+  const raw = events
     .filter((event) => event.type === 'assistant_text')
     .map((event) => event.text)
     .join('');
+  return raw.replace(PROMPT_SUGGESTIONS_RE, '').trimEnd();
 };


### PR DESCRIPTION
## Summary

- Enables `include_partial_messages` in the Claude Agent SDK so text and thinking tokens stream incrementally to the UI instead of arriving as complete blocks
- Adds `CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING` env var to the custom sandbox transport (matching upstream SDK behavior)
- Handles `SDKStreamEvent` partial deltas in `StreamProcessor`, skipping duplicate re-emission from the complete `AssistantMessage`
- Batches consecutive `assistant_thinking` deltas into a single segment on the frontend (previously each delta rendered as a separate "Thought process" block)
- Strips `<prompt_suggestions>` markup from persisted `content_text`, streamed text segments, and clipboard copy

## Test plan

- [ ] Send a message with thinking enabled — verify a single "Thought process" block appears and shows the active thinking indicator while streaming
- [ ] Send a normal message — verify text streams token-by-token instead of appearing as a complete block
- [ ] Verify prompt suggestions still appear after message completion
- [ ] Copy a completed message — verify no `<prompt_suggestions>` XML tags in clipboard
- [ ] Refresh and verify persisted messages render correctly (no raw XML tags in content)
- [ ] Test with thinking disabled — verify non-streamed thinking blocks still render correctly from complete `AssistantMessage`