### PR TITLE
Fix invalid GitHub token handling in PR review

### DIFF
--- a/backend/app/services/github.py
+++ b/backend/app/services/github.py
@@ -31,10 +31,12 @@ class GitHubService:
 
     def _check_auth(self, response: httpx.Response) -> None:
         if response.status_code == 401:
+            # Reserve HTTP 401 for this app's own auth/session failures so the frontend
+            # does not treat an invalid GitHub PAT as a reason to log the user out.
             raise GitHubException(
                 "GitHub token is invalid or expired",
                 error_code=ErrorCode.GITHUB_TOKEN_INVALID,
-                status_code=401,
+                status_code=400,
             )
 
     def _check_response(self, response: httpx.Response) -> None:

--- a/frontend/src/components/views/PRReviewView.tsx
+++ b/frontend/src/components/views/PRReviewView.tsx
@@ -137,6 +137,7 @@ export const PRReviewView = memo(function PRReviewView() {
     data: pullsData,
     isLoading,
     isError,
+    error: pullsError,
   } = useGitHubPullsQuery(owner, repo, !!owner && !!repo);
 
   const [expandedPR, setExpandedPR] = useState<number | null>(null);
@@ -194,7 +195,7 @@ export const PRReviewView = memo(function PRReviewView() {
               Failed to load pull requests
             </p>
             <p className="mt-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-              Check that your GitHub token is valid
+              {pullsError?.message}
             </p>
           </div>
         ) : !pullsData?.items.length ? (


### PR DESCRIPTION
## Summary
- return a 400 for invalid or expired GitHub PAT responses instead of a 401 used for app auth failures
- show the backend error message in the PR review view so invalid token failures are surfaced directly