### PR TITLE
Fix marketplace not finding plugins in Docker deployments

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -1,5 +1,10 @@
+import os
 from pathlib import Path
 from typing import Final
+
+CLAUDE_DIR: Final[Path] = (
+    Path(d) if (d := os.environ.get("CLAUDE_CONFIG_DIR")) else Path.home() / ".claude"
+)
 
 HOST_REQUIRED_PATH_PREFIX: Final[str] = (
     f"{Path.home()}/.local/bin:/opt/homebrew/bin:/usr/local/bin"

--- a/backend/app/services/claude_folder_sync.py
+++ b/backend/app/services/claude_folder_sync.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
+from app.constants import CLAUDE_DIR
 from app.core.config import get_settings
 from app.models.types import (
     CustomAgentDict,
@@ -21,8 +22,6 @@ from app.utils.yaml_parser import YAMLParser
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
-
-CLAUDE_DIR = Path.home() / ".claude"
 CLAUDE_AGENTS_DIR = CLAUDE_DIR / "agents"
 CLAUDE_COMMANDS_DIR = CLAUDE_DIR / "commands"
 CLAUDE_SKILLS_DIR = CLAUDE_DIR / "skills"

--- a/backend/app/services/marketplace.py
+++ b/backend/app/services/marketplace.py
@@ -12,11 +12,12 @@ from app.models.types import (
     PluginComponentsDict,
     PluginDetailsDict,
 )
+from app.constants import CLAUDE_DIR
 from app.services.exceptions import ErrorCode, MarketplaceException
 
 logger = logging.getLogger(__name__)
 
-CLAUDE_PLUGINS_DIR = Path.home() / ".claude" / "plugins"
+CLAUDE_PLUGINS_DIR = CLAUDE_DIR / "plugins"
 KNOWN_MARKETPLACES_JSON = CLAUDE_PLUGINS_DIR / "known_marketplaces.json"
 MAX_SKILL_FILES = 50
 SAFE_PATH_SEGMENT = re.compile(r"^[a-zA-Z0-9_\-\.]+$")

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
-from app.constants import REDIS_KEY_USER_SETTINGS
+from app.constants import CLAUDE_DIR, REDIS_KEY_USER_SETTINGS
 from app.core.config import get_settings
 from app.models.db_models.user import UserSettings
 from pydantic import BaseModel
@@ -19,7 +19,7 @@ from app.models.schemas.settings import (
     UserSettingsResponse,
 )
 from app.models.types import InstalledPluginDict
-from app.services.claude_folder_sync import CLAUDE_DIR, ClaudeFolderSync
+from app.services.claude_folder_sync import ClaudeFolderSync
 from app.services.db import BaseDbService, SessionFactoryType
 from app.services.exceptions import UserException
 from app.utils.cache import CacheStore, cache_connection


### PR DESCRIPTION
## Summary
- Marketplace and plugin discovery hardcoded `Path.home() / ".claude"` as the config directory, but in Docker the `CLAUDE_CONFIG_DIR` env var points to `/app/storage/claude-data`
- Centralized `CLAUDE_DIR` in `constants.py` to respect `CLAUDE_CONFIG_DIR` env var, falling back to `~/.claude`
- Updated `claude_folder_sync.py`, `marketplace.py`, and `user.py` to import from the single source of truth

## Test plan
- [ ] Verify marketplace catalog loads on VPS (Docker) deployment
- [ ] Verify marketplace still works in desktop mode (no `CLAUDE_CONFIG_DIR` set)
- [ ] Verify plugin install/uninstall works on both deployment modes