### PR TITLE
Fix: remove external: true from sandbox network definition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,6 @@ services:
 networks:
   sandbox:
     name: agentrove-sandbox-net
-    external: true
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

- Remove `external: true` from the `sandbox` network in `docker-compose.yml` so Docker Compose creates the network automatically on `docker compose up`

## Problem

The sandbox network was declared as `external: true`, which tells Docker Compose the network must already exist before any containers start. Compose validates external networks upfront and fails immediately if they're missing:

```
Error response from daemon: network agentrove-sandbox-net not found
```

The `entrypoint.sh` already contains logic to create the network, but it never gets a chance to run because Compose fails before starting any containers — a chicken-and-egg problem.

## Fix

Removing `external: true` lets Docker Compose own the network lifecycle — it creates the network on `up` and removes it on `down`. The `entrypoint.sh` network creation becomes a harmless no-op since the network already exists by the time the container starts.

## Test plan

- [ ] `docker compose down` then `docker compose up -d` succeeds without manually creating the network first
- [ ] Sandbox containers can still communicate over the network

🤖 Generated with [Claude Code](https://claude.com/claude-code)