### PR TITLE
Fix terminal reattach artifacts and stale output

### DIFF
--- a/backend/app/api/endpoints/websocket.py
+++ b/backend/app/api/endpoints/websocket.py
@@ -129,11 +129,11 @@ async def terminal_websocket(
                 )
 
                 if is_reattach and session.pty_id is not None:
-                    # Send space + Ctrl-L to force a terminal redraw after
-                    # reattaching to an existing tmux session so the user
-                    # sees current content instead of a blank screen.
+                    # Force a redraw after reattaching to an existing tmux
+                    # session so the terminal repaints without injecting a
+                    # literal space into the active shell buffer.
                     await session.sandbox_service.send_pty_input(
-                        session.sandbox_id, session.pty_id, b" \x0c"
+                        session.sandbox_id, session.pty_id, b"\x0c"
                     )
 
             elif data_type == WS_MSG_RESIZE:

--- a/frontend/src/components/sandbox/terminal/TerminalTab.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab.tsx
@@ -38,6 +38,7 @@ export const TerminalTab: FC<TerminalTabProps> = ({
   const wsRef = useRef<WebSocket | null>(null);
   const isClosingRef = useRef(false);
   const shouldCloseRef = useRef(shouldClose);
+  const lastSessionKeyRef = useRef<string | null>(null);
 
   const backgroundClass = getTerminalBackgroundClass(theme);
 
@@ -83,6 +84,14 @@ export const TerminalTab: FC<TerminalTabProps> = ({
 
   useEffect(() => {
     if (!sandboxId || !isReady) return;
+
+    const sessionKey = sandboxId + ':' + (terminalId ?? '');
+    if (lastSessionKeyRef.current !== sessionKey) {
+      // Reset the terminal when rebinding to a different session so stale
+      // screen contents and cursor position do not leak into the next PTY.
+      terminalRef.current?.reset();
+      lastSessionKeyRef.current = sessionKey;
+    }
 
     const token = authService.getToken();
     if (!token) return;
@@ -181,6 +190,7 @@ export const TerminalTab: FC<TerminalTabProps> = ({
       }
       ws.close();
       resetWsRefs();
+      lastSessionKeyRef.current = null;
       setSessionState('idle');
     };
   }, [sandboxId, terminalId, isReady, fitTerminal, terminalRef, resetWsRefs]);

--- a/frontend/src/hooks/useXterm.ts
+++ b/frontend/src/hooks/useXterm.ts
@@ -120,7 +120,6 @@ export const useXterm = ({
         scrollback: 1000,
         fontSize: 12,
         fontFamily: 'monospace',
-        convertEol: true,
         theme: buildTerminalTheme(modeRef.current),
         disableStdin,
       });


### PR DESCRIPTION
## Summary
- Remove leading space from Ctrl-L redraw on tmux reattach — prevents injecting a literal space into the active shell buffer
- Clear xterm screen when terminal tab is rebound to a different sandbox/terminal so stale output doesn't linger while the new PTY connects
- Reset session key ref on effect cleanup to avoid skipping the clear on remount

## Test plan
- [ ] Reattach to an existing terminal session — verify no extra space appears in the shell
- [ ] Switch between sandboxes while the terminal tab is open — verify previous output is cleared immediately
- [ ] Unmount and remount the terminal tab for the same sandbox — verify terminal clears and reconnects cleanly