### PR TITLE
Fix message input layout and design token corrections

### DIFF
--- a/frontend/src/components/chat/message-input/DropIndicator.tsx
+++ b/frontend/src/components/chat/message-input/DropIndicator.tsx
@@ -44,7 +44,7 @@ export function DropIndicator({
             <Upload className="h-5 w-5" />
           )}
         </IconWrapper>
-        <p className="text-sm font-semibold">{message}</p>
+        <p className="text-sm font-medium">{message}</p>
         <div className="max-w-xs text-center text-xs font-medium text-text-tertiary dark:text-text-dark-tertiary">
           {fileType === 'image'
             ? 'PNG • JPEG • GIF • WebP'

--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -67,7 +67,7 @@ function InputLayout() {
     <form ref={meta.formRef} onSubmit={actions.handleSubmit} className="relative px-4 sm:px-6">
       <div
         {...meta.dragHandlers}
-        className={`relative rounded-2xl border bg-surface-secondary shadow-soft transition-[border-color,box-shadow] duration-300 dark:bg-surface-dark-secondary ${
+        className={`relative rounded-2xl border bg-surface-secondary shadow-sm transition-[border-color,box-shadow] duration-300 dark:bg-surface-dark-secondary ${
           state.isDragging
             ? 'scale-[1.01] border-border-hover dark:border-border-dark-hover'
             : 'border-border dark:border-border-dark'
@@ -105,11 +105,11 @@ function InputLayout() {
           <InputSuggestionsPanel />
         </div>
 
-        <div className="absolute bottom-0 left-0 right-0 px-3 py-2 pb-safe">
-          <div className="relative flex items-center justify-between">
+        <div className="absolute bottom-2.5 left-3 right-3 pb-safe">
+          <div className="flex items-center justify-between gap-2">
             <InputControls />
 
-            <div className="absolute bottom-2.5 right-3 flex items-center gap-1">
+            <div className="flex flex-shrink-0 items-center gap-1">
               <AttachButton
                 disabled={state.isDisabled}
                 onAttach={() => {
@@ -147,7 +147,7 @@ function InputLayout() {
         )}
 
       {state.showTip && !state.hasAttachments && (
-        <div className="mt-1 animate-fade-in text-center text-2xs text-text-quaternary dark:text-text-dark-tertiary">
+        <div className="mt-1 animate-fade-in text-center text-2xs text-text-quaternary dark:text-text-dark-quaternary">
           <span className="font-medium">Tip:</span> Drag and drop images, pdfs and xlsx files into
           the input area, type `/` for slash commands, or `@` to mention files and agents
         </div>

--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -18,7 +18,7 @@ export function InputControls() {
 
   return (
     <div
-      className="absolute bottom-2.5 left-3 right-20 flex items-center gap-1 sm:gap-1.5"
+      className="flex min-w-0 flex-1 items-center gap-1 sm:gap-1.5"
       onMouseDown={(e) => e.preventDefault()}
     >
       <EnhanceButton

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -65,11 +65,6 @@ export function InputProvider({
   const messageRef = useRef(message);
   messageRef.current = message;
 
-  const prevChatId = useRef(chatId);
-  if (prevChatId.current !== chatId) {
-    prevChatId.current = chatId;
-  }
-
   const hasMessage = message.trim().length > 0;
   const hasAttachments = (attachedFiles?.length ?? 0) > 0;
 
@@ -80,8 +75,6 @@ export function InputProvider({
   }
 
   const showPreview = showAttachedFilesPreview && hasAttachments && !previewDismissed;
-
-  const clearAttachedFiles = onAttach;
 
   const { previewUrls } = useFileHandling({
     initialFiles: attachedFiles,
@@ -236,7 +229,7 @@ export function InputProvider({
           attachedFiles ?? undefined,
         );
       setMessage('');
-      clearAttachedFiles?.([]);
+      onAttach?.([]);
       setPreviewDismissed(true);
       return;
     }
@@ -271,9 +264,10 @@ export function InputProvider({
     chatId,
     attachedFiles,
     setMessage,
-    clearAttachedFiles,
+    onAttach,
     agentKind,
     selectedModelId,
+    personas,
   ]);
 
   const handleKeyDown = useCallback(

--- a/frontend/src/components/chat/message-input/SendButton.tsx
+++ b/frontend/src/components/chat/message-input/SendButton.tsx
@@ -20,7 +20,7 @@ const PRIMARY_BG =
 
 const VISUAL_COLORS: Record<'spinner' | 'stop' | 'ready' | 'idle', string> = {
   spinner: PRIMARY_BG,
-  stop: 'bg-error-500 hover:bg-error-600',
+  stop: PRIMARY_BG,
   ready: PRIMARY_BG,
   idle: 'bg-surface-tertiary dark:bg-surface-dark-tertiary',
 };
@@ -58,7 +58,7 @@ export function SendButton({
   } else if (showStopIcon) {
     ariaLabel = 'Stop generating';
     icon = (
-      <Pause className="h-3 w-3 animate-pulse text-text-dark-primary motion-reduce:animate-none" />
+      <Pause className="h-3 w-3 animate-pulse text-surface motion-reduce:animate-none dark:text-surface-dark" />
     );
   } else {
     ariaLabel = 'Send message';


### PR DESCRIPTION
## Summary
- Refactor controls row from absolute positioning to flexbox layout so controls and send button size correctly relative to each other
- Fix `shadow-soft` (invalid/custom token) to `shadow-sm` on the input container
- Fix stop button color from red `bg-error-500` to monochrome primary (consistent with design system)
- Fix dark mode tip text using wrong color token (`text-text-dark-tertiary` → `text-text-dark-quaternary`)
- Remove dead `prevChatId` ref that was tracking chat ID changes but doing nothing with it
- Remove redundant `clearAttachedFiles` alias for `onAttach`; call `onAttach` directly
- Add `personas` to `handleSubmit` dependency array

## Test plan
- [ ] Message input controls (enhance, model selector, etc.) display correctly without overlap
- [ ] Send/stop button displays correctly in both light and dark mode
- [ ] Stop button shows monochrome style (not red) while streaming
- [ ] Drag-and-drop indicator shows `font-medium` text
- [ ] Tip text renders with correct quaternary color in dark mode
- [ ] Submitting a message still clears attached files correctly