### PR TITLE
Add minimum window size for desktop app

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -15,6 +15,8 @@
         "title": "Claudex",
         "width": 1280,
         "height": 800,
+        "minWidth": 940,
+        "minHeight": 560,
         "resizable": true,
         "visible": false,
         "devtools": true,


### PR DESCRIPTION
## Summary
- Set `minWidth: 940` and `minHeight: 560` on the Tauri desktop window to prevent the app from being resized too small

## Test plan
- [ ] Build and run the desktop app
- [ ] Verify the window cannot be resized below 940×560