### PR TITLE
Add new thread button per workspace in sidebar

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Plus, FolderOpen, ChevronRight, MoreHorizontal } from 'lucide-react';
+import { Plus, FolderOpen, ChevronRight, MoreHorizontal, MessageSquarePlus } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useInView } from 'react-intersection-observer';
 import type { FetchNextPageOptions } from '@tanstack/react-query';
@@ -352,6 +352,17 @@ export function Sidebar({
     });
   }, []);
 
+  const handleNewWorkspaceThread = useCallback(
+    (e: React.MouseEvent, workspaceId: string) => {
+      e.stopPropagation();
+      navigate('/', { state: { workspaceId } });
+      if (isMobile) {
+        useUIStore.getState().setSidebarOpen(false);
+      }
+    },
+    [navigate, isMobile],
+  );
+
   const handleWorkspaceContextMenu = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>, workspaceId: string) => {
       e.stopPropagation();
@@ -494,6 +505,14 @@ export function Sidebar({
                         <span className="truncate text-xs font-medium text-text-secondary dark:text-text-dark-secondary">
                           {group.workspace.name}
                         </span>
+                      </button>
+                      <button
+                        type="button"
+                        title="New thread"
+                        onClick={(e) => handleNewWorkspaceThread(e, group.workspace.id)}
+                        className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+                      >
+                        <MessageSquarePlus className="h-3.5 w-3.5" />
                       </button>
                       <button
                         type="button"

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo, useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useRef, useMemo, useCallback, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { useLayoutSidebar } from '@/components/layout/layoutState';
@@ -22,6 +22,7 @@ const EXAMPLE_PROMPTS = [
 
 export function LandingPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const attachedFiles = useChatStore((state) => state.attachedFiles);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { selectedModelId, selectModel } = useModelSelection({ enabled: isAuthenticated });
@@ -54,7 +55,21 @@ export function LandingPage() {
   const createChat = useCreateChatMutation();
   const [message, setMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const initialWorkspaceId = (location.state as { workspaceId?: string })?.workspaceId ?? null;
+  const consumedWorkspaceRef = useRef<string | null>(null);
+
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (
+      initialWorkspaceId &&
+      initialWorkspaceId !== consumedWorkspaceRef.current &&
+      workspaces.some((ws) => ws.id === initialWorkspaceId)
+    ) {
+      consumedWorkspaceRef.current = initialWorkspaceId;
+      setSelectedWorkspaceId(initialWorkspaceId);
+    }
+  }, [initialWorkspaceId, workspaces]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Summary
- Add a "New thread" button (MessageSquarePlus icon) that appears on hover next to the 3-dots menu on workspace headers in the sidebar
- Clicking it navigates to the landing page with the workspace pre-selected via router state
- Landing page reads the workspace ID from navigation state and auto-selects it in the WorkspaceSelector

## Test plan
- [ ] Hover over a workspace name in the sidebar — verify both the new thread icon and the 3-dots icon appear
- [ ] Click the new thread button — verify it navigates to the landing page with the correct workspace pre-selected
- [ ] Click new thread for a different workspace while already on the landing page — verify the workspace selection updates
- [ ] On mobile, verify the sidebar closes after clicking the new thread button