### PR TITLE
Collapse sidebar sub-threads by default with count badge

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -127,15 +127,13 @@ interface WorkspaceGroupProps {
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
   onNewThread: (e: React.MouseEvent, workspaceId: string) => void;
   onWorkspaceContextMenu: (e: React.MouseEvent<HTMLButtonElement>, workspaceId: string) => void;
-  collapsedSubThreads: Set<string>;
+  expandedSubThreads: Set<string>;
   onToggleSubThreads: (chatId: string) => void;
-  selectedChatParentId: string | null;
 }
 
 const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
   workspace,
   selectedChatId,
-  selectedChatParentId,
   dropdownChatId,
   streamingChatIdSet,
   isCollapsed,
@@ -144,7 +142,7 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
   onDropdownClick,
   onNewThread,
   onWorkspaceContextMenu,
-  collapsedSubThreads,
+  expandedSubThreads,
   onToggleSubThreads,
 }: WorkspaceGroupProps) {
   const [isChatsExpanded, setIsChatsExpanded] = useState(false);
@@ -223,11 +221,10 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
                     onMouseLeave={handleMouseLeave}
                     onToggleSubThreads={chat.sub_thread_count > 0 ? onToggleSubThreads : undefined}
                     isSubThreadsExpanded={
-                      chat.sub_thread_count > 0 ? !collapsedSubThreads.has(chat.id) : undefined
+                      chat.sub_thread_count > 0 ? expandedSubThreads.has(chat.id) : undefined
                     }
-                    isParentOfSelectedChat={chat.id === selectedChatParentId}
                   />
-                  {chat.sub_thread_count > 0 && !collapsedSubThreads.has(chat.id) && (
+                  {chat.sub_thread_count > 0 && expandedSubThreads.has(chat.id) && (
                     <SubThreadList
                       parentChatId={chat.id}
                       selectedChatId={selectedChatId}
@@ -333,9 +330,8 @@ export function Sidebar({
     workspaceId: string;
     position: { top: number; left: number };
   } | null>(null);
-  // Tracks which parent chats have their sub-threads collapsed — sub-threads are visible by default
-  const [collapsedSubThreads, toggleSubThreadCollapse, setCollapsedSubThreads] =
-    useToggleSet<string>();
+  // Tracks which parent chats have their sub-threads expanded — collapsed by default to keep the sidebar compact
+  const [expandedSubThreads, toggleSubThreadExpand, setExpandedSubThreads] = useToggleSet<string>();
 
   const searchInputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -365,16 +361,16 @@ export function Sidebar({
     });
   }, [selectedChatWorkspaceId, setCollapsedWorkspaces]);
 
-  // Auto-uncollapse parent when navigating to a sub-thread from outside the sidebar
+  // Auto-expand parent when navigating to a sub-thread from outside the sidebar
   useEffect(() => {
     if (!selectedChatParentId) return;
-    setCollapsedSubThreads((prev) => {
-      if (!prev.has(selectedChatParentId)) return prev;
+    setExpandedSubThreads((prev) => {
+      if (prev.has(selectedChatParentId)) return prev;
       const next = new Set(prev);
-      next.delete(selectedChatParentId);
+      next.add(selectedChatParentId);
       return next;
     });
-  }, [selectedChatParentId, setCollapsedSubThreads]);
+  }, [selectedChatParentId, setExpandedSubThreads]);
 
   useMountEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -428,10 +424,10 @@ export function Sidebar({
   // target may become hidden
   const handleToggleSubThreads = useCallback(
     (chatId: string) => {
-      toggleSubThreadCollapse(chatId);
+      toggleSubThreadExpand(chatId);
       if (dropdownStateRef.current) setDropdown(null);
     },
-    [toggleSubThreadCollapse],
+    [toggleSubThreadExpand],
   );
 
   const handleChatSelect = useCallback(
@@ -668,13 +664,10 @@ export function Sidebar({
                             chat.sub_thread_count > 0 ? handleToggleSubThreads : undefined
                           }
                           isSubThreadsExpanded={
-                            chat.sub_thread_count > 0
-                              ? !collapsedSubThreads.has(chat.id)
-                              : undefined
+                            chat.sub_thread_count > 0 ? expandedSubThreads.has(chat.id) : undefined
                           }
-                          isParentOfSelectedChat={chat.id === selectedChatParentId}
                         />
-                        {chat.sub_thread_count > 0 && !collapsedSubThreads.has(chat.id) && (
+                        {chat.sub_thread_count > 0 && expandedSubThreads.has(chat.id) && (
                           <SubThreadList
                             parentChatId={chat.id}
                             selectedChatId={selectedChatId}
@@ -702,9 +695,8 @@ export function Sidebar({
                   onDropdownClick={handleDropdownClick}
                   onNewThread={handleNewWorkspaceThread}
                   onWorkspaceContextMenu={handleWorkspaceContextMenu}
-                  collapsedSubThreads={collapsedSubThreads}
+                  expandedSubThreads={expandedSubThreads}
                   onToggleSubThreads={handleToggleSubThreads}
-                  selectedChatParentId={selectedChatParentId ?? null}
                 />
               ))}
             </div>

--- a/frontend/src/components/layout/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/SidebarChatItem.tsx
@@ -18,7 +18,6 @@ interface SidebarChatItemProps {
   onMouseLeave: () => void;
   onToggleSubThreads?: (chatId: string) => void;
   isSubThreadsExpanded?: boolean;
-  isParentOfSelectedChat?: boolean;
 }
 
 export const SidebarChatItem = memo(function SidebarChatItem({
@@ -33,10 +32,9 @@ export const SidebarChatItem = memo(function SidebarChatItem({
   onMouseLeave,
   onToggleSubThreads,
   isSubThreadsExpanded,
-  isParentOfSelectedChat,
 }: SidebarChatItemProps) {
-  // Blocked for unselected non-parent rows so clicking them navigates normally
-  const canToggle = onToggleSubThreads != null && (isSelected || isParentOfSelectedChat);
+  // onToggleSubThreads is only set when sub_thread_count > 0
+  const hasSubThreads = onToggleSubThreads != null;
   return (
     <div
       className={cn(
@@ -60,25 +58,28 @@ export const SidebarChatItem = memo(function SidebarChatItem({
 
       <Button
         onClick={() => {
-          if (!canToggle) {
-            onSelect(chat.id);
-            return;
-          }
-          onToggleSubThreads(chat.id);
-          // When a sub-thread is active, also navigate to the parent so the
-          // click still opens the parent conversation
-          if (!isSelected) {
-            onSelect(chat.id);
+          // Always navigate to the chat; additionally toggle sub-threads if present
+          onSelect(chat.id);
+          if (hasSubThreads) {
+            onToggleSubThreads(chat.id);
           }
         }}
         aria-current={isSelected ? 'page' : undefined}
-        aria-expanded={canToggle ? isSubThreadsExpanded : undefined}
+        aria-expanded={hasSubThreads ? isSubThreadsExpanded : undefined}
         variant="unstyled"
         title={chat.title}
-        className="min-w-0 flex-1 truncate pr-10 text-left text-[13px]"
+        className="min-w-0 flex-1 pr-10 text-left text-[13px]"
       >
-        <span className={cn('truncate', isSelected && 'font-medium')}>
-          {stripMarkdownTitle(chat.title)}
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className={cn('min-w-0 truncate', isSelected && 'font-medium')}>
+            {stripMarkdownTitle(chat.title)}
+          </span>
+          {/* Sub-thread count pill — only shown when collapsed so the user knows there are expandable threads */}
+          {chat.sub_thread_count > 0 && !isSubThreadsExpanded && (
+            <span className="flex-shrink-0 rounded-full bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-tertiary dark:bg-surface-dark-tertiary dark:text-text-dark-tertiary">
+              {chat.sub_thread_count}
+            </span>
+          )}
         </span>
       </Button>
 


### PR DESCRIPTION
## Summary
- Sub-threads are now collapsed by default in the sidebar to keep it compact (inverted `collapsedSubThreads` → `expandedSubThreads` Set semantics)
- Added a small count pill badge next to parent chat titles when sub-threads are collapsed, so users know expandable threads exist
- Clicking any parent with sub-threads now both navigates to it and toggles expand/collapse (removed the restriction that only the selected/parent-of-selected row could toggle)
- Removed the now-unused `isParentOfSelectedChat` prop from `SidebarChatItem` and `WorkspaceGroupProps`
- Fixed truncation for long titles by adding `min-w-0` to the flex wrapper and title span

## Test plan
- [ ] Verify sub-threads are collapsed by default when opening the sidebar
- [ ] Verify the count pill badge appears next to parents with sub-threads
- [ ] Verify clicking any parent with sub-threads expands them and navigates to the parent
- [ ] Verify clicking an already-expanded parent collapses its sub-threads
- [ ] Verify navigating to a sub-thread (e.g. via URL) auto-expands the parent
- [ ] Verify long chat titles truncate with ellipsis and don't overflow into the pill/timestamp
- [ ] Verify pill badge styling matches the existing pill pattern (WorkspaceSelector)