### PR TITLE
Update dark mode primary surface to charcoal

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -87,7 +87,7 @@ export default {
           hover: '#e0e0e0',
           active: '#d8d8d8',
           dark: {
-            DEFAULT: '#0a0a0a',
+            DEFAULT: '#111111',
             secondary: '#141414',
             tertiary: '#1e1e1e',
             hover: '#282828',


### PR DESCRIPTION
## Summary
- Change dark mode primary surface color from `#0a0a0a` (near-black) to `#111111` (charcoal) for improved eye comfort and reduced harsh contrast against white text
- Surface hierarchy remains clear: `#111111` → `#141414` → `#1e1e1e`

## Test plan
- [ ] Verify dark mode background across all pages
- [ ] Check surface layer distinction (primary vs secondary vs tertiary panels)
- [ ] Confirm text readability on the new background