### PR TITLE
Add file-type icons to file tree, diff view, and editor header

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "fuzzysort": "^3.1.0",
         "jszip": "^3.10.1",
         "lucide-react": "^0.525.0",
+        "material-file-icons": "^2.4.0",
         "mermaid": "^10.6.1",
         "monaco-editor": "^0.52.2",
         "qrcode": "^1.5.4",
@@ -4924,6 +4925,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/material-file-icons": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/material-file-icons/-/material-file-icons-2.4.0.tgz",
+      "integrity": "sha512-MgxhwBgoiNXyQdZVtXvdqP8t7Fu/Z3zW1aPeYN+UqtepzbKyf41b+Wme6DnwGk5Crt2JzmWLtl1XGE2YMooaQw==",
+      "license": "MIT"
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "fuzzysort": "^3.1.0",
     "jszip": "^3.10.1",
     "lucide-react": "^0.525.0",
+    "material-file-icons": "^2.4.0",
     "mermaid": "^10.6.1",
     "monaco-editor": "^0.52.2",
     "qrcode": "^1.5.4",

--- a/frontend/src/components/editor/editor-view/Header.tsx
+++ b/frontend/src/components/editor/editor-view/Header.tsx
@@ -2,7 +2,9 @@ import { memo } from 'react';
 import { AlertTriangle, Code, FileText, Save, Loader2, PanelLeft, Maximize2 } from 'lucide-react';
 import type { FileStructure } from '@/types/file-system.types';
 import { Button } from '@/components/ui/primitives/Button';
+import { FileIcon } from '@/components/editor/file-tree/FileIcon';
 import { isPreviewableFile } from '@/utils/fileTypes';
+import { getFileName } from '@/utils/file';
 import { cn } from '@/utils/cn';
 
 export interface HeaderProps {
@@ -52,6 +54,7 @@ export const Header = memo(function Header({
             <PanelLeft size={14} />
           </button>
         )}
+        <FileIcon name={getFileName(filePath)} className="h-3.5 w-3.5 shrink-0" />
         <span className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-tertiary">
           {filePath}
         </span>

--- a/frontend/src/components/editor/file-tree/FileIcon.tsx
+++ b/frontend/src/components/editor/file-tree/FileIcon.tsx
@@ -1,23 +1,88 @@
-import { Folder, FolderOpen, File } from 'lucide-react';
+import { memo, useState, useEffect } from 'react';
+import { Folder, FolderOpen } from 'lucide-react';
 import { cn } from '@/utils/cn';
+
+type GetIconFn = (name: string) => { svg: string };
+
+let cachedGetIcon: GetIconFn | null = null;
+let loadPromise: Promise<GetIconFn | null> | null = null;
+const svgCache = new Map<string, string>();
+
+function getSvg(name: string): string | null {
+  const cached = svgCache.get(name);
+  if (cached) return cached;
+  if (!cachedGetIcon) return null;
+  const svg = cachedGetIcon(name).svg;
+  svgCache.set(name, svg);
+  return svg;
+}
+
+function loadModule(): Promise<GetIconFn | null> {
+  if (!loadPromise) {
+    loadPromise = import('material-file-icons').then(
+      (m) => {
+        cachedGetIcon = m.getIcon as GetIconFn;
+        return cachedGetIcon;
+      },
+      () => {
+        loadPromise = null;
+        return null;
+      },
+    );
+  }
+  return loadPromise;
+}
 
 export interface FileIconProps {
   name: string;
-  isFolder: boolean;
+  isFolder?: boolean;
   isExpanded?: boolean;
   className?: string;
 }
 
-export function FileIcon({ isFolder, isExpanded, className }: FileIconProps) {
-  const baseClassName = cn(
-    'text-text-quaternary dark:text-text-dark-quaternary transition-colors',
-    className,
-  );
+export const FileIcon = memo(function FileIcon({
+  name,
+  isFolder = false,
+  isExpanded,
+  className,
+}: FileIconProps) {
+  const [svg, setSvg] = useState<string | null>(() => (isFolder ? null : getSvg(name)));
+
+  useEffect(() => {
+    if (isFolder) return;
+    const resolved = getSvg(name);
+    if (resolved) {
+      setSvg(resolved);
+      return;
+    }
+    setSvg(null);
+    let cancelled = false;
+    loadModule().then((getIcon) => {
+      if (!cancelled && getIcon) setSvg(getSvg(name));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [name, isFolder]);
 
   if (isFolder) {
     const FolderIcon = isExpanded ? FolderOpen : Folder;
-    return <FolderIcon className={baseClassName} />;
+    return (
+      <FolderIcon
+        className={cn(
+          'text-text-quaternary transition-colors dark:text-text-dark-quaternary',
+          className,
+        )}
+      />
+    );
   }
 
-  return <File className={baseClassName} />;
-}
+  if (!svg) return <span className={cn('inline-flex shrink-0', className)} />;
+
+  return (
+    <span
+      className={cn('inline-flex shrink-0', className)}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+});

--- a/frontend/src/components/views/DiffView.tsx
+++ b/frontend/src/components/views/DiffView.tsx
@@ -5,11 +5,11 @@ import {
   ChevronsDownUp,
   ChevronsUpDown,
   Columns2,
-  FileText,
   GitCompareArrows,
   Rows2,
   RotateCcw,
 } from 'lucide-react';
+import { FileIcon } from '@/components/editor/file-tree/FileIcon';
 import { Button } from '@/components/ui/primitives/Button';
 import { Dropdown } from '@/components/ui/primitives/Dropdown';
 import { Spinner } from '@/components/ui/primitives/Spinner';
@@ -362,7 +362,7 @@ export const DiffView = memo(function DiffView({ sandboxId }: DiffViewProps) {
                         isExpanded && 'rotate-90',
                       )}
                     />
-                    <FileText className="h-3 w-3 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
+                    <FileIcon name={file.name} className="h-3 w-3" />
                     <span className="min-w-0 truncate font-mono text-2xs text-text-secondary dark:text-text-dark-secondary">
                       {isRenamed && file.prevName ? (
                         <>


### PR DESCRIPTION
## Summary
- Add `material-file-icons` package for extension-aware file icons (377 icons, material design style)
- Replace generic `File`/`FileText` Lucide icons with colored SVG icons that match file types (`.py` → Python, `.tsx` → React TS, `Dockerfile` → Docker, etc.)
- Icons display in three locations: **file tree**, **diff view**, and **editor header**
- The 486KB icon library is lazy-loaded via dynamic `import()` with module-level caching and an SVG result cache to minimize overhead when rendering hundreds of file tree items

## Test plan
- [ ] Open file tree — verify files show colored type-specific icons, folders still show Lucide folder icons
- [ ] Open diff view — verify each changed file shows its type icon instead of generic FileText
- [ ] Select a file in editor — verify the header bar shows the file icon next to the path
- [ ] Verify icons load without visible delay after first render
- [ ] Check dark mode renders correctly