### PR TITLE
Redesign sidebar layout and chat item styling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@
 - Do not introduce a new frontend type/interface when an existing one has the same shape — reuse the existing type directly, even across module boundaries
 - When defining an abstract method signature during a refactor, verify every parameter receives a meaningful value from all call sites — do not carry forward parameters from the old design that become dead in the new interface (e.g., always hardcoded to `None`)
 - Do not create inline dict literals for identity mappings (where every key maps to itself) — use a `set`/`frozenset` membership check instead, hoisted to a module-level constant
+- In JSX conditionals with numeric values, use explicit checks (`value != null && value > 0`) instead of truthy checks (`value && ...`) — numeric `0` is falsy but renders as text in React
 
 ## Naming Conventions
 
@@ -137,6 +138,9 @@
 - `LayoutContext` (`components/layout/layoutState.tsx`) — sidebar state
 - `FileTreeProvider` (`components/editor/file-tree/FileTreeProvider.tsx`) — file tree selection and expansion state
 
+### Responsive Awareness
+- Before removing a UI element, check if it serves a responsive or functional role beyond its visual purpose — icons often double as compact-mode fallbacks (`compactOnMobile`), and labels may be the only visible element at certain breakpoints
+
 ### File Placement
 - When extracting non-component code (contexts, utils, hooks) from a component file, place it in the project's canonical folder for that type (`contexts/`, `utils/`, `hooks/`) — do not leave it next to the component it was extracted from
 - The `components/chat/tools/` directory is exclusively for tool components (one per tool type) — helper modals, dialogs, and detail views triggered by tools belong in `components/chat/` or a relevant feature folder, not in `tools/`
@@ -181,6 +185,7 @@
 - Prefer single-pass iteration (`.reduce()`) over chained `.filter().map()` in render paths
 - When reordering a function call to run earlier in a per-event hot path (e.g., stream envelope processing), gate the call with the cheapest possible condition check at the call site — avoid paying function-call overhead for the 99% of events that will just early-return
 - Keep `useEffect` for external system subscriptions and DOM side effects — keyboard shortcuts, resize observers, WebSocket lifecycle, scroll-into-view, and focus management require post-render timing and cleanup; do not convert these to ref-based render checks
+- When unifying components with variant-specific features, gate Zustand selectors to return a stable value for variants that don't use the subscribed state — e.g., `useStore((s) => needsFeature ? s.value : false)` — to avoid unnecessary re-renders
 
 ### Async Patterns
 - Use `Promise.all()` for independent async operations (e.g., multiple `queryClient.invalidateQueries()` calls)
@@ -193,6 +198,7 @@
 - Fully monochrome aesthetic — no brand/blue accent colors in structural UI
 - Clean, minimal, and refined — prefer subtlety over visual weight
 - Every element should feel quiet and intentional
+- When multiple visual approaches are viable for a UI element (connector styles, layout patterns, color choices), present visual mockups to the user for selection before writing implementation code — avoids repeated code iterations
 
 ### Color Palette
 - Always refer to `frontend/tailwind.config.js` for defined colors
@@ -211,6 +217,7 @@
 - Do not use semantic colors (`error-*`, `warning-*`, `success-*`) for interactive button backgrounds — use monochrome surface tokens; semantic colors are for status badges and text indicators only
 - Every `dark:text-*` / `dark:bg-*` class must have a corresponding light-mode class — never rely on browser defaults or inherited color for one mode while explicitly setting the other
 - Use opacity modifiers sparingly for glassmorphism (`/50`, `/30` are common) — white/black only as opacity overlays (`bg-white/5`, `bg-black/50`), never solid
+- Do not use opacity below /30 for structural lines (connectors, tree branches, dividers) — at /20 or lower, lines become invisible against surface backgrounds; use /50 minimum or full opacity for elements that must be clearly visible
 
 ### Typography
 - `text-xs` is the default for most UI, `text-sm` for primary inputs, `text-2xs` for meta-data and section headers, `text-lg` for dialog titles only — avoid `text-base` and larger in dense UI
@@ -233,6 +240,7 @@
 - Icon color is `text-text-tertiary` / `dark:text-text-dark-tertiary` by default, `text-text-primary` on hover/active
 - Toolbar dropdown selectors (model, thinking, permission): text-only labels with chevrons, no left icons
 - Loading spinners: `text-text-quaternary` / `dark:text-text-dark-quaternary` — never brand colors
+- Do not generate SVG path data from memory — fetch official brand icon SVGs from authoritative sources (e.g., Simple Icons, brand asset pages) and use the exact path data
 
 ### Panel Headers
 - Standardized `h-9` height with `px-3` padding
@@ -253,6 +261,7 @@
 
 - Do not use absolute positioning for layout of sibling elements within a container — use flexbox (`flex`, `justify-between`, `gap-*`); reserve `absolute` for overlays, tooltips, dropdowns, and decorative elements only
 - When action buttons have variable-length or long text labels, stack them vertically (`flex-col`) at full width instead of placing them in a horizontal row — horizontal layouts break awkwardly when text wraps or buttons have uneven widths
+- When nesting child items under parent items in lists (e.g., sub-threads), always maintain visible indentation — do not align child text flush with parent text; use connector lines or visual indicators for nesting cues, but indentation is the primary hierarchy signal
 
 ## Code Review Guidelines
 

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -81,7 +81,7 @@ export function Layout({
             id="main-content"
             className={cn(
               'relative min-w-0 flex-1 overflow-y-auto overflow-x-hidden bg-surface transition-[padding] duration-500 ease-in-out dark:bg-surface-dark',
-              shouldPushContent ? 'pl-64' : 'pl-0',
+              shouldPushContent ? 'pl-[300px]' : 'pl-0',
               contentClassName,
             )}
           >

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useNavigate } from 'react-router-dom';
-import { Plus, FolderOpen, ChevronRight, MoreHorizontal, SquarePen } from 'lucide-react';
+import { Plus, MoreHorizontal, SquarePen, ChevronDown } from 'lucide-react';
 import toast from 'react-hot-toast';
 import type { Chat } from '@/types/chat.types';
 import type { Workspace } from '@/types/workspace.types';
@@ -94,8 +94,7 @@ interface WorkspaceGroupProps {
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
   onNewThread: (e: React.MouseEvent, workspaceId: string) => void;
   onWorkspaceContextMenu: (e: React.MouseEvent<HTMLButtonElement>, workspaceId: string) => void;
-  expandedSubThreads: Set<string>;
-  onToggleSubThreads: (chatId: string) => void;
+  collapsedSubThreads: Set<string>;
 }
 
 const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
@@ -109,8 +108,7 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
   onDropdownClick,
   onNewThread,
   onWorkspaceContextMenu,
-  expandedSubThreads,
-  onToggleSubThreads,
+  collapsedSubThreads,
 }: WorkspaceGroupProps) {
   const [isChatsExpanded, setIsChatsExpanded] = useState(false);
   const [hoveredChatId, setHoveredChatId] = useState<string | null>(null);
@@ -138,21 +136,14 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
   const showLoadMore = isChatsExpanded && hasNextPage;
 
   return (
-    <div className="mb-1">
-      <div className="group flex items-center gap-0.5 px-1 pb-0.5 pt-2">
+    <div>
+      <div className="group flex items-center gap-1 pb-2 pt-3.5">
         <button
           type="button"
           onClick={() => onToggleCollapse(workspace.id)}
-          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md px-1.5 py-0.5 transition-colors duration-200 hover:bg-surface-hover dark:hover:bg-surface-dark-hover"
+          className="min-w-0 flex-1 text-left"
         >
-          <ChevronRight
-            className={cn(
-              'h-3 w-3 shrink-0 text-text-quaternary transition-transform duration-200 dark:text-text-dark-quaternary',
-              !isCollapsed && 'rotate-90',
-            )}
-          />
-          <FolderOpen className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
-          <span className="truncate text-xs font-medium text-text-secondary dark:text-text-dark-secondary">
+          <span className="text-2xs font-medium uppercase tracking-wider text-text-quaternary transition-colors duration-200 group-hover:text-text-tertiary dark:text-text-dark-quaternary dark:group-hover:text-text-dark-tertiary">
             {workspace.name}
           </span>
         </button>
@@ -162,7 +153,7 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
           onClick={(e) => onNewThread(e, workspace.id)}
           className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
         >
-          <SquarePen className="h-3.5 w-3.5" />
+          <SquarePen className="h-3 w-3" />
         </button>
         <button
           type="button"
@@ -170,13 +161,13 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
           onClick={(e) => onWorkspaceContextMenu(e, workspace.id)}
           className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
         >
-          <MoreHorizontal className="h-3.5 w-3.5" />
+          <MoreHorizontal className="h-3 w-3" />
         </button>
       </div>
       {!isCollapsed && (
-        <div className="space-y-px pl-6">
+        <div>
           {isLoading ? null : chats.length === 0 ? (
-            <p className="px-2.5 py-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+            <p className="py-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
               No threads
             </p>
           ) : (
@@ -189,14 +180,12 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
                     isHovered={hoveredChatId === chat.id}
                     isDropdownOpen={dropdownChatId === chat.id}
                     isChatStreaming={streamingChatIdSet.has(chat.id)}
-                    isSubThreadsExpanded={expandedSubThreads.has(chat.id)}
                     onSelect={onChatSelect}
                     onDropdownClick={onDropdownClick}
                     onMouseEnter={handleMouseEnter}
                     onMouseLeave={handleMouseLeave}
-                    onToggleSubThreads={onToggleSubThreads}
                   />
-                  {chat.sub_thread_count > 0 && expandedSubThreads.has(chat.id) && (
+                  {chat.sub_thread_count > 0 && !collapsedSubThreads.has(chat.id) && (
                     <SubThreadList
                       parentChatId={chat.id}
                       selectedChatId={selectedChatId}
@@ -211,13 +200,14 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
                 <button
                   type="button"
                   onClick={() => setIsChatsExpanded(true)}
-                  className="w-full px-2.5 py-1 text-left text-2xs text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+                  className="flex w-full items-center gap-1 py-1.5 text-left text-xs text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
                 >
                   Show more ({chats.length - CHATS_PER_WORKSPACE})
+                  <ChevronDown className="h-3 w-3" />
                 </button>
               )}
               {(hasMoreLocalChats || showLoadMore) && isChatsExpanded && (
-                <div className="flex items-center gap-2 px-2.5 py-1">
+                <div className="flex items-center gap-2 py-1.5">
                   <button
                     type="button"
                     onClick={() => setIsChatsExpanded(false)}
@@ -292,7 +282,8 @@ export function Sidebar({
     workspaceId: string;
     position: { top: number; left: number };
   } | null>(null);
-  const [expandedSubThreads, toggleSubThreads, setExpandedSubThreads] = useToggleSet<string>();
+  // Tracks which parent chats have their sub-threads collapsed — sub-threads are visible by default
+  const [collapsedSubThreads, , setCollapsedSubThreads] = useToggleSet<string>();
 
   const searchInputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -322,13 +313,16 @@ export function Sidebar({
     });
   }, [selectedChatWorkspaceId, setCollapsedWorkspaces]);
 
+  // Auto-uncollapse parent when navigating to a sub-thread from outside the sidebar
   useEffect(() => {
     if (!selectedChatParentId) return;
-    setExpandedSubThreads((prev) => {
-      if (prev.has(selectedChatParentId)) return prev;
-      return new Set(prev).add(selectedChatParentId);
+    setCollapsedSubThreads((prev) => {
+      if (!prev.has(selectedChatParentId)) return prev;
+      const next = new Set(prev);
+      next.delete(selectedChatParentId);
+      return next;
     });
-  }, [selectedChatParentId, setExpandedSubThreads]);
+  }, [selectedChatParentId, setCollapsedSubThreads]);
 
   useMountEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -564,31 +558,24 @@ export function Sidebar({
       <aside
         aria-label="Chat history"
         className={cn(
-          'absolute left-0 top-0 h-full w-64',
-          'border-r border-border bg-surface-secondary dark:border-border-dark dark:bg-surface-dark-secondary',
+          'absolute left-0 top-0 h-full w-[300px]',
+          'border-r border-border/50 bg-surface-secondary dark:border-border-dark/50 dark:bg-surface-dark-secondary',
           'z-40 flex flex-col transition-transform duration-500 ease-in-out',
           sidebarOpen ? 'translate-x-0' : '-translate-x-full',
         )}
       >
-        <div className="border-b border-border px-3 py-3 dark:border-border-dark">
+        <div className="px-4 pt-2">
           <Button
             onClick={handleNewChat}
             variant="unstyled"
-            className={cn(
-              'w-full px-3 py-2',
-              'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-              'border border-border dark:border-border-dark',
-              'text-text-secondary dark:text-text-dark-secondary',
-              'rounded-lg transition-colors duration-200',
-              'flex items-center justify-center gap-1.5 text-xs font-medium',
-            )}
+            className="flex w-full items-center justify-center gap-2.5 rounded-lg bg-surface-tertiary/50 px-2 py-2 text-[13px] font-medium text-text-secondary transition-colors duration-200 hover:bg-surface-tertiary hover:text-text-primary dark:bg-surface-dark-tertiary/50 dark:text-text-dark-secondary dark:hover:bg-surface-dark-tertiary dark:hover:text-text-dark-primary"
           >
             <Plus className="h-3.5 w-3.5" />
             New thread
           </Button>
         </div>
 
-        <div ref={scrollContainerRef} className="flex-1 overflow-y-auto px-2 pt-1">
+        <div ref={scrollContainerRef} className="flex-1 overflow-y-auto px-6">
           {!hasAnyContent ? (
             <p className="py-8 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
               No chats yet
@@ -597,12 +584,12 @@ export function Sidebar({
             <div>
               {pinnedChats.length > 0 && (
                 <div className="mb-1">
-                  <div className="px-2.5 pb-1 pt-2">
-                    <span className="text-2xs font-medium uppercase tracking-widest text-text-quaternary dark:text-text-dark-quaternary">
+                  <div className="pb-2 pt-2.5">
+                    <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
                       Pinned
                     </span>
                   </div>
-                  <div className="space-y-px">
+                  <div>
                     {pinnedChats.map((chat) => (
                       <div key={chat.id}>
                         <SidebarChatItem
@@ -611,14 +598,12 @@ export function Sidebar({
                           isHovered={pinnedHoveredId === chat.id}
                           isDropdownOpen={dropdown?.chat.id === chat.id}
                           isChatStreaming={streamingChatIdSet.has(chat.id)}
-                          isSubThreadsExpanded={expandedSubThreads.has(chat.id)}
                           onSelect={handleChatSelect}
                           onDropdownClick={handleDropdownClick}
                           onMouseEnter={handlePinnedMouseEnter}
                           onMouseLeave={handlePinnedMouseLeave}
-                          onToggleSubThreads={toggleSubThreads}
                         />
-                        {chat.sub_thread_count > 0 && expandedSubThreads.has(chat.id) && (
+                        {chat.sub_thread_count > 0 && !collapsedSubThreads.has(chat.id) && (
                           <SubThreadList
                             parentChatId={chat.id}
                             selectedChatId={selectedChatId}
@@ -646,8 +631,7 @@ export function Sidebar({
                   onDropdownClick={handleDropdownClick}
                   onNewThread={handleNewWorkspaceThread}
                   onWorkspaceContextMenu={handleWorkspaceContextMenu}
-                  expandedSubThreads={expandedSubThreads}
-                  onToggleSubThreads={toggleSubThreads}
+                  collapsedSubThreads={collapsedSubThreads}
                 />
               ))}
             </div>

--- a/frontend/src/components/layout/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/SidebarChatItem.tsx
@@ -1,25 +1,10 @@
 import { memo } from 'react';
-import { ChevronRight, MoreHorizontal, Loader2, Pin } from 'lucide-react';
+import { MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { cn } from '@/utils/cn';
+import { stripMarkdownTitle } from '@/utils/format';
+import { getRelativeTime } from '@/utils/date';
 import type { Chat } from '@/types/chat.types';
-
-function getRelativeTime(dateStr: string): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diff = now - then;
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return 'now';
-  if (mins < 60) return `${mins}m`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d`;
-  const weeks = Math.floor(days / 7);
-  if (weeks < 4) return `${weeks}w`;
-  const months = Math.floor(days / 30);
-  return `${months}mo`;
-}
 
 interface SidebarChatItemProps {
   chat: Chat;
@@ -27,12 +12,10 @@ interface SidebarChatItemProps {
   isHovered: boolean;
   isDropdownOpen: boolean;
   isChatStreaming: boolean;
-  isSubThreadsExpanded?: boolean;
   onSelect: (chatId: string) => void;
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
   onMouseEnter: (chatId: string) => void;
   onMouseLeave: () => void;
-  onToggleSubThreads?: (chatId: string) => void;
 }
 
 export const SidebarChatItem = memo(function SidebarChatItem({
@@ -41,69 +24,60 @@ export const SidebarChatItem = memo(function SidebarChatItem({
   isHovered,
   isDropdownOpen,
   isChatStreaming,
-  isSubThreadsExpanded,
   onSelect,
   onDropdownClick,
   onMouseEnter,
   onMouseLeave,
-  onToggleSubThreads,
 }: SidebarChatItemProps) {
-  const isPinned = !!chat.pinned_at;
-  const hasSubThreads = chat.sub_thread_count > 0;
-
   return (
     <div
       className={cn(
-        'group relative flex items-center rounded-lg px-2.5 py-1.5 transition-colors duration-200',
+        'group relative -mx-2 flex items-center gap-[11px] rounded-lg px-2 py-[7px] transition-colors duration-200',
         isSelected
-          ? 'bg-surface-hover text-text-primary dark:bg-surface-dark-hover dark:text-text-dark-primary'
+          ? 'bg-surface-hover/50 text-text-primary dark:bg-surface-dark-hover/50 dark:text-text-dark-primary'
           : 'text-text-secondary hover:bg-surface-hover/50 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover/50 dark:hover:text-text-dark-secondary',
       )}
       onMouseEnter={() => onMouseEnter(chat.id)}
       onMouseLeave={onMouseLeave}
     >
+      {isSelected && !isChatStreaming && (
+        <div className="absolute bottom-2 left-0 top-2 w-0.5 rounded-full bg-text-primary dark:bg-text-dark-primary" />
+      )}
+
+      {isChatStreaming ? (
+        <div className="h-1.5 w-1.5 flex-shrink-0 animate-pulse rounded-full bg-warning-500" />
+      ) : (
+        <div className="h-1.5 w-1.5 flex-shrink-0" />
+      )}
+
       <Button
         onClick={() => onSelect(chat.id)}
         aria-current={isSelected ? 'page' : undefined}
         variant="unstyled"
-        className="flex min-w-0 flex-1 items-center text-left text-xs"
+        title={chat.title}
+        className="min-w-0 flex-1 truncate pr-10 text-left text-[13px]"
       >
-        {isChatStreaming && (
-          <Loader2 className="mr-2.5 h-3 w-3 flex-shrink-0 animate-spin text-text-tertiary dark:text-text-dark-tertiary" />
-        )}
-        {hasSubThreads && onToggleSubThreads && (
-          <ChevronRight
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleSubThreads(chat.id);
-            }}
-            className={cn(
-              '-ml-1.5 mr-0.5 h-3 w-3 flex-shrink-0 cursor-pointer text-text-quaternary transition-all duration-200 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
-              isSubThreadsExpanded && 'rotate-90',
-            )}
-          />
-        )}
-        <span className="flex-1 truncate">{chat.title}</span>
-        {isPinned && (
-          <Pin className="h-2.5 w-2.5 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
-        )}
-        <span
-          className={cn(
-            'flex-shrink-0 text-2xs tabular-nums text-text-quaternary dark:text-text-dark-quaternary',
-            'transition-opacity duration-200',
-            isHovered || isSelected || isDropdownOpen ? 'opacity-0' : 'opacity-100',
-          )}
-        >
-          {getRelativeTime(chat.updated_at)}
+        <span className={cn('truncate', isSelected && 'font-medium')}>
+          {stripMarkdownTitle(chat.title)}
         </span>
       </Button>
+
+      <span
+        className={cn(
+          'absolute right-2 text-[10px] tabular-nums text-text-quaternary dark:text-text-dark-quaternary',
+          'transition-opacity duration-200',
+          isHovered || isSelected || isDropdownOpen ? 'opacity-0' : 'opacity-100',
+        )}
+      >
+        {getRelativeTime(chat.updated_at)}
+      </span>
 
       <Button
         onClick={(e) => onDropdownClick(e, chat)}
         onMouseDown={(e) => e.stopPropagation()}
         variant="unstyled"
         className={cn(
-          'absolute right-1 flex-shrink-0 rounded-md p-1 transition-all duration-200',
+          'absolute right-2 flex-shrink-0 rounded-md p-0.5 transition-all duration-200',
           'text-text-quaternary dark:text-text-dark-quaternary',
           'hover:text-text-primary dark:hover:text-text-dark-primary',
           isHovered || isSelected || isDropdownOpen

--- a/frontend/src/components/layout/SubThreadList.tsx
+++ b/frontend/src/components/layout/SubThreadList.tsx
@@ -1,8 +1,10 @@
 import { memo, useState, useCallback } from 'react';
-import { Loader2, MoreHorizontal } from 'lucide-react';
+import { MoreHorizontal } from 'lucide-react';
 import { useSubThreadsQuery } from '@/hooks/queries/useChatQueries';
 import { Button } from '@/components/ui/primitives/Button';
 import { cn } from '@/utils/cn';
+import { stripMarkdownTitle } from '@/utils/format';
+import { getRelativeTime } from '@/utils/date';
 import type { Chat } from '@/types/chat.types';
 
 interface SubThreadListProps {
@@ -30,7 +32,8 @@ export const SubThreadList = memo(function SubThreadList({
 
   if (isError) {
     return (
-      <div className="ml-4 border-l border-border/30 px-2 py-1 dark:border-border-dark/30">
+      <div className="relative ml-[11px] mt-0.5 pl-[22px]">
+        <div className="absolute bottom-2 left-0 top-0 w-px bg-border-secondary dark:bg-border-dark-secondary" />
         <button
           type="button"
           onClick={() => refetch()}
@@ -45,7 +48,9 @@ export const SubThreadList = memo(function SubThreadList({
   if (!subThreads || subThreads.length === 0) return null;
 
   return (
-    <div className="ml-4 border-l border-border/30 dark:border-border-dark/30">
+    <div className="relative ml-[11px] mt-0.5 pl-[22px]">
+      <div className="absolute bottom-[14px] left-0 top-0 w-px bg-border-secondary dark:bg-border-dark-secondary" />
+
       {subThreads.map((thread) => {
         const isSelected = thread.id === selectedChatId;
         const isStreaming = streamingChatIdSet.has(thread.id);
@@ -54,31 +59,56 @@ export const SubThreadList = memo(function SubThreadList({
         return (
           <div
             key={thread.id}
-            className="group relative flex items-center"
+            className={cn(
+              'group relative flex items-center rounded-lg transition-colors duration-200',
+              isSelected
+                ? 'bg-surface-hover/50 dark:bg-surface-dark-hover/50'
+                : 'hover:bg-surface-hover/50 dark:hover:bg-surface-dark-hover/50',
+            )}
             onMouseEnter={() => handleMouseEnter(thread.id)}
             onMouseLeave={handleMouseLeave}
           >
+            <div className="absolute -left-[22px] top-1/2 h-px w-[18px] bg-border-secondary dark:bg-border-dark-secondary" />
+
+            {isSelected && !isStreaming && (
+              <div className="absolute bottom-1.5 left-0 top-1.5 w-0.5 rounded-full bg-text-primary dark:bg-text-dark-primary" />
+            )}
+
             <button
               type="button"
               onClick={() => onSelect(thread.id)}
+              title={thread.title}
               className={cn(
-                'flex w-full items-center gap-1.5 rounded-r-md py-1 pl-2 pr-6 transition-colors duration-200',
+                'flex w-full items-center gap-2 px-2 py-1.5 pr-10 transition-colors duration-200',
                 isSelected
-                  ? 'bg-surface-hover text-text-primary dark:bg-surface-dark-hover dark:text-text-dark-primary'
-                  : 'text-text-secondary hover:bg-surface-hover dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover',
+                  ? 'text-text-primary dark:text-text-dark-primary'
+                  : 'text-text-tertiary hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-secondary',
               )}
             >
               {isStreaming && (
-                <Loader2 className="h-3 w-3 shrink-0 animate-spin text-text-quaternary dark:text-text-dark-quaternary" />
+                <div className="h-[5px] w-[5px] flex-shrink-0 animate-pulse rounded-full bg-warning-500" />
               )}
-              <span className="truncate text-xs">{thread.title}</span>
+              <span className={cn('truncate text-xs', isSelected && 'font-medium')}>
+                {stripMarkdownTitle(thread.title)}
+              </span>
             </button>
+
+            <span
+              className={cn(
+                'absolute right-2 text-[10px] tabular-nums text-text-quaternary dark:text-text-dark-quaternary',
+                'transition-opacity duration-200',
+                isHovered || isSelected ? 'opacity-0' : 'opacity-100',
+              )}
+            >
+              {getRelativeTime(thread.updated_at)}
+            </span>
+
             <Button
               onClick={(e) => onDropdownClick(e, thread)}
               onMouseDown={(e) => e.stopPropagation()}
               variant="unstyled"
               className={cn(
-                'absolute right-1 flex-shrink-0 rounded-md p-1 transition-all duration-200',
+                'absolute right-2 flex-shrink-0 rounded-md p-0.5 transition-all duration-200',
                 'text-text-quaternary dark:text-text-dark-quaternary',
                 'hover:text-text-primary dark:hover:text-text-dark-primary',
                 isHovered || isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -34,6 +34,23 @@ export const formatRelativeTime = (date: string | Date): string => {
   }).format(targetDate);
 };
 
+export function getRelativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diff = now - then;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'now';
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 4) return `${weeks}w`;
+  const months = Math.floor(days / 30);
+  return `${months}mo`;
+}
+
 export const formatFullTimestamp = (date: string | Date): string => {
   const targetDate = typeof date === 'string' ? new Date(date) : date;
 

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -17,6 +17,18 @@ export function formatNumberCompact(num: number): string {
   return (num / 1000000).toFixed(1).replace(/\.0$/, '') + 'M';
 }
 
+// Strips paired markdown delimiters while preserving content between them —
+// uses matched pairs so isolated chars (e.g. underscores in `my_var`) aren't mangled
+export function stripMarkdownTitle(title: string): string {
+  return title
+    .replace(/\*{1,2}(.+?)\*{1,2}/g, '$1')
+    .replace(/_{1,2}(.+?)_{1,2}/g, '$1')
+    .replace(/^#{1,6}\s+/, '')
+    .replace(/`(.+?)`/g, '$1')
+    .replace(/~~(.+?)~~/g, '$1')
+    .trim();
+}
+
 export const extractDomain = (url: string): string => {
   try {
     return new URL(url).hostname.replace('www.', '');


### PR DESCRIPTION
## Summary
- Widen sidebar from 256px to 300px and restyle workspace headers as minimal section labels (uppercase, quaternary text)
- Redesign chat items with active indicator bar, streaming pulse dot, markdown-stripped titles, and repositioned timestamps
- Add tree-line connectors to sub-thread lists and show sub-threads expanded by default (inverted toggle to collapse)
- Extract `getRelativeTime` to `utils/date.ts` and add `stripMarkdownTitle` to `utils/format.ts` for shared reuse
- Add CLAUDE.md rules: JSX numeric falsy guards, responsive awareness, Zustand variant selectors, SVG icon sourcing

## Test plan
- [ ] Verify sidebar opens at 300px width and content pushes correctly
- [ ] Confirm workspace section headers render as uppercase quaternary labels
- [ ] Check chat items show active bar on selection and pulse dot when streaming
- [ ] Verify sub-threads appear expanded by default with tree-line connectors
- [ ] Confirm markdown formatting (bold, italic, backticks) is stripped from chat titles
- [ ] Test relative timestamps display correctly and hide on hover/selection
- [ ] Verify pinned chats section renders properly with new styling