### PR TITLE
Publish full stream envelopes via Redis pub/sub

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -428,9 +428,9 @@ class ChatService(BaseDbService[Chat]):
 
     @staticmethod
     def _build_stream_sse_event(
-        # Single source of truth for the SSE envelope shape sent to the frontend —
-        # every stream event (backlog replay, live Redis, errors) goes through here
-        # so the client always receives a consistent {id, event, data} structure.
+        # Canonical builder for the SSE envelope shape sent to the frontend.
+        # The live-Redis path in _stream_live_redis_events constructs the same
+        # {id, event, data} shape directly from pre-serialized envelope JSON.
         *,
         chat_id: UUID,
         message_id: UUID,
@@ -439,18 +439,17 @@ class ChatService(BaseDbService[Chat]):
         kind: str,
         payload: dict[str, Any],
     ) -> dict[str, Any]:
-        envelope = StreamEnvelope.build(
-            chat_id=chat_id,
-            message_id=message_id,
-            stream_id=stream_id,
-            seq=seq,
-            kind=kind,
-            payload=payload,
-        )
         return {
             "id": str(seq),
             "event": StreamEventKind.STREAM.value,
-            "data": json.dumps(envelope, ensure_ascii=False),
+            "data": StreamEnvelope.serialize(
+                chat_id=chat_id,
+                message_id=message_id,
+                stream_id=stream_id,
+                seq=seq,
+                kind=kind,
+                payload=payload,
+            ),
         }
 
     async def _build_stream_error_event(
@@ -512,37 +511,54 @@ class ChatService(BaseDbService[Chat]):
         last_seq: int,
         live_pubsub: CachePubSub,
     ) -> AsyncIterator[dict[str, Any]]:
-        # Real-time leg of the SSE connection: after the backlog replay catches
-        # the client up, this loop waits for Redis pub/sub notifications and
-        # reads new events from the DB. Terminates when a terminal event
-        # (complete/cancelled/error) is encountered.
+        # Real-time leg of the SSE connection: events are published as full
+        # envelopes on the Redis channel so we can yield them directly without
+        # a DB round-trip.
         while True:
             message = await live_pubsub.get_message(
                 ignore_subscribe_messages=True, timeout=1.0
             )
-            if not message:
-                continue
-            if message.get("type") != "message":
+            if not message or message.get("type") != "message":
                 continue
 
-            live_events = await self.message_service.get_chat_events_after_seq(
-                chat_id=chat_id,
-                after_seq=last_seq,
-                limit=5000,
-            )
-            for event in live_events:
-                yield self._build_stream_sse_event(
-                    chat_id=event.chat_id,
-                    message_id=event.message_id,
-                    stream_id=event.stream_id,
-                    seq=int(event.seq),
-                    kind=event.event_type,
-                    payload=event.render_payload,
-                )
-                last_seq = int(event.seq)
+            raw = message.get("data")
+            if not raw:
+                continue
 
-                if event.event_type in TERMINAL_STREAM_EVENT_TYPES:
-                    return
+            try:
+                envelope = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Malformed Redis stream message for chat %s", chat_id)
+                continue
+
+            if not isinstance(envelope, dict) or "seq" not in envelope:
+                logger.warning("Redis stream message missing seq for chat %s", chat_id)
+                continue
+
+            seq = int(envelope["seq"])
+            if seq <= last_seq:
+                continue
+
+            # Gap detected — a pub/sub message was missed. Fall back to DB
+            # to recover the skipped events before yielding this one.
+            if seq > last_seq + 1:
+                async for event in self._replay_stream_backlog(chat_id, last_seq):
+                    yield event
+                    last_seq = int(event["id"])
+                if last_seq >= seq:
+                    if envelope.get("kind") in TERMINAL_STREAM_EVENT_TYPES:
+                        return
+                    continue
+
+            yield {
+                "id": str(seq),
+                "event": StreamEventKind.STREAM.value,
+                "data": raw,
+            }
+            last_seq = seq
+
+            if envelope.get("kind") in TERMINAL_STREAM_EVENT_TYPES:
+                return
 
     async def _get_active_stream_targets(
         self, chat_id: UUID

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -309,7 +309,7 @@ class ChatStreamRuntime:
             audit_payload=audit,
         )
         self.last_seq = seq
-        await self._signal_redis()
+        await self._publish_to_redis([self._serialize_envelope(seq, kind, payload)])
         return seq
 
     async def _flush_event_buffer(self) -> None:
@@ -325,20 +325,36 @@ class ChatStreamRuntime:
         self._event_buffer = []
         self.last_seq = seq
 
-    async def _signal_redis(self) -> None:
-        if not self.cache:
+        start_seq = seq - len(batch) + 1
+        redis_events = [
+            self._serialize_envelope(start_seq + i, kind, payload)
+            for i, (kind, payload, _audit) in enumerate(batch)
+        ]
+        await self._publish_to_redis(redis_events)
+
+    def _serialize_envelope(self, seq: int, kind: str, payload: dict[str, Any]) -> str:
+        return StreamEnvelope.serialize(
+            chat_id=self.chat.id,
+            message_id=UUID(self.assistant_message_id),
+            stream_id=self.stream_id,
+            seq=seq,
+            kind=kind,
+            payload=payload,
+        )
+
+    async def _publish_to_redis(self, events: list[str]) -> None:
+        if not self.cache or not events:
             return
-        try:
-            await self.cache.publish(
-                REDIS_KEY_CHAT_STREAM_LIVE.format(chat_id=self.chat_id),
-                "flush",
-            )
-        except CacheError as exc:
-            logger.warning(
-                "Failed to publish Redis signal for chat %s: %s",
-                self.chat_id,
-                exc,
-            )
+        channel = REDIS_KEY_CHAT_STREAM_LIVE.format(chat_id=self.chat_id)
+        for raw in events:
+            try:
+                await self.cache.publish(channel, raw)
+            except CacheError as exc:
+                logger.warning(
+                    "Failed to publish event for chat %s: %s",
+                    self.chat_id,
+                    exc,
+                )
 
     async def _flush_snapshot(self, *, force: bool) -> None:
         if not self.assistant_message_id:
@@ -358,7 +374,6 @@ class ChatStreamRuntime:
             last_seq=self.last_seq,
             active_stream_id=self.stream_id,
         )
-        await self._signal_redis()
         self.pending_since_flush = 0
         self.last_flush_at = time.monotonic()
 

--- a/backend/app/services/streaming/types.py
+++ b/backend/app/services/streaming/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from hashlib import sha256
@@ -133,6 +134,28 @@ class StreamEnvelope:
             "kind": kind,
             "payload": payload or {},
         }
+
+    @staticmethod
+    def serialize(
+        *,
+        chat_id: UUID,
+        message_id: UUID,
+        stream_id: UUID,
+        seq: int,
+        kind: str,
+        payload: dict[str, Any] | None = None,
+    ) -> str:
+        return json.dumps(
+            StreamEnvelope.build(
+                chat_id=chat_id,
+                message_id=message_id,
+                stream_id=stream_id,
+                seq=seq,
+                kind=kind,
+                payload=payload,
+            ),
+            ensure_ascii=False,
+        )
 
     @staticmethod
     def sanitize_payload(value: Any) -> Any:

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -19,10 +19,27 @@ import { streamService } from '@/services/streamService';
 import type { StreamOptions } from '@/services/streamService';
 import { useUIStore } from '@/store/uiStore';
 
-const STREAM_FLUSH_INTERVAL_MS = 200;
+const STREAM_FLUSH_INTERVAL_MS = 130;
 
 function createEmptyRenderSnapshot(): ContentRenderSnapshot {
   return { events: [] };
+}
+
+function buildProjectionUpdate(
+  streamId: string,
+  accumulator: StreamingContentAccumulator,
+  session: StreamSessionState,
+): (msg: Message) => Message {
+  const nextRender = accumulator.snapshot();
+  const nextText = accumulator.getContentText();
+  const nextSeq = session.lastSeq;
+  return (msg: Message): Message => ({
+    ...msg,
+    content_text: nextText,
+    content_render: nextRender,
+    last_seq: nextSeq,
+    active_stream_id: streamId,
+  });
 }
 
 interface UseStreamCallbacksParams {
@@ -184,16 +201,7 @@ export function useStreamCallbacks({
       const session = streamSessionsRef.current.get(streamId);
       if (!accumulator || !session) return;
 
-      const nextRender = accumulator.snapshot();
-      const nextText = accumulator.getContentText();
-      const nextSeq = session.lastSeq;
-      const update = (message: Message): Message => ({
-        ...message,
-        content_text: nextText,
-        content_render: nextRender,
-        last_seq: nextSeq,
-        active_stream_id: streamId,
-      });
+      const update = buildProjectionUpdate(streamId, accumulator, session);
 
       setMessages((prevMessages) =>
         prevMessages.map((msg) => (msg.id === session.messageId ? update(msg) : msg)),
@@ -214,8 +222,6 @@ export function useStreamCallbacks({
 
       const timer = setTimeout(() => {
         flushTimersRef.current.delete(streamId);
-        // Persist throttled snapshots to cache while streaming so switching chats/views
-        // does not drop the currently accumulated in-memory stream content.
         applyProjection(streamId, { writeToCache: true });
       }, STREAM_FLUSH_INTERVAL_MS);
 


### PR DESCRIPTION
## Summary
- **Redis-direct streaming**: The SSE consumer now reads pre-serialized envelopes directly from Redis pub/sub instead of querying the DB on every "flush" signal, eliminating a DB round-trip per event on the hot path
- **Gap recovery**: Added sequence gap detection in the live Redis path — if a pub/sub message is missed, falls back to `_replay_stream_backlog` to recover skipped events from the DB
- **`StreamEnvelope.serialize()`**: Consolidated the duplicated `build() + json.dumps(ensure_ascii=False)` pattern into a single method on `StreamEnvelope`, used by both the runtime publisher and the SSE builder
- **Frontend flush interval**: Lowered from 200ms to 130ms for snappier streaming UI updates
- **`buildProjectionUpdate` helper**: Extracted the shared message update shape from `applyProjection` into a module-level function to eliminate duplication

## Test plan
- [ ] Verify streaming works end-to-end (send a message, confirm tokens render smoothly)
- [ ] Switch chats mid-stream and verify content is preserved in the previous chat
- [ ] Verify gap recovery by checking logs for any "Malformed Redis stream message" warnings
- [ ] Confirm terminal events (complete/cancelled/error) properly close the SSE stream