### PR TITLE
Improve transport layer code quality

### DIFF
--- a/backend/app/services/transports/base.py
+++ b/backend/app/services/transports/base.py
@@ -19,10 +19,17 @@ from app.constants import TERMINAL_TYPE
 
 logger = logging.getLogger(__name__)
 
+# Safety cap on the JSON accumulation buffer — if the CLI emits a single
+# un-terminated JSON value larger than this, we abort rather than OOM.
 DEFAULT_MAX_BUFFER_SIZE = 1024 * 1024 * 10  # 10MB
+
+# Bounds the in-memory queue between the stdout reader task and the JSON
+# parser; back-pressure stalls the reader when the parser falls behind.
 STDOUT_QUEUE_MAXSIZE = 32
+
+# Claude CLI output may contain ANSI escape sequences (colors, cursor moves)
+# that must be stripped before JSON parsing.
 ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
-JSON_START_RE = re.compile(r"[{\[]")
 
 
 class BaseSandboxTransport(Transport, ABC):
@@ -51,6 +58,8 @@ class BaseSandboxTransport(Transport, ABC):
         self._stdin_closed = False
 
     async def __aenter__(self) -> Self:
+        # Connection is lazy — callers must explicitly call connect() after
+        # entering the context manager, so __aenter__ just returns self.
         return self
 
     async def __aexit__(
@@ -59,6 +68,9 @@ class BaseSandboxTransport(Transport, ABC):
         _exc_val: BaseException | None,
         _exc_tb: TracebackType | None,
     ) -> bool:
+        # Always attempts cleanup; if close() fails and there was no original
+        # exception we re-raise the cleanup error, otherwise we log it and let
+        # the original exception propagate to avoid masking it.
         try:
             await self.close()
         except Exception as cleanup_error:
@@ -71,6 +83,9 @@ class BaseSandboxTransport(Transport, ABC):
         return False
 
     def _prepare_environment(self) -> tuple[dict[str, str], str, str]:
+        # Build the env/cwd/user triple used by both Docker exec and host
+        # subprocess. User-provided env vars are merged last so they can
+        # override any of the built-in defaults.
         envs = {
             "CLAUDE_CODE_ENTRYPOINT": "sdk-py",
             "CLAUDE_AGENT_SDK_VERSION": sdk_version,
@@ -92,12 +107,20 @@ class BaseSandboxTransport(Transport, ABC):
         )
 
     async def _cancel_task(self, task: asyncio.Task[Any] | None) -> None:
+        # Cancel and await the task so it finishes before we continue teardown.
+        # Awaiting is required to avoid "task destroyed but pending" warnings;
+        # CancelledError is suppressed because the cancellation is intentional.
         if task:
             task.cancel()
             with suppress(asyncio.CancelledError):
                 await task
 
-    async def _put_sentinel(self) -> None:
+    def _put_sentinel(self) -> None:
+        # Signal the JSON parser (_parse_cli_output) that no more data is
+        # coming so it exits its queue-read loop. Uses put_nowait because this
+        # runs in cleanup paths where blocking would delay teardown; if the
+        # queue is full the sentinel is dropped, but the reader tasks also push
+        # their own sentinel when the stream ends, so the parser still unblocks.
         try:
             self._stdout_queue.put_nowait(self._SENTINEL)
         except asyncio.QueueFull:
@@ -105,25 +128,39 @@ class BaseSandboxTransport(Transport, ABC):
 
     @abstractmethod
     async def connect(self) -> None:
+        # Establish the underlying connection (Docker exec or local subprocess)
+        # and start the background reader/monitor tasks.
         pass
 
     @abstractmethod
     async def _cleanup_resources(self) -> None:
+        # Tear down transport-specific resources (kill processes, close streams).
+        # Called by close() after the monitor task has already been cancelled.
         pass
 
     @abstractmethod
     def _is_connection_ready(self) -> bool:
+        # Quick liveness check used by write() and end_input() to guard against
+        # sending data after the underlying stream/process has disappeared.
         pass
 
     @abstractmethod
     async def _send_data(self, data: str) -> None:
+        # Write raw string data to the CLI process's stdin. Raises
+        # CLIConnectionError if the underlying transport is unavailable.
         pass
 
     @abstractmethod
     async def _send_eof(self) -> None:
+        # Close the stdin side of the connection to signal the CLI that no more
+        # input is coming, allowing it to finalize and exit.
         pass
 
     async def close(self) -> None:
