### PR TITLE
Add full file context toggle to diff view

### DIFF
--- a/backend/app/api/endpoints/sandbox.py
+++ b/backend/app/api/endpoints/sandbox.py
@@ -265,6 +265,7 @@ async def get_git_diff(
     sandbox_id: str = Depends(validate_sandbox_ownership),
     sandbox_service: SandboxService = Depends(get_sandbox_service),
     mode: Literal["all", "staged", "unstaged", "branch"] = Query("all"),
+    full_context: bool = Query(False),
 ) -> GitDiffResponse:
     # Workspace is mounted at /home/user/workspace in Docker containers;
     # cd there first, falling back to /home/user for non-Docker sandboxes.
@@ -276,9 +277,12 @@ async def get_git_diff(
         if check.exit_code != 0:
             return GitDiffResponse(diff="", has_changes=False, is_git_repo=False)
 
+        # Large context window so the patch includes the entire file, enabling full-file diff view
+        ctx = " -U99999" if full_context else ""
+
         untracked_diff = (
             " git ls-files --others --exclude-standard -z"
-            " | xargs -0 -I{} git diff --no-index -- /dev/null {} 2>/dev/null"
+            f" | xargs -0 -I{{}} git diff{ctx} --no-index -- /dev/null {{}} 2>/dev/null"
         )
 
         if mode == "branch":
@@ -291,16 +295,16 @@ async def get_git_diff(
                 " git rev-parse --verify $b >/dev/null 2>&1 && base=$b && break; done;"
                 ' if [ -z "$base" ]; then exit 2; fi;'
                 ' merge_base=$(git merge-base "$base" HEAD 2>/dev/null || echo "$base");'
-                ' git diff "$merge_base" HEAD 2>/dev/null'
+                f' git diff{ctx} "$merge_base" HEAD 2>/dev/null'
             )
         elif mode == "staged":
-            cmd = "git diff --cached 2>/dev/null"
+            cmd = f"git diff{ctx} --cached 2>/dev/null"
         elif mode == "unstaged":
-            cmd = f"git diff 2>/dev/null;{untracked_diff}"
+            cmd = f"git diff{ctx} 2>/dev/null;{untracked_diff}"
         else:
             cmd = (
-                "{ git diff HEAD 2>/dev/null"
-                " || { git diff --cached 2>/dev/null; git diff 2>/dev/null; }; };"
+                f"{{ git diff{ctx} HEAD 2>/dev/null"
+                f" || {{ git diff{ctx} --cached 2>/dev/null; git diff{ctx} 2>/dev/null; }}; }};"
                 f"{untracked_diff}"
             )
 

--- a/frontend/src/components/views/DiffView.tsx
+++ b/frontend/src/components/views/DiffView.tsx
@@ -8,6 +8,8 @@ import {
   GitCompareArrows,
   Rows2,
   RotateCcw,
+  UnfoldVertical,
+  FoldVertical,
 } from 'lucide-react';
 import { FileIcon } from '@/components/editor/file-tree/FileIcon';
 import { Button } from '@/components/ui/primitives/Button';
@@ -156,13 +158,14 @@ export const DiffView = memo(function DiffView({ sandboxId }: DiffViewProps) {
   const [parsingDone, setParsingDone] = useState(false);
   const [mode, setMode] = useState<DiffMode>('all');
   const [diffStyle, setDiffStyle] = useState<'unified' | 'split'>('unified');
+  const [expandUnchanged, setExpandUnchanged] = useState(false);
 
   const {
     data: diffData,
     isFetching,
     isError,
     refetch,
-  } = useGitDiffQuery(sandboxId || '', mode, { enabled: !!sandboxId });
+  } = useGitDiffQuery(sandboxId || '', mode, expandUnchanged, { enabled: !!sandboxId });
 
   const diffContent = diffData?.diff ?? '';
 
@@ -196,9 +199,10 @@ export const DiffView = memo(function DiffView({ sandboxId }: DiffViewProps) {
       theme: DIFF_THEMES,
       themeType: theme,
       diffStyle,
+      expandUnchanged,
       disableFileHeader: true,
     }),
-    [theme, diffStyle],
+    [theme, diffStyle, expandUnchanged],
   );
 
   const toggleFile = useCallback((index: number) => {
@@ -279,6 +283,20 @@ export const DiffView = memo(function DiffView({ sandboxId }: DiffViewProps) {
             </Button>
           </>
         )}
+
+        <Button
+          onClick={() => setExpandUnchanged(!expandUnchanged)}
+          variant="unstyled"
+          className="rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+          title={expandUnchanged ? 'Show changes only' : 'Show full file'}
+          aria-label={expandUnchanged ? 'Show changes only' : 'Show full file'}
+        >
+          {expandUnchanged ? (
+            <FoldVertical className="h-3 w-3" />
+          ) : (
+            <UnfoldVertical className="h-3 w-3" />
+          )}
+        </Button>
 
         <Button
           onClick={() => setDiffStyle(diffStyle === 'unified' ? 'split' : 'unified')}

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -18,8 +18,8 @@ export const queryKeys = {
     ideUrl: (sandboxId: string) => ['sandbox', sandboxId, 'ide-url'] as const,
     vncUrl: (sandboxId: string) => ['sandbox', sandboxId, 'vnc-url'] as const,
     browserStatus: (sandboxId: string) => ['sandbox', sandboxId, 'browser-status'] as const,
-    gitDiff: (sandboxId: string, mode: DiffMode) =>
-      ['sandbox', sandboxId, 'git-diff', mode] as const,
+    gitDiff: (sandboxId: string, mode: DiffMode, fullContext: boolean = false) =>
+      ['sandbox', sandboxId, 'git-diff', mode, fullContext] as const,
     gitDiffAll: (sandboxId: string) => ['sandbox', sandboxId, 'git-diff'] as const,
     gitBranches: (sandboxId: string) => ['sandbox', sandboxId, 'git-branches'] as const,
   },

--- a/frontend/src/hooks/queries/useSandboxQueries.ts
+++ b/frontend/src/hooks/queries/useSandboxQueries.ts
@@ -182,11 +182,12 @@ export const useCheckoutBranchMutation = () => {
 export const useGitDiffQuery = (
   sandboxId: string,
   mode: DiffMode = 'all',
+  fullContext: boolean = false,
   options?: Partial<UseQueryOptions<GitDiffData>>,
 ) => {
   return useQuery({
-    queryKey: queryKeys.sandbox.gitDiff(sandboxId, mode),
-    queryFn: () => sandboxService.getGitDiff(sandboxId, mode),
+    queryKey: queryKeys.sandbox.gitDiff(sandboxId, mode, fullContext),
+    queryFn: () => sandboxService.getGitDiff(sandboxId, mode, fullContext),
     enabled: !!sandboxId,
     staleTime: 30_000,
     ...options,

--- a/frontend/src/services/sandboxService.ts
+++ b/frontend/src/services/sandboxService.ts
@@ -219,11 +219,15 @@ async function getBrowserStatus(sandboxId: string): Promise<BrowserStatus> {
   });
 }
 
-async function getGitDiff(sandboxId: string, mode: DiffMode = 'all'): Promise<GitDiffData> {
+async function getGitDiff(
+  sandboxId: string,
+  mode: DiffMode = 'all',
+  fullContext: boolean = false,
+): Promise<GitDiffData> {
   validateRequired(sandboxId, 'Sandbox ID');
 
   return serviceCall(async () => {
-    const qs = buildQueryString({ mode });
+    const qs = buildQueryString({ mode, full_context: fullContext || undefined });
     const response = await apiClient.get<GitDiffData>(`/sandbox/${sandboxId}/git/diff${qs}`);
     return response ?? { diff: '', has_changes: false, is_git_repo: false };
   });


### PR DESCRIPTION
## Summary
- Add a toggle button in the diff toolbar to show diffs within the full file context (like VS Code/Cursor)
- Backend sends `git diff -U99999` when `full_context=true` to include all unchanged lines in the patch
- Moved split/unified and expand buttons inside the `showFiles` guard so they only appear when there are diffs to display
- Expanded files persist when toggling full context, but reset when switching diff modes

## Test plan
- [ ] Open diff view with uncommitted changes
- [ ] Click the unfold icon to toggle full file context — unchanged lines should appear around the diff hunks
- [ ] Toggle back — should return to changes-only view without collapsing expanded files
- [ ] Switch diff modes (Uncommitted/Staged/Unstaged/Branch) — expanded files should reset
- [ ] Verify split/unified toggle still works in both context modes