### PR TITLE
Fix @ file mentions on landing page

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -17,9 +17,11 @@ import {
   useWorkspacesQuery,
   useWorkspaceResourcesQuery,
 } from '@/hooks/queries/useWorkspaceQueries';
+import { useFilesMetadataQuery } from '@/hooks/queries/useSandboxQueries';
 import { useModelSelection } from '@/hooks/queries/useModelQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
 import { ChatProvider } from '@/contexts/ChatContext';
+import { buildFileStructureFromSandboxFiles } from '@/utils/file';
 
 const EXAMPLE_PROMPTS = [
   'Build a REST API with authentication',
@@ -82,6 +84,21 @@ export function LandingPage() {
       enabled: isAuthenticated && !!selectedWorkspaceId,
     },
   );
+
+  // Enable @ file mentions in the input bar before a chat is created
+  const selectedSandboxId = selectedWorkspaceId
+    ? workspaces.find((ws) => ws.id === selectedWorkspaceId)?.sandbox_id
+    : undefined;
+
+  const { data: filesMetadata = [] } = useFilesMetadataQuery(selectedSandboxId, {
+    enabled: isAuthenticated && !!selectedSandboxId,
+  });
+
+  const fileStructure = useMemo(
+    () => buildFileStructureFromSandboxFiles(filesMetadata, []),
+    [filesMetadata],
+  );
+
   const { data: settings } = useSettingsQuery({
     enabled: isAuthenticated,
   });
@@ -177,6 +194,7 @@ export function LandingPage() {
             </div>
 
             <ChatProvider
+              fileStructure={fileStructure}
               customSkills={workspaceResources?.skills}
               builtinSlashCommands={workspaceResources?.builtin_slash_commands}
               personas={settings?.personas}


### PR DESCRIPTION
## Summary
- The landing page input bar placeholder advertised `@ to mention` but the feature didn't work because `ChatProvider` received no `fileStructure`
- When a workspace is selected, derive its `sandbox_id`, fetch file metadata via `useFilesMetadataQuery`, build the file structure, and pass it to `ChatProvider`
- This enables the `useMentionSuggestions` hook to show file suggestions when typing `@` on the landing page

## Test plan
- [ ] Select a workspace on the landing page
- [ ] Type `@` in the input bar — file suggestions from the workspace sandbox should appear
- [ ] Switch workspaces — file suggestions should update to the new workspace's files
- [ ] With no workspace selected, `@` should show no suggestions (empty state)