### PR TITLE
Remove defensive output sanitization from title generation

### DIFF
--- a/backend/app/services/claude_agent.py
+++ b/backend/app/services/claude_agent.py
@@ -324,13 +324,7 @@ class ClaudeAgentService:
                         title = message.result
 
             title = title.strip().strip('"').strip("'")
-            if not title:
-                return None
-            # If the model returned a long response instead of a title, take just the first line
-            first_line = title.split("\n", 1)[0].strip()
-            if len(first_line) > 80:
-                first_line = first_line[:77] + "..."
-            return first_line or None
+            return title or None
         except ClaudeSDKError:
             logger.debug("Title generation SDK call failed for user %s", user.id)
             return None


### PR DESCRIPTION
## Summary
- Removed first-line extraction and 80-char truncation from `generate_title` — the stronger system prompt with few-shot examples from #372 makes this unnecessary

## Test plan
- [ ] Verify title generation still produces short, clean titles