### PR TITLE
Add git branch selector to chat input controls

### DIFF
--- a/frontend/src/components/chat/branch-selector/BranchSelector.tsx
+++ b/frontend/src/components/chat/branch-selector/BranchSelector.tsx
@@ -1,0 +1,66 @@
+import { memo } from 'react';
+import toast from 'react-hot-toast';
+import { GitBranch } from 'lucide-react';
+import { Dropdown } from '@/components/ui/primitives/Dropdown';
+import { useUIStore } from '@/store/uiStore';
+import { useChatContext } from '@/hooks/useChatContext';
+import { useGitBranchesQuery, useCheckoutBranchMutation } from '@/hooks/queries/useSandboxQueries';
+
+export interface BranchSelectorProps {
+  dropdownPosition?: 'top' | 'bottom';
+  disabled?: boolean;
+}
+
+export const BranchSelector = memo(function BranchSelector({
+  dropdownPosition = 'bottom',
+  disabled = false,
+}: BranchSelectorProps) {
+  const { sandboxId } = useChatContext();
+  const isSplitMode = useUIStore((state) => state.isSplitMode);
+
+  const { data: branchesData } = useGitBranchesQuery(sandboxId ?? '', !!sandboxId);
+  const checkoutBranch = useCheckoutBranchMutation();
+
+  if (!sandboxId || !branchesData?.is_git_repo || branchesData.branches.length === 0) {
+    return null;
+  }
+
+  const currentBranch = branchesData.current_branch;
+  const branches = branchesData.branches;
+
+  return (
+    <Dropdown
+      value={currentBranch}
+      items={branches}
+      getItemKey={(branch) => branch}
+      getItemLabel={(branch) => branch}
+      onSelect={(branch) => {
+        if (branch === currentBranch) return;
+        checkoutBranch.mutate(
+          { sandboxId, branch },
+          {
+            onSuccess: (data) => {
+              if (data.success) {
+                toast.success(`Switched to ${branch}`);
+              } else {
+                toast.error(data.error ?? 'Failed to switch branch');
+              }
+            },
+            onError: (err) => {
+              toast.error(err instanceof Error ? err.message : 'Failed to switch branch');
+            },
+          },
+        );
+      }}
+      leftIcon={GitBranch}
+      width="w-48"
+      dropdownPosition={dropdownPosition}
+      disabled={disabled || checkoutBranch.isPending}
+      compactOnMobile
+      forceCompact={isSplitMode}
+      searchable={branches.length >= 6}
+      searchPlaceholder="Search branches..."
+      itemClassName="font-mono"
+    />
+  );
+});

--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -2,6 +2,7 @@ import { EnhanceButton } from './EnhanceButton';
 import { PermissionModeSelector } from '@/components/chat/permission-mode-selector/PermissionModeSelector';
 import { ModelSelector } from '@/components/chat/model-selector/ModelSelector';
 import { ThinkingModeSelector } from '@/components/chat/thinking-mode-selector/ThinkingModeSelector';
+import { BranchSelector } from '@/components/chat/branch-selector/BranchSelector';
 import { useInputState, useInputActions } from '@/hooks/useInputContext';
 
 export function InputControls() {
@@ -32,6 +33,8 @@ export function InputControls() {
         dropdownPosition={state.dropdownPosition}
         disabled={state.isLoading}
       />
+
+      <BranchSelector dropdownPosition={state.dropdownPosition} disabled={state.isLoading} />
     </div>
   );
 }

--- a/frontend/src/hooks/queries/useSandboxQueries.ts
+++ b/frontend/src/hooks/queries/useSandboxQueries.ts
@@ -162,9 +162,9 @@ export const useCheckoutBranchMutation = () => {
   return useMutation({
     mutationFn: ({ sandboxId, branch }: { sandboxId: string; branch: string }) =>
       sandboxService.checkoutGitBranch(sandboxId, branch),
-    onSuccess: (data, variables) => {
+    onSuccess: async (data, variables) => {
       if (!data.success) return;
-      Promise.all([
+      await Promise.all([
         queryClient.invalidateQueries({
           queryKey: queryKeys.sandbox.gitBranches(variables.sandboxId),
         }),


### PR DESCRIPTION
## Summary
- Add a `BranchSelector` component to the chat input toolbar, allowing users to view and switch git branches directly from the chat page
- Uses the existing `Dropdown` component and backend git endpoints (`/git/branches`, `/git/checkout`)
- Only renders when the sandbox is a git repo with branches; searchable when 6+ branches exist
- Fix `useCheckoutBranchMutation` to properly `await` query invalidation so `isPending` stays true until caches refresh

## Test plan
- [ ] Open a chat with a git-based workspace and verify the branch selector appears in the input toolbar
- [ ] Verify branch selector does not appear for non-git workspaces
- [ ] Switch branches and confirm toast notification and file tree refresh
- [ ] Verify search appears when there are 6+ branches
- [ ] Confirm the selector is disabled while streaming or during checkout