### PR TITLE
Fix model selector not persisting chosen model across pages

### DIFF
--- a/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
+++ b/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
@@ -50,7 +50,20 @@ export function ChatSessionOrchestrator({
     })),
   );
 
-  const { selectedModelId, selectModel } = useModelSelection({ chatId });
+  const lastAssistantModelId = useMemo((): string | null | undefined => {
+    if (messagesQuery.isLoading) return null;
+    for (let i = fetchedMessages.length - 1; i >= 0; i--) {
+      if (fetchedMessages[i].role === 'assistant' && fetchedMessages[i].model_id) {
+        return fetchedMessages[i].model_id;
+      }
+    }
+    return undefined;
+  }, [fetchedMessages, messagesQuery.isLoading]);
+
+  const { selectedModelId, selectModel } = useModelSelection({
+    chatId,
+    initialModelId: lastAssistantModelId,
+  });
 
   const {
     initialPrompt,

--- a/frontend/src/hooks/queries/useModelQueries.ts
+++ b/frontend/src/hooks/queries/useModelQueries.ts
@@ -17,8 +17,14 @@ export const useModelsQuery = (options?: Partial<UseQueryOptions<Model[]>>) => {
   });
 };
 
-export const useModelSelection = (options?: { enabled?: boolean; chatId?: string }) => {
+export const useModelSelection = (options?: {
+  enabled?: boolean;
+  chatId?: string;
+  // null = still loading (defer default), undefined = no initial model (use models[0])
+  initialModelId?: string | null;
+}) => {
   const chatId = options?.chatId ?? DEFAULT_MODEL_KEY;
+  const initialModelId = options?.initialModelId;
   const { data: models = [], isLoading } = useModelsQuery({
     enabled: options?.enabled,
   });
@@ -27,10 +33,17 @@ export const useModelSelection = (options?: { enabled?: boolean; chatId?: string
   useEffect(() => {
     if (models.length === 0) return;
     const selectedExists = models.some((m) => m.model_id === selectedModelId);
-    if (!selectedExists) {
-      useModelStore.getState().selectModel(chatId, models[0].model_id);
-    }
-  }, [models, selectedModelId, chatId]);
+    if (selectedExists) return;
+
+    // Still loading initial model from message history — wait before defaulting
+    if (initialModelId === null) return;
+
+    const fallback =
+      initialModelId && models.some((m) => m.model_id === initialModelId)
+        ? initialModelId
+        : models[0].model_id;
+    useModelStore.getState().selectModel(chatId, fallback);
+  }, [models, selectedModelId, chatId, initialModelId]);
 
   const selectedModel = useMemo(
     () => models.find((m) => m.model_id === selectedModelId) ?? null,

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -6,6 +6,7 @@ import { useLayoutSidebar } from '@/components/layout/layoutState';
 import { Input as ChatInput } from '@/components/chat/message-input/Input';
 import { WorkspaceSelector } from '@/components/chat/WorkspaceSelector';
 import { useChatStore } from '@/store/chatStore';
+import { useModelStore } from '@/store/modelStore';
 import { useAuthStore } from '@/store/authStore';
 import { useInfiniteChatsQuery, useCreateChatMutation } from '@/hooks/queries/useChatQueries';
 import { useWorkspacesQuery } from '@/hooks/queries/useWorkspaceQueries';
@@ -131,6 +132,7 @@ export function LandingPage() {
           model_id: selectedModelId,
           workspace_id: selectedWorkspaceId,
         });
+        useModelStore.getState().selectModel(newChat.id, selectedModelId);
         setMessage('');
         navigate(`/chat/${newChat.id}`, { state: { initialPrompt: trimmedPrompt } });
       } catch (error) {


### PR DESCRIPTION
## Summary
- **Landing page → new chat**: the selected model was stored under a `__default__` key but the chat page looked it up by `chatId`, always falling back to `models[0]`. Pre-seed the model store with the new chatId before navigating.
- **Reopening existing chats**: always showed `models[0]` instead of the last model used. Derive `initialModelId` from the last assistant message's `model_id` and pass it as a fallback to `useModelSelection`.
- **Race condition**: models loading before messages caused eager defaulting to `models[0]`, ignoring the history-based model. Use `null` to signal "still loading" so the hook defers until the messages query completes.

## Changed files
- `frontend/src/pages/LandingPage.tsx` — seed model store entry for new chatId before navigation
- `frontend/src/hooks/queries/useModelQueries.ts` — accept `initialModelId` (string | null | undefined) with three-state semantics: null = defer, undefined = use models[0], string = preferred fallback
- `frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx` — derive last assistant model from fetched messages, pass to useModelSelection

## Test plan
- [ ] Select a non-default model on the landing page, start a chat, verify the first response uses the selected model
- [ ] Reopen an existing chat, verify the selector shows the last model used in that conversation
- [ ] Switch models mid-chat, navigate away and back, verify the manual selection is preserved
- [ ] Disable a provider whose model was last used in a chat, reopen, verify it falls back to the first available model
- [ ] Open a brand new empty chat directly (not from landing page), verify models[0] is selected