### PR TITLE
Custom title bar with traffic lights and sidebar profile

### DIFF
--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -6,6 +6,11 @@
   "permissions": [
     "core:default",
     "core:window:allow-show",
+    "core:window:allow-close",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-is-maximized",
+    "core:window:allow-start-dragging",
     "store:default",
     "updater:default",
     "notification:default",

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -192,6 +192,12 @@ fn main() {
         .manage(backend_port.clone())
         .invoke_handler(tauri::generate_handler![get_backend_port])
         .setup(move |app| {
+            // Hide native title bar on macOS only — the frontend renders custom traffic lights
+            #[cfg(target_os = "macos")]
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.set_decorations(false);
+            }
+
             let child = spawn_backend(app.handle(), &data_dir, &secret_key, port);
             *backend_process.lock().unwrap() = Some(child);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import { check } from '@tauri-apps/plugin-updater';
 import { ask } from '@tauri-apps/plugin-dialog';
 import { authStorage } from '@/utils/storage';
+import { DesktopDragRegion } from '@/components/layout/TitleBar';
 
 const LandingPage = lazy(() =>
   import('@/pages/LandingPage').then((m) => ({ default: m.LandingPage })),
@@ -281,9 +282,12 @@ export default function App() {
 
   if (desktopError) {
     return (
-      <div className="bg-surface-primary dark:bg-surface-dark-primary flex min-h-screen items-center justify-center text-text-primary dark:text-text-dark-primary">
-        <div className="rounded-lg border border-border/50 bg-surface-secondary px-4 py-3 text-xs dark:border-border-dark/50 dark:bg-surface-dark-secondary">
-          {desktopError}
+      <div className="bg-surface-primary dark:bg-surface-dark-primary flex min-h-screen flex-col text-text-primary dark:text-text-dark-primary">
+        <DesktopDragRegion />
+        <div className="flex flex-1 items-center justify-center">
+          <div className="rounded-lg border border-border/50 bg-surface-secondary px-4 py-3 text-xs dark:border-border-dark/50 dark:bg-surface-dark-secondary">
+            {desktopError}
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,44 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { ArrowLeft, Command, LogOut, Monitor, Moon, Settings, Sun } from 'lucide-react';
+import { ArrowLeft, LogOut, Monitor, Moon, Sun } from 'lucide-react';
 import { useNavigate, useMatch } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
-import { useCurrentUserQuery, useLogoutMutation } from '@/hooks/queries/useAuthQueries';
+import { useLogoutMutation } from '@/hooks/queries/useAuthQueries';
 import { Button } from '@/components/ui/primitives/Button';
-import { ToggleButton } from '@/components/ui/ToggleButton';
 import { cn } from '@/utils/cn';
-import { UserAvatarCircle } from '@/components/chat/message-bubble/MessageAvatars';
 
 export interface HeaderProps {
-  onLogout?: () => void;
-  userName?: string;
   isAuthPage?: boolean;
-}
-
-const menuItemClasses = cn(
-  'w-full px-2.5 py-1.5 text-left text-xs',
-  'text-text-tertiary dark:text-text-dark-tertiary',
-  'hover:bg-surface-hover/60 dark:hover:bg-surface-dark-hover/60',
-  'hover:text-text-primary dark:hover:text-text-dark-primary',
-  'rounded-lg transition-colors duration-200',
-  'flex items-center gap-2.5',
-);
-
-function useClickOutside<T extends HTMLElement>(
-  ref: React.RefObject<T | null>,
-  handler: () => void,
-) {
-  useEffect(() => {
-    function handle(event: MouseEvent) {
-      if (!ref.current || ref.current.contains(event.target as Node)) {
-        return;
-      }
-      handler();
-    }
-
-    document.addEventListener('mousedown', handle);
-    return () => document.removeEventListener('mousedown', handle);
-  }, [handler, ref]);
 }
 
 const THEME_ICON_MAP = {
@@ -107,107 +76,15 @@ function AuthButtons({ onLogin, onSignup }: { onLogin: () => void; onSignup: () 
   );
 }
 
-function UserMenu({
-  displayName,
-  onSettings,
-  onPrefetchSettings,
-  onLogout,
-}: {
-  displayName: string;
-  onSettings: () => void;
-  onPrefetchSettings: () => void;
-  onLogout: () => void;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  const closeMenu = useCallback(() => setIsOpen(false), []);
-  const toggleMenu = useCallback(() => setIsOpen((prev) => !prev), []);
-
-  useClickOutside(dropdownRef, closeMenu);
-
-  return (
-    <div className="relative" ref={dropdownRef}>
-      <Button
-        onClick={toggleMenu}
-        variant="unstyled"
-        className={cn(
-          'flex items-center rounded-full p-0.5',
-          'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-          'transition-colors duration-200',
-        )}
-        aria-label="User menu"
-        title="Open user menu"
-      >
-        <UserAvatarCircle displayName={displayName} />
-      </Button>
-
-      {isOpen && (
-        <div
-          className={cn(
-            'absolute right-0 mt-1.5 w-52',
-            'bg-surface-secondary/95 dark:bg-surface-dark-secondary/95',
-            'border border-border/50 dark:border-border-dark/50',
-            'overflow-hidden rounded-xl shadow-medium backdrop-blur-xl',
-            'animate-fadeIn',
-          )}
-        >
-          <div className="border-b border-border/50 px-3 py-2.5 dark:border-border-dark/50">
-            <div className="flex items-center gap-2.5">
-              <UserAvatarCircle displayName={displayName} />
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-xs font-medium text-text-primary dark:text-text-dark-primary">
-                  {displayName}
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className="p-1">
-            <Button
-              onClick={() => {
-                onSettings();
-                closeMenu();
-              }}
-              onMouseEnter={onPrefetchSettings}
-              onFocus={onPrefetchSettings}
-              variant="unstyled"
-              className={menuItemClasses}
-            >
-              <Settings className="h-3.5 w-3.5" />
-              <span>Settings</span>
-            </Button>
-            <div className="my-1 border-t border-border/50 dark:border-border-dark/50" />
-            <Button
-              onClick={() => {
-                onLogout();
-                closeMenu();
-              }}
-              variant="unstyled"
-              className={menuItemClasses}
-            >
-              <LogOut className="h-3.5 w-3.5" />
-              <span>Sign out</span>
-            </Button>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-export function Header({ onLogout, userName = 'User', isAuthPage = false }: HeaderProps) {
+export function Header({ isAuthPage = false }: HeaderProps) {
   const navigate = useNavigate();
   const isChatPage = useMatch('/chat/:chatId');
   const isLandingPage = useMatch('/');
-  const showSidebar = isChatPage || isLandingPage;
   const theme = useUIStore((state) => state.theme);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const sidebarOpen = useUIStore((state) => state.sidebarOpen);
 
-  const { data: user } = useCurrentUserQuery({
-    enabled: isAuthenticated && !isAuthPage,
-  });
+  // Sidebar pages (landing, chat) use TitleBar + Sidebar for all controls
+  const isSidebarPage = isChatPage || isLandingPage;
 
   const logoutMutation = useLogoutMutation({
     onSuccess: () => {
@@ -216,25 +93,8 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
     },
   });
 
-  const handleLogout = useCallback(() => {
-    logoutMutation.mutate();
-    onLogout?.();
-  }, [logoutMutation, onLogout]);
-
-  const displayName = user?.username || user?.email || userName;
-
-  const handleNavigate = useCallback(
-    (path: string) => {
-      navigate(path);
-    },
-    [navigate],
-  );
-
-  const prefetchSettingsPage = useCallback(() => {
-    void import('@/pages/SettingsPage');
-  }, []);
-
-  const showStandaloneThemeToggle = isAuthPage || !isAuthenticated;
+  // Sidebar pages have controls in TitleBar + Sidebar footer — no header needed
+  if (!isAuthPage && isAuthenticated && isSidebarPage) return null;
 
   return (
     <header className="z-50 border-b border-border/50 bg-surface px-4 dark:border-border-dark/50 dark:bg-surface-dark">
@@ -257,54 +117,29 @@ export function Header({ onLogout, userName = 'User', isAuthPage = false }: Head
               <span>Home</span>
             </Button>
           )}
-          {isAuthenticated && showSidebar && (
-            <>
-              <ToggleButton
-                isOpen={sidebarOpen}
-                onClick={() => useUIStore.getState().setSidebarOpen(!sidebarOpen)}
-                position="left"
-                className="mr-1"
-                ariaLabel="Toggle sidebar"
-              />
-              {isChatPage && (
-                <Button
-                  onClick={() => useUIStore.getState().setCommandMenuOpen(true)}
-                  variant="unstyled"
-                  className={cn(
-                    'rounded-full p-1.5',
-                    'text-text-tertiary hover:text-text-primary',
-                    'dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
-                    'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-                    'transition-colors duration-200',
-                  )}
-                  aria-label="Open command menu"
-                >
-                  <Command className="h-3.5 w-3.5" />
-                </Button>
-              )}
-            </>
-          )}
         </div>
 
         <div className="flex items-center gap-1.5">
-          {showStandaloneThemeToggle && (
-            <ThemeToggleButton theme={theme} onToggle={() => useUIStore.getState().toggleTheme()} />
+          <ThemeToggleButton theme={theme} onToggle={() => useUIStore.getState().toggleTheme()} />
+          {isAuthenticated && !isAuthPage && (
+            <Button
+              onClick={() => logoutMutation.mutate()}
+              variant="unstyled"
+              className={cn(
+                'rounded-full p-1.5',
+                'text-text-tertiary hover:text-text-primary',
+                'dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
+                'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+                'transition-colors duration-200',
+              )}
+              aria-label="Sign out"
+              title="Sign out"
+            >
+              <LogOut className="h-3.5 w-3.5" />
+            </Button>
           )}
-          {isAuthPage ? null : isAuthenticated ? (
-            <UserMenu
-              displayName={displayName}
-              onSettings={() => {
-                prefetchSettingsPage();
-                handleNavigate('/settings');
-              }}
-              onPrefetchSettings={prefetchSettingsPage}
-              onLogout={handleLogout}
-            />
-          ) : (
-            <AuthButtons
-              onLogin={() => handleNavigate('/login')}
-              onSignup={() => handleNavigate('/signup')}
-            />
+          {!isAuthPage && !isAuthenticated && (
+            <AuthButtons onLogin={() => navigate('/login')} onSignup={() => navigate('/signup')} />
           )}
         </div>
       </div>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { Header, type HeaderProps } from './Header';
+import { TitleBar } from './TitleBar';
 import { cn } from '@/utils/cn';
 import { LayoutContext, type LayoutContextValue } from './layoutState';
 import { useUIStore } from '@/store/uiStore';
@@ -29,8 +30,6 @@ export interface LayoutProps extends HeaderProps {
 
 export function Layout({
   children,
-  onLogout,
-  userName = 'User',
   isAuthPage = false,
   className,
   contentClassName,
@@ -68,7 +67,8 @@ export function Layout({
         >
           Skip to main content
         </a>
-        {showHeader && <Header onLogout={onLogout} userName={userName} isAuthPage={isAuthPage} />}
+        <TitleBar />
+        {showHeader && <Header isAuthPage={isAuthPage} />}
 
         <div className="flex min-h-0 flex-1">
           {sidebarContent && <MobileSidebarOverlay />}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,7 +1,17 @@
 import { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useNavigate } from 'react-router-dom';
-import { Plus, MoreHorizontal, SquarePen, ChevronDown } from 'lucide-react';
+import {
+  Plus,
+  MoreHorizontal,
+  SquarePen,
+  ChevronDown,
+  Settings,
+  LogOut,
+  Sun,
+  Moon,
+  Monitor,
+} from 'lucide-react';
 import toast from 'react-hot-toast';
 import type { Chat } from '@/types/chat.types';
 import type { Workspace } from '@/types/workspace.types';
@@ -24,12 +34,35 @@ import { cn } from '@/utils/cn';
 import { useUIStore } from '@/store/uiStore';
 import { useStreamStore } from '@/store/streamStore';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { useCurrentUserQuery, useLogoutMutation } from '@/hooks/queries/useAuthQueries';
+import { useAuthStore } from '@/store/authStore';
+import { UserAvatarCircle } from '@/components/chat/message-bubble/MessageAvatars';
 import { SidebarChatItem } from './SidebarChatItem';
 import { SubThreadList } from './SubThreadList';
 import { ChatDropdown } from './ChatDropdown';
 import { DROPDOWN_WIDTH, DROPDOWN_HEIGHT, DROPDOWN_MARGIN } from '@/config/constants';
 
 const CHATS_PER_WORKSPACE = 5;
+
+const THEME_ICON_MAP = { dark: Sun, light: Moon, system: Monitor } as const;
+const THEME_NEXT_LABEL = { dark: 'light', light: 'system', system: 'dark' } as const;
+
+function ThemeToggle() {
+  const theme = useUIStore((state) => state.theme);
+  const Icon = THEME_ICON_MAP[theme as keyof typeof THEME_ICON_MAP] ?? Monitor;
+  const nextLabel = THEME_NEXT_LABEL[theme as keyof typeof THEME_NEXT_LABEL] ?? 'dark';
+  return (
+    <Button
+      onClick={() => useUIStore.getState().toggleTheme()}
+      variant="unstyled"
+      className="rounded-full p-1.5 text-text-quaternary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+      aria-label="Toggle theme"
+      title={`Switch to ${nextLabel} mode`}
+    >
+      <Icon className="h-3.5 w-3.5" />
+    </Button>
+  );
+}
 
 async function mutateWithToast<T>(
   mutateFn: () => Promise<T>,
@@ -262,6 +295,15 @@ export function Sidebar({
   const navigate = useNavigate();
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
   const isMobile = useIsMobile();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const { data: currentUser } = useCurrentUserQuery({ enabled: isAuthenticated });
+  const userDisplayName = currentUser?.username || currentUser?.email || '';
+  const logoutMutation = useLogoutMutation({
+    onSuccess: () => {
+      useAuthStore.getState().setAuthenticated(false);
+      navigate('/login');
+    },
+  });
   const activeStreamMetadata = useStreamStore((state) => state.activeStreamMetadata);
   const streamingChatIdSet = useMemo(
     () => new Set(activeStreamMetadata.map((meta) => meta.chatId)),
@@ -636,6 +678,40 @@ export function Sidebar({
               ))}
             </div>
           )}
+        </div>
+
+        {/* User profile — fixed at sidebar bottom; always rendered so settings/logout are accessible even if the user query is loading or failed */}
+        <div className="flex-shrink-0 border-t border-border/50 px-4 py-2.5 dark:border-border-dark/50">
+          <div className="flex items-center gap-2.5">
+            <UserAvatarCircle displayName={userDisplayName} size="large" />
+            {userDisplayName && (
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-xs font-medium text-text-primary dark:text-text-dark-primary">
+                  {userDisplayName}
+                </p>
+              </div>
+            )}
+            {!userDisplayName && <div className="flex-1" />}
+            <ThemeToggle />
+            <Button
+              onClick={() => navigate('/settings')}
+              variant="unstyled"
+              className="rounded-full p-1.5 text-text-quaternary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+              aria-label="Settings"
+              title="Settings"
+            >
+              <Settings className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              onClick={() => logoutMutation.mutate()}
+              variant="unstyled"
+              className="rounded-full p-1.5 text-text-quaternary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+              aria-label="Sign out"
+              title="Sign out"
+            >
+              <LogOut className="h-3.5 w-3.5" />
+            </Button>
+          </div>
         </div>
       </aside>
 

--- a/frontend/src/components/layout/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useState } from 'react';
+import { Command } from 'lucide-react';
+import { useMatch } from 'react-router-dom';
+import { isTauri } from '@tauri-apps/api/core';
+import { useAuthStore } from '@/store/authStore';
+import { useUIStore } from '@/store/uiStore';
+import { Button } from '@/components/ui/primitives/Button';
+import { ToggleButton } from '@/components/ui/ToggleButton';
+import { cn } from '@/utils/cn';
+
+export async function getTauriWindow() {
+  const { getCurrentWindow } = await import('@tauri-apps/api/window');
+  return getCurrentWindow();
+}
+
+export function TrafficLights() {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleClose = useCallback(async () => {
+    await (await getTauriWindow()).close();
+  }, []);
+
+  const handleMinimize = useCallback(async () => {
+    await (await getTauriWindow()).minimize();
+  }, []);
+
+  const handleMaximize = useCallback(async () => {
+    await (await getTauriWindow()).toggleMaximize();
+  }, []);
+
+  return (
+    <div
+      className="flex items-center gap-2 pl-3"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <button
+        type="button"
+        onClick={handleClose}
+        className="group flex h-3 w-3 items-center justify-center rounded-full bg-[#ff5f57] transition-opacity hover:opacity-90"
+        aria-label="Close window"
+      >
+        {isHovered && (
+          <svg width="6" height="6" viewBox="0 0 6 6" className="text-black/60">
+            <path
+              d="M0.5 0.5L5.5 5.5M5.5 0.5L0.5 5.5"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              strokeLinecap="round"
+            />
+          </svg>
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={handleMinimize}
+        className="group flex h-3 w-3 items-center justify-center rounded-full bg-[#febc2e] transition-opacity hover:opacity-90"
+        aria-label="Minimize window"
+      >
+        {isHovered && (
+          <svg width="6" height="2" viewBox="0 0 6 2" className="text-black/60">
+            <path d="M0.5 1H5.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+          </svg>
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={handleMaximize}
+        className="group flex h-3 w-3 items-center justify-center rounded-full bg-[#28c840] transition-opacity hover:opacity-90"
+        aria-label="Maximize window"
+      >
+        {isHovered && (
+          <svg width="6" height="6" viewBox="0 0 6 6" className="text-black/60">
+            <path
+              d="M1 2L3 0.5L5 2M1 4L3 5.5L5 4"
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+}
+
+// Decorations are only removed on macOS — traffic lights and custom drag region are macOS-only
+export const IS_MACOS_DESKTOP = isTauri() && navigator.platform.toUpperCase().startsWith('MAC');
+
+// Minimal drag region with traffic lights for screens rendered outside Layout (error, loading).
+// Does not depend on react-router or auth state.
+export function DesktopDragRegion() {
+  if (!IS_MACOS_DESKTOP) return null;
+
+  const handleMouseDown = async (e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).closest('button')) return;
+    await (await getTauriWindow()).startDragging();
+  };
+
+  const handleDoubleClick = async () => {
+    await (await getTauriWindow()).toggleMaximize();
+  };
+
+  return (
+    <div
+      className="z-50 flex h-10 flex-shrink-0 select-none items-center"
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDoubleClick}
+    >
+      <TrafficLights />
+      <div className="flex-1" />
+    </div>
+  );
+}
+
+export function TitleBar() {
+  const isChatPage = useMatch('/chat/:chatId');
+  const isLandingPage = useMatch('/');
+  const showSidebar = isChatPage || isLandingPage;
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const sidebarOpen = useUIStore((state) => state.sidebarOpen);
+
+  const hasContent = IS_MACOS_DESKTOP || (isAuthenticated && showSidebar);
+  // Don't render an empty bar when there are no controls to show
+  if (!hasContent) return null;
+
+  // Uses native startDragging API — data-tauri-drag-region doesn't work on frameless windows in Tauri v2
+  const handleMouseDown = async (e: React.MouseEvent) => {
+    if (!IS_MACOS_DESKTOP) return;
+    // Only drag from the bar itself, not from interactive children
+    if ((e.target as HTMLElement).closest('button')) return;
+    await (await getTauriWindow()).startDragging();
+  };
+
+  const handleDoubleClick = async () => {
+    if (!IS_MACOS_DESKTOP) return;
+    await (await getTauriWindow()).toggleMaximize();
+  };
+
+  return (
+    <div
+      className="z-50 flex h-10 flex-shrink-0 select-none items-center"
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDoubleClick}
+    >
+      {/* Sidebar-width section — matches sidebar background */}
+      <div
+        className={cn(
+          'flex h-full items-center gap-1 bg-surface-secondary dark:bg-surface-dark-secondary',
+          'transition-[width,padding] duration-500 ease-in-out',
+          isAuthenticated && showSidebar && sidebarOpen
+            ? 'w-[300px] border-r border-border/50 dark:border-border-dark/50'
+            : 'w-auto',
+        )}
+      >
+        {IS_MACOS_DESKTOP && <TrafficLights />}
+
+        {isAuthenticated && showSidebar && (
+          <div className="ml-3 flex items-center gap-0.5">
+            <ToggleButton
+              isOpen={sidebarOpen}
+              onClick={() => useUIStore.getState().setSidebarOpen(!sidebarOpen)}
+              position="left"
+              ariaLabel="Toggle sidebar"
+            />
+            {isChatPage && (
+              <Button
+                onClick={() => useUIStore.getState().setCommandMenuOpen(true)}
+                variant="unstyled"
+                className={cn(
+                  'rounded-full p-1.5',
+                  'text-text-tertiary hover:text-text-primary',
+                  'dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
+                  'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+                  'transition-colors duration-200',
+                )}
+                aria-label="Open command menu"
+              >
+                <Command className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
+        )}
+
+        {/* Spacing after traffic lights when no sidebar controls are shown */}
+        {IS_MACOS_DESKTOP && !(isAuthenticated && showSidebar) && <div className="w-1" />}
+      </div>
+
+      {/* Main content area — matches main bg */}
+      <div className="flex-1 bg-surface dark:bg-surface-dark" />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/LoadingScreen.tsx
+++ b/frontend/src/components/ui/LoadingScreen.tsx
@@ -1,11 +1,15 @@
 import { Loader2 } from 'lucide-react';
+import { DesktopDragRegion } from '@/components/layout/TitleBar';
 
 export function LoadingScreen() {
   return (
-    <div className="min-h-viewport flex items-center justify-center bg-surface dark:bg-surface-dark">
-      <div className="flex flex-col items-center gap-4" role="status" aria-live="polite">
-        <Loader2 className="h-8 w-8 animate-spin text-text-quaternary dark:text-text-dark-quaternary" />
-        <p className="text-text-dark-quaternary">Loading...</p>
+    <div className="min-h-viewport flex flex-col bg-surface dark:bg-surface-dark">
+      <DesktopDragRegion />
+      <div className="flex flex-1 items-center justify-center">
+        <div className="flex flex-col items-center gap-4" role="status" aria-live="polite">
+          <Loader2 className="h-8 w-8 animate-spin text-text-quaternary dark:text-text-dark-quaternary" />
+          <p className="text-text-dark-quaternary">Loading...</p>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -150,8 +150,17 @@ export function ChatPage() {
     [navigate],
   );
 
+  // Auto-close sidebar when switching to non-agent views (editor-only, terminal-only, etc.)
+  // to reclaim the 300px. Users can re-open via the TitleBar toggle.
+  const agentVisible = activeViews.includes('agent');
+  useEffect(() => {
+    if (!agentVisible) {
+      useUIStore.getState().setSidebarOpen(false);
+    }
+  }, [agentVisible]);
+
+  // Sidebar is always available on chat pages — it holds navigation, settings, and logout
   const sidebarContent = useMemo(() => {
-    if (!activeViews.includes('agent')) return null;
     return (
       <Sidebar
         workspaces={workspaces}
@@ -162,7 +171,6 @@ export function ChatPage() {
       />
     );
   }, [
-    activeViews,
     workspaces,
     chatId,
     currentChat?.workspace_id,


### PR DESCRIPTION
## Summary
- Replace native macOS title bar with a custom frameless title bar featuring traffic light buttons, sidebar toggle, and command menu
- Move user profile (avatar, settings, theme toggle, sign out) from the header dropdown to a fixed sidebar footer
- Strip the old Header to only render on auth pages and authenticated non-sidebar pages (e.g. settings)
- Ensure all loading/error screens on macOS desktop retain window controls via DesktopDragRegion
- Auto-close sidebar in non-agent views (editor/terminal/diff) to avoid stealing 300px
- Platform-guard: decorations only removed on macOS at runtime via `#[cfg(target_os = "macos")]`

## Test plan
- [ ] macOS desktop: traffic lights render, window dragging works, close/minimize/maximize functional
- [ ] macOS desktop: loading screen and error screen show drag region + traffic lights
- [ ] Web: no title bar changes, sidebar toggle + command menu still work on chat/landing pages
- [ ] Settings page: header renders with theme toggle and sign-out button
- [ ] Sidebar footer: avatar, theme toggle, settings, and sign-out always visible
- [ ] Editor-only / terminal-only view: sidebar auto-closes, can be toggled back open