+        # Ordered teardown: send EOF, mark closed, stop monitor, release
+        # transport resources, reset state for potential reconnection, then
+        # unblock the parser. Monitor must stop before resource cleanup to
+        # avoid inspecting already-killed processes.
         if self._ready:
             await self.end_input()
         self._ready = False
@@ -131,9 +168,12 @@ class BaseSandboxTransport(Transport, ABC):
         self._monitor_task = None
         await self._cleanup_resources()
         self._stdin_closed = False
-        await self._put_sentinel()
+        self._put_sentinel()
 
     async def write(self, data: str) -> None:
+        # Send data to the CLI's stdin. Non-CLIConnectionError failures are
+        # wrapped and stored in _exit_error so the parser can surface them
+        # after the stream ends, in addition to raising immediately here.
         if not self._ready or not self._is_connection_ready():
             raise CLIConnectionError("Transport is not ready for writing")
         if self._stdin_closed:
@@ -149,6 +189,9 @@ class BaseSandboxTransport(Transport, ABC):
             raise self._exit_error
 
     async def end_input(self) -> None:
+        # Best-effort EOF — called by close() and also available to SDK
+        # consumers directly, so it must be idempotent. Errors are swallowed
+        # because a broken pipe means the process already exited.
         if not self._ready or not self._is_connection_ready() or self._stdin_closed:
             return
         try:
@@ -164,6 +207,10 @@ class BaseSandboxTransport(Transport, ABC):
         return self._ready
 
     def _build_command(self) -> str:
+        # Translate ClaudeAgentOptions into a shell-escaped CLI invocation
+        # string. Used by Docker (passed to `bash -c`) and host (split back
+        # with shlex.split). Always bookended by --output-format and
+        # --input-format stream-json for bidirectional JSON streaming.
         cmd = [
             str(self._options.cli_path or "claude"),
             "--output-format",
@@ -215,6 +262,9 @@ class BaseSandboxTransport(Transport, ABC):
 
         if self._options.mcp_servers:
             if isinstance(self._options.mcp_servers, dict):
+                # SDK-type MCP servers carry a live Python "instance" object
+                # that can't be JSON-serialized — strip it before passing
+                # the config to the CLI.
                 servers_for_cli = {
                     name: {k: v for k, v in config.items() if k != "instance"}
                     if isinstance(config, dict) and config.get("type") == "sdk"
@@ -267,6 +317,9 @@ class BaseSandboxTransport(Transport, ABC):
         return shlex.join(cmd)
 
     def _parse_json_buffer(self, buffer: str) -> tuple[str, list[Any]]:
+        # Greedy JSON extractor: uses raw_decode to pull as many complete JSON
+        # values as possible from the buffer, returning any trailing incomplete
+        # fragment so the caller can accumulate it across chunks.
         messages: list[Any] = []
         while buffer:
             buffer = buffer.lstrip()
@@ -279,6 +332,14 @@ class BaseSandboxTransport(Transport, ABC):
         return buffer, messages
 
     async def _parse_cli_output(self) -> AsyncIterator[dict[str, Any]]:
+        # Core streaming parser: reads raw stdout chunks from the queue, strips
+        # ANSI escapes, skips non-JSON preamble until the first { or [, then
+        # accumulates lines into a buffer and greedily extracts complete JSON
+        # values via _parse_json_buffer. A "result" message acts as a hard
+        # boundary that resets the parser state. After the sentinel signals
+        # end-of-stream, any buffered remainder is drained and _exit_error
+        # (set by write() or _monitor_process) is raised so consumers see all
+        # available data before the error.
         if not self._ready and not self._monitor_task:
             raise CLIConnectionError("Transport is not connected")
 
@@ -293,18 +354,24 @@ class BaseSandboxTransport(Transport, ABC):
             if not isinstance(chunk, str):
                 continue
 
-            clean_chunk = ANSI_ESCAPE_RE.sub("", chunk).replace("\r", "")
+            if "\x1b" in chunk:
+                chunk = ANSI_ESCAPE_RE.sub("", chunk)
+            if "\r" in chunk:
+                chunk = chunk.replace("\r", "")
 
-            for json_line in clean_chunk.split("\n"):
+            for json_line in chunk.split("\n"):
                 json_line = json_line.strip()
                 if not json_line:
                     continue
 
                 if not json_started:
-                    match = JSON_START_RE.search(json_line)
-                    if not match:
+                    start = json_line.find("{")
+                    array_start = json_line.find("[")
+                    if array_start != -1 and (start == -1 or array_start < start):
+                        start = array_start
+                    if start == -1:
                         continue
-                    json_line = json_line[match.start() :]
+                    json_line = json_line[start:]
                     json_started = True
 
                 json_buffer += json_line

--- a/backend/app/services/transports/docker.py
+++ b/backend/app/services/transports/docker.py
@@ -21,6 +21,8 @@ class DockerSandboxTransport(BaseSandboxTransport):
         docker_config: DockerConfig,
         options: ClaudeAgentOptions,
     ) -> None:
+        # Docker connection state: client → container → exec instance → multiplexed stream.
+        # Types are Any because aiodocker doesn't export typed classes for these objects.
         super().__init__(sandbox_id=sandbox_id, options=options)
         self._docker_config = docker_config
         self._docker: aiodocker.Docker | None = None
@@ -30,14 +32,18 @@ class DockerSandboxTransport(BaseSandboxTransport):
         self._reader_task: asyncio.Task[None] | None = None
 
     def _get_docker(self) -> aiodocker.Docker:
+        # Lazy-init the Docker client, reusing it across calls within
+        # this transport's lifetime (connect + cleanup cycle).
         if self._docker is None:
             try:
                 self._docker = aiodocker.Docker(url=self._docker_config.host or None)
             except Exception as e:
-                raise CLIConnectionError(f"Failed to connect to Docker: {e}")
+                raise CLIConnectionError(f"Failed to connect to Docker: {e}") from e
         return self._docker
 
     async def _get_container(self) -> Any:
+        # Fetch the sandbox container by naming convention and auto-start
+        # it if stopped (e.g., after a Docker daemon restart).
         try:
             container = await self._get_docker().containers.get(
                 f"agentrove-sandbox-{self._sandbox_id}"
@@ -49,9 +55,12 @@ class DockerSandboxTransport(BaseSandboxTransport):
         except Exception as e:
             raise CLIConnectionError(
                 f"Failed to connect to sandbox {self._sandbox_id}: {e}"
-            )
+            ) from e
 
     async def connect(self) -> None:
+        # Create a Docker exec instance inside the container and start the multiplexed
+        # stream. `exec` wraps the CLI in `bash -c` with `exec` so signals reach the
+        # CLI directly instead of being absorbed by the shell.
         if self._ready:
             return
         self._stdin_closed = False
@@ -83,6 +92,8 @@ class DockerSandboxTransport(BaseSandboxTransport):
         return self._stream is not None
 
     async def _read_stream_data(self) -> None:
+        # Demultiplex the Docker exec stream — stdout (stream==1) goes to the
+        # queue for JSON parsing, stderr (stream==2) to the caller's callback.
         try:
             while True:
                 msg = await self._stream.read_out()
@@ -103,9 +114,11 @@ class DockerSandboxTransport(BaseSandboxTransport):
         except Exception as e:
             logger.error("Stream reader error: %s", e)
         finally:
-            await self._put_sentinel()
+            self._put_sentinel()
 
     async def _get_exec_info(self) -> dict[str, Any] | None:
+        # Inspect the exec instance to check Running status, ExitCode, and Pid.
+        # Used by both _monitor_process (polling) and _kill_exec_process (cleanup).
         if not self._exec:
             return None
         try:
@@ -116,6 +129,8 @@ class DockerSandboxTransport(BaseSandboxTransport):
             return None
 
     async def _kill_exec_process(self) -> None:
+        # Send SIGKILL to the exec process group (negative PID) inside the container
+        # via a secondary exec. Process group kill ensures child processes are cleaned up.
         if not self._exec or not self._container:
             return
         try:
@@ -133,6 +148,8 @@ class DockerSandboxTransport(BaseSandboxTransport):
             logger.debug("Failed to kill exec process: %s", e)
 
     async def _cleanup_resources(self) -> None:
+        # Ordered teardown: cancel reader, kill exec process, close stream,
+        # then close the Docker client.
         await self._cancel_task(self._reader_task)
         self._reader_task = None
 
@@ -156,6 +173,8 @@ class DockerSandboxTransport(BaseSandboxTransport):
         await self._stream.write_in(data.encode("utf-8"))
 
     async def _send_eof(self) -> None:
+        # aiodocker doesn't expose EOF on exec streams, so we reach into the
+        # underlying aiohttp transport to send a TCP half-close directly.
         if not self._stream:
             return
         try:
@@ -168,6 +187,8 @@ class DockerSandboxTransport(BaseSandboxTransport):
             pass
 
     async def _monitor_process(self) -> None:
+        # Docker exec doesn't support blocking wait, so we poll every 500ms.
+        # Detects process exit or disappearance and sets _exit_error accordingly.
         if not self._exec or not self._container:
             return
 
@@ -199,4 +220,4 @@ class DockerSandboxTransport(BaseSandboxTransport):
             )
         finally:
             self._ready = False
-            await self._put_sentinel()
+            self._put_sentinel()

--- a/backend/app/services/transports/factory.py
+++ b/backend/app/services/transports/factory.py
@@ -14,10 +14,9 @@ def create_sandbox_transport(
     workspace_path: str | None,
     options: ClaudeAgentOptions,
 ) -> SandboxTransport:
-    if (
-        sandbox_provider == SandboxProviderType.DOCKER
-        or sandbox_provider == SandboxProviderType.DOCKER.value
-    ):
+    # Route to the right transport: Docker exec for containerized sandboxes,
+    # local subprocess for host-mode sandboxes.
+    if sandbox_provider == SandboxProviderType.DOCKER:
         docker_config = SandboxProviderFactory.create_docker_config()
         return DockerSandboxTransport(
             sandbox_id=sandbox_id,
@@ -25,7 +24,9 @@ def create_sandbox_transport(
             options=options,
         )
 
-    if sandbox_provider == SandboxProviderType.HOST.value:
+    if sandbox_provider == SandboxProviderType.HOST:
+        if not workspace_path:
+            raise ValueError("workspace_path is required for host sandbox transport")
         return HostSandboxTransport(
             sandbox_id=sandbox_id,
             workspace_path=workspace_path,

--- a/backend/app/services/transports/host.py
+++ b/backend/app/services/transports/host.py
@@ -27,9 +27,13 @@ class HostSandboxTransport(BaseSandboxTransport):
         self,
         *,
         sandbox_id: str,
-        workspace_path: str | None,
+        workspace_path: str,
         options: ClaudeAgentOptions,
     ) -> None:
+        # _home_dir is a per-sandbox directory on the host (e.g. ~/.agentrove/sandboxes/<id>/)
+        # used as HOME for the CLI process so each sandbox gets isolated config/auth.
+        # _workspace_dir is the cwd the CLI runs in — a real project path in desktop
+        # mode, or the home dir itself in web mode.
         super().__init__(sandbox_id=sandbox_id, options=options)
         self._process: asyncio.subprocess.Process | None = None
         self._stdout_task: asyncio.Task[None] | None = None
@@ -38,20 +42,23 @@ class HostSandboxTransport(BaseSandboxTransport):
             Path(settings.get_host_sandbox_base_dir()).expanduser().resolve()
             / sandbox_id
         )
-        if workspace_path:
-            self._workspace_dir = Path(workspace_path).expanduser().resolve()
-        else:
-            self._workspace_dir = self._home_dir
+        self._workspace_dir = Path(workspace_path).expanduser().resolve()
 
     def _resolve_virtual_env_paths(self, envs: dict[str, str]) -> dict[str, str]:
+        # Env vars from _prepare_environment use virtual sandbox paths (e.g. /home/user/...).
+        # Translate them to real host paths so the subprocess can find them.
+        home = SANDBOX_HOME_DIR
         return {
             key: str(self._resolve_cwd(value))
-            if value.startswith(SANDBOX_HOME_DIR)
+            if value == home or value.startswith(home + "/")
             else value
             for key, value in envs.items()
         }
 
     def _resolve_cwd(self, cwd: str) -> Path:
+        # The rest of the codebase uses virtual sandbox paths (/home/user, /home/user/workspace)
+        # that match the Docker container layout. Map them to real host paths here so callers
+        # don't need to know whether they're running in Docker or on the host.
         if cwd == SANDBOX_HOME_DIR:
             return self._home_dir
         if cwd == SANDBOX_WORKSPACE_DIR:
@@ -61,16 +68,15 @@ class HostSandboxTransport(BaseSandboxTransport):
         if cwd.startswith(workspace_prefix):
             return (self._workspace_dir / cwd.removeprefix(workspace_prefix)).resolve()
 
-        relative = cwd.removeprefix(f"{SANDBOX_HOME_DIR}/")
-        if relative != cwd:
-            return (self._home_dir / relative).resolve()
+        home_prefix = f"{SANDBOX_HOME_DIR}/"
+        if cwd.startswith(home_prefix):
+            return (self._home_dir / cwd.removeprefix(home_prefix)).resolve()
 
-        path = Path(cwd)
-        if path.is_absolute():
-            return path
-        return (self._workspace_dir / path).resolve()
+        return Path(cwd)
 
     def _resolve_run_user(self, requested_user: str) -> tuple[int, int] | None:
+        # When running as root, drop privileges for the CLI subprocess so Claude's
+        # tool use (bash, file writes) can't operate with root access.
         if os.geteuid() != 0:
             return None
 
@@ -84,10 +90,15 @@ class HostSandboxTransport(BaseSandboxTransport):
 
     @staticmethod
     def _set_process_ids(uid: int, gid: int) -> None:
+        # preexec_fn callback — GID must be set before UID because
+        # setting UID first would lose the privilege needed to change GID.
         os.setgid(gid)
         os.setuid(uid)
 
     async def connect(self) -> None:
+        # Spawn the CLI as a local subprocess with resolved paths, sandbox-scoped env,
+        # and optional privilege dropping. Inherits the host's PATH (prefixed with
+        # required tool paths) and os.environ as the base environment.
         if self._ready:
             return
         self._stdin_closed = False
@@ -139,6 +150,8 @@ class HostSandboxTransport(BaseSandboxTransport):
         return self._process is not None and self._process.stdin is not None
 
     async def _cleanup_resources(self) -> None:
+        # Cancel reader tasks first so they don't read from a dead pipe, then
+        # SIGTERM with 2s grace period, then SIGKILL if still alive.
         await self._cancel_task(self._stdout_task)
         await self._cancel_task(self._stderr_task)
         self._stdout_task = None
@@ -167,6 +180,8 @@ class HostSandboxTransport(BaseSandboxTransport):
         await self._process.stdin.drain()
 
     async def _read_stdout(self) -> None:
+        # Feed raw stdout chunks into the queue for the base class JSON parser.
+        # Sentinel on exit ensures the parser unblocks even if the process dies.
         if not self._process or not self._process.stdout:
             return
         try:
@@ -178,9 +193,11 @@ class HostSandboxTransport(BaseSandboxTransport):
         except asyncio.CancelledError:
             pass
         finally:
-            await self._put_sentinel()
+            self._put_sentinel()
 
     async def _read_stderr(self) -> None:
+        # Forward stderr to the caller's callback. No sentinel needed — stderr
+        # doesn't feed the JSON parser.
         if not self._process or not self._process.stderr:
             return
         try:
@@ -197,6 +214,8 @@ class HostSandboxTransport(BaseSandboxTransport):
             pass
 
     async def _monitor_process(self) -> None:
+        # Await process exit directly (unlike Docker which polls). Sets _exit_error
+        # on non-zero exit so the parser surfaces it after draining all buffered output.
         if not self._process:
             return
         try:
@@ -215,4 +234,4 @@ class HostSandboxTransport(BaseSandboxTransport):
             )
         finally:
             self._ready = False
-            await self._put_sentinel()
+            self._put_sentinel()


### PR DESCRIPTION
## Summary
- **base.py**: Make `_put_sentinel` sync (was async but never awaited), replace `JSON_START_RE` regex with `str.find()` in hot-path parser, add ANSI/CR fast-path guards, add method-level comments to all methods
- **docker.py**: Fix missing exception chaining (`from e`) on two re-raises, add method-level comments
- **host.py**: Make `workspace_path` required (was `str | None`), fix `startswith` false-match on sandbox paths (e.g. `/home/username` matching `/home/user`), make prefix checks consistent, remove dead branches in `_resolve_cwd`, add method-level comments
- **factory.py**: Add `workspace_path` validation for host transport, simplify enum comparison (redundant `.value` check on `str` enum), add comment

## Test plan
- [ ] Verify host transport connects with a valid workspace path
- [ ] Verify Docker transport connects and streams output
- [ ] Verify streaming output parses correctly (no regressions from JSON start detection change)
- [ ] Verify `_put_sentinel` sync change doesn't break teardown flow