### PR TITLE
Move worktree creation from adapters to GitService

### DIFF
--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -75,7 +75,6 @@ class AgentAdapter(ABC):
     # differs in CLI flags, env vars, session metadata, and permission models.
     # Adapters encapsulate those differences so the rest of the codebase works
     # with a uniform AcpSessionConfig regardless of which agent is running.
-    supports_worktree: bool = False
 
     def __init__(self, kind: AgentKind) -> None:
         self.kind = kind
@@ -98,7 +97,6 @@ class AgentAdapter(ABC):
         *,
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
-        worktree: bool,
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:
@@ -113,8 +111,6 @@ class AgentAdapter(ABC):
 
 
 class ClaudeAgentAdapter(AgentAdapter):
-    supports_worktree = True
-
     def __init__(self) -> None:
         super().__init__(kind=AgentKind.CLAUDE)
 
@@ -135,7 +131,6 @@ class ClaudeAgentAdapter(AgentAdapter):
         *,
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
-        worktree: bool,
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:
@@ -149,12 +144,6 @@ class ClaudeAgentAdapter(AgentAdapter):
                 meta["systemPrompt"] = system_prompt
             else:
                 meta["systemPrompt"] = {"append": system_prompt}
-
-        agent_options: dict[str, Any] = {}
-        if worktree:
-            agent_options["worktree"] = True
-        if agent_options:
-            meta["claudeCode"] = {"options": agent_options}
 
         # Claude uses MAX_THINKING_TOKENS env var for thinking budget.
         env_overrides: dict[str, str] = {}
@@ -210,7 +199,6 @@ class CodexAgentAdapter(AgentAdapter):
         *,
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
-        worktree: bool,
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -57,7 +57,6 @@ class AcpSessionConfig:
     workspace_path: str | None = None
     system_prompt: str | None = None
     system_prompt_is_full_replace: bool = False
-    worktree: bool = False
     reasoning_effort: str | None = None
     session_meta: dict[str, Any] = field(default_factory=dict)
 
@@ -468,17 +467,30 @@ class AcpSession:
         )
 
     @staticmethod
+    def _is_virtual_prefix(cwd: str, prefix: str) -> bool:
+        # Exact match or prefix followed by "/" — avoids false positives
+        # on real Linux paths like /home/username/... when the virtual
+        # prefix is /home/user.
+        return cwd == prefix or cwd.startswith(prefix + "/")
+
+    @staticmethod
     def _resolve_cwd(config: AcpSessionConfig) -> str:
         # Host mode needs the real filesystem path since the virtual
         # sandbox path (/home/user/workspace) doesn't exist on the host.
         if config.sandbox_provider == SandboxProviderType.HOST.value:
-            # Real host paths should be used as-is. Only rewrite the
-            # virtual sandbox paths that don't exist on the host.
-            if config.cwd not in (SANDBOX_HOME_DIR, SANDBOX_WORKSPACE_DIR):
-                return config.cwd
-            if config.workspace_path:
-                return config.workspace_path
-            return f"{settings.get_host_sandbox_base_dir()}/{config.sandbox_id}"
+            host_base = f"{settings.get_host_sandbox_base_dir()}/{config.sandbox_id}"
+            # Rewrite virtual sandbox paths (and sub-paths like worktrees)
+            # to real host paths. Check workspace first — its prefix is
+            # longer so it must win over the home-dir prefix.
+            if config.workspace_path and AcpSession._is_virtual_prefix(
+                config.cwd, SANDBOX_WORKSPACE_DIR
+            ):
+                return config.cwd.replace(
+                    SANDBOX_WORKSPACE_DIR, config.workspace_path, 1
+                )
+            if AcpSession._is_virtual_prefix(config.cwd, SANDBOX_HOME_DIR):
+                return config.cwd.replace(SANDBOX_HOME_DIR, host_base, 1)
+            return config.cwd
         return config.cwd
 
     @staticmethod

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -5,6 +5,9 @@ from collections.abc import AsyncIterator
 from typing import Any, cast
 from uuid import UUID
 
+from sqlalchemy import update
+from sqlalchemy.exc import SQLAlchemyError
+
 from app.constants import (
     SANDBOX_GIT_ASKPASS_PATH,
     SANDBOX_HOME_DIR,
@@ -30,6 +33,7 @@ from app.services.acp.client import AcpClientHandler
 from app.services.acp.session import AcpSession, AcpSessionConfig
 from app.services.exceptions import AgentException, ChatException, ErrorCode
 from app.constants import MODELS
+from app.services.git import GitService
 from app.services.sandbox import SandboxService
 from app.services.sandbox_providers import SandboxProviderType
 from app.services.sandbox_providers.factory import SandboxProviderFactory
@@ -57,6 +61,20 @@ class AgentService:
             session_factory=self.session_factory
         ).get_user_settings(user_id)
 
+    async def _save_worktree_cwd(self, chat_id: UUID, worktree_cwd: str) -> None:
+        # Best-effort persistence — if it fails the worktree still exists on
+        # disk but won't be reused on session resume (a new one will be created).
+        try:
+            async with self.session_factory() as db:
+                await db.execute(
+                    update(Chat)
+                    .where(Chat.id == chat_id)
+                    .values(worktree_cwd=worktree_cwd)
+                )
+                await db.commit()
+        except (SQLAlchemyError, ValueError) as exc:
+            logger.error("Failed to persist worktree_cwd for chat %s: %s", chat_id, exc)
+
     async def build_session_config(
         self,
         *,
@@ -80,17 +98,31 @@ class AgentService:
             cwd = SANDBOX_WORKSPACE_DIR
 
         agent_kind = MODELS[model_id].agent_kind
-        adapter = AGENT_ADAPTERS[agent_kind]
         stored_agent_kind = getattr(chat, "session_agent_kind", None)
         if stored_agent_kind and stored_agent_kind != agent_kind.value:
             raise ChatException(
                 f"Cannot switch from {stored_agent_kind} to {agent_kind.value} in the same chat",
                 error_code=ErrorCode.VALIDATION_ERROR,
             )
-        if not adapter.supports_worktree:
-            worktree = False
-        elif worktree and session_id and chat.worktree_cwd:
-            cwd = chat.worktree_cwd
+
+        if worktree and sandbox_id:
+            if chat.worktree_cwd:
+                # Reuse the already-persisted worktree path from a prior turn.
+                cwd = chat.worktree_cwd
+            else:
+                provider = SandboxProviderFactory.create(
+                    SandboxProviderType(sandbox_provider)
+                )
+                git_service = GitService(SandboxService(provider))
+                worktree_cwd = await git_service.create_worktree(
+                    sandbox_id,
+                    cwd,
+                    str(chat.id),
+                )
+                if worktree_cwd:
+                    cwd = worktree_cwd
+                    chat.worktree_cwd = worktree_cwd
+                    await self._save_worktree_cwd(chat.id, worktree_cwd)
 
         is_custom_persona = selected_persona_name != DEFAULT_PERSONA_NAME
 
@@ -107,7 +139,6 @@ class AgentService:
             workspace_path=workspace_path,
             system_prompt=system_prompt,
             system_prompt_is_full_replace=is_custom_persona,
-            worktree=worktree,
         )
 
     async def stream_response(
@@ -362,7 +393,6 @@ class AgentService:
         workspace_path: str | None = None,
         system_prompt: str | None = None,
         system_prompt_is_full_replace: bool = False,
-        worktree: bool = False,
     ) -> AcpSessionConfig:
         env: dict[str, str] = {}
 
@@ -381,7 +411,6 @@ class AgentService:
         session_config = adapter.build_session_config(
             system_prompt=system_prompt,
             system_prompt_is_full_replace=system_prompt_is_full_replace,
-            worktree=worktree,
             thinking_mode=thinking_mode,
             permission_mode=permission_mode,
         )
@@ -400,7 +429,6 @@ class AgentService:
             workspace_path=workspace_path,
             system_prompt=system_prompt,
             system_prompt_is_full_replace=system_prompt_is_full_replace,
-            worktree=worktree,
             reasoning_effort=session_config.reasoning_effort,
             session_meta=session_config.meta,
         )

--- a/backend/app/services/git.py
+++ b/backend/app/services/git.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import Literal
 
@@ -12,6 +13,8 @@ from app.models.schemas.sandbox import (
 from app.services.exceptions import SandboxException
 from app.services.sandbox import SandboxService
 from app.utils.sandbox import BRANCH_NAME_RE, git_cd_prefix
+
+logger = logging.getLogger(__name__)
 
 GITHUB_REMOTE_RE = re.compile(
     r"(?:https?://github\.com/|git@github\.com:)([^/]+)/([^/]+?)(?:\.git)?$"
@@ -297,6 +300,50 @@ class GitService:
             repo=match.group(2),
             remote_url=remote_url,
         )
+
+    async def create_worktree(
+        self,
+        sandbox_id: str,
+        base_cwd: str,
+        chat_id: str,
+    ) -> str | None:
+        # Graceful fallback: if the sandbox has no git repo or the worktree
+        # command fails, return None so the caller uses the original cwd.
+        # This lets non-git workspaces work without worktree isolation.
+        short_id = chat_id[:8]
+        worktree_dir = f"{base_cwd}/.worktrees/{short_id}"
+        branch_name = f"worktree-{short_id}"
+        # Idempotent: if a previous attempt created the worktree but the DB
+        # persist failed, the directory already exists. Check first so we
+        # don't fail on a duplicate branch/path from git worktree add.
+        cd_prefix = git_cd_prefix(base_cwd)
+        cmd = (
+            f"{cd_prefix}"
+            f"git rev-parse --is-inside-work-tree >/dev/null 2>&1 && "
+            f"if [ -e '{worktree_dir}/.git' ]; then echo 'exists'; exit 0; fi && "
+            f"mkdir -p '{base_cwd}/.worktrees' && "
+            f"git worktree add '{worktree_dir}' -b '{branch_name}' 2>&1"
+        )
+        try:
+            # Local git operation — no user secrets needed, so bypass
+            # SandboxService.execute_command and call the provider directly.
+            result = await self.sandbox_service.provider.execute_command(
+                sandbox_id,
+                cmd,
+            )
+        except SandboxException:
+            logger.warning(
+                "Failed to create worktree in sandbox %s", sandbox_id, exc_info=True
+            )
+            return None
+        if result.exit_code == 0:
+            return worktree_dir
+        logger.warning(
+            "git worktree add failed (exit %d): %s",
+            result.exit_code,
+            result.stdout or result.stderr,
+        )
+        return None
 
     @staticmethod
     def _validate_branch_name(name: str, label: str = "branch") -> None:

--- a/backend/app/services/session_registry.py
+++ b/backend/app/services/session_registry.py
@@ -140,20 +140,16 @@ class SessionRegistry:
 
     @staticmethod
     def _compute_fingerprint(config: AcpSessionConfig) -> str:
+        # cwd is excluded: it drifts during a session when the agent
+        # reports sub-paths via SessionInfoUpdate.
         fingerprint_dict: dict[str, Any] = {
             "agent_kind": config.agent_kind.value,
             "env": config.env,
             "mcp_servers": config.mcp_servers,
             "system_prompt": config.system_prompt,
-            "worktree": config.worktree,
             "reasoning_effort": config.reasoning_effort,
             "launch_approval_policy": config.launch_approval_policy,
         }
-        # cwd changes dynamically in worktree mode (workspace → worktree path
-        # after session init), so including it would invalidate the session on
-        # the second turn.
-        if not config.worktree:
-            fingerprint_dict["cwd"] = config.cwd
         data = json.dumps(fingerprint_dict, sort_keys=True, default=str)
         return hashlib.sha256(data.encode()).hexdigest()
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -33,7 +33,7 @@ export function LandingPage() {
   const location = useLocation();
   const attachedFiles = useChatStore((state) => state.attachedFiles);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const { selectedModelId, selectedModel, selectModel } = useModelSelection({
+  const { selectedModelId, selectModel } = useModelSelection({
     enabled: isAuthenticated,
   });
 
@@ -181,7 +181,7 @@ export function LandingPage() {
                 onWorkspaceChange={setSelectedWorkspaceId}
                 enabled={isAuthenticated}
               />
-              {selectedModel?.agent_kind !== 'codex' && <WorktreeToggle disabled={isLoading} />}
+              <WorktreeToggle disabled={isLoading} />
             </div>
 
             <ChatProvider


### PR DESCRIPTION
## Summary
- Move git worktree creation logic from ACP adapter layer to `GitService.create_worktree`, where git operations belong
- Handle worktree orchestration (create + persist) in `AgentService.build_session_config` with warm-path short-circuit (reuse `chat.worktree_cwd` on subsequent turns)
- Remove `worktree` field from `AcpSessionConfig`, `supports_worktree` from adapters, and `claudeCode.options.worktree` metadata
- Fix `_resolve_cwd` to handle worktree sub-paths via prefix matching instead of exact equality
- Remove agent_kind gate on `WorktreeToggle` — now available for all agents
- Simplify session fingerprint (always exclude `cwd`, remove `worktree` key)