### PR TITLE
Refine chat queue layout and model selection

### DIFF
--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -413,8 +413,8 @@ export const Chat = memo(function Chat() {
         <div className="relative bg-surface pb-safe dark:bg-surface-dark">
           <div className="relative w-full py-2 lg:mx-auto lg:max-w-3xl">
             {pendingMessages.length > 0 && (
-              <div className="relative z-0 -mb-6 px-10 sm:px-14">
-                <div className="flex flex-col overflow-hidden rounded-t-2xl border border-b-0 border-border/50 bg-surface-secondary pb-6 dark:border-border-dark/50 dark:bg-surface-dark-secondary">
+              <div className="relative z-0 -mb-4 px-10 sm:px-14">
+                <div className="flex flex-col overflow-hidden rounded-t-2xl border border-b-0 border-border/50 bg-surface-secondary pb-4 dark:border-border-dark/50 dark:bg-surface-dark-secondary">
                   {pendingMessages.map((pending) => (
                     <QueueMessageCard
                       key={pending.id}

--- a/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
+++ b/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
@@ -22,7 +22,6 @@ interface ChatSessionOrchestratorProps {
   hasFetchedMessages: boolean;
   messagesQuery: ReturnType<typeof useInfiniteMessagesQuery>;
   refetchFilesMetadata: () => Promise<unknown>;
-  selectedModelId: string;
   children: ReactNode;
 }
 
@@ -33,7 +32,6 @@ export function ChatSessionOrchestrator({
   hasFetchedMessages,
   messagesQuery,
   refetchFilesMetadata,
-  selectedModelId,
   children,
 }: ChatSessionOrchestratorProps) {
   const queryClient = useQueryClient();
@@ -52,7 +50,7 @@ export function ChatSessionOrchestrator({
     })),
   );
 
-  const { selectModel } = useModelSelection();
+  const { selectedModelId, selectModel } = useModelSelection({ chatId });
 
   const {
     initialPrompt,

--- a/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
+++ b/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
@@ -228,10 +228,10 @@ export const QueueMessageCard = memo(function QueueMessageCard({
   );
 
   return (
-    <div className="flex w-full flex-col px-4 py-2.5">
+    <div className="flex w-full flex-col px-3 py-1.5">
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <CornerDownRight className="h-3.5 w-3.5 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+          <CornerDownRight className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
           {hasLocalFiles && !hasServerAttachments && (
             <div className="flex flex-wrap gap-1">
               {message.files!.map((file, idx) => (
@@ -258,10 +258,10 @@ export const QueueMessageCard = memo(function QueueMessageCard({
               onChange={(e) => setEditContent(e.target.value)}
               onKeyDown={handleKeyDown}
               aria-label="Edit message"
-              className="min-w-0 flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-quaternary focus:outline-none dark:text-text-dark-primary"
+              className="min-w-0 flex-1 bg-transparent text-xs text-text-primary placeholder:text-text-quaternary focus:outline-none dark:text-text-dark-primary"
             />
           ) : (
-            <span className="truncate text-sm text-text-secondary dark:text-text-dark-secondary">
+            <span className="truncate text-xs text-text-secondary dark:text-text-dark-secondary">
               {message.content}
             </span>
           )}
@@ -277,14 +277,14 @@ export const QueueMessageCard = memo(function QueueMessageCard({
               <Button
                 onClick={handleSaveEdit}
                 variant="ghost"
-                className="h-6 rounded-md px-2 py-0 text-xs font-medium text-text-primary dark:text-text-dark-primary"
+                className="h-5 rounded-md px-1.5 py-0 text-2xs font-medium text-text-primary dark:text-text-dark-primary"
               >
                 Save
               </Button>
               <Button
                 onClick={handleCancelEdit}
                 variant="ghost"
-                className="h-6 rounded-md px-2 py-0 text-xs font-medium text-text-tertiary dark:text-text-dark-tertiary"
+                className="h-5 rounded-md px-1.5 py-0 text-2xs font-medium text-text-tertiary dark:text-text-dark-tertiary"
               >
                 Cancel
               </Button>
@@ -295,27 +295,27 @@ export const QueueMessageCard = memo(function QueueMessageCard({
                 <Button
                   onClick={() => onSendNow(message.id)}
                   variant="ghost"
-                  className="h-6 rounded-md px-2 py-0 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+                  className="h-5 rounded-md px-1.5 py-0 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
                   aria-label="Send now"
                 >
-                  <Send className="h-3.5 w-3.5" />
+                  <Send className="h-3 w-3" />
                 </Button>
               )}
               <Button
                 onClick={handleStartEdit}
                 variant="ghost"
-                className="h-6 rounded-md px-2 py-0 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+                className="h-5 rounded-md px-1.5 py-0 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
                 aria-label="Edit message"
               >
-                <Pencil className="h-3.5 w-3.5" />
+                <Pencil className="h-3 w-3" />
               </Button>
               <Button
                 onClick={() => onCancel(message.id)}
                 variant="ghost"
-                className="h-6 rounded-md px-2 py-0 text-text-tertiary hover:bg-error-50 hover:text-error-600 dark:hover:bg-error-500/10 dark:hover:text-error-400"
+                className="h-5 rounded-md px-1.5 py-0 text-text-tertiary hover:bg-error-50 hover:text-error-600 dark:hover:bg-error-500/10 dark:hover:text-error-400"
                 aria-label="Cancel message"
               >
-                <X className="h-3.5 w-3.5" />
+                <X className="h-3 w-3" />
               </Button>
             </>
           )}

--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useEffect } from 'react';
+import { memo, useMemo } from 'react';
 import { Cpu } from 'lucide-react';
 import { Dropdown } from '@/components/ui/primitives/Dropdown';
 import type { DropdownItemType } from '@/components/ui/primitives/Dropdown';
@@ -56,12 +56,6 @@ export const ModelSelector = memo(function ModelSelector({
   }, [models]);
 
   const selectedModel = models.find((m) => m.model_id === selectedModelId);
-
-  useEffect(() => {
-    if (models.length > 0 && !selectedModel) {
-      onModelChange(models[0].model_id);
-    }
-  }, [models, selectedModel, onModelChange]);
 
   if (isLoading) {
     return (

--- a/frontend/src/hooks/queries/useModelQueries.ts
+++ b/frontend/src/hooks/queries/useModelQueries.ts
@@ -7,6 +7,7 @@ import { useModelStore } from '@/store/modelStore';
 import { queryKeys } from './queryKeys';
 
 const EMPTY_MODEL_MAP = new Map<string, Model>();
+const DEFAULT_MODEL_KEY = '__default__';
 
 export const useModelsQuery = (options?: Partial<UseQueryOptions<Model[]>>) => {
   return useQuery({
@@ -16,19 +17,20 @@ export const useModelsQuery = (options?: Partial<UseQueryOptions<Model[]>>) => {
   });
 };
 
-export const useModelSelection = (options?: { enabled?: boolean }) => {
+export const useModelSelection = (options?: { enabled?: boolean; chatId?: string }) => {
+  const chatId = options?.chatId ?? DEFAULT_MODEL_KEY;
   const { data: models = [], isLoading } = useModelsQuery({
     enabled: options?.enabled,
   });
-  const selectedModelId = useModelStore((state) => state.selectedModelId);
+  const selectedModelId = useModelStore((state) => state.modelByChat[chatId] ?? '');
 
   useEffect(() => {
     if (models.length === 0) return;
     const selectedExists = models.some((m) => m.model_id === selectedModelId);
     if (!selectedExists) {
-      useModelStore.getState().selectModel(models[0].model_id);
+      useModelStore.getState().selectModel(chatId, models[0].model_id);
     }
-  }, [models, selectedModelId]);
+  }, [models, selectedModelId, chatId]);
 
   const selectedModel = useMemo(
     () => models.find((m) => m.model_id === selectedModelId) ?? null,
@@ -36,8 +38,8 @@ export const useModelSelection = (options?: { enabled?: boolean }) => {
   );
 
   const selectModel = useCallback(
-    (modelId: string) => useModelStore.getState().selectModel(modelId),
-    [],
+    (modelId: string) => useModelStore.getState().selectModel(chatId, modelId),
+    [chatId],
   );
 
   return { models, selectedModelId, selectedModel, selectModel, isLoading };

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -15,7 +15,6 @@ import { ChatSessionOrchestrator } from '@/components/chat/chat-window/ChatSessi
 import { useEditorState } from '@/hooks/useEditorState';
 import { useChatData } from '@/hooks/useChatData';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
-import { useModelSelection } from '@/hooks/queries/useModelQueries';
 import { useWorkspacesQuery } from '@/hooks/queries/useWorkspaceQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
 import { mergeAgents } from '@/utils/settings';
@@ -57,7 +56,6 @@ export function ChatPage() {
   const { chatId } = useParams();
   const navigate = useNavigate();
 
-  const { selectedModelId } = useModelSelection();
   useCommandMenu();
 
   const { currentView, secondaryView } = useUIStore(
@@ -295,7 +293,6 @@ export function ChatPage() {
         hasFetchedMessages={hasFetchedMessages}
         messagesQuery={messagesQuery}
         refetchFilesMetadata={refetchFilesMetadata}
-        selectedModelId={selectedModelId}
       >
         <div className="relative flex h-full">
           <div className="flex h-full flex-1 overflow-hidden bg-surface text-text-primary dark:bg-surface-dark dark:text-text-dark-primary">

--- a/frontend/src/store/modelStore.ts
+++ b/frontend/src/store/modelStore.ts
@@ -5,11 +5,13 @@ import type { ModelSelectionState } from '@/types/ui.types';
 export const useModelStore = create<ModelSelectionState>()(
   persist(
     (set) => ({
-      selectedModelId: '',
-      selectModel: (modelId: string) => {
+      modelByChat: {},
+      selectModel: (chatId: string, modelId: string) => {
         const trimmedId = modelId?.trim();
         if (trimmedId) {
-          set({ selectedModelId: trimmedId });
+          set((state) => ({
+            modelByChat: { ...state.modelByChat, [chatId]: trimmedId },
+          }));
         }
       },
     }),

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -22,8 +22,8 @@ export interface ThemeState {
 }
 
 export interface ModelSelectionState {
-  selectedModelId: string;
-  selectModel: (modelId: string) => void;
+  modelByChat: Record<string, string>;
+  selectModel: (chatId: string, modelId: string) => void;
 }
 
 export interface PermissionModeState {


### PR DESCRIPTION
## Summary
- make the queued message panel more compact with smaller spacing, text, and action icons
- scope selected model state by chat so each conversation keeps its own selected model
- remove duplicated model defaulting and selection prop plumbing after moving selection to the chat-scoped hook

## Test plan
- [ ] Open a chat with queued messages and confirm the queue panel is visually smaller
- [ ] Verify queued message actions still work (send now, edit, cancel)
- [ ] Switch between chats and confirm each chat keeps its selected model
- [ ] Confirm model selector still defaults to the first available model when needed