### PR TITLE
Fix desktop mode sync with ~/.claude/ folder

### DIFF
--- a/backend/app/api/endpoints/workspace.py
+++ b/backend/app/api/endpoints/workspace.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from pathlib import Path
 from typing import NoReturn
 from uuid import UUID
 
@@ -9,11 +11,14 @@ from app.core.deps import get_workspace_service
 from app.core.security import get_current_user
 from app.models.db_models.user import User
 from app.models.schemas.pagination import PaginatedResponse
+from app.models.schemas.settings import CustomAgent, CustomSkill, CustomSlashCommand
 from app.models.schemas.workspace import (
     Workspace as WorkspaceSchema,
     WorkspaceCreate,
+    WorkspaceResources,
     WorkspaceUpdate,
 )
+from app.services.claude_folder_sync import ClaudeFolderSync
 from app.services.exceptions import WorkspaceException
 from app.services.workspace import WorkspaceService
 
@@ -80,6 +85,27 @@ async def update_workspace(
         )
     except WorkspaceException as e:
         _raise_workspace_http_exception(e)
+
+
+@router.get("/{workspace_id}/resources", response_model=WorkspaceResources)
+async def get_workspace_resources(
+    workspace_id: UUID,
+    current_user: User = Depends(get_current_user),
+    workspace_service: WorkspaceService = Depends(get_workspace_service),
+) -> WorkspaceResources:
+    try:
+        workspace = await workspace_service.get_workspace(workspace_id, current_user)
+    except WorkspaceException as e:
+        _raise_workspace_http_exception(e)
+    project_claude_dir = Path(workspace.workspace_path) / ".claude"
+    raw_agents, raw_commands, raw_skills = await asyncio.to_thread(
+        ClaudeFolderSync.discover_all, project_claude_dir
+    )
+    return WorkspaceResources(
+        agents=[CustomAgent.model_validate(a) for a in raw_agents],
+        commands=[CustomSlashCommand.model_validate(c) for c in raw_commands],
+        skills=[CustomSkill.model_validate(s) for s in raw_skills],
+    )
 
 
 @router.delete("/{workspace_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/models/schemas/workspace.py
+++ b/backend/app/models/schemas/workspace.py
@@ -4,6 +4,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.models.schemas.settings import CustomAgent, CustomSkill, CustomSlashCommand
+
 
 class WorkspaceCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
@@ -30,3 +32,9 @@ class Workspace(BaseModel):
     source_url: str | None = None
     created_at: datetime
     updated_at: datetime
+
+
+class WorkspaceResources(BaseModel):
+    agents: list[CustomAgent] = Field(default_factory=list)
+    commands: list[CustomSlashCommand] = Field(default_factory=list)
+    skills: list[CustomSkill] = Field(default_factory=list)

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -1,7 +1,7 @@
 from typing import Literal, cast
 
 from app.models.types import CustomAgentDict, YamlMetadata
-
+from app.services.claude_folder_sync import ClaudeFolderSync
 from app.services.resource import BaseMarkdownResourceService
 from app.services.exceptions import AgentException
 
@@ -18,6 +18,14 @@ class AgentService(BaseMarkdownResourceService[CustomAgentDict]):
 
     def _validate_additional_fields(self, metadata: YamlMetadata) -> None:
         pass
+
+    def _sync_write_to_claude_folder(self, name: str, content: str) -> None:
+        if ClaudeFolderSync.is_active():
+            ClaudeFolderSync.write_agent(name, content)
+
+    def _sync_delete_from_claude_folder(self, name: str) -> None:
+        if ClaudeFolderSync.is_active():
+            ClaudeFolderSync.delete_agent(name)
 
     def _build_response(
         self, name: str, metadata: YamlMetadata, content: str

--- a/backend/app/services/claude_folder_sync.py
+++ b/backend/app/services/claude_folder_sync.py
@@ -1,0 +1,267 @@
+import logging
+import os
+import shutil
+import stat as stat_module
+import zipfile
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import TypeVar, cast
+
+from app.core.config import get_settings
+from app.models.types import (
+    CustomAgentDict,
+    CustomSkillDict,
+    CustomSlashCommandDict,
+    YamlMetadata,
+)
+from app.utils.yaml_parser import YAMLParser
+
+settings = get_settings()
+logger = logging.getLogger(__name__)
+
+CLAUDE_DIR = Path.home() / ".claude"
+CLAUDE_AGENTS_DIR = CLAUDE_DIR / "agents"
+CLAUDE_COMMANDS_DIR = CLAUDE_DIR / "commands"
+CLAUDE_SKILLS_DIR = CLAUDE_DIR / "skills"
+
+T = TypeVar("T", bound=Mapping[str, object])
+
+
+class ClaudeFolderSync:
+    """Bidirectional sync between Agentrove's storage and ~/.claude/ in desktop mode.
+
+    In desktop mode, HOME is not overridden, so the Claude CLI reads agents,
+    commands, and skills from ~/.claude/. This service ensures that:
+    1. Resources managed by Agentrove are written to ~/.claude/ so the CLI finds them
+    2. Resources already in ~/.claude/ (from Claude CLI usage) are discovered by Agentrove
+    """
+
+    @staticmethod
+    def is_active() -> bool:
+        return settings.DESKTOP_MODE
+
+    @staticmethod
+    def _parse_md_metadata(content: str) -> YamlMetadata:
+        try:
+            parsed = YAMLParser.parse(content)
+            return parsed["metadata"]
+        except (ValueError, KeyError):
+            return {}
+
+    @staticmethod
+    def _merge_by_name(
+        db_items: list[T] | None,
+        discover_fn: Callable[[], list[T]],
+    ) -> list[T]:
+        existing = list(db_items) if db_items else []
+        existing_names = {str(item["name"]).lower() for item in existing}
+        for item in discover_fn():
+            if str(item["name"]).lower() not in existing_names:
+                existing.append(item)
+        return existing
+
+    @staticmethod
+    def _discover_md_resources(
+        directory: Path, service_cls: type
+    ) -> list[Mapping[str, object]]:
+        if not directory.is_dir():
+            return []
+        service = service_cls()
+        results = []
+        for md_file in directory.glob("*.md"):
+            try:
+                content = md_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            metadata = ClaudeFolderSync._parse_md_metadata(content)
+            results.append(service._build_response(md_file.stem, metadata, content))
+        return results
+
+    @staticmethod
+    def discover_agents(
+        base_dir: Path = CLAUDE_AGENTS_DIR,
+    ) -> list[CustomAgentDict]:
+        from app.services.agent import AgentService
+
+        return cast(
+            list[CustomAgentDict],
+            ClaudeFolderSync._discover_md_resources(base_dir, AgentService),
+        )
+
+    @staticmethod
+    def discover_commands(
+        base_dir: Path = CLAUDE_COMMANDS_DIR,
+    ) -> list[CustomSlashCommandDict]:
+        from app.services.command import CommandService
+
+        return cast(
+            list[CustomSlashCommandDict],
+            ClaudeFolderSync._discover_md_resources(base_dir, CommandService),
+        )
+
+    @staticmethod
+    def discover_skills(
+        base_dir: Path = CLAUDE_SKILLS_DIR,
+    ) -> list[CustomSkillDict]:
+        if not base_dir.is_dir():
+            return []
+        skills: list[CustomSkillDict] = []
+        for entry in base_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            skill_md = entry / "SKILL.md"
+            if not skill_md.exists():
+                skill_md = entry / "skill.md"
+            if not skill_md.exists():
+                continue
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            metadata = ClaudeFolderSync._parse_md_metadata(content)
+            file_count = 0
+            total_size = 0
+            for f in entry.rglob("*"):
+                try:
+                    st = f.stat()
+                except OSError:
+                    continue
+                if stat_module.S_ISREG(st.st_mode):
+                    file_count += 1
+                    total_size += st.st_size
+            skills.append(
+                {
+                    "name": entry.name,
+                    "description": str(metadata.get("description", "")),
+                    "enabled": True,
+                    "size_bytes": total_size,
+                    "file_count": file_count,
+                }
+            )
+        return skills
+
+    @staticmethod
+    def discover_all(
+        claude_dir: Path = CLAUDE_DIR,
+    ) -> tuple[
+        list[CustomAgentDict], list[CustomSlashCommandDict], list[CustomSkillDict]
+    ]:
+        return (
+            ClaudeFolderSync.discover_agents(claude_dir / "agents"),
+            ClaudeFolderSync.discover_commands(claude_dir / "commands"),
+            ClaudeFolderSync.discover_skills(claude_dir / "skills"),
+        )
+
+    @staticmethod
+    def merge_agents(
+        db_agents: list[CustomAgentDict] | None,
+    ) -> list[CustomAgentDict]:
+        return ClaudeFolderSync._merge_by_name(
+            db_agents, ClaudeFolderSync.discover_agents
+        )
+
+    @staticmethod
+    def merge_commands(
+        db_commands: list[CustomSlashCommandDict] | None,
+    ) -> list[CustomSlashCommandDict]:
+        return ClaudeFolderSync._merge_by_name(
+            db_commands, ClaudeFolderSync.discover_commands
+        )
+
+    @staticmethod
+    def merge_skills(
+        db_skills: list[CustomSkillDict] | None,
+    ) -> list[CustomSkillDict]:
+        return ClaudeFolderSync._merge_by_name(
+            db_skills, ClaudeFolderSync.discover_skills
+        )
+
+    @staticmethod
+    def _write_md(directory: Path, name: str, content: str) -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f"{name}.md"
+        # Remove dangling symlinks left by old sandbox-based deployments;
+        # write_text fails on a symlink whose target no longer exists.
+        if path.is_symlink():
+            path.unlink()
+        path.write_text(content, encoding="utf-8")
+
+    @staticmethod
+    def _delete_md(directory: Path, name: str) -> None:
+        path = directory / f"{name}.md"
+        if path.is_symlink() or path.exists():
+            os.remove(path)
+
+    @staticmethod
+    def write_agent(name: str, content: str) -> None:
+        ClaudeFolderSync._write_md(CLAUDE_AGENTS_DIR, name, content)
+
+    @staticmethod
+    def delete_agent(name: str) -> None:
+        ClaudeFolderSync._delete_md(CLAUDE_AGENTS_DIR, name)
+
+    @staticmethod
+    def write_command(name: str, content: str) -> None:
+        ClaudeFolderSync._write_md(CLAUDE_COMMANDS_DIR, name, content)
+
+    @staticmethod
+    def delete_command(name: str) -> None:
+        ClaudeFolderSync._delete_md(CLAUDE_COMMANDS_DIR, name)
+
+    @staticmethod
+    def write_skill(name: str, zip_path: Path) -> None:
+        from app.services.skill import SkillService
+
+        skill_dir = CLAUDE_SKILLS_DIR / name
+        if skill_dir.is_symlink():
+            skill_dir.unlink()
+        elif skill_dir.exists():
+            shutil.rmtree(skill_dir)
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            for rel, file_bytes in SkillService.iter_zip_entries(zf, name):
+                dest = skill_dir / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(file_bytes)
+
+    @staticmethod
+    def delete_skill(name: str) -> None:
+        skill_dir = CLAUDE_SKILLS_DIR / name
+        if skill_dir.is_symlink():
+            skill_dir.unlink()
+        elif skill_dir.exists():
+            shutil.rmtree(skill_dir)
+
+    @staticmethod
+    def export_all_to_claude_folder(
+        user_id: str,
+        agents: list[CustomAgentDict] | None,
+        commands: list[CustomSlashCommandDict] | None,
+        skills: list[CustomSkillDict] | None,
+    ) -> None:
+        """Write all enabled resources from Agentrove storage to ~/.claude/."""
+        storage = Path(settings.STORAGE_PATH)
+
+        if agents:
+            for agent in agents:
+                if not agent.get("enabled", True):
+                    continue
+                content = agent.get("content")
+                if content:
+                    ClaudeFolderSync.write_agent(agent["name"], content)
+
+        if commands:
+            for cmd in commands:
+                if not cmd.get("enabled", True):
+                    continue
+                content = cmd.get("content")
+                if content:
+                    ClaudeFolderSync.write_command(cmd["name"], content)
+
+        if skills:
+            for skill in skills:
+                if not skill.get("enabled", True):
+                    continue
+                zip_path = storage / "skills" / user_id / f"{skill['name']}.zip"
+                if zip_path.exists():
+                    ClaudeFolderSync.write_skill(skill["name"], zip_path)

--- a/backend/app/services/command.py
+++ b/backend/app/services/command.py
@@ -1,4 +1,5 @@
 from app.models.types import CustomSlashCommandDict, YamlMetadata
+from app.services.claude_folder_sync import ClaudeFolderSync
 from app.services.resource import BaseMarkdownResourceService
 from app.services.exceptions import CommandException
 
@@ -14,6 +15,14 @@ class CommandService(BaseMarkdownResourceService[CustomSlashCommandDict]):
         arg_hint = metadata.get("argument_hint")
         if arg_hint and len(arg_hint) > 100:
             self._raise("argument_hint too long (max 100 characters)")
+
+    def _sync_write_to_claude_folder(self, name: str, content: str) -> None:
+        if ClaudeFolderSync.is_active():
+            ClaudeFolderSync.write_command(name, content)
+
+    def _sync_delete_from_claude_folder(self, name: str) -> None:
+        if ClaudeFolderSync.is_active():
+            ClaudeFolderSync.delete_command(name)
 
     def _build_response(
         self, name: str, metadata: YamlMetadata, content: str

--- a/backend/app/services/resource.py
+++ b/backend/app/services/resource.py
@@ -167,6 +167,12 @@ class BaseMarkdownResourceService(ABC, Generic[T]):
     def _validate_additional_fields(self, metadata: YamlMetadata) -> None:
         pass
 
+    def _sync_write_to_claude_folder(self, name: str, content: str) -> None:
+        pass
+
+    def _sync_delete_from_claude_folder(self, name: str) -> None:
+        pass
+
     def _validate_markdown_file(self, content: str) -> ParsedResourceResult:
         if len(content) > self.max_size_bytes:
             self._raise(
@@ -237,6 +243,8 @@ class BaseMarkdownResourceService(ABC, Generic[T]):
         with open(resource_path, "w", encoding="utf-8") as f:
             f.write(content_str)
 
+        self._sync_write_to_claude_folder(sanitized_name, content_str)
+
         logger.info(
             f"Stored {self.resource_type}: {sanitized_name}, size={len(contents)} bytes"
         )
@@ -247,6 +255,7 @@ class BaseMarkdownResourceService(ABC, Generic[T]):
         resource_path = self._get_resource_path(user_id, name)
         if resource_path.exists():
             os.remove(resource_path)
+        self._sync_delete_from_claude_folder(name)
 
     async def update(
         self,
@@ -290,6 +299,10 @@ class BaseMarkdownResourceService(ABC, Generic[T]):
 
         with open(new_path, "w", encoding="utf-8") as f:
             f.write(content)
+
+        if new_sanitized_name != current_name:
+            self._sync_delete_from_claude_folder(current_name)
+        self._sync_write_to_claude_folder(new_sanitized_name, content)
 
         logger.info(
             f"Updated {self.resource_type}: {current_name} -> {new_sanitized_name}, "

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -38,6 +38,7 @@ from app.services.sandbox_providers import (
     PtySize,
     SandboxProvider,
 )
+from app.services.claude_folder_sync import ClaudeFolderSync
 from app.services.sandbox_providers.types import CommandResult
 from app.services.skill import SkillService
 
@@ -312,6 +313,15 @@ class SandboxService:
         custom_slash_commands: list[CustomSlashCommandDict] | None,
         custom_agents: list[CustomAgentDict] | None,
     ) -> None:
+        # In desktop mode, HOME is not overridden so the Claude CLI reads
+        # ~/.claude/ directly. Write resources there instead of the sandbox's
+        # isolated .claude/ directory which the CLI would never find.
+        if ClaudeFolderSync.is_active():
+            ClaudeFolderSync.export_all_to_claude_folder(
+                user_id, custom_agents, custom_slash_commands, custom_skills
+            )
+            return
+
         skill_service = SkillService()
         command_service = CommandService()
         agent_service = AgentService()
@@ -338,13 +348,9 @@ class SandboxService:
                 continue
 
             with zipfile.ZipFile(local_zip_path, "r") as skill_zip:
-                # Strip the skill-name prefix if the zip nests files under it
-                prefix = f"{skill_name}/"
-                for entry in skill_zip.namelist():
-                    if entry.endswith("/"):
-                        continue
-                    file_bytes = skill_zip.read(entry)
-                    rel = entry[len(prefix) :] if entry.startswith(prefix) else entry
+                for rel, file_bytes in SkillService.iter_zip_entries(
+                    skill_zip, skill_name
+                ):
                     remote_path = f"{SANDBOX_CLAUDE_DIR}/skills/{skill_name}/{rel}"
                     writes.append((remote_path, file_bytes))
 

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import zipfile
+from collections.abc import Iterator
 from pathlib import Path
 
 from fastapi import UploadFile
@@ -14,6 +15,7 @@ from app.constants import (
 )
 from app.core.config import get_settings
 from app.models.types import CustomSkillDict, EnabledResourceInfo, YamlMetadata
+from app.services.claude_folder_sync import ClaudeFolderSync
 from app.services.exceptions import SkillException
 from app.services.resource import BaseMarkdownResourceService
 from app.utils.yaml_parser import YAMLParser
@@ -24,6 +26,19 @@ MAX_SKILL_SIZE_BYTES = 100 * 1024 * 1024
 
 
 class SkillService:
+    @staticmethod
+    def iter_zip_entries(
+        zf: zipfile.ZipFile, skill_name: str
+    ) -> Iterator[tuple[str, bytes]]:
+        """Yield (relative_path, file_bytes) for each file in a skill zip."""
+        prefix = f"{skill_name}/"
+        for entry in zf.namelist():
+            if entry.endswith("/"):
+                continue
+            file_bytes = zf.read(entry)
+            rel = entry[len(prefix) :] if entry.startswith(prefix) else entry
+            yield rel, file_bytes
+
     def __init__(self) -> None:
         self.storage_path = Path(settings.STORAGE_PATH)
         self.skills_base_path = self.storage_path / "skills"
@@ -141,6 +156,9 @@ class SkillService:
                 with open(final_zip_path, "wb") as f:
                     f.write(contents)
 
+                if ClaudeFolderSync.is_active():
+                    ClaudeFolderSync.write_skill(skill_name, final_zip_path)
+
                 logger.info(
                     f"Stored skill ZIP: {skill_name}, "
                     f"size={len(contents)}, "
@@ -165,6 +183,8 @@ class SkillService:
         skill_path = self._get_skill_path(user_id, skill_name)
         if skill_path.exists():
             os.remove(skill_path)
+        if ClaudeFolderSync.is_active():
+            ClaudeFolderSync.delete_skill(skill_name)
 
     def get_enabled(
         self, user_id: str, custom_skills: list[CustomSkillDict]

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -10,8 +10,16 @@ from sqlalchemy.orm.attributes import flag_modified
 from app.constants import REDIS_KEY_USER_SETTINGS
 from app.core.config import get_settings
 from app.models.db_models.user import UserSettings
-from app.models.schemas.settings import UserSettingsResponse
+from pydantic import BaseModel
+
+from app.models.schemas.settings import (
+    CustomAgent,
+    CustomSkill,
+    CustomSlashCommand,
+    UserSettingsResponse,
+)
 from app.models.types import InstalledPluginDict
+from app.services.claude_folder_sync import CLAUDE_DIR, ClaudeFolderSync
 from app.services.db import BaseDbService, SessionFactoryType
 from app.services.exceptions import UserException
 from app.utils.cache import CacheStore, cache_connection
@@ -84,6 +92,10 @@ class UserService(BaseDbService[UserSettings]):
         response: UserSettingsResponse = UserSettingsResponse.model_validate(
             user_settings
         )
+
+        if ClaudeFolderSync.is_active():
+            self._merge_claude_folder_resources(response)
+
         if cache:
             await cache.setex(
                 cache_key,
@@ -92,6 +104,30 @@ class UserService(BaseDbService[UserSettings]):
             )
 
         return response
+
+    @staticmethod
+    def _merge_claude_folder_resources(response: UserSettingsResponse) -> None:
+        if not CLAUDE_DIR.is_dir():
+            return
+
+        merge_specs: list[tuple[str, Any, type[BaseModel]]] = [
+            ("custom_agents", ClaudeFolderSync.merge_agents, CustomAgent),
+            (
+                "custom_slash_commands",
+                ClaudeFolderSync.merge_commands,
+                CustomSlashCommand,
+            ),
+            ("custom_skills", ClaudeFolderSync.merge_skills, CustomSkill),
+        ]
+        for attr, merge_fn, model_cls in merge_specs:
+            current = getattr(response, attr) or []
+            db_items = [x.model_dump() for x in current]
+            merged = merge_fn(db_items)
+            if len(merged) > len(db_items):
+                new_items = [
+                    model_cls.model_validate(x) for x in merged[len(current) :]
+                ]
+                setattr(response, attr, list(current) + new_items)
 
     async def update_user_settings(
         self, user_id: UUID, settings_update: dict[str, Any], db: AsyncSession

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -9,6 +9,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "agentrove-desktop"
+version = "0.1.0"
+dependencies = [
+ "dirs 5.0.1",
+ "libc",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-notification",
+ "tauri-plugin-opener",
+ "tauri-plugin-store",
+ "tauri-plugin-updater",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,24 +466,6 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "claudex-desktop"
-version = "0.1.0"
-dependencies = [
- "dirs 5.0.1",
- "libc",
- "rand 0.9.2",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-dialog",
- "tauri-plugin-notification",
- "tauri-plugin-opener",
- "tauri-plugin-store",
- "tauri-plugin-updater",
 ]
 
 [[package]]

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -24,6 +24,7 @@ export const queryKeys = {
     gitBranches: (sandboxId: string) => ['sandbox', sandboxId, 'git-branches'] as const,
   },
   workspaces: ['workspaces'] as const,
+  workspaceResources: (workspaceId: string) => ['workspaces', workspaceId, 'resources'] as const,
   models: 'models',
   scheduler: {
     tasks: ['scheduler', 'tasks'] as const,

--- a/frontend/src/hooks/queries/useWorkspaceQueries.ts
+++ b/frontend/src/hooks/queries/useWorkspaceQueries.ts
@@ -3,11 +3,25 @@ import type { UseMutationOptions, UseQueryOptions } from '@tanstack/react-query'
 import { workspaceService } from '@/services/workspaceService';
 import type {
   Workspace,
+  WorkspaceResources,
   CreateWorkspaceRequest,
   UpdateWorkspaceRequest,
 } from '@/types/workspace.types';
 import type { PaginatedResponse } from '@/types/api.types';
 import { queryKeys } from './queryKeys';
+
+export const useWorkspaceResourcesQuery = (
+  workspaceId: string | undefined,
+  options?: Partial<UseQueryOptions<WorkspaceResources>>,
+) => {
+  return useQuery({
+    queryKey: queryKeys.workspaceResources(workspaceId ?? ''),
+    queryFn: () => workspaceService.getWorkspaceResources(workspaceId!),
+    enabled: !!workspaceId,
+    staleTime: 30_000,
+    ...options,
+  });
+};
 
 export const useWorkspacesQuery = (
   options?: Partial<UseQueryOptions<PaginatedResponse<Workspace>>>,

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -15,9 +15,12 @@ import { ChatSessionOrchestrator } from '@/components/chat/chat-window/ChatSessi
 import { useEditorState } from '@/hooks/useEditorState';
 import { useChatData } from '@/hooks/useChatData';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
-import { useWorkspacesQuery } from '@/hooks/queries/useWorkspaceQueries';
+import {
+  useWorkspacesQuery,
+  useWorkspaceResourcesQuery,
+} from '@/hooks/queries/useWorkspaceQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
-import { mergeAgents } from '@/utils/settings';
+import { mergeAgents, mergeByName } from '@/utils/settings';
 import { findFileByToolPath } from '@/utils/file';
 import { ChatProvider } from '@/contexts/ChatContext';
 
@@ -112,11 +115,21 @@ export function ChatPage() {
 
   const { data: settings } = useSettingsQuery();
 
-  const allAgents = useMemo(() => mergeAgents(settings?.custom_agents), [settings?.custom_agents]);
+  const { data: workspaceResources } = useWorkspaceResourcesQuery(currentChat?.workspace_id);
 
-  const enabledSlashCommands = useMemo(() => {
-    return settings?.custom_slash_commands?.filter((cmd) => cmd.enabled) || [];
-  }, [settings?.custom_slash_commands]);
+  const allAgents = useMemo(
+    () => mergeByName(mergeAgents(settings?.custom_agents), workspaceResources?.agents ?? []),
+    [settings?.custom_agents, workspaceResources?.agents],
+  );
+
+  const enabledSlashCommands = useMemo(
+    () =>
+      mergeByName(
+        settings?.custom_slash_commands?.filter((cmd) => cmd.enabled) || [],
+        workspaceResources?.commands ?? [],
+      ),
+    [settings?.custom_slash_commands, workspaceResources?.commands],
+  );
 
   const customPrompts = useMemo(() => {
     return settings?.custom_prompts || [];

--- a/frontend/src/services/workspaceService.ts
+++ b/frontend/src/services/workspaceService.ts
@@ -2,6 +2,7 @@ import { apiClient } from '@/lib/api';
 import { ensureResponse, serviceCall, buildQueryString } from '@/services/base/BaseService';
 import type {
   Workspace,
+  WorkspaceResources,
   CreateWorkspaceRequest,
   UpdateWorkspaceRequest,
 } from '@/types/workspace.types';
@@ -40,9 +41,19 @@ async function deleteWorkspace(workspaceId: string): Promise<void> {
   });
 }
 
+async function getWorkspaceResources(workspaceId: string): Promise<WorkspaceResources> {
+  return serviceCall(async () => {
+    const response = await apiClient.get<WorkspaceResources>(
+      `/workspaces/${workspaceId}/resources`,
+    );
+    return ensureResponse(response, 'Failed to fetch workspace resources');
+  });
+}
+
 export const workspaceService = {
   listWorkspaces,
   createWorkspace,
   updateWorkspace,
   deleteWorkspace,
+  getWorkspaceResources,
 };

--- a/frontend/src/types/workspace.types.ts
+++ b/frontend/src/types/workspace.types.ts
@@ -1,3 +1,5 @@
+import type { CustomAgent, CustomCommand, CustomSkill } from './user.types';
+
 export type WorkspaceSourceType = 'git' | 'local' | 'empty';
 
 export interface Workspace {
@@ -23,4 +25,10 @@ export interface CreateWorkspaceRequest {
 
 export interface UpdateWorkspaceRequest {
   name?: string;
+}
+
+export interface WorkspaceResources {
+  agents: CustomAgent[];
+  commands: CustomCommand[];
+  skills: CustomSkill[];
 }

--- a/frontend/src/utils/settings.ts
+++ b/frontend/src/utils/settings.ts
@@ -3,11 +3,14 @@ import type { GeneralSecretFieldConfig } from '@/types/settings.types';
 import { validateRequired, validateRequiredIf, validateUnique } from '@/utils/validation';
 import { BUILT_IN_AGENTS } from '@/config/constants';
 
+export const mergeByName = <T extends { name: string }>(primary: T[], secondary: T[]): T[] => {
+  if (!secondary.length) return primary;
+  const primaryNames = new Set(primary.map((item) => item.name.toLowerCase()));
+  return [...primary, ...secondary.filter((item) => !primaryNames.has(item.name.toLowerCase()))];
+};
+
 export const mergeAgents = (customAgents: CustomAgent[] | null | undefined): CustomAgent[] => {
-  const custom = customAgents ?? [];
-  const builtInNames = new Set(BUILT_IN_AGENTS.map((a) => a.name.toLowerCase()));
-  const uniqueCustomAgents = custom.filter((a) => !builtInNames.has(a.name.toLowerCase()));
-  return [...BUILT_IN_AGENTS, ...uniqueCustomAgents];
+  return mergeByName(BUILT_IN_AGENTS, customAgents ?? []);
 };
 
 export const createDefaultEnvVarForm = (): CustomEnvVar => ({


### PR DESCRIPTION
## Summary
- Adds `ClaudeFolderSync` service for bidirectional sync between Agentrove's storage and `~/.claude/` in desktop mode
- Write-through on CRUD: agents, commands, and skills are written to `~/.claude/` when created/updated/deleted
- Read-merge on settings load: resources already in `~/.claude/` (from direct Claude CLI usage) are discovered and merged into the API response
- Desktop deploy redirected: `_deploy_resources` writes to `~/.claude/` instead of the sandbox's isolated `.claude/` directory which the CLI never reads

## Test plan
- [ ] Verify agents created in the desktop app appear in `~/.claude/agents/`
- [ ] Verify commands created in the desktop app appear in `~/.claude/commands/`
- [ ] Verify skills uploaded in the desktop app are extracted to `~/.claude/skills/`
- [ ] Verify agents/commands/skills already in `~/.claude/` appear in the desktop app settings
- [ ] Verify deleting a resource in the app removes it from `~/.claude/`
- [ ] Verify renaming a resource updates `~/.claude/` (old deleted, new created)
- [ ] Verify non-desktop mode (Docker) is unaffected — sync hooks are no-ops