### PR TITLE
Read marketplace catalog from local filesystem

### DIFF
--- a/backend/app/api/endpoints/marketplace.py
+++ b/backend/app/api/endpoints/marketplace.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -38,6 +38,7 @@ from app.models.types import (
     InstalledPluginDict,
 )
 from app.services.agent import AgentService
+from app.services.claude_folder_sync import ClaudeFolderSync
 from app.services.command import CommandService
 from app.services.exceptions import (
     MarketplaceException,
@@ -53,11 +54,10 @@ router = APIRouter()
 
 @router.get("/catalog", response_model=list[MarketplacePlugin])
 async def get_catalog(
-    force_refresh: bool = Query(False, description="Force refresh catalog cache"),
     marketplace_service: MarketplaceService = Depends(get_marketplace_service),
 ) -> list[MarketplacePlugin]:
     try:
-        plugins = await marketplace_service.fetch_catalog(force_refresh=force_refresh)
+        plugins = await marketplace_service.fetch_catalog()
         return [MarketplacePlugin(**p) for p in plugins]
     except MarketplaceException as e:
         raise HTTPException(status_code=e.status_code, detail=str(e))
@@ -106,7 +106,7 @@ async def install_plugin_components(
     try:
         result = await installer_service.install_components(
             user_id=str(current_user.id),
-            plugin_name=request.plugin_name,
+            details=details,
             components=request.components,
             current_agents=current_agents,
             current_commands=current_commands,
@@ -180,6 +180,10 @@ async def get_installed_plugins(
     user_settings = await load_user_settings_or_404(user_service, current_user.id, db)
 
     installed: list[InstalledPluginDict] = list(user_settings.installed_plugins or [])
+
+    for cli_plugin in ClaudeFolderSync.get_cli_installed_plugins():
+        append_named_item_if_missing(installed, cli_plugin)
+
     return [InstalledPlugin(**p) for p in installed]
 
 

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -69,16 +69,12 @@ async def get_github_token(
         return None
 
 
-async def get_marketplace_service(
-    github_token: str | None = Depends(get_github_token),
-) -> MarketplaceService:
-    return MarketplaceService(github_token=github_token)
+def get_marketplace_service() -> MarketplaceService:
+    return MarketplaceService()
 
 
-async def get_plugin_installer_service(
-    github_token: str | None = Depends(get_github_token),
-) -> PluginInstallerService:
-    return PluginInstallerService(github_token=github_token)
+def get_plugin_installer_service() -> PluginInstallerService:
+    return PluginInstallerService()
 
 
 def get_scheduler_service() -> SchedulerService:

--- a/backend/app/models/schemas/marketplace.py
+++ b/backend/app/models/schemas/marketplace.py
@@ -12,6 +12,7 @@ class MarketplacePlugin(BaseModel):
     description: str = Field(..., description="What the plugin does")
     category: str = Field(..., description="Plugin category")
     source: str = Field(..., description="Source path in repository")
+    marketplace: str = Field("", description="Marketplace this plugin belongs to")
     version: str | None = Field(None, description="Plugin version")
     author: MarketplaceAuthor | None = None
     homepage: str | None = None

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -103,6 +103,7 @@ class MarketplacePluginDict(TypedDict, total=False):
     description: str
     category: str
     source: str
+    marketplace: str
     version: str | None
     author: MarketplaceAuthorDict | None
     homepage: str | None
@@ -121,6 +122,7 @@ class PluginDetailsDict(TypedDict, total=False):
     description: str
     category: str
     source: str
+    marketplace: str
     version: str | None
     author: MarketplaceAuthorDict | None
     homepage: str | None

--- a/backend/app/services/claude_folder_sync.py
+++ b/backend/app/services/claude_folder_sync.py
@@ -7,13 +7,14 @@ import stat as stat_module
 import zipfile
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from app.core.config import get_settings
 from app.models.types import (
     CustomAgentDict,
     CustomSkillDict,
     CustomSlashCommandDict,
+    InstalledPluginDict,
     YamlMetadata,
 )
 from app.utils.yaml_parser import YAMLParser
@@ -54,17 +55,20 @@ class ClaudeFolderSync:
             return {}
 
     @staticmethod
-    def read_installed_plugins() -> dict | None:
+    def read_installed_plugins() -> dict[str, Any] | None:
         if not INSTALLED_PLUGINS_JSON.is_file():
             return None
         try:
-            return json.loads(INSTALLED_PLUGINS_JSON.read_text(encoding="utf-8"))
+            result: dict[str, Any] = json.loads(
+                INSTALLED_PLUGINS_JSON.read_text(encoding="utf-8")
+            )
+            return result
         except (json.JSONDecodeError, OSError):
             return None
 
     @staticmethod
     def get_active_plugin_paths(
-        data: dict | None = None,
+        data: dict[str, Any] | None = None,
     ) -> list[Path]:
         if data is None:
             data = ClaudeFolderSync.read_installed_plugins()
@@ -83,9 +87,28 @@ class ClaudeFolderSync:
         return paths
 
     @staticmethod
+    def get_cli_installed_plugins() -> list[InstalledPluginDict]:
+        data = ClaudeFolderSync.read_installed_plugins()
+        if not data:
+            return []
+        results: list[InstalledPluginDict] = []
+        for key, entries in data.get("plugins", {}).items():
+            plugin_name = key.split("@", 1)[0] if "@" in key else key
+            entry = entries[0] if entries else {}
+            results.append(
+                {
+                    "name": plugin_name,
+                    "version": entry.get("version"),
+                    "installed_at": entry.get("installedAt", ""),
+                    "components": [],
+                }
+            )
+        return results
+
+    @staticmethod
     def rewrite_installed_plugins_for_container(
         container_cache_dir: str,
-        data: dict | None = None,
+        data: dict[str, Any] | None = None,
     ) -> str | None:
         if data is None:
             data = ClaudeFolderSync.read_installed_plugins()

--- a/backend/app/services/marketplace.py
+++ b/backend/app/services/marketplace.py
@@ -3,13 +3,9 @@ import json
 import logging
 import re
 import zipfile
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, cast
 
-import httpx
-
-from app.core.config import get_settings
 from app.models.types import (
     MarketplaceAuthorDict,
     MarketplacePluginDict,
@@ -18,31 +14,26 @@ from app.models.types import (
 )
 from app.services.exceptions import ErrorCode, MarketplaceException
 
-settings = get_settings()
 logger = logging.getLogger(__name__)
 
-CATALOG_URL = "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main/.claude-plugin/marketplace.json"
-REPO_RAW_BASE = (
-    "https://raw.githubusercontent.com/anthropics/claude-plugins-official/main"
-)
-GITHUB_API_BASE = (
-    "https://api.github.com/repos/anthropics/claude-plugins-official/contents"
-)
-CACHE_TTL_SECONDS = 3600
-MAX_RECURSION_DEPTH = 5
+CLAUDE_PLUGINS_DIR = Path.home() / ".claude" / "plugins"
+KNOWN_MARKETPLACES_JSON = CLAUDE_PLUGINS_DIR / "known_marketplaces.json"
 MAX_SKILL_FILES = 50
 SAFE_PATH_SEGMENT = re.compile(r"^[a-zA-Z0-9_\-\.]+$")
 
 
 class MarketplaceService:
-    _catalog_cache: list[MarketplacePluginDict] | None = None
-    _catalog_cached_at: datetime | None = None
-
-    def __init__(self, github_token: str | None = None) -> None:
-        self.cache_path = Path(settings.STORAGE_PATH) / "marketplace_cache"
-        self.cache_path.mkdir(parents=True, exist_ok=True)
-        self._cache_file = self.cache_path / "catalog.json"
-        self._github_token = github_token
+    @staticmethod
+    def _read_known_marketplaces() -> dict[str, Any]:
+        if not KNOWN_MARKETPLACES_JSON.is_file():
+            return {}
+        try:
+            result: dict[str, Any] = json.loads(
+                KNOWN_MARKETPLACES_JSON.read_text(encoding="utf-8")
+            )
+            return result
+        except (json.JSONDecodeError, OSError):
+            return {}
 
     @staticmethod
     def _validate_path_segment(segment: str) -> bool:
@@ -55,24 +46,6 @@ class MarketplaceService:
         return True
 
     @staticmethod
-    def _validate_source_path(source: str) -> str:
-        if source.startswith("./"):
-            source = source[2:]
-        if source.startswith("/"):
-            raise MarketplaceException(
-                "Invalid source path: absolute paths not allowed",
-                error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
-            )
-        segments = source.split("/")
-        for seg in segments:
-            if seg and not MarketplaceService._validate_path_segment(seg):
-                raise MarketplaceException(
-                    f"Invalid path segment: {seg}",
-                    error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
-                )
-        return source
-
-    @staticmethod
     def _validate_component_name(name: str) -> str:
         if not MarketplaceService._validate_path_segment(name):
             raise MarketplaceException(
@@ -81,115 +54,19 @@ class MarketplaceService:
             )
         return name
 
-    def _get_github_api_headers(self) -> dict[str, str]:
-        headers = {"Accept": "application/vnd.github.v3+json"}
-        if self._github_token:
-            headers["Authorization"] = f"Bearer {self._github_token}"
-        return headers
-
-    def _check_rate_limit_error(self, response: httpx.Response) -> None:
-        if response.status_code == 403:
-            remaining = response.headers.get("X-RateLimit-Remaining", "")
-            if remaining == "0":
-                reset_timestamp = response.headers.get("X-RateLimit-Reset", "")
-                msg = (
-                    "GitHub API rate limit exceeded. "
-                    "Configure your GitHub Personal Access Token in Settings."
-                )
-                if reset_timestamp:
-                    try:
-                        reset_time = datetime.fromtimestamp(
-                            int(reset_timestamp), tz=timezone.utc
-                        )
-                        minutes_until_reset = max(
-                            1,
-                            int(
-                                (
-                                    reset_time - datetime.now(timezone.utc)
-                                ).total_seconds()
-                                / 60
-                            ),
-                        )
-                        msg += f" Resets in ~{minutes_until_reset} min."
-                    except (ValueError, TypeError, OverflowError):
-                        pass
-                raise MarketplaceException(
-                    msg,
-                    error_code=ErrorCode.MARKETPLACE_FETCH_FAILED,
-                    status_code=429,
-                )
-
-    async def fetch_catalog(
-        self, force_refresh: bool = False
-    ) -> list[MarketplacePluginDict]:
-        if not force_refresh and self._is_cache_valid():
-            return MarketplaceService._catalog_cache or []
-
-        if not force_refresh and self._load_disk_cache():
-            return MarketplaceService._catalog_cache or []
-
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            try:
-                response = await client.get(CATALOG_URL)
-                response.raise_for_status()
-                data = response.json()
-            except httpx.HTTPError as e:
-                logger.error("Failed to fetch marketplace catalog: %s", e)
-                raise MarketplaceException(
-                    f"Failed to fetch marketplace catalog: {e}",
-                    error_code=ErrorCode.MARKETPLACE_FETCH_FAILED,
-                )
-
-        all_plugins: list[MarketplacePluginDict] = []
-        for plugin in data.get("plugins", []):
-            all_plugins.append(self._normalize_plugin(plugin))
-
-        plugins = [
-            p
-            for p in all_plugins
-            if not p["source"].startswith("external:")
-            and not p.get("has_lsp_only", False)
-        ]
-
-        MarketplaceService._catalog_cache = plugins
-        MarketplaceService._catalog_cached_at = datetime.now(timezone.utc)
-        self._save_disk_cache(plugins)
-        return plugins
-
-    def _is_cache_valid(self) -> bool:
-        cls = MarketplaceService
-        if cls._catalog_cache is None or cls._catalog_cached_at is None:
-            return False
-        expiry = cls._catalog_cached_at + timedelta(seconds=CACHE_TTL_SECONDS)
-        return datetime.now(timezone.utc) < expiry
-
-    def _load_disk_cache(self) -> bool:
-        cls = MarketplaceService
-        try:
-            if not self._cache_file.exists():
-                return False
-            stat = self._cache_file.stat()
-            cache_age = datetime.now(timezone.utc) - datetime.fromtimestamp(
-                stat.st_mtime, tz=timezone.utc
-            )
-            if cache_age.total_seconds() > CACHE_TTL_SECONDS:
-                return False
-            with open(self._cache_file, "r") as f:
-                cls._catalog_cache = json.load(f)
-            cls._catalog_cached_at = datetime.fromtimestamp(
-                stat.st_mtime, tz=timezone.utc
-            )
-            return True
-        except (OSError, json.JSONDecodeError) as e:
-            logger.warning("Failed to load disk cache: %s", e)
-            return False
-
-    def _save_disk_cache(self, plugins: list[MarketplacePluginDict]) -> None:
-        try:
-            with open(self._cache_file, "w") as f:
-                json.dump(plugins, f)
-        except OSError as e:
-            logger.warning("Failed to save disk cache: %s", e)
+    def _resolve_local_plugin_dir(self, source: str, marketplace: str) -> Path | None:
+        known = self._read_known_marketplaces()
+        marketplace_info = known.get(marketplace)
+        if not marketplace_info:
+            return None
+        install_location = marketplace_info.get("installLocation")
+        if not install_location:
+            return None
+        clean_source = source.lstrip("./")
+        local_dir = Path(install_location) / clean_source
+        if local_dir.is_dir():
+            return local_dir
+        return None
 
     def _normalize_plugin(self, raw: dict[str, Any]) -> MarketplacePluginDict:
         author_raw = raw.get("author") or raw.get("owner")
@@ -219,11 +96,41 @@ class MarketplaceService:
             "description": raw.get("description", ""),
             "category": raw.get("category", "other"),
             "source": source,
+            "marketplace": "",
             "version": raw.get("version"),
             "author": author,
             "homepage": raw.get("homepage"),
             "has_lsp_only": has_lsp_only,
         }
+
+    async def fetch_catalog(self) -> list[MarketplacePluginDict]:
+        known = self._read_known_marketplaces()
+        if not known:
+            return []
+        all_plugins: list[MarketplacePluginDict] = []
+        for marketplace_name, info in known.items():
+            install_location = info.get("installLocation")
+            if not install_location:
+                continue
+            catalog_path = (
+                Path(install_location) / ".claude-plugin" / "marketplace.json"
+            )
+            if not catalog_path.is_file():
+                continue
+            try:
+                data = json.loads(catalog_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            for plugin in data.get("plugins", []):
+                normalized = self._normalize_plugin(plugin)
+                normalized["marketplace"] = marketplace_name
+                all_plugins.append(normalized)
+        return [
+            p
+            for p in all_plugins
+            if not p["source"].startswith("external:")
+            and not p.get("has_lsp_only", False)
+        ]
 
     async def get_plugin_details(self, plugin_name: str) -> PluginDetailsDict:
         catalog = await self.fetch_catalog()
@@ -237,33 +144,27 @@ class MarketplaceService:
             )
 
         source = plugin.get("source", "")
-        if source.startswith("external:"):
-            return {
-                "name": plugin["name"],
-                "description": plugin.get("description", ""),
-                "category": plugin.get("category", "other"),
-                "source": source,
-                "version": plugin.get("version"),
-                "author": plugin.get("author"),
-                "homepage": plugin.get("homepage"),
-                "readme": None,
-                "components": {
-                    "agents": [],
-                    "commands": [],
-                    "skills": [],
-                    "mcp_servers": [],
-                },
-            }
+        marketplace = plugin.get("marketplace", "")
 
-        source = self._validate_source_path(source)
-        readme = await self._fetch_readme(source)
-        components = await self._discover_components(source)
+        readme: str | None = None
+        components: PluginComponentsDict = {
+            "agents": [],
+            "commands": [],
+            "skills": [],
+            "mcp_servers": [],
+        }
+        if not source.startswith("external:"):
+            local_dir = self._resolve_local_plugin_dir(source, marketplace)
+            if local_dir:
+                readme = self._read_local_readme(local_dir)
+                components = self._discover_components_local(local_dir)
 
         return {
             "name": plugin["name"],
             "description": plugin.get("description", ""),
             "category": plugin.get("category", "other"),
-            "source": plugin.get("source", ""),
+            "source": source,
+            "marketplace": marketplace,
             "version": plugin.get("version"),
             "author": plugin.get("author"),
             "homepage": plugin.get("homepage"),
@@ -271,18 +172,107 @@ class MarketplaceService:
             "components": components,
         }
 
-    async def _fetch_readme(self, source: str) -> str | None:
-        url = f"{REPO_RAW_BASE}/{source}/README.md"
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            try:
-                response = await client.get(url)
-                if response.status_code == 200:
-                    return str(response.text)
-            except httpx.HTTPError:
-                pass
-        return None
+    async def download_agent(
+        self, source: str, agent_name: str, marketplace: str = ""
+    ) -> bytes:
+        agent_name = self._validate_component_name(agent_name)
+        return self._read_local_file(source, marketplace, f"agents/{agent_name}.md")
 
-    async def _discover_components(self, source: str) -> PluginComponentsDict:
+    async def download_command(
+        self, source: str, command_name: str, marketplace: str = ""
+    ) -> bytes:
+        command_name = self._validate_component_name(command_name)
+        return self._read_local_file(source, marketplace, f"commands/{command_name}.md")
+
+    async def download_skill_as_zip(
+        self, source: str, skill_name: str, marketplace: str = ""
+    ) -> bytes:
+        skill_name = self._validate_component_name(skill_name)
+        local_dir = self._resolve_local_plugin_dir(source, marketplace)
+        if not local_dir:
+            raise MarketplaceException(
+                f"Plugin directory not found for {source}",
+                error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
+            )
+        skill_dir = local_dir / "skills" / skill_name
+        if not skill_dir.is_dir():
+            raise MarketplaceException(
+                f"Skill '{skill_name}' directory not found",
+                error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
+            )
+        zip_buffer = io.BytesIO()
+        file_count = 0
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            for f in skill_dir.rglob("*"):
+                if not f.is_file():
+                    continue
+                if file_count >= MAX_SKILL_FILES:
+                    logger.warning("Max skill file count (%d) reached", MAX_SKILL_FILES)
+                    break
+                rel = str(f.relative_to(skill_dir))
+                try:
+                    zf.writestr(rel, f.read_bytes())
+                    file_count += 1
+                except OSError as e:
+                    logger.warning("Failed to read %s: %s", f, e)
+        if file_count == 0:
+            raise MarketplaceException(
+                f"Skill '{skill_name}' has no files",
+                error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
+            )
+        zip_buffer.seek(0)
+        return zip_buffer.read()
+
+    async def download_mcp_config(
+        self, source: str, marketplace: str = ""
+    ) -> dict[str, Any] | None:
+        local_dir = self._resolve_local_plugin_dir(source, marketplace)
+        if not local_dir:
+            return None
+        mcp_path = local_dir / ".mcp.json"
+        if not mcp_path.is_file():
+            return None
+        try:
+            return cast(
+                dict[str, Any],
+                json.loads(mcp_path.read_text(encoding="utf-8")),
+            )
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def _read_local_file(self, source: str, marketplace: str, rel_path: str) -> bytes:
+        local_dir = self._resolve_local_plugin_dir(source, marketplace)
+        if not local_dir:
+            raise MarketplaceException(
+                f"Plugin directory not found for {source}",
+                error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
+            )
+        file_path = local_dir / rel_path
+        if not file_path.is_file():
+            raise MarketplaceException(
+                f"File not found: {rel_path}",
+                error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
+            )
+        try:
+            return file_path.read_bytes()
+        except OSError as e:
+            raise MarketplaceException(
+                f"Failed to read {rel_path}: {e}",
+                error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
+            ) from e
+
+    @staticmethod
+    def _read_local_readme(plugin_dir: Path) -> str | None:
+        readme = plugin_dir / "README.md"
+        if not readme.is_file():
+            return None
+        try:
+            return readme.read_text(encoding="utf-8")
+        except OSError:
+            return None
+
+    @staticmethod
+    def _discover_components_local(plugin_dir: Path) -> PluginComponentsDict:
         components: PluginComponentsDict = {
             "agents": [],
             "commands": [],
@@ -290,187 +280,36 @@ class MarketplaceService:
             "mcp_servers": [],
         }
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            agents = await self._list_directory(client, f"{source}/agents")
-            components["agents"] = [
-                f.replace(".md", "") for f in agents if f.endswith(".md")
-            ]
+        agents_dir = plugin_dir / "agents"
+        if agents_dir.is_dir():
+            components["agents"] = [f.stem for f in agents_dir.glob("*.md")]
 
-            commands = await self._list_directory(client, f"{source}/commands")
-            components["commands"] = [
-                f.replace(".md", "") for f in commands if f.endswith(".md")
-            ]
+        commands_dir = plugin_dir / "commands"
+        if commands_dir.is_dir():
+            components["commands"] = [f.stem for f in commands_dir.glob("*.md")]
 
-            skills_dirs = await self._list_directory(client, f"{source}/skills")
+        skills_dir = plugin_dir / "skills"
+        if skills_dir.is_dir():
             components["skills"] = [
-                d
-                for d in skills_dirs
-                if not d.startswith(".") and self._validate_path_segment(d)
+                d.name
+                for d in skills_dir.iterdir()
+                if d.is_dir()
+                and not d.name.startswith(".")
+                and MarketplaceService._validate_path_segment(d.name)
             ]
 
-            mcp_servers = await self._fetch_mcp_config(client, source)
-            components["mcp_servers"] = mcp_servers
+        mcp_path = plugin_dir / ".mcp.json"
+        if mcp_path.is_file():
+            try:
+                data = json.loads(mcp_path.read_text(encoding="utf-8"))
+                servers = data.get("mcpServers") or data
+                components["mcp_servers"] = [
+                    k
+                    for k in servers.keys()
+                    if MarketplaceService._validate_path_segment(k)
+                    and isinstance(servers[k], dict)
+                ]
+            except (json.JSONDecodeError, OSError):
+                pass
 
         return components
-
-    async def _list_directory(self, client: httpx.AsyncClient, path: str) -> list[str]:
-        url = f"{GITHUB_API_BASE}/{path}"
-        try:
-            response = await client.get(url, headers=self._get_github_api_headers())
-            self._check_rate_limit_error(response)
-            if response.status_code != 200:
-                return []
-            data = response.json()
-            if isinstance(data, list):
-                return [
-                    item["name"]
-                    for item in data
-                    if self._validate_path_segment(item.get("name", ""))
-                ]
-        except httpx.HTTPError:
-            pass
-        return []
-
-    async def _fetch_mcp_config(
-        self, client: httpx.AsyncClient, source: str
-    ) -> list[str]:
-        url = f"{REPO_RAW_BASE}/{source}/.mcp.json"
-        try:
-            response = await client.get(url)
-            if response.status_code != 200:
-                return []
-            data = response.json()
-            if not isinstance(data, dict):
-                return []
-            servers = data.get("mcpServers") or data
-            return [
-                k
-                for k in servers.keys()
-                if self._validate_path_segment(k) and isinstance(servers[k], dict)
-            ]
-        except (httpx.HTTPError, ValueError):
-            pass
-        return []
-
-    async def download_agent(self, source: str, agent_name: str) -> bytes:
-        source = self._validate_source_path(source)
-        agent_name = self._validate_component_name(agent_name)
-        return await self._download_file(f"{source}/agents/{agent_name}.md")
-
-    async def download_command(self, source: str, command_name: str) -> bytes:
-        source = self._validate_source_path(source)
-        command_name = self._validate_component_name(command_name)
-        return await self._download_file(f"{source}/commands/{command_name}.md")
-
-    async def download_skill_as_zip(self, source: str, skill_name: str) -> bytes:
-        source = self._validate_source_path(source)
-        skill_name = self._validate_component_name(skill_name)
-
-        skill_path = f"{source}/skills/{skill_name}"
-        zip_buffer = io.BytesIO()
-
-        async with httpx.AsyncClient(timeout=60.0) as client:
-            files = await self._collect_files_recursive(client, skill_path, depth=0)
-
-            if not files:
-                raise MarketplaceException(
-                    f"Skill '{skill_name}' has no files",
-                    error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
-                )
-
-            failed_files: list[str] = []
-            with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-                for file_path in files:
-                    url = f"{REPO_RAW_BASE}/{file_path}"
-                    try:
-                        response = await client.get(url)
-                        response.raise_for_status()
-                        relative = file_path.replace(f"{skill_path}/", "")
-                        zf.writestr(relative, response.content)
-                    except httpx.HTTPError as e:
-                        failed_files.append(file_path)
-                        logger.warning("Failed to download %s: %s", file_path, e)
-
-            if failed_files:
-                raise MarketplaceException(
-                    f"Failed to download {len(failed_files)} of {len(files)} files",
-                    error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
-                    details={
-                        "failed_count": str(len(failed_files)),
-                        "failed_files": ", ".join(failed_files[:10]),
-                    },
-                )
-
-        zip_buffer.seek(0)
-        return zip_buffer.read()
-
-    async def _collect_files_recursive(
-        self,
-        client: httpx.AsyncClient,
-        path: str,
-        depth: int,
-        total_count: list[int] | None = None,
-    ) -> list[str]:
-        if total_count is None:
-            total_count = [0]
-
-        if depth > MAX_RECURSION_DEPTH:
-            logger.warning("Max recursion depth reached for %s", path)
-            return []
-
-        if total_count[0] >= MAX_SKILL_FILES:
-            return []
-
-        files: list[str] = []
-        url = f"{GITHUB_API_BASE}/{path}"
-        try:
-            response = await client.get(url, headers=self._get_github_api_headers())
-            self._check_rate_limit_error(response)
-            if response.status_code != 200:
-                return []
-            data = response.json()
-            if not isinstance(data, list):
-                return []
-            for item in data:
-                if total_count[0] >= MAX_SKILL_FILES:
-                    logger.warning("Max total file count (%d) reached", MAX_SKILL_FILES)
-                    break
-                name = item.get("name", "")
-                if not self._validate_path_segment(name):
-                    continue
-                if item["type"] == "file":
-                    files.append(item["path"])
-                    total_count[0] += 1
-                elif item["type"] == "dir":
-                    sub_files = await self._collect_files_recursive(
-                        client, item["path"], depth + 1, total_count
-                    )
-                    files.extend(sub_files)
-        except httpx.HTTPError:
-            pass
-        return files
-
-    async def download_mcp_config(self, source: str) -> dict[str, Any] | None:
-        source = self._validate_source_path(source)
-        url = f"{REPO_RAW_BASE}/{source}/.mcp.json"
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            try:
-                response = await client.get(url)
-                if response.status_code == 200:
-                    return cast(dict[str, Any], response.json())
-            except (httpx.HTTPError, ValueError):
-                pass
-        return None
-
-    async def _download_file(self, path: str) -> bytes:
-        url = f"{REPO_RAW_BASE}/{path}"
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            try:
-                response = await client.get(url)
-                response.raise_for_status()
-                return bytes(response.content)
-            except httpx.HTTPError as e:
-                raise MarketplaceException(
-                    f"Failed to download {path}: {e}",
-                    error_code=ErrorCode.MARKETPLACE_INSTALL_FAILED,
-                )

--- a/backend/app/services/plugin_installer.py
+++ b/backend/app/services/plugin_installer.py
@@ -15,6 +15,7 @@ from app.models.types import (
     CustomSlashCommandDict,
     InstalledPluginDict,
     PluginComponentsDict,
+    PluginDetailsDict,
 )
 from app.services.agent import AgentService
 from app.services.command import CommandService
@@ -38,8 +39,8 @@ class InstallResult:
 
 
 class PluginInstallerService:
-    def __init__(self, github_token: str | None = None) -> None:
-        self.marketplace = MarketplaceService(github_token=github_token)
+    def __init__(self) -> None:
+        self.marketplace = MarketplaceService()
         self.skill_service = SkillService()
         self.agent_service = AgentService()
         self.command_service = CommandService()
@@ -47,15 +48,15 @@ class PluginInstallerService:
     async def install_components(
         self,
         user_id: str,
-        plugin_name: str,
+        details: PluginDetailsDict,
         components: list[str],
         current_agents: list[CustomAgentDict],
         current_commands: list[CustomSlashCommandDict],
         current_skills: list[CustomSkillDict],
         current_mcps: list[CustomMcpDict],
     ) -> InstallResult:
-        details = await self.marketplace.get_plugin_details(plugin_name)
         source = details.get("source", "")
+        marketplace = details.get("marketplace", "")
         available_components = details.get("components", {})
 
         installed: list[str] = []
@@ -94,27 +95,29 @@ class PluginInstallerService:
             try:
                 if comp_type == "agent":
                     agent = await self._install_agent(
-                        user_id, source, comp_name, current_agents
+                        user_id, source, comp_name, current_agents, marketplace
                     )
                     agent["name"] = comp_name
                     new_agents.append(agent)
                     installed.append(component)
                 elif comp_type == "command":
                     cmd = await self._install_command(
-                        user_id, source, comp_name, current_commands
+                        user_id, source, comp_name, current_commands, marketplace
                     )
                     cmd["name"] = comp_name
                     new_commands.append(cmd)
                     installed.append(component)
                 elif comp_type == "skill":
                     skill = await self._install_skill(
-                        user_id, source, comp_name, current_skills
+                        user_id, source, comp_name, current_skills, marketplace
                     )
                     skill["name"] = comp_name
                     new_skills.append(skill)
                     installed.append(component)
                 elif comp_type == "mcp":
-                    mcp = await self._install_mcp(source, comp_name, current_mcps)
+                    mcp = await self._install_mcp(
+                        source, comp_name, current_mcps, marketplace
+                    )
                     if mcp:
                         mcp["name"] = comp_name
                         new_mcps.append(mcp)
@@ -180,8 +183,9 @@ class PluginInstallerService:
         source: str,
         agent_name: str,
         current_agents: list[CustomAgentDict],
+        marketplace: str = "",
     ) -> CustomAgentDict:
-        content = await self.marketplace.download_agent(source, agent_name)
+        content = await self.marketplace.download_agent(source, agent_name, marketplace)
         file = self._create_upload_file(f"{agent_name}.md", content)
         return await self.agent_service.upload(user_id, file, current_agents)
 
@@ -191,8 +195,11 @@ class PluginInstallerService:
         source: str,
         command_name: str,
         current_commands: list[CustomSlashCommandDict],
+        marketplace: str = "",
     ) -> CustomSlashCommandDict:
-        content = await self.marketplace.download_command(source, command_name)
+        content = await self.marketplace.download_command(
+            source, command_name, marketplace
+        )
         file = self._create_upload_file(f"{command_name}.md", content)
         return await self.command_service.upload(user_id, file, current_commands)
 
@@ -202,8 +209,11 @@ class PluginInstallerService:
         source: str,
         skill_name: str,
         current_skills: list[CustomSkillDict],
+        marketplace: str = "",
     ) -> CustomSkillDict:
-        zip_content = await self.marketplace.download_skill_as_zip(source, skill_name)
+        zip_content = await self.marketplace.download_skill_as_zip(
+            source, skill_name, marketplace
+        )
         file = self._create_upload_file(f"{skill_name}.zip", zip_content)
         return await self.skill_service.upload(user_id, file, current_skills)
 
@@ -212,8 +222,9 @@ class PluginInstallerService:
         source: str,
         mcp_name: str,
         current_mcps: list[CustomMcpDict],
+        marketplace: str = "",
     ) -> CustomMcpDict | None:
-        config = await self.marketplace.download_mcp_config(source)
+        config = await self.marketplace.download_mcp_config(source, marketplace)
         if not config:
             return None
 

--- a/backend/tests/test_marketplace.py
+++ b/backend/tests/test_marketplace.py
@@ -22,20 +22,6 @@ class TestGetCatalog:
         plugin_names = [p["name"] for p in data]
         assert TEST_PLUGIN in plugin_names
 
-    async def test_get_catalog_force_refresh(
-        self,
-        marketplace_client: AsyncClient,
-    ) -> None:
-        response = await marketplace_client.get(
-            "/api/v1/marketplace/catalog",
-            params={"force_refresh": True},
-        )
-
-        assert response.status_code == 200
-        data = response.json()
-        assert isinstance(data, list)
-        assert len(data) > 0
-
     async def test_get_catalog_returns_correct_schema(
         self,
         marketplace_client: AsyncClient,
@@ -50,6 +36,7 @@ class TestGetCatalog:
             assert "description" in plugin
             assert "category" in plugin
             assert "source" in plugin
+            assert "marketplace" in plugin
 
 
 class TestGetPluginDetails:

--- a/frontend/src/components/settings/dialogs/PluginDetailModal.tsx
+++ b/frontend/src/components/settings/dialogs/PluginDetailModal.tsx
@@ -38,28 +38,32 @@ function InstalledComponentRow({
   componentId,
   isSelectedForUninstall,
   onToggle,
+  readOnly,
 }: {
   comp: ComponentEntry;
   componentId: string;
   isSelectedForUninstall: boolean;
   onToggle: (id: string) => void;
+  readOnly?: boolean;
 }) {
   const Icon = COMPONENT_ICONS[comp.type];
 
   return (
     <label
-      className={`flex cursor-pointer items-center justify-between rounded-lg border p-3 transition-colors ${
-        isSelectedForUninstall
-          ? 'border-error-500 bg-error-50 dark:border-error-400 dark:bg-error-900/20'
-          : 'border-success-200 bg-success-50 dark:border-success-800 dark:bg-success-900/20'
+      className={`flex items-center justify-between rounded-lg border p-3 transition-colors ${
+        readOnly
+          ? 'border-border/50 bg-surface-active dark:border-border-dark/50 dark:bg-surface-dark-active'
+          : isSelectedForUninstall
+            ? 'cursor-pointer border-border-hover bg-surface-hover dark:border-border-dark-hover dark:bg-surface-dark-hover'
+            : 'cursor-pointer border-border/50 bg-surface-active dark:border-border-dark/50 dark:bg-surface-dark-active'
       }`}
     >
       <div className="flex items-center gap-3">
         <Icon
           className={`h-4 w-4 ${
-            isSelectedForUninstall
-              ? 'text-error-600 dark:text-error-400'
-              : 'text-success-600 dark:text-success-400'
+            isSelectedForUninstall && !readOnly
+              ? 'text-text-tertiary dark:text-text-dark-tertiary'
+              : 'text-text-secondary dark:text-text-dark-secondary'
           }`}
         />
         <div>
@@ -69,14 +73,21 @@ function InstalledComponentRow({
           <span className="ml-2 text-xs capitalize text-text-tertiary dark:text-text-dark-tertiary">
             {comp.type}
           </span>
+          {readOnly && (
+            <span className="ml-2 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+              installed via CLI
+            </span>
+          )}
         </div>
       </div>
-      <input
-        type="checkbox"
-        checked={isSelectedForUninstall}
-        onChange={() => onToggle(componentId)}
-        className="h-4 w-4 rounded border-border text-error-600 focus:ring-error-500 dark:border-border-dark"
-      />
+      {!readOnly && (
+        <input
+          type="checkbox"
+          checked={isSelectedForUninstall}
+          onChange={() => onToggle(componentId)}
+          className="h-4 w-4 rounded border-border text-text-primary accent-text-primary focus:ring-text-quaternary/30 dark:border-border-dark"
+        />
+      )}
     </label>
   );
 }
@@ -192,6 +203,8 @@ export const PluginDetailModal: React.FC<PluginDetailModalProps> = ({
   const uninstallMutation = useUninstallComponentsMutation();
 
   const installedPlugin = installedPlugins.find((p) => p.name === plugin?.name);
+  const cliInstalledWithoutComponents =
+    installedPlugin !== undefined && (installedPlugin.components ?? []).length === 0;
   const installedComponents = new Set(installedPlugin?.components ?? []);
 
   useEffect(() => {
@@ -232,26 +245,23 @@ export const PluginDetailModal: React.FC<PluginDetailModalProps> = ({
     setSelectedForUninstall(newSelected);
   };
 
+  const isComponentInstalled = (c: ComponentEntry) =>
+    cliInstalledWithoutComponents || installedComponents.has(`${c.type}:${c.name}`);
+
   const selectAll = () => {
     const notInstalled = allComponents
-      .map((c) => `${c.type}:${c.name}`)
-      .filter((id) => !installedComponents.has(id));
+      .filter((c) => !isComponentInstalled(c))
+      .map((c) => `${c.type}:${c.name}`);
     setSelectedComponents(new Set(notInstalled));
   };
 
   const selectAllForUninstall = () => {
-    const installed = allComponents
-      .map((c) => `${c.type}:${c.name}`)
-      .filter((id) => installedComponents.has(id));
+    const installed = allComponents.filter(isComponentInstalled).map((c) => `${c.type}:${c.name}`);
     setSelectedForUninstall(new Set(installed));
   };
 
-  const hasUninstalledComponents = allComponents.some(
-    (c) => !installedComponents.has(`${c.type}:${c.name}`),
-  );
-  const hasInstalledComponents = allComponents.some((c) =>
-    installedComponents.has(`${c.type}:${c.name}`),
-  );
+  const hasUninstalledComponents = allComponents.some((c) => !isComponentInstalled(c));
+  const hasInstalledComponents = allComponents.some(isComponentInstalled);
 
   const handleInstall = async () => {
     if (selectedComponents.size === 0) {
@@ -342,10 +352,10 @@ export const PluginDetailModal: React.FC<PluginDetailModalProps> = ({
                   Components
                 </h3>
                 <div className="flex gap-3">
-                  {hasInstalledComponents && (
+                  {hasInstalledComponents && !cliInstalledWithoutComponents && (
                     <button
                       onClick={selectAllForUninstall}
-                      className="text-xs text-error-600 hover:text-error-700 dark:text-error-400 dark:hover:text-error-300"
+                      className="text-xs text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
                     >
                       Select all installed
                     </button>
@@ -364,7 +374,7 @@ export const PluginDetailModal: React.FC<PluginDetailModalProps> = ({
               <div className="mb-4 space-y-2">
                 {allComponents.map((comp) => {
                   const componentId = `${comp.type}:${comp.name}`;
-                  const isInstalled = installedComponents.has(componentId);
+                  const isInstalled = isComponentInstalled(comp);
 
                   return isInstalled ? (
                     <InstalledComponentRow
@@ -373,6 +383,7 @@ export const PluginDetailModal: React.FC<PluginDetailModalProps> = ({
                       componentId={componentId}
                       isSelectedForUninstall={selectedForUninstall.has(componentId)}
                       onToggle={toggleUninstall}
+                      readOnly={cliInstalledWithoutComponents}
                     />
                   ) : (
                     <AvailableComponentRow

--- a/frontend/src/components/settings/tabs/marketplace/PluginCard.tsx
+++ b/frontend/src/components/settings/tabs/marketplace/PluginCard.tsx
@@ -1,6 +1,5 @@
 import type { MarketplacePlugin } from '@/types/marketplace.types';
-import { ChevronRight } from 'lucide-react';
-import { Badge } from '@/components/ui/primitives/Badge';
+import { ChevronRight, Check } from 'lucide-react';
 
 interface PluginCardProps {
   plugin: MarketplacePlugin;
@@ -8,54 +7,34 @@ interface PluginCardProps {
   onClick: () => void;
 }
 
-const CATEGORY_COLORS: Record<string, string> = {
-  development:
-    'bg-surface-tertiary text-text-secondary dark:bg-surface-dark-tertiary dark:text-text-dark-secondary',
-  productivity:
-    'bg-surface-tertiary text-text-secondary dark:bg-surface-dark-tertiary dark:text-text-dark-secondary',
-  testing:
-    'bg-surface-tertiary text-text-secondary dark:bg-surface-dark-tertiary dark:text-text-dark-secondary',
-  database:
-    'bg-surface-tertiary text-text-secondary dark:bg-surface-dark-tertiary dark:text-text-dark-secondary',
-  deployment:
-    'bg-surface-tertiary text-text-secondary dark:bg-surface-dark-tertiary dark:text-text-dark-secondary',
-  security:
-    'bg-surface-tertiary text-text-secondary dark:bg-surface-dark-tertiary dark:text-text-dark-secondary',
-  design:
-    'bg-surface-tertiary text-text-secondary dark:bg-surface-dark-tertiary dark:text-text-dark-secondary',
-  other:
-    'bg-surface-tertiary text-text-secondary dark:bg-surface-dark-tertiary dark:text-text-dark-secondary',
-};
-
 export const PluginCard: React.FC<PluginCardProps> = ({ plugin, isInstalled, onClick }) => {
-  const categoryColor = CATEGORY_COLORS[plugin.category] || CATEGORY_COLORS.other;
-
   return (
     <button
       onClick={onClick}
-      className="group flex w-full flex-col rounded-xl border border-border p-4 text-left transition-all duration-200 hover:border-border-hover dark:border-border-dark dark:hover:border-border-dark-hover"
+      className="group flex w-full flex-col rounded-xl border border-border/50 p-4 text-left transition-all duration-200 hover:border-border-hover dark:border-border-dark/50 dark:hover:border-border-dark-hover"
     >
       <div className="mb-2 flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-1.5">
             <h3 className="truncate text-xs font-medium text-text-primary dark:text-text-dark-primary">
               {plugin.name}
             </h3>
             {isInstalled && (
-              <Badge variant="success" size="sm">
+              <span className="inline-flex items-center gap-1 rounded-full bg-surface-active px-1.5 py-0.5 text-2xs font-medium text-text-secondary dark:bg-surface-dark-active dark:text-text-dark-secondary">
+                <Check className="h-2.5 w-2.5" />
                 Installed
-              </Badge>
+              </span>
             )}
           </div>
           {plugin.author?.name && (
-            <p className="mt-0.5 text-xs text-text-tertiary dark:text-text-dark-tertiary">
+            <p className="mt-0.5 text-2xs text-text-tertiary dark:text-text-dark-tertiary">
               by {plugin.author.name}
             </p>
           )}
         </div>
         {plugin.version && (
-          <span className="flex-shrink-0 rounded-md border border-border px-1.5 py-0.5 text-2xs text-text-quaternary dark:border-border-dark dark:text-text-dark-quaternary">
-            v{plugin.version}
+          <span className="flex-shrink-0 font-mono text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+            {plugin.version}
           </span>
         )}
       </div>
@@ -65,7 +44,7 @@ export const PluginCard: React.FC<PluginCardProps> = ({ plugin, isInstalled, onC
       </p>
 
       <div className="flex items-center justify-between">
-        <span className={`rounded-full px-2 py-0.5 text-2xs font-medium ${categoryColor}`}>
+        <span className="rounded-full bg-surface-tertiary px-2 py-0.5 text-2xs font-medium text-text-tertiary dark:bg-surface-dark-tertiary dark:text-text-dark-tertiary">
           {plugin.category}
         </span>
         <ChevronRight className="h-3.5 w-3.5 text-text-quaternary transition-colors duration-200 group-hover:text-text-secondary dark:text-text-dark-quaternary dark:group-hover:text-text-dark-secondary" />

--- a/frontend/src/hooks/queries/useMarketplaceQueries.ts
+++ b/frontend/src/hooks/queries/useMarketplaceQueries.ts
@@ -11,10 +11,10 @@ import type {
 } from '@/types/marketplace.types';
 import { queryKeys } from './queryKeys';
 
-export const useMarketplaceCatalogQuery = (forceRefresh = false) => {
+export const useMarketplaceCatalogQuery = () => {
   return useQuery<MarketplacePlugin[]>({
     queryKey: queryKeys.marketplace.catalog,
-    queryFn: () => marketplaceService.getCatalog(forceRefresh),
+    queryFn: () => marketplaceService.getCatalog(),
     staleTime: 5 * 60 * 1000,
   });
 };
@@ -31,6 +31,7 @@ export const useInstalledPluginsQuery = () => {
   return useQuery<InstalledPlugin[]>({
     queryKey: queryKeys.marketplace.installed,
     queryFn: () => marketplaceService.getInstalledPlugins(),
+    staleTime: 5 * 60 * 1000,
   });
 };
 
@@ -62,7 +63,7 @@ export const useRefreshCatalogMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation<MarketplacePlugin[], Error>({
-    mutationFn: () => marketplaceService.getCatalog(true),
+    mutationFn: () => marketplaceService.getCatalog(),
     onSuccess: (data) => {
       queryClient.setQueryData(queryKeys.marketplace.catalog, data);
     },

--- a/frontend/src/services/marketplaceService.ts
+++ b/frontend/src/services/marketplaceService.ts
@@ -10,10 +10,9 @@ import type {
   UninstallResponse,
 } from '@/types/marketplace.types';
 
-async function getCatalog(forceRefresh = false): Promise<MarketplacePlugin[]> {
+async function getCatalog(): Promise<MarketplacePlugin[]> {
   return withAuth(async () => {
-    const params = forceRefresh ? '?force_refresh=true' : '';
-    const response = await apiClient.get<MarketplacePlugin[]>(`/marketplace/catalog${params}`);
+    const response = await apiClient.get<MarketplacePlugin[]>('/marketplace/catalog');
     return response ?? [];
   });
 }

--- a/frontend/src/types/marketplace.types.ts
+++ b/frontend/src/types/marketplace.types.ts
@@ -9,6 +9,7 @@ export interface MarketplacePlugin {
   description: string;
   category: string;
   source: string;
+  marketplace: string;
   version?: string;
   author?: MarketplaceAuthor;
   homepage?: string;


### PR DESCRIPTION
## Summary
- Replace GitHub HTTP API calls with local filesystem reads from `~/.claude/plugins/marketplaces/` — the Claude CLI already maintains these as shallow git clones
- Support multiple marketplaces via `known_marketplaces.json` (not just the official one)
- Remove all httpx/GitHub API/caching code from `MarketplaceService` — no fallbacks, local-only
- Thread `marketplace` field through plugin types, schemas, installer, and frontend

## Changes
- **`marketplace.py`**: Rewrite to read catalogs, READMEs, components, and files from local directories
- **`plugin_installer.py`**: Pass `marketplace` to all download method calls
- **`deps.py`**: Remove `github_token` dependency from marketplace/installer factories
- **`types.py` / `schemas/marketplace.py` / `marketplace.types.ts`**: Add `marketplace` field
- **`endpoints/marketplace.py`**: Remove unused `force_refresh` query param
- **Frontend service/hooks**: Remove `forceRefresh` parameter

## Test plan
- [ ] Verify marketplace catalog loads from local `~/.claude/plugins/marketplaces/`
- [ ] Install a plugin component (agent, command, skill, MCP) from the marketplace
- [ ] Verify plugin details page shows README and components
- [ ] Verify multiple marketplaces are listed if registered in `known_marketplaces.json`
- [ ] Verify uninstall still works correctly