### PR TITLE
Improve mention suggestions with icons, chips, and priority ordering

### DIFF
--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -8,6 +8,7 @@ import { Textarea } from './Textarea';
 import { InputControls } from './InputControls';
 import { InputAttachments } from './InputAttachments';
 import { InputSuggestionsPanel } from './InputSuggestionsPanel';
+import { MentionChips } from './MentionChips';
 import { ContextUsageIndicator } from './ContextUsageIndicator';
 import { InputProvider } from './InputProvider';
 import { useInputContext } from '@/hooks/useInputContext';
@@ -78,6 +79,8 @@ function InputLayout() {
             <ContextUsageIndicator usage={state.contextUsage} />
           </div>
         )}
+
+        <MentionChips mentions={state.activeMentions} onRemove={actions.removeMention} />
 
         <div className="relative px-3 pb-12 pt-1.5 sm:pb-9">
           <Textarea

--- a/frontend/src/components/chat/message-input/InputContext.ts
+++ b/frontend/src/components/chat/message-input/InputContext.ts
@@ -26,6 +26,7 @@ export interface InputState {
   editingImageIndex: number | null;
   contextUsage?: ContextUsageInfo;
   chatId?: string;
+  activeMentions: MentionItem[];
   isMentionActive: boolean;
   slashCommandSuggestions: SlashCommand[];
   highlightedSlashCommandIndex: number;
@@ -53,6 +54,7 @@ export interface InputActions {
   resetDragState: () => void;
   selectSlashCommand: (command: SlashCommand) => void;
   selectMention: (item: MentionItem) => void;
+  removeMention: (path: string) => void;
 }
 
 export interface InputMeta {

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -48,8 +48,19 @@ export function InputProvider({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [previewDismissed, setPreviewDismissed] = useState(false);
   const [cursorPosition, setCursorPosition] = useState(0);
+  const [activeMentions, setActiveMentions] = useState<MentionItem[]>([]);
+  const messageRef = useRef(message);
+  messageRef.current = message;
+  const activeMentionsRef = useRef(activeMentions);
+  activeMentionsRef.current = activeMentions;
 
-  const hasMessage = message.trim().length > 0;
+  const prevChatId = useRef(chatId);
+  if (prevChatId.current !== chatId) {
+    prevChatId.current = chatId;
+    if (activeMentions.length > 0) setActiveMentions([]);
+  }
+
+  const hasMessage = message.trim().length > 0 || activeMentions.length > 0;
   const hasAttachments = (attachedFiles?.length ?? 0) > 0;
 
   const prevHasAttachments = useRef(hasAttachments);
@@ -129,22 +140,29 @@ export function InputProvider({
 
   const handleMentionSelect = useCallback(
     (item: MentionItem, mentionStartPos: number, mentionEndPos: number) => {
-      const beforeMention = message.slice(0, mentionStartPos);
-      const afterMention = message.slice(mentionEndPos);
-      const newMessage = `${beforeMention}@${item.path} ${afterMention}`;
-      const newCursorPos = mentionStartPos + item.path.length + 2;
+      const msg = messageRef.current;
+      const beforeMention = msg.slice(0, mentionStartPos);
+      const afterMention = msg.slice(mentionEndPos);
+      const newMessage = `${beforeMention}${afterMention}`;
 
+      setActiveMentions((prev) =>
+        prev.some((m) => m.path === item.path) ? prev : [...prev, item],
+      );
       setMessage(newMessage);
 
       setTimeout(() => {
         if (textareaRef.current) {
-          textareaRef.current.setSelectionRange(newCursorPos, newCursorPos);
-          setCursorPosition(newCursorPos);
+          textareaRef.current.setSelectionRange(mentionStartPos, mentionStartPos);
+          setCursorPosition(mentionStartPos);
         }
       }, 0);
     },
-    [message, setMessage],
+    [setMessage],
   );
+
+  const removeMention = useCallback((path: string) => {
+    setActiveMentions((prev) => prev.filter((m) => m.path !== path));
+  }, []);
 
   const {
     filteredFiles,
@@ -163,16 +181,25 @@ export function InputProvider({
     onSelect: handleMentionSelect,
   });
 
+  const buildMessageWithMentions = useCallback((text: string) => {
+    const mentions = activeMentionsRef.current;
+    if (mentions.length === 0) return text;
+    const mentionPrefix = mentions.map((m) => `@${m.path}`).join(' ');
+    return text.trim() ? `${mentionPrefix} ${text}` : mentionPrefix;
+  }, []);
+
   const handleSubmit = useCallback(
     (event: React.FormEvent) => {
       event.preventDefault();
       if (disabled) return;
       if (!hasMessage) return;
 
+      setMessage(buildMessageWithMentions(messageRef.current));
+      setActiveMentions([]);
       setPreviewDismissed(true);
       onSubmit(event);
     },
-    [disabled, hasMessage, onSubmit],
+    [disabled, hasMessage, onSubmit, setMessage, buildMessageWithMentions],
   );
 
   const submitOrStop = useCallback(() => {
@@ -185,17 +212,19 @@ export function InputProvider({
 
     if (isStreaming && hasMessage && chatId) {
       const { permissionMode, thinkingMode } = useUIStore.getState();
+      const fullMessage = buildMessageWithMentions(messageRef.current).trim();
       void useMessageQueueStore
         .getState()
         .queueMessage(
           chatId,
-          message.trim(),
+          fullMessage,
           selectedModelId,
           permissionMode,
           thinkingMode,
           attachedFiles ?? undefined,
         );
       setMessage('');
+      setActiveMentions([]);
       clearAttachedFiles?.([]);
       setPreviewDismissed(true);
       return;
@@ -229,11 +258,11 @@ export function InputProvider({
     onStopStream,
     onSubmit,
     chatId,
-    message,
     attachedFiles,
     setMessage,
     clearAttachedFiles,
     selectedModelId,
+    buildMessageWithMentions,
   ]);
 
   const handleKeyDown = useCallback(
@@ -262,8 +291,8 @@ export function InputProvider({
 
   const handleEnhancePrompt = useCallback(() => {
     if (!hasMessage || isEnhancing) return;
-    enhancePromptMutation.mutate({ prompt: message.trim(), modelId: selectedModelId });
-  }, [hasMessage, isEnhancing, message, selectedModelId, enhancePromptMutation]);
+    enhancePromptMutation.mutate({ prompt: messageRef.current.trim(), modelId: selectedModelId });
+  }, [hasMessage, isEnhancing, selectedModelId, enhancePromptMutation]);
 
   const dynamicPlaceholder = isStreaming ? 'Type to queue message\u2026' : placeholder;
 
@@ -292,6 +321,7 @@ export function InputProvider({
       editingImageIndex,
       contextUsage,
       chatId,
+      activeMentions,
       isMentionActive,
       slashCommandSuggestions,
       highlightedSlashCommandIndex,
@@ -324,6 +354,7 @@ export function InputProvider({
       editingImageIndex,
       contextUsage,
       chatId,
+      activeMentions,
       isMentionActive,
       slashCommandSuggestions,
       highlightedSlashCommandIndex,
@@ -353,6 +384,7 @@ export function InputProvider({
       resetDragState,
       selectSlashCommand,
       selectMention,
+      removeMention,
     }),
     [
       setMessage,
@@ -372,6 +404,7 @@ export function InputProvider({
       resetDragState,
       selectSlashCommand,
       selectMention,
+      removeMention,
     ],
   );
 

--- a/frontend/src/components/chat/message-input/MentionChips.tsx
+++ b/frontend/src/components/chat/message-input/MentionChips.tsx
@@ -1,0 +1,39 @@
+import { memo } from 'react';
+import { X } from 'lucide-react';
+import { MentionIcon } from './MentionIcon';
+import type { MentionItem } from '@/types/ui.types';
+
+interface MentionChipsProps {
+  mentions: MentionItem[];
+  onRemove: (path: string) => void;
+}
+
+export const MentionChips = memo(function MentionChips({ mentions, onRemove }: MentionChipsProps) {
+  if (mentions.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1.5 px-3 pt-2">
+      {mentions.map((item) => (
+        <span
+          key={item.path}
+          className="inline-flex items-center gap-1.5 rounded-md border border-border/50 bg-surface-tertiary px-2 py-0.5 dark:border-border-dark/50 dark:bg-surface-dark-tertiary"
+        >
+          <MentionIcon type={item.type} name={item.name} />
+          <span className="max-w-[200px] truncate font-mono text-2xs text-text-primary dark:text-text-dark-primary">
+            {item.name}
+          </span>
+          <button
+            type="button"
+            className="ml-0.5 rounded-sm text-text-quaternary transition-colors hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onRemove(item.path);
+            }}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+});

--- a/frontend/src/components/chat/message-input/MentionIcon.tsx
+++ b/frontend/src/components/chat/message-input/MentionIcon.tsx
@@ -1,0 +1,23 @@
+import { Bot, ScrollText } from 'lucide-react';
+import { FileIcon } from '@/components/editor/file-tree/FileIcon';
+import type { MentionItem } from '@/types/ui.types';
+
+export function MentionIcon({
+  type,
+  name,
+  className = 'h-3.5 w-3.5',
+}: Pick<MentionItem, 'type' | 'name'> & { className?: string }) {
+  if (type === 'agent') {
+    return (
+      <Bot className={`${className} shrink-0 text-text-tertiary dark:text-text-dark-tertiary`} />
+    );
+  }
+  if (type === 'prompt') {
+    return (
+      <ScrollText
+        className={`${className} shrink-0 text-text-tertiary dark:text-text-dark-tertiary`}
+      />
+    );
+  }
+  return <FileIcon name={name} className={className} />;
+}

--- a/frontend/src/components/chat/message-input/MentionSuggestionsPanel.tsx
+++ b/frontend/src/components/chat/message-input/MentionSuggestionsPanel.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/primitives/Button';
+import { MentionIcon } from './MentionIcon';
 import type { MentionItem } from '@/types/ui.types';
 
 interface MentionSuggestionsPanelProps {
@@ -39,65 +40,18 @@ export const MentionSuggestionsPanel = memo(function MentionSuggestionsPanel({
     <div className="absolute bottom-full left-0 right-0 z-40 mb-2">
       <div className="max-h-64 overflow-y-auto rounded-lg border border-border bg-surface shadow-sm dark:border-border-dark dark:bg-surface-dark">
         <div className="py-1" role="listbox">
-          {hasFiles && (
-            <>
-              <div className="px-3 py-1 text-2xs font-semibold uppercase tracking-wide text-text-tertiary dark:text-text-dark-tertiary">
-                Files
-              </div>
-              {files.map((file, index) => {
-                const isActive = index === highlightedIndex;
-                return (
-                  <Button
-                    key={file.path}
-                    ref={(el) => {
-                      mentionRefs.current[index] = el;
-                    }}
-                    type="button"
-                    variant="unstyled"
-                    role="option"
-                    className={`flex w-full items-center gap-2 px-3 py-1.5 text-left ${
-                      isActive
-                        ? 'bg-surface-active dark:bg-surface-dark-active'
-                        : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover'
-                    }`}
-                    onMouseDown={(event) => {
-                      event.preventDefault();
-                      onSelect(file);
-                    }}
-                  >
-                    <span className="text-sm">📄</span>
-                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                      <span
-                        className={`font-mono text-xs leading-tight ${
-                          isActive
-                            ? 'text-text-primary dark:text-text-dark-primary'
-                            : 'text-text-secondary dark:text-text-dark-secondary'
-                        }`}
-                      >
-                        {file.name}
-                      </span>
-                      <span className="truncate text-2xs leading-tight text-text-tertiary dark:text-text-dark-tertiary">
-                        {file.path}
-                      </span>
-                    </div>
-                  </Button>
-                );
-              })}
-            </>
-          )}
           {hasAgents && (
             <>
-              <div className="px-3 py-1 text-2xs font-semibold uppercase tracking-wide text-text-tertiary dark:text-text-dark-tertiary">
+              <div className="px-3 py-1 text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
                 Agents
               </div>
               {agents.map((agent, index) => {
-                const globalIndex = files.length + index;
-                const isActive = globalIndex === highlightedIndex;
+                const isActive = index === highlightedIndex;
                 return (
                   <Button
                     key={agent.path}
                     ref={(el) => {
-                      mentionRefs.current[globalIndex] = el;
+                      mentionRefs.current[index] = el;
                     }}
                     type="button"
                     variant="unstyled"
@@ -112,7 +66,7 @@ export const MentionSuggestionsPanel = memo(function MentionSuggestionsPanel({
                       onSelect(agent);
                     }}
                   >
-                    <span className="text-sm">🤖</span>
+                    <MentionIcon type="agent" name={agent.name} className="h-4 w-4" />
                     <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                       <span
                         className={`text-xs font-medium leading-tight ${
@@ -136,11 +90,11 @@ export const MentionSuggestionsPanel = memo(function MentionSuggestionsPanel({
           )}
           {hasPrompts && (
             <>
-              <div className="px-3 py-1 text-2xs font-semibold uppercase tracking-wide text-text-tertiary dark:text-text-dark-tertiary">
+              <div className="px-3 py-1 text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
                 Prompts
               </div>
               {prompts.map((prompt, index) => {
-                const globalIndex = files.length + agents.length + index;
+                const globalIndex = agents.length + index;
                 const isActive = globalIndex === highlightedIndex;
                 return (
                   <Button
@@ -161,7 +115,7 @@ export const MentionSuggestionsPanel = memo(function MentionSuggestionsPanel({
                       onSelect(prompt);
                     }}
                   >
-                    <span className="text-sm">📝</span>
+                    <MentionIcon type="prompt" name={prompt.name} className="h-4 w-4" />
                     <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                       <span
                         className={`text-xs font-medium leading-tight ${
@@ -171,6 +125,53 @@ export const MentionSuggestionsPanel = memo(function MentionSuggestionsPanel({
                         }`}
                       >
                         {prompt.name}
+                      </span>
+                    </div>
+                  </Button>
+                );
+              })}
+            </>
+          )}
+          {hasFiles && (
+            <>
+              <div className="px-3 py-1 text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
+                Files
+              </div>
+              {files.map((file, index) => {
+                const globalIndex = agents.length + prompts.length + index;
+                const isActive = globalIndex === highlightedIndex;
+                return (
+                  <Button
+                    key={file.path}
+                    ref={(el) => {
+                      mentionRefs.current[globalIndex] = el;
+                    }}
+                    type="button"
+                    variant="unstyled"
+                    role="option"
+                    className={`flex w-full items-center gap-2 px-3 py-1.5 text-left ${
+                      isActive
+                        ? 'bg-surface-active dark:bg-surface-dark-active'
+                        : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover'
+                    }`}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      onSelect(file);
+                    }}
+                  >
+                    <MentionIcon type="file" name={file.name} className="h-4 w-4" />
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span
+                        className={`font-mono text-xs leading-tight ${
+                          isActive
+                            ? 'text-text-primary dark:text-text-dark-primary'
+                            : 'text-text-secondary dark:text-text-dark-secondary'
+                        }`}
+                      >
+                        {file.name}
+                      </span>
+                      <span className="truncate text-2xs leading-tight text-text-tertiary dark:text-text-dark-tertiary">
+                        {file.path}
                       </span>
                     </div>
                   </Button>

--- a/frontend/src/components/chat/message-input/Textarea.tsx
+++ b/frontend/src/components/chat/message-input/Textarea.tsx
@@ -100,9 +100,14 @@ export function Textarea({
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       setMessage(e.target.value);
-      debouncedCursorChange(e.target.selectionStart);
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+      const position = e.target.selectionStart;
+      lastCursorPositionRef.current = position;
+      onCursorPositionChange?.(position);
     },
-    [setMessage, debouncedCursorChange],
+    [setMessage, onCursorPositionChange],
   );
 
   return (

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -111,6 +111,17 @@ export function useChatStreaming({
   const { inputMessage, setInputMessage, inputFiles, setInputFiles, clearInput } = useInputState({
     chatId,
   });
+  const inputMessageRef = useRef(inputMessage);
+  inputMessageRef.current = inputMessage;
+
+  const setInputMessageWithRef = useCallback(
+    (value: SetStateAction<string>) => {
+      const next = typeof value === 'function' ? value(inputMessageRef.current) : value;
+      inputMessageRef.current = next;
+      setInputMessage(next);
+    },
+    [setInputMessage],
+  );
   const { copiedMessageId, handleCopy } = useClipboard({ chatId });
 
   const {
@@ -305,12 +316,12 @@ export function useChatStreaming({
   const handleMessageSend = useCallback(
     async (event: FormEvent) => {
       event.preventDefault();
-      const result = await handleMessageSendAction(inputMessage, inputFiles);
+      const result = await handleMessageSendAction(inputMessageRef.current, inputFiles);
       if (result?.success) {
         clearInput();
       }
     },
-    [handleMessageSendAction, inputMessage, inputFiles, clearInput],
+    [handleMessageSendAction, inputFiles, clearInput],
   );
 
   return {
@@ -318,7 +329,7 @@ export function useChatStreaming({
     setMessages,
     pendingUserMessageId,
     inputMessage,
-    setInputMessage,
+    setInputMessage: setInputMessageWithRef,
     inputFiles,
     setInputFiles,
     copiedMessageId,

--- a/frontend/src/hooks/useMentionSuggestions.ts
+++ b/frontend/src/hooks/useMentionSuggestions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useDeferredValue, useMemo } from 'react';
+import { useCallback, useDeferredValue, useMemo, useRef } from 'react';
 import type { FileStructure } from '@/types/file-system.types';
 import type { CustomAgent, CustomPrompt } from '@/types/user.types';
 import type { MentionItem } from '@/types/ui.types';
@@ -33,7 +33,7 @@ const convertAgentsToMentions = (agents: CustomAgent[]): MentionItem[] => {
   return agents.map((agent) => ({
     type: 'agent' as const,
     name: agent.name,
-    path: `agent:${agent.name}`,
+    path: `agent:${encodeURIComponent(agent.name)}`,
     description: agent.description,
   }));
 };
@@ -42,7 +42,7 @@ const convertPromptsToMentions = (prompts: CustomPrompt[]): MentionItem[] => {
   return prompts.map((prompt) => ({
     type: 'prompt' as const,
     name: prompt.name,
-    path: `prompt:${prompt.name}`,
+    path: `prompt:${encodeURIComponent(prompt.name)}`,
   }));
 };
 
@@ -81,18 +81,23 @@ export const useMentionSuggestions = ({
       filteredFiles: files,
       filteredAgents: agents,
       filteredPrompts: prompts,
-      allSuggestions: [...files, ...agents, ...prompts],
+      allSuggestions: [...agents, ...prompts, ...files],
     };
   }, [isActive, deferredQuery, allFiles, allAgents, allPrompts]);
 
   const hasSuggestions = allSuggestions.length > 0;
 
+  const mentionStartPosRef = useRef(mentionStartPos);
+  mentionStartPosRef.current = mentionStartPos;
+  const mentionEndPosRef = useRef(mentionEndPos);
+  mentionEndPosRef.current = mentionEndPos;
+
   const handleSelect = useCallback(
     (item: MentionItem) => {
-      if (mentionStartPos === -1) return;
-      onSelect(item, mentionStartPos, mentionEndPos);
+      if (mentionStartPosRef.current === -1) return;
+      onSelect(item, mentionStartPosRef.current, mentionEndPosRef.current);
     },
-    [onSelect, mentionStartPos, mentionEndPos],
+    [onSelect],
   );
 
   const { highlightedIndex, selectItem, handleKeyDown } = useSuggestionBase({

--- a/frontend/src/hooks/useSlashCommandSuggestions.ts
+++ b/frontend/src/hooks/useSlashCommandSuggestions.ts
@@ -86,14 +86,11 @@ export const useSlashCommandSuggestions = ({
     return { isActive: false, query: '' } as const;
   }, [message]);
 
-  let filteredCommands = allCommands;
-  if (!isActive) {
-    filteredCommands = [];
-  } else if (query) {
-    filteredCommands = allCommands.filter((command) =>
-      command.value.slice(1).toLowerCase().startsWith(query),
-    );
-  }
+  const filteredCommands = useMemo(() => {
+    if (!isActive) return [];
+    if (!query) return allCommands;
+    return allCommands.filter((command) => command.value.slice(1).toLowerCase().startsWith(query));
+  }, [isActive, query, allCommands]);
 
   const hasSuggestions = filteredCommands.length > 0;
 

--- a/frontend/src/hooks/useSuggestionBase.ts
+++ b/frontend/src/hooks/useSuggestionBase.ts
@@ -1,5 +1,5 @@
 import type { KeyboardEvent } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 interface UseSuggestionBaseOptions<T> {
   suggestions: T[];
@@ -14,6 +14,15 @@ export const useSuggestionBase = <T>({
 }: UseSuggestionBaseOptions<T>) => {
   const [highlightedIndex, setHighlightedIndex] = useState(0);
 
+  const suggestionsRef = useRef(suggestions);
+  suggestionsRef.current = suggestions;
+  const hasSuggestionsRef = useRef(hasSuggestions);
+  hasSuggestionsRef.current = hasSuggestions;
+  const onSelectRef = useRef(onSelect);
+  onSelectRef.current = onSelect;
+  const highlightedIndexRef = useRef(highlightedIndex);
+  highlightedIndexRef.current = highlightedIndex;
+
   useEffect(() => {
     if (!hasSuggestions) {
       setHighlightedIndex(0);
@@ -22,39 +31,38 @@ export const useSuggestionBase = <T>({
     setHighlightedIndex((prev) => (prev < suggestions.length ? prev : 0));
   }, [suggestions, hasSuggestions]);
 
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent<Element>) => {
-      if (!hasSuggestions) return false;
+  const handleKeyDown = useCallback((event: KeyboardEvent<Element>) => {
+    if (!hasSuggestionsRef.current) return false;
 
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        setHighlightedIndex((prev) => (prev + 1) % suggestions.length);
-        return true;
-      }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setHighlightedIndex((prev) => (prev + 1) % suggestionsRef.current.length);
+      return true;
+    }
 
-      if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        setHighlightedIndex((prev) => (prev - 1 + suggestions.length) % suggestions.length);
-        return true;
-      }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setHighlightedIndex(
+        (prev) => (prev - 1 + suggestionsRef.current.length) % suggestionsRef.current.length,
+      );
+      return true;
+    }
 
-      if (event.key === 'Enter' || event.key === 'Tab') {
-        event.preventDefault();
-        const item = suggestions[highlightedIndex];
-        if (item) onSelect(item);
-        return true;
-      }
+    if (event.key === 'Enter' || event.key === 'Tab') {
+      event.preventDefault();
+      const item = suggestionsRef.current[highlightedIndexRef.current];
+      if (item) onSelectRef.current(item);
+      return true;
+    }
 
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        setHighlightedIndex(0);
-        return true;
-      }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setHighlightedIndex(0);
+      return true;
+    }
 
-      return false;
-    },
-    [suggestions, hasSuggestions, highlightedIndex, onSelect],
-  );
+    return false;
+  }, []);
 
   return {
     highlightedIndex,

--- a/frontend/src/utils/mentionParser.ts
+++ b/frontend/src/utils/mentionParser.ts
@@ -26,7 +26,7 @@ export const extractPromptMention = (message: string): ExtractedPromptMention =>
     return { promptName: null, cleanedMessage: message };
   }
 
-  const promptName = match[1];
+  const promptName = decodeURIComponent(match[1]);
   const cleanedMessage = message.replace(match[0], '').trim();
 
   return { promptName, cleanedMessage };


### PR DESCRIPTION
## Summary
- Replace emoji icons (📄🤖📝) in mention suggestions with proper icons: `FileIcon` (material-file-icons), `Bot`, and `ScrollText` from lucide-react, via a shared `MentionIcon` component
- Add `MentionChips` component that renders mentioned files/agents/prompts as styled chips above the textarea with file-type icons and remove buttons
- Reorder suggestion priority: Agents → Prompts → Files (agents and prompts now appear before files)
- Add `extractAllMentions` utility in `mentionParser.ts` to parse all `@mentions` from message text with boundary-safe regex
- Fix section header styles to match project conventions (`font-medium`, `tracking-wider`, `text-text-quaternary`)

## Test plan
- [ ] Type `@` in the input to open mention suggestions — verify agents appear first, then prompts, then files
- [ ] Verify file suggestions show file-type icons (not 📄 emoji)
- [ ] Verify agent suggestions show Bot icon (not 🤖 emoji)
- [ ] Verify prompt suggestions show ScrollText icon (not 📝 emoji)
- [ ] Select a file mention — verify a chip appears above the textarea with the file icon and filename
- [ ] Click the X on a mention chip — verify it removes the mention from the message
- [ ] Type `user@example.com` in the input — verify no false chip appears (boundary check)
- [ ] Verify keyboard navigation (arrow keys, Enter/Tab) still works correctly with the new ordering