### PR TITLE
Fix suggestions panel not scrolling with keyboard navigation

### DIFF
--- a/frontend/src/components/chat/message-input/MentionSuggestionsPanel.tsx
+++ b/frontend/src/components/chat/message-input/MentionSuggestionsPanel.tsx
@@ -29,7 +29,6 @@ export const MentionSuggestionsPanel = memo(function MentionSuggestionsPanel({
     if (highlightedIndex >= 0 && mentionRefs.current[highlightedIndex]) {
       mentionRefs.current[highlightedIndex]?.scrollIntoView({
         block: 'nearest',
-        behavior: 'smooth',
       });
     }
   }, [highlightedIndex]);

--- a/frontend/src/components/chat/message-input/SlashCommandsPanel.tsx
+++ b/frontend/src/components/chat/message-input/SlashCommandsPanel.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/primitives/Button';
 import type { SlashCommand } from '@/types/ui.types';
 
@@ -13,6 +13,16 @@ export const SlashCommandsPanel = memo(function SlashCommandsPanel({
   highlightedIndex,
   onSelect,
 }: SlashCommandsPanelProps) {
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  useEffect(() => {
+    if (highlightedIndex >= 0 && itemRefs.current[highlightedIndex]) {
+      itemRefs.current[highlightedIndex]?.scrollIntoView({
+        block: 'nearest',
+      });
+    }
+  }, [highlightedIndex]);
+
   if (suggestions.length === 0) return null;
 
   return (
@@ -24,6 +34,9 @@ export const SlashCommandsPanel = memo(function SlashCommandsPanel({
             return (
               <Button
                 key={command.value}
+                ref={(el) => {
+                  itemRefs.current[index] = el;
+                }}
                 type="button"
                 variant="unstyled"
                 role="option"


### PR DESCRIPTION
## Summary
- Add `scrollIntoView({ block: 'nearest' })` to `SlashCommandsPanel` — it was completely missing scroll-follow behavior when navigating with arrow keys
- Remove `behavior: 'smooth'` from `MentionSuggestionsPanel` to prevent scroll lag when rapidly pressing arrow keys

## Test plan
- [ ] Open slash command suggestions (type `/`) with enough items to overflow
- [ ] Press arrow down/up past the visible area — panel should scroll to follow
- [ ] Open mention suggestions (type `@`) and navigate with arrow keys — should scroll instantly without lag