### PR TITLE
Remove expandable prop from ToolCard and auto-derive from children

### DIFF
--- a/frontend/src/components/chat/tools/claude/AgentOutputTool.tsx
+++ b/frontend/src/components/chat/tools/claude/AgentOutputTool.tsx
@@ -22,7 +22,6 @@ const OutputToolInner: React.FC<{
   const idSuffix = id ? `: ${truncatedId}` : '';
 
   const output = formatResult(tool.result);
-  const hasOutput = output.length > 0 && tool.status === 'completed';
 
   return (
     <ToolCard
@@ -42,9 +41,8 @@ const OutputToolInner: React.FC<{
       }}
       loadingContent={`Waiting for ${label} output\u2026`}
       error={tool.error}
-      expandable={hasOutput}
     >
-      {hasOutput && (
+      {output && (
         <div className="max-h-48 overflow-auto rounded bg-black/5 px-2 py-1.5 font-mono text-xs text-text-secondary dark:bg-white/5 dark:text-text-dark-secondary">
           <pre className="whitespace-pre-wrap break-all">{output}</pre>
         </div>

--- a/frontend/src/components/chat/tools/claude/AgentTool.tsx
+++ b/frontend/src/components/chat/tools/claude/AgentTool.tsx
@@ -36,9 +36,6 @@ export const AgentTool: React.FC<AgentToolProps> = ({ tool }) => {
   const subagentType = tool.input?.subagent_type as string | undefined;
 
   const result = extractResultText(tool.result);
-
-  const hasDetails = Boolean(prompt) || Boolean(result) || tool.children.length > 0;
-
   // Scoped context for nested Agent tools so they see their own siblings
   const childAgentTools = useMemo(
     () => tool.children.filter((c) => c.name === 'Agent'),
@@ -85,10 +82,9 @@ export const AgentTool: React.FC<AgentToolProps> = ({ tool }) => {
             </p>
           ) : undefined
         }
-        expandable={hasDetails}
         actions={expandAction}
       >
-        {hasDetails && (
+        {(prompt || result || tool.children.length > 0) && (
           <div className="space-y-2">
             {prompt && (
               <div className="space-y-2">

--- a/frontend/src/components/chat/tools/claude/BashTool.tsx
+++ b/frontend/src/components/chat/tools/claude/BashTool.tsx
@@ -18,8 +18,6 @@ const BashToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
   const description = input?.description;
 
   const output = formatResult(tool.result);
-  const hasExpandableContent =
-    command.length > 50 || (output.length > 0 && tool.status === 'completed');
 
   return (
     <ToolCard
@@ -41,11 +39,10 @@ const BashToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent="Running command..."
       error={tool.error}
-      expandable={hasExpandableContent}
     >
-      {hasExpandableContent && (
+      {(command || output) && (
         <div className="space-y-1">
-          {command.length > 50 && (
+          {command && (
             <pre className="whitespace-pre-wrap break-all font-mono text-2xs leading-relaxed text-text-secondary dark:text-text-dark-tertiary">
               <span className="select-none text-text-quaternary dark:text-text-dark-quaternary">
                 ${' '}
@@ -53,9 +50,7 @@ const BashToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
               {command}
             </pre>
           )}
-          {output.length > 0 && tool.status === 'completed' && (
-            <pre className={TOOL_OUTPUT_PRE_CLASS}>{output}</pre>
-          )}
+          {output.length > 0 && <pre className={TOOL_OUTPUT_PRE_CLASS}>{output}</pre>}
         </div>
       )}
     </ToolCard>

--- a/frontend/src/components/chat/tools/claude/FileOperationTool.tsx
+++ b/frontend/src/components/chat/tools/claude/FileOperationTool.tsx
@@ -183,8 +183,8 @@ const FileOperationToolInner: React.FC<FileOperationToolProps> = ({ tool, varian
     );
   };
 
-  const hasExpandableContent =
-    (variant === 'read' && tool.result && tool.status === 'completed') ||
+  const hasContent =
+    (variant === 'read' && tool.result) ||
     (variant === 'edit' &&
       (typeof tool.input?.old_string === 'string' || typeof tool.input?.new_string === 'string')) ||
     (variant === 'write' && typeof tool.input?.content === 'string' && tool.input.content);
@@ -205,10 +205,9 @@ const FileOperationToolInner: React.FC<FileOperationToolProps> = ({ tool, varian
       }}
       loadingContent={config.loadingContent}
       error={tool.error}
-      expandable={Boolean(hasExpandableContent)}
       actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
     >
-      {renderContent()}
+      {hasContent ? renderContent() : null}
     </ToolCard>
   );
 };

--- a/frontend/src/components/chat/tools/claude/GlobTool.tsx
+++ b/frontend/src/components/chat/tools/claude/GlobTool.tsx
@@ -20,7 +20,6 @@ const GlobToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
   const path = input?.path;
 
   const files = parseResult(tool.result);
-  const hasFiles = files.length > 0 && tool.status === 'completed';
   const locationSuffix = path ? ` in ${path}` : '';
 
   return (
@@ -41,9 +40,8 @@ const GlobToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent="Searching for files..."
       error={tool.error}
-      expandable={hasFiles}
     >
-      {hasFiles && (
+      {files.length > 0 && (
         <div className="max-h-48 overflow-auto font-mono text-2xs leading-relaxed text-text-tertiary dark:text-text-dark-quaternary">
           {files.map((file) => (
             <div key={file} className="truncate">

--- a/frontend/src/components/chat/tools/claude/GrepTool.tsx
+++ b/frontend/src/components/chat/tools/claude/GrepTool.tsx
@@ -27,7 +27,6 @@ const GrepToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
   const outputMode = input?.output_mode ?? 'files_with_matches';
 
   const result = formatResult(tool.result);
-  const hasResult = result.length > 0 && tool.status === 'completed';
   const modeLabel = MODE_LABELS[outputMode];
 
   return (
@@ -46,9 +45,8 @@ const GrepToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent="Searching..."
       error={tool.error}
-      expandable={hasResult}
     >
-      {hasResult && <pre className={TOOL_OUTPUT_PRE_CLASS}>{result}</pre>}
+      {result && <pre className={TOOL_OUTPUT_PRE_CLASS}>{result}</pre>}
     </ToolCard>
   );
 };

--- a/frontend/src/components/chat/tools/claude/LSPTool.tsx
+++ b/frontend/src/components/chat/tools/claude/LSPTool.tsx
@@ -36,8 +36,6 @@ const LSPToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
   const opLabel = operation ?? 'query';
 
   const result = formatResult(tool.result);
-  const hasExpandableContent =
-    filePath.length > 0 || (result.length > 0 && tool.status === 'completed');
 
   return (
     <ToolCard
@@ -55,9 +53,8 @@ const LSPToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent={`Running ${opLabel}...`}
       error={tool.error}
-      expandable={hasExpandableContent}
     >
-      {hasExpandableContent && (
+      {(filePath || result) && (
         <div className="space-y-1.5">
           {filePath && (
             <div className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-quaternary">
@@ -65,9 +62,7 @@ const LSPToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
               {location}
             </div>
           )}
-          {result.length > 0 && tool.status === 'completed' && (
-            <pre className={TOOL_OUTPUT_PRE_CLASS}>{result}</pre>
-          )}
+          {result && <pre className={TOOL_OUTPUT_PRE_CLASS}>{result}</pre>}
         </div>
       )}
     </ToolCard>

--- a/frontend/src/components/chat/tools/claude/MCPTool.tsx
+++ b/frontend/src/components/chat/tools/claude/MCPTool.tsx
@@ -50,7 +50,7 @@ const MCPToolInner: React.FC<MCPToolProps> = ({ tool }) => {
         ? Object.keys(tool.result as object).length > 0
         : true),
   );
-  const hasDetails = hasInput || (hasResult && toolStatus === 'completed');
+  const hasDetails = hasInput || hasResult;
   const title = description ? `${formattedToolName}: ${description}` : formattedToolName;
 
   return (
@@ -60,7 +60,6 @@ const MCPToolInner: React.FC<MCPToolProps> = ({ tool }) => {
       title={title}
       loadingContent="Processing..."
       error={errorMessage}
-      expandable={hasDetails}
     >
       {hasDetails ? (
         <div className="space-y-1.5">
@@ -76,7 +75,7 @@ const MCPToolInner: React.FC<MCPToolProps> = ({ tool }) => {
                 </div>
               ))
             : null}
-          {hasResult && toolStatus === 'completed' ? (
+          {hasResult ? (
             <pre className={TOOL_OUTPUT_PRE_CLASS}>{formatResult(tool.result)}</pre>
           ) : null}
         </div>

--- a/frontend/src/components/chat/tools/claude/NotebookEditTool.tsx
+++ b/frontend/src/components/chat/tools/claude/NotebookEditTool.tsx
@@ -35,8 +35,6 @@ const NotebookEditToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
     delete: 'Deleted cell in',
   };
 
-  const hasExpandableContent = notebookPath.length > 0 || newSource.length > 0 || cellId;
-
   return (
     <ToolCard
       icon={<BookOpen className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />}
@@ -54,9 +52,8 @@ const NotebookEditToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent="Editing notebook..."
       error={tool.error}
-      expandable={Boolean(hasExpandableContent)}
     >
-      {hasExpandableContent && (
+      {(notebookPath || newSource || cellId || cellType) && (
         <div className="space-y-1.5">
           {notebookPath && (
             <div className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-quaternary">

--- a/frontend/src/components/chat/tools/claude/PlanModeTool.tsx
+++ b/frontend/src/components/chat/tools/claude/PlanModeTool.tsx
@@ -131,7 +131,6 @@ const ExitPlanModeInner: React.FC<PlanModeToolProps> = ({ tool, chatId }) => {
       }}
       loadingContent="Waiting for plan approval\u2026"
       error={tool.error}
-      expandable={hasContent}
     >
       {hasContent && (
         <div className="space-y-2">

--- a/frontend/src/components/chat/tools/claude/TodoWrite.tsx
+++ b/frontend/src/components/chat/tools/claude/TodoWrite.tsx
@@ -70,9 +70,8 @@ export const TodoWrite: React.FC<TodoWriteProps> = ({ tool }) => {
       }}
       loadingContent="Updating todo list..."
       error={errorMessage}
-      expandable={todoCount > 0 && toolStatus === 'completed'}
     >
-      {todoCount > 0 && toolStatus === 'completed' && (
+      {todoCount > 0 && (
         <div>
           <div className="mb-2 flex gap-3 text-2xs">{summaryMeta}</div>
           <div className="space-y-1">

--- a/frontend/src/components/chat/tools/claude/WebFetchTool.tsx
+++ b/frontend/src/components/chat/tools/claude/WebFetchTool.tsx
@@ -17,7 +17,6 @@ const WebFetchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
 
   const domain = extractDomain(url) || 'content';
   const result = formatResult(tool.result);
-  const hasExpandableContent = url.length > 0 || (result.length > 0 && tool.status === 'completed');
 
   return (
     <ToolCard
@@ -35,9 +34,8 @@ const WebFetchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent="Fetching content\u2026"
       error={tool.error}
-      expandable={hasExpandableContent}
     >
-      {hasExpandableContent && (
+      {(url || prompt || result) && (
         <div className="space-y-1.5">
           {url && (
             <div className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-quaternary">
@@ -47,9 +45,7 @@ const WebFetchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
           {prompt && (
             <p className="text-2xs text-text-tertiary dark:text-text-dark-tertiary">{prompt}</p>
           )}
-          {result.length > 0 && tool.status === 'completed' && (
-            <pre className={TOOL_OUTPUT_PRE_CLASS}>{result}</pre>
-          )}
+          {result && <pre className={TOOL_OUTPUT_PRE_CLASS}>{result}</pre>}
         </div>
       )}
     </ToolCard>

--- a/frontend/src/components/chat/tools/claude/WebSearch.tsx
+++ b/frontend/src/components/chat/tools/claude/WebSearch.tsx
@@ -77,9 +77,6 @@ export const WebSearch: React.FC<WebSearchProps> = ({ tool }) => {
 
     return [];
   }, [tool.result]);
-
-  const canShowSources = sources.length > 0;
-
   return (
     <ToolCard
       icon={<Search className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />}
@@ -96,9 +93,8 @@ export const WebSearch: React.FC<WebSearchProps> = ({ tool }) => {
       }}
       loadingContent={<SearchLoadingDots label="Searching the web" />}
       error={errorMessage}
-      expandable={canShowSources}
     >
-      {canShowSources && (
+      {sources.length > 0 && (
         <div>
           <div className="flex flex-wrap gap-1">
             {sources.map((source, index) => (

--- a/frontend/src/components/chat/tools/codex/EditTool.tsx
+++ b/frontend/src/components/chat/tools/codex/EditTool.tsx
@@ -104,7 +104,6 @@ const EditToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
 
   const Icon = isNewFile ? FilePlus : FileEdit;
 
-  const hasExpandableContent = changedFiles.length > 0 && tool.status === 'completed';
   const target = fileCount > 1 ? `${fileCount} files` : firstFileName;
 
   return (
@@ -125,10 +124,9 @@ const EditToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent={isNewFile ? 'Creating file...' : 'Applying changes...'}
       error={tool.error}
-      expandable={hasExpandableContent}
       actions={firstFilePath ? <OpenInEditorButton filePath={firstFilePath} /> : null}
     >
-      {hasExpandableContent && (
+      {changedFiles.length > 0 && (
         <div className="max-h-48 overflow-auto font-mono text-2xs leading-relaxed">
           {changedFiles.map(([filePath, change]) => (
             <div key={filePath} className="mb-2 last:mb-0">

--- a/frontend/src/components/chat/tools/codex/FetchTool.tsx
+++ b/frontend/src/components/chat/tools/codex/FetchTool.tsx
@@ -40,8 +40,6 @@ const FetchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
   const result = formatResult(tool.result);
 
   const sources = useMemo(() => extractSources(input), [input]);
-  const hasExpandableContent =
-    sources.length > 0 || url.length > 0 || pattern.length > 0 || result.length > 0;
 
   return (
     <ToolCard
@@ -60,9 +58,8 @@ const FetchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent="Fetching content..."
       error={tool.error}
-      expandable={hasExpandableContent}
     >
-      {hasExpandableContent && (
+      {(sources.length > 0 || url || pattern || result) && (
         <div className={sources.length > 0 ? 'flex flex-wrap gap-1' : 'space-y-1.5'}>
           {sources.length > 0 ? (
             sources.map((source, index) => (
@@ -80,9 +77,7 @@ const FetchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
                   {pattern}
                 </p>
               )}
-              {result.length > 0 && tool.status === 'completed' && (
-                <pre className={TOOL_OUTPUT_PRE_CLASS}>{result}</pre>
-              )}
+              {result && <pre className={TOOL_OUTPUT_PRE_CLASS}>{result}</pre>}
             </>
           )}
         </div>

--- a/frontend/src/components/chat/tools/codex/FileActionTool.tsx
+++ b/frontend/src/components/chat/tools/codex/FileActionTool.tsx
@@ -37,7 +37,6 @@ const DeleteToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent="Deleting file..."
       error={tool.error}
-      expandable={Boolean(filePath)}
     >
       {filePath && (
         <div className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-quaternary">
@@ -72,7 +71,6 @@ const MoveToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent="Moving file..."
       error={tool.error}
-      expandable={Boolean(source || destination)}
       actions={destination ? <OpenInEditorButton filePath={destination} /> : null}
     >
       {(source || destination) && (

--- a/frontend/src/components/chat/tools/codex/ReadTool.tsx
+++ b/frontend/src/components/chat/tools/codex/ReadTool.tsx
@@ -19,10 +19,6 @@ const ReadToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
   const fileLabel = filePath ? extractFilename(filePath) : 'file';
   const content = extractOutput(result);
   const command = extractCommand(input);
-  const hasExpandableContent =
-    command.length > 50 ||
-    filePath.length > 0 ||
-    (content.length > 0 && tool.status === 'completed');
 
   return (
     <ToolCard
@@ -40,10 +36,9 @@ const ReadToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent="Loading file content..."
       error={tool.error}
-      expandable={hasExpandableContent}
       actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
     >
-      {hasExpandableContent && (
+      {(filePath || command || content) && (
         <div className="space-y-1.5">
           {filePath && (
             <div className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-quaternary">
@@ -51,7 +46,7 @@ const ReadToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
             </div>
           )}
           {renderCommand(command)}
-          {content.length > 0 && tool.status === 'completed' && (
+          {content && (
             <div className="max-h-48 overflow-auto font-mono text-2xs leading-relaxed">
               {content.split('\n').map((line, idx) => (
                 <div key={idx} className="flex">

--- a/frontend/src/components/chat/tools/codex/SearchTool.tsx
+++ b/frontend/src/components/chat/tools/codex/SearchTool.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { FileSearch } from 'lucide-react';
 import type { ToolAggregate } from '@/types/tools.types';
 import { extractFilename } from '@/utils/format';
@@ -41,10 +41,6 @@ const SearchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
   const output = extractOutput(result);
   const command = extractCommand(input);
   const filePath = input?.parsed_cmd?.[0]?.path ?? '';
-  const hasExpandableContent = useMemo(
-    () => command.length > 50 || filePath.length > 0 || output.length > 0,
-    [command, filePath, output],
-  );
 
   return (
     <ToolCard
@@ -65,10 +61,9 @@ const SearchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
         <SearchLoadingDots label="Searching files" />
       }
       error={tool.error}
-      expandable={hasExpandableContent}
       actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
     >
-      {hasExpandableContent && (
+      {(filePath || command || output) && (
         <div className="space-y-1.5">
           {filePath && (
             <div className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-quaternary">
@@ -76,7 +71,7 @@ const SearchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
             </div>
           )}
           {renderCommand(command)}
-          {tool.status === 'completed' && renderOutput(output)}
+          {renderOutput(output)}
         </div>
       )}
     </ToolCard>

--- a/frontend/src/components/chat/tools/codex/ShellTool.tsx
+++ b/frontend/src/components/chat/tools/codex/ShellTool.tsx
@@ -31,8 +31,6 @@ const ShellToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
   const toolKindLabel = toolType === 'unknown' ? 'Execute' : `Execute (${toolType})`;
 
   const output = extractOutput(result);
-  const hasExpandableContent =
-    command.length > 50 || (output.length > 0 && tool.status === 'completed');
 
   return (
     <ToolCard
@@ -61,12 +59,11 @@ const ShellToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
       }}
       loadingContent="Running command..."
       error={tool.error}
-      expandable={hasExpandableContent}
     >
-      {hasExpandableContent && (
+      {(command || output) && (
         <div className="space-y-1">
           {renderCommand(command)}
-          {tool.status === 'completed' && renderOutput(output)}
+          {renderOutput(output)}
         </div>
       )}
     </ToolCard>

--- a/frontend/src/components/chat/tools/codex/codexShellPayload.tsx
+++ b/frontend/src/components/chat/tools/codex/codexShellPayload.tsx
@@ -38,7 +38,7 @@ export const extractOutput = (result: ShellLikeOutput | undefined): string => {
 };
 
 export const renderCommand = (command: string): React.ReactNode => {
-  if (command.length <= 50) {
+  if (!command) {
     return null;
   }
 

--- a/frontend/src/components/chat/tools/common/ToolCard.tsx
+++ b/frontend/src/components/chat/tools/common/ToolCard.tsx
@@ -1,6 +1,7 @@
 import React, { JSX, memo, useState } from 'react';
 import { Check, ChevronRight, Circle, X } from 'lucide-react';
 import type { ToolEventStatus } from '@/types/tools.types';
+import { TOOL_ERROR_PRE_CLASS } from '@/utils/toolStyles';
 
 export const statusIndicator: Record<ToolEventStatus, JSX.Element> = {
   completed: <Check className="h-3 w-3 text-success-600 dark:text-success-400" />,
@@ -24,7 +25,6 @@ interface ToolCardProps {
   statusDetail?: Content;
   children?: React.ReactNode;
   className?: string;
-  expandable?: boolean;
   defaultExpanded?: boolean;
 }
 
@@ -38,14 +38,27 @@ const ToolCardInner: React.FC<ToolCardProps> = ({
   statusDetail,
   children,
   className = '',
-  expandable = false,
   defaultExpanded = false,
 }) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const resolvedTitle = typeof title === 'function' ? title(status) : title;
 
-  const hasExpandableContent = expandable && children;
-  const showChildren = !expandable || expanded;
+  const hasDetailsError = status === 'failed' && error;
+  const hasExpandableContent = Boolean(children) || Boolean(hasDetailsError);
+  const showChildren = !hasExpandableContent || expanded;
+  const details =
+    children || hasDetailsError ? (
+      <div className="mt-1.5 space-y-1.5 border-l border-border pl-3 dark:border-border-dark">
+        {children}
+        {hasDetailsError &&
+          (React.isValidElement(error) ? (
+            error
+          ) : (
+            // Multiline error output belongs inside the collapsible body alongside normal results
+            <pre className={TOOL_ERROR_PRE_CLASS}>{error}</pre>
+          ))}
+      </div>
+    ) : null;
 
   const header = (
     <div className="flex items-center gap-1.5">
@@ -78,13 +91,6 @@ const ToolCardInner: React.FC<ToolCardProps> = ({
             {loadingContent}
           </p>
         ))}
-      {status === 'failed' &&
-        error &&
-        (React.isValidElement(error) ? (
-          error
-        ) : (
-          <p className="mt-0.5 pl-5 text-2xs text-error-600 dark:text-error-500">{error}</p>
-        ))}
       {statusDetail &&
         (React.isValidElement(statusDetail) ? (
           statusDetail
@@ -114,9 +120,7 @@ const ToolCardInner: React.FC<ToolCardProps> = ({
         {actions}
       </div>
       {meta}
-      {showChildren && children && (
-        <div className="mt-1.5 border-l border-border pl-3 dark:border-border-dark">{children}</div>
-      )}
+      {showChildren && details}
     </div>
   );
 };

--- a/frontend/src/utils/toolStyles.ts
+++ b/frontend/src/utils/toolStyles.ts
@@ -1,2 +1,5 @@
 export const TOOL_OUTPUT_PRE_CLASS =
   'max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-2xs leading-relaxed text-text-tertiary dark:text-text-dark-quaternary';
+
+export const TOOL_ERROR_PRE_CLASS =
+  'max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-2xs leading-relaxed text-error-600 dark:text-error-500';


### PR DESCRIPTION
## Summary
- Remove the `expandable` prop from `ToolCard` — expandability is now auto-derived from whether `children` (or an error in failed state) exist
- Remove redundant `hasExpandableContent` / `hasDetails` variables from all 22 tool components (claude + codex)
- Move error display into the collapsible body so errors can be expanded/collapsed alongside output
- Remove `tool.status === 'completed'` guards on output rendering so results are visible during streaming, not only after completion
- Add `TOOL_ERROR_PRE_CLASS` for consistent multiline error styling inside the collapsible body

## Test plan
- [ ] Verify tool cards auto-expand/collapse correctly when children are present
- [ ] Verify errors appear inside the collapsible section and can be toggled
- [ ] Verify tool output is visible while streaming (not gated on `completed` status)
- [ ] Spot-check each tool type (Bash, Grep, Glob, FileOp, MCP, Agent, etc.) for correct rendering