### PR TITLE
Migrate raw buttons to Button primitive & redesign input controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,9 @@
 ### React Version
 - Project uses React 19 — use `use()` instead of `useContext()`, pass `ref` as a regular prop instead of `forwardRef`
 
+### UI Primitives
+- Never use raw HTML interactive elements (`<button>`, `<input>`, `<select>`, `<a>`) when a corresponding UI primitive exists in `components/ui/primitives/` — use `Button`, `Input`, etc. instead; for fully custom styling, use `variant="unstyled"` which still provides consistent focus-visible and disabled styles automatically; do not duplicate those built-in styles in `className`
+
 ### Composition Patterns
 - Avoid boolean prop proliferation — don't add `isX`, `showX`, `hideX` boolean props to customize component behavior; use composition instead
 - When a component exceeds ~10 props or has 3+ boolean flags, refactor to a context provider + compound components

--- a/frontend/src/components/chat/branch-selector/BranchSelector.tsx
+++ b/frontend/src/components/chat/branch-selector/BranchSelector.tsx
@@ -10,11 +10,15 @@ import { useGitBranchesQuery, useCheckoutBranchMutation } from '@/hooks/queries/
 export interface BranchSelectorProps {
   dropdownPosition?: 'top' | 'bottom';
   disabled?: boolean;
+  variant?: 'default' | 'text';
+  dropdownAlign?: 'left' | 'right';
 }
 
 export const BranchSelector = memo(function BranchSelector({
   dropdownPosition = 'bottom',
+  dropdownAlign,
   disabled = false,
+  variant = 'default',
 }: BranchSelectorProps) {
   const { sandboxId } = useChatContext();
   const worktreeCwd = useChatStore((s) => s.currentChat?.worktree_cwd) ?? undefined;
@@ -61,6 +65,8 @@ export const BranchSelector = memo(function BranchSelector({
       disabled={disabled || checkoutBranch.isPending}
       compactOnMobile
       forceCompact={isSplitMode}
+      triggerVariant={variant}
+      dropdownAlign={dropdownAlign}
       searchable={branches.length >= 6}
       searchPlaceholder="Search branches..."
       itemClassName="font-mono"

--- a/frontend/src/components/chat/github/CreatePRDialog.tsx
+++ b/frontend/src/components/chat/github/CreatePRDialog.tsx
@@ -247,14 +247,15 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
                     {existingPR.title}
                   </p>
                 </div>
-                <button
+                <Button
+                  variant="unstyled"
                   type="button"
                   onClick={() => openExternalUrl(existingPR.html_url)}
                   className="ml-3 flex flex-shrink-0 items-center gap-1 rounded-md px-2 py-1 text-2xs text-text-secondary transition-colors duration-200 hover:bg-surface-hover dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover"
                 >
                   View on GitHub
                   <ExternalLink className="h-3 w-3" />
-                </button>
+                </Button>
               </div>
             )}
             <div>
@@ -339,7 +340,8 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
                     </span>
                   ) : (
                     collaborators.map((c) => (
-                      <button
+                      <Button
+                        variant="unstyled"
                         key={c.login}
                         type="button"
                         onClick={() => toggleReviewer(c.login)}
@@ -350,7 +352,7 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
                         }`}
                       >
                         {c.login}
-                      </button>
+                      </Button>
                     ))
                   )}
                 </div>

--- a/frontend/src/components/chat/message-bubble/PromptSuggestions.tsx
+++ b/frontend/src/components/chat/message-bubble/PromptSuggestions.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Button } from '@/components/ui/primitives/Button';
 
 interface PromptSuggestionsProps {
   suggestions: string[];
@@ -13,14 +14,15 @@ const PromptSuggestionsInner: React.FC<PromptSuggestionsProps> = ({ suggestions,
   return (
     <div className="mt-3 flex flex-wrap gap-1.5">
       {suggestions.map((suggestion, index) => (
-        <button
+        <Button
+          variant="unstyled"
           key={`${index}-${suggestion}`}
           type="button"
           onClick={() => onSelect(suggestion)}
           className="rounded-md bg-surface-tertiary/60 px-2.5 py-1 text-2xs text-text-tertiary transition-colors duration-150 hover:bg-surface-hover hover:text-text-primary dark:bg-surface-dark-tertiary/60 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
         >
           {suggestion}
-        </button>
+        </Button>
       ))}
     </div>
   );

--- a/frontend/src/components/chat/message-input/EnhanceButton.tsx
+++ b/frontend/src/components/chat/message-input/EnhanceButton.tsx
@@ -16,6 +16,10 @@ export function EnhanceButton({
     <Button
       type="button"
       onClick={onEnhance}
+      onMouseDown={(event) => {
+        // Preserve the textarea selection so enhance can act on the current prompt without blurring the composer.
+        event.preventDefault();
+      }}
       disabled={disabled || isEnhancing}
       variant="unstyled"
       className={`group rounded-full p-1.5 transition-colors duration-200 ${

--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -5,6 +5,7 @@ import { DropIndicator } from './DropIndicator';
 import { SendButton } from './SendButton';
 import type { SendButtonStatus } from './SendButton';
 import { AttachButton } from './AttachButton';
+import { EnhanceButton } from './EnhanceButton';
 import { Textarea } from './Textarea';
 import { InputControls } from './InputControls';
 import { InputAttachments } from './InputAttachments';
@@ -67,7 +68,7 @@ function InputLayout() {
     <form ref={meta.formRef} onSubmit={actions.handleSubmit} className="relative px-4 sm:px-6">
       <div
         {...meta.dragHandlers}
-        className={`relative rounded-2xl border bg-surface-secondary shadow-sm transition-[border-color,box-shadow] duration-300 dark:bg-surface-dark-secondary ${
+        className={`relative rounded-2xl border bg-surface-secondary transition-[border-color] duration-300 dark:bg-surface-dark-secondary ${
           state.isDragging
             ? 'scale-[1.01] border-border-hover dark:border-border-dark-hover'
             : 'border-border dark:border-border-dark'
@@ -84,13 +85,7 @@ function InputLayout() {
           />
         )}
 
-        {state.contextUsage && (
-          <div className="absolute right-3 top-3 z-10">
-            <ContextUsageIndicator usage={state.contextUsage} />
-          </div>
-        )}
-
-        <div className="relative px-3 pb-12 pt-1.5 sm:pb-9">
+        <div className="relative px-4 pt-2.5">
           <Textarea
             ref={meta.textareaRef}
             message={state.message}
@@ -105,28 +100,34 @@ function InputLayout() {
           <InputSuggestionsPanel />
         </div>
 
-        <div className="absolute bottom-2.5 left-3 right-3 pb-safe">
-          <div className="flex items-center justify-between gap-2">
-            <InputControls />
-
-            <div className="flex flex-shrink-0 items-center gap-1">
-              <AttachButton
-                disabled={state.isDisabled}
-                onAttach={() => {
-                  actions.resetDragState();
-                  actions.setShowFileUpload(true);
-                }}
-              />
-              <SendButton
-                status={sendStatus}
-                disabled={sendStatus === 'idle' || state.isEnhancing || state.isDisabled}
-                onClick={actions.handleSendClick}
-                type="button"
-                showLoadingSpinner={state.showLoadingSpinner}
-              />
-            </div>
-          </div>
+        <div className="flex items-center justify-end gap-0.5 px-2 pb-2 pt-0.5">
+          <EnhanceButton
+            onEnhance={actions.handleEnhancePrompt}
+            isEnhancing={state.isEnhancing}
+            disabled={state.isLoading || !state.hasMessage}
+          />
+          <AttachButton
+            disabled={state.isDisabled}
+            onAttach={() => {
+              actions.resetDragState();
+              actions.setShowFileUpload(true);
+            }}
+          />
+          <SendButton
+            status={sendStatus}
+            disabled={sendStatus === 'idle' || state.isEnhancing || state.isDisabled}
+            onClick={actions.handleSendClick}
+            type="button"
+            showLoadingSpinner={state.showLoadingSpinner}
+          />
         </div>
+      </div>
+
+      <div className="flex items-center justify-between px-2 pb-safe pt-1.5">
+        <div className="flex-shrink-0">
+          {state.contextUsage && <ContextUsageIndicator usage={state.contextUsage} />}
+        </div>
+        <InputControls />
       </div>
 
       <FileUploadDialog

--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -1,4 +1,3 @@
-import { EnhanceButton } from './EnhanceButton';
 import { PermissionModeSelector } from '@/components/chat/permission-mode-selector/PermissionModeSelector';
 import { ModelSelector } from '@/components/chat/model-selector/ModelSelector';
 import { ThinkingModeSelector } from '@/components/chat/thinking-mode-selector/ThinkingModeSelector';
@@ -7,6 +6,10 @@ import { BranchSelector } from '@/components/chat/branch-selector/BranchSelector
 import { useInputState, useInputActions } from '@/hooks/useInputContext';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
 import { useChatQuery } from '@/hooks/queries/useChatQueries';
+import { useChatContext } from '@/hooks/useChatContext';
+import { useChatStore } from '@/store/chatStore';
+import { useGitBranchesQuery } from '@/hooks/queries/useSandboxQueries';
+import { SelectorDot } from '@/components/ui/primitives/SelectorDot';
 
 export function InputControls() {
   const state = useInputState();
@@ -16,47 +19,72 @@ export function InputControls() {
   const { data: chat } = useChatQuery(state.chatId, { enabled: !!state.chatId });
   const lockedAgentKind = chat?.session_agent_kind ?? null;
 
+  const { sandboxId, personas } = useChatContext();
+  const worktreeCwd = useChatStore((s) => s.currentChat?.worktree_cwd) ?? undefined;
+  const { data: branchesData } = useGitBranchesQuery(sandboxId, !!sandboxId, worktreeCwd);
+
+  const showPersona = personas.length > 0;
+  const showBranch = !!sandboxId && !!branchesData?.is_git_repo && branchesData.branches.length > 0;
+
   return (
-    <div
-      className="flex min-w-0 flex-1 items-center gap-1 sm:gap-1.5"
-      onMouseDown={(e) => e.preventDefault()}
-    >
-      <EnhanceButton
-        onEnhance={actions.handleEnhancePrompt}
-        isEnhancing={state.isEnhancing}
-        disabled={state.isLoading || !state.hasMessage}
-      />
-
-      <PermissionModeSelector
-        chatId={state.chatId}
-        agentKind={agentKind}
-        dropdownPosition={state.dropdownPosition}
-        disabled={state.isLoading}
-      />
-
-      <ThinkingModeSelector
-        chatId={state.chatId}
-        agentKind={agentKind}
-        dropdownPosition={state.dropdownPosition}
-        disabled={state.isLoading}
-      />
-
-      <PersonaSelector
-        chatId={state.chatId}
-        dropdownPosition={state.dropdownPosition}
-        disabled={state.isLoading}
-      />
-
+    <div className="flex min-w-0 items-center gap-1" onMouseDown={(e) => e.preventDefault()}>
       <ModelSelector
         selectedModelId={state.selectedModelId}
         onModelChange={actions.onModelChange}
         chatId={state.chatId}
         dropdownPosition={state.dropdownPosition}
+        dropdownAlign="right"
         disabled={state.isLoading || state.isStreaming}
         lockedAgentKind={lockedAgentKind}
+        variant="text"
       />
 
-      <BranchSelector dropdownPosition={state.dropdownPosition} disabled={state.isLoading} />
+      <SelectorDot />
+
+      <ThinkingModeSelector
+        chatId={state.chatId}
+        agentKind={agentKind}
+        dropdownPosition={state.dropdownPosition}
+        dropdownAlign="right"
+        disabled={state.isLoading}
+        variant="text"
+      />
+
+      <SelectorDot />
+
+      <PermissionModeSelector
+        chatId={state.chatId}
+        agentKind={agentKind}
+        dropdownPosition={state.dropdownPosition}
+        dropdownAlign="right"
+        disabled={state.isLoading}
+        variant="text"
+      />
+
+      {showPersona && (
+        <>
+          <SelectorDot />
+          <PersonaSelector
+            chatId={state.chatId}
+            dropdownPosition={state.dropdownPosition}
+            dropdownAlign="right"
+            disabled={state.isLoading}
+            variant="text"
+          />
+        </>
+      )}
+
+      {showBranch && (
+        <>
+          <SelectorDot />
+          <BranchSelector
+            dropdownPosition={state.dropdownPosition}
+            dropdownAlign="right"
+            disabled={state.isLoading}
+            variant="text"
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/chat/message-input/Textarea.tsx
+++ b/frontend/src/components/chat/message-input/Textarea.tsx
@@ -124,7 +124,7 @@ export function Textarea({
       placeholder={placeholder}
       disabled={isLoading || disabled}
       rows={1}
-      className={`max-h-[180px] w-full resize-none overflow-y-auto bg-transparent py-1.5 pr-14 text-xs leading-normal text-text-primary outline-none transition-all duration-200 placeholder:text-text-quaternary focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary ${isMobile && compact ? 'min-h-[28px]' : 'min-h-[80px]'}`}
+      className={`max-h-[180px] w-full resize-none overflow-y-auto bg-transparent py-1.5 text-xs leading-normal text-text-primary outline-none transition-all duration-200 placeholder:text-text-quaternary focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary ${isMobile && compact ? 'min-h-[28px]' : 'min-h-[36px]'}`}
       style={THIN_SCROLLBAR_STYLE}
       aria-label="Message input"
     />

--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -27,6 +27,8 @@ export interface ModelSelectorProps {
   disabled?: boolean;
   compact?: boolean;
   lockedAgentKind?: AgentKind | null;
+  variant?: 'default' | 'text';
+  dropdownAlign?: 'left' | 'right';
 }
 
 export const ModelSelector = memo(function ModelSelector({
@@ -34,9 +36,11 @@ export const ModelSelector = memo(function ModelSelector({
   onModelChange,
   chatId,
   dropdownPosition = 'bottom',
+  dropdownAlign,
   disabled = false,
   compact,
   lockedAgentKind,
+  variant = 'default',
 }: ModelSelectorProps) {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const isSplitMode = useIsSplitMode();
@@ -109,6 +113,8 @@ export const ModelSelector = memo(function ModelSelector({
       searchPlaceholder="Filter..."
       searchVariant="underline"
       selectionStyle="accent"
+      triggerVariant={variant}
+      dropdownAlign={dropdownAlign}
       renderItem={(model, isSelected) => (
         <div className="flex items-center justify-between gap-2">
           <span

--- a/frontend/src/components/chat/permission-mode-selector/PermissionModeSelector.tsx
+++ b/frontend/src/components/chat/permission-mode-selector/PermissionModeSelector.tsx
@@ -82,6 +82,8 @@ export interface PermissionModeSelectorProps {
   agentKind?: AgentKind;
   dropdownPosition?: 'top' | 'bottom';
   disabled?: boolean;
+  variant?: 'default' | 'text';
+  dropdownAlign?: 'left' | 'right';
 }
 
 function renderPermissionItem(mode: PermissionModeOption, isSelected: boolean) {
@@ -103,7 +105,9 @@ export const PermissionModeSelector = memo(function PermissionModeSelector({
   chatId,
   agentKind,
   dropdownPosition = 'bottom',
+  dropdownAlign,
   disabled = false,
+  variant = 'default',
 }: PermissionModeSelectorProps) {
   const resolvedAgentKind = agentKind ?? 'claude';
   const showPlanMode = resolvedAgentKind === 'codex';
@@ -139,6 +143,8 @@ export const PermissionModeSelector = memo(function PermissionModeSelector({
       disabled={disabled}
       compactOnMobile
       forceCompact={isSplitMode}
+      triggerVariant={variant}
+      dropdownAlign={dropdownAlign}
       renderItem={renderPermissionItem}
       renderFooter={
         showPlanMode

--- a/frontend/src/components/chat/persona-selector/PersonaSelector.tsx
+++ b/frontend/src/components/chat/persona-selector/PersonaSelector.tsx
@@ -20,12 +20,16 @@ export interface PersonaSelectorProps {
   chatId?: string;
   dropdownPosition?: 'top' | 'bottom';
   disabled?: boolean;
+  variant?: 'default' | 'text';
+  dropdownAlign?: 'left' | 'right';
 }
 
 export const PersonaSelector = memo(function PersonaSelector({
   chatId,
   dropdownPosition = 'bottom',
+  dropdownAlign,
   disabled = false,
+  variant = 'default',
 }: PersonaSelectorProps) {
   const { personas } = useChatContext();
   const key = chatId ?? DEFAULT_CHAT_SETTINGS_KEY;
@@ -56,6 +60,8 @@ export const PersonaSelector = memo(function PersonaSelector({
       disabled={disabled}
       compactOnMobile
       forceCompact={isSplitMode}
+      triggerVariant={variant}
+      dropdownAlign={dropdownAlign}
     />
   );
 });

--- a/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
+++ b/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
@@ -61,13 +61,17 @@ export interface ThinkingModeSelectorProps {
   agentKind?: AgentKind;
   dropdownPosition?: 'top' | 'bottom';
   disabled?: boolean;
+  variant?: 'default' | 'text';
+  dropdownAlign?: 'left' | 'right';
 }
 
 export const ThinkingModeSelector = memo(function ThinkingModeSelector({
   chatId,
   agentKind,
   dropdownPosition = 'bottom',
+  dropdownAlign,
   disabled = false,
+  variant = 'default',
 }: ThinkingModeSelectorProps) {
   const key = chatId ?? DEFAULT_CHAT_SETTINGS_KEY;
   const resolvedAgentKind = agentKind ?? 'claude';
@@ -92,6 +96,8 @@ export const ThinkingModeSelector = memo(function ThinkingModeSelector({
       disabled={disabled}
       compactOnMobile
       forceCompact={isSplitMode}
+      triggerVariant={variant}
+      dropdownAlign={dropdownAlign}
       renderItem={(mode, isSelected) => (
         <span
           className={`text-2xs font-medium ${isSelected ? 'text-text-primary dark:text-text-dark-primary' : 'text-text-secondary dark:text-text-dark-secondary'}`}

--- a/frontend/src/components/chat/tools/claude/AgentTool.tsx
+++ b/frontend/src/components/chat/tools/claude/AgentTool.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState, useRef, lazy, Suspense } from 'react';
+import { Button } from '@/components/ui/primitives/Button';
 import { Bot, Maximize2 } from 'lucide-react';
 import type { ToolAggregate } from '@/types/tools.types';
 import { ToolCard } from '../common/ToolCard';
@@ -43,17 +44,18 @@ export const AgentTool: React.FC<AgentToolProps> = ({ tool }) => {
   );
 
   const expandAction = (
-    <button
+    <Button
+      variant="unstyled"
       type="button"
       onClick={(e) => {
         e.stopPropagation();
         setModalOpen(true);
       }}
-      className="rounded-sm opacity-0 transition-opacity duration-150 focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-text-quaternary/30 group-hover/tool:opacity-100"
+      className="rounded-sm opacity-0 transition-opacity duration-150 focus-visible:opacity-100 group-hover/tool:opacity-100"
       title="Expand agent view"
     >
       <Maximize2 className="h-3 w-3 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary" />
-    </button>
+    </Button>
   );
 
   return (

--- a/frontend/src/components/chat/tools/common/ToolCard.tsx
+++ b/frontend/src/components/chat/tools/common/ToolCard.tsx
@@ -1,4 +1,5 @@
 import React, { JSX, memo, useState } from 'react';
+import { Button } from '@/components/ui/primitives/Button';
 import { Check, ChevronRight, Circle, X } from 'lucide-react';
 import type { ToolEventStatus } from '@/types/tools.types';
 import { TOOL_ERROR_PRE_CLASS } from '@/utils/toolStyles';
@@ -106,14 +107,15 @@ const ToolCardInner: React.FC<ToolCardProps> = ({
     <div className={`group/tool ${className}`}>
       <div className="flex items-center gap-1">
         {hasExpandableContent ? (
-          <button
+          <Button
+            variant="unstyled"
             type="button"
             onClick={() => setExpanded((prev) => !prev)}
             className="-ml-1 rounded-md px-1 py-0.5 text-left transition-colors duration-150 hover:bg-surface-hover dark:hover:bg-surface-dark-hover"
             aria-expanded={expanded}
           >
             {header}
-          </button>
+          </Button>
         ) : (
           <div className="-ml-1 px-1 py-0.5">{header}</div>
         )}

--- a/frontend/src/components/chat/workspace-selector/WorkspaceSelector.tsx
+++ b/frontend/src/components/chat/workspace-selector/WorkspaceSelector.tsx
@@ -53,16 +53,22 @@ function ProviderToggle({
       <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
         Provider:
       </span>
-      <button type="button" onClick={() => onChange('host')} className={btnCls(value === 'host')}>
+      <Button
+        variant="unstyled"
+        type="button"
+        onClick={() => onChange('host')}
+        className={btnCls(value === 'host')}
+      >
         Host
-      </button>
-      <button
+      </Button>
+      <Button
+        variant="unstyled"
         type="button"
         onClick={() => onChange('docker')}
         className={btnCls(value === 'docker')}
       >
         Docker
-      </button>
+      </Button>
     </div>
   );
 }
@@ -110,7 +116,8 @@ function WorkspaceItem({
 
   return (
     <div>
-      <button
+      <Button
+        variant="unstyled"
         type="button"
         onClick={() => {
           setBranchesExpanded(false);
@@ -149,10 +156,11 @@ function WorkspaceItem({
             )}
           </div>
         </div>
-      </button>
+      </Button>
       {showBranchSelector && (
         <div className="ml-6 mt-0.5">
-          <button
+          <Button
+            variant="unstyled"
             type="button"
             onClick={(e) => {
               e.stopPropagation();
@@ -170,7 +178,7 @@ function WorkspaceItem({
             <span className="truncate font-mono text-2xs text-text-secondary dark:text-text-dark-secondary">
               {branchesData?.current_branch || '…'}
             </span>
-          </button>
+          </Button>
           {branchesExpanded && (
             <div className="mt-0.5 overflow-hidden rounded-md border border-border/50 dark:border-border-dark/50">
               {branchesLoading ? (
@@ -208,7 +216,8 @@ function WorkspaceItem({
                         {filteredBranches.map((branch) => {
                           const isCurrent = branch === branchesData.current_branch;
                           return (
-                            <button
+                            <Button
+                              variant="unstyled"
                               key={branch}
                               type="button"
                               disabled={checkoutBranch.isPending}
@@ -248,7 +257,7 @@ function WorkspaceItem({
                                 <span className="h-3 w-3 shrink-0" />
                               )}
                               <span className="truncate font-mono">{branch}</span>
-                            </button>
+                            </Button>
                           );
                         })}
                       </div>
@@ -274,7 +283,8 @@ const GitHubRepoItem = memo(function GitHubRepoItem({
   isCloning: boolean;
 }) {
   return (
-    <button
+    <Button
+      variant="unstyled"
       type="button"
       disabled={isCloning}
       onClick={() => onSelect(repo.clone_url, repo.name)}
@@ -308,7 +318,7 @@ const GitHubRepoItem = memo(function GitHubRepoItem({
           )}
         </div>
       </div>
-    </button>
+    </Button>
   );
 });
 
@@ -477,10 +487,11 @@ export function WorkspaceSelector({
   return (
     <>
       <div className="relative">
-        <button
+        <Button
+          variant="unstyled"
           type="button"
           onClick={() => setIsModalOpen(true)}
-          className="inline-flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-2xs text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-quaternary/30 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+          className="inline-flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-2xs text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
         >
           <FolderOpen className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
           <span className="max-w-[16rem] truncate">{label}</span>
@@ -491,7 +502,7 @@ export function WorkspaceSelector({
           >
             <path d="M4.427 6.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 6H4.604a.25.25 0 00-.177.427z" />
           </svg>
-        </button>
+        </Button>
       </div>
 
       <BaseModal isOpen={isModalOpen} onClose={closeModal} size="md" ariaLabel="Select workspace">
@@ -536,14 +547,15 @@ export function WorkspaceSelector({
 
           <div className="border-t border-border/50 px-4 py-3 dark:border-border-dark/50">
             {creationMode === 'none' ? (
-              <button
+              <Button
+                variant="unstyled"
                 type="button"
                 onClick={() => setCreationMode('menu')}
                 className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-xs text-text-secondary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
               >
                 <Plus className="h-3.5 w-3.5 text-text-quaternary dark:text-text-dark-quaternary" />
                 New workspace
-              </button>
+              </Button>
             ) : creationMode === 'empty' ? (
               <div className="flex flex-col gap-2">
                 <div className="flex items-center gap-2 text-xs text-text-secondary dark:text-text-dark-secondary">
@@ -591,7 +603,8 @@ export function WorkspaceSelector({
                     Clone Git repo
                   </div>
                   {hasGitHubToken && (
-                    <button
+                    <Button
+                      variant="unstyled"
                       type="button"
                       onClick={() => {
                         setShowUrlInput(!showUrlInput);
@@ -601,7 +614,7 @@ export function WorkspaceSelector({
                       className="text-2xs text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
                     >
                       {showUrlInput ? 'Browse repos' : 'Paste URL'}
-                    </button>
+                    </Button>
                   )}
                 </div>
 
@@ -698,16 +711,18 @@ export function WorkspaceSelector({
                 <div className="px-2.5 py-1.5">
                   <ProviderToggle value={sandboxProvider} onChange={setSandboxProvider} />
                 </div>
-                <button
+                <Button
+                  variant="unstyled"
                   type="button"
                   onClick={() => setCreationMode('empty')}
                   className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-xs text-text-secondary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
                 >
                   <Box className="h-3.5 w-3.5 text-text-quaternary dark:text-text-dark-quaternary" />
                   Empty workspace
-                </button>
+                </Button>
                 {isDesktop && (
-                  <button
+                  <Button
+                    variant="unstyled"
                     type="button"
                     onClick={() => void handleChooseLocal()}
                     disabled={createWorkspace.isPending}
@@ -715,16 +730,17 @@ export function WorkspaceSelector({
                   >
                     <HardDrive className="h-3.5 w-3.5 text-text-quaternary dark:text-text-dark-quaternary" />
                     Local folder
-                  </button>
+                  </Button>
                 )}
-                <button
+                <Button
+                  variant="unstyled"
                   type="button"
                   onClick={() => setCreationMode('git')}
                   className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-xs text-text-secondary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
                 >
                   <GitBranch className="h-3.5 w-3.5 text-text-quaternary dark:text-text-dark-quaternary" />
                   Clone Git repo
-                </button>
+                </Button>
               </div>
             )}
           </div>

--- a/frontend/src/components/chat/worktree-selector/WorktreeToggle.tsx
+++ b/frontend/src/components/chat/worktree-selector/WorktreeToggle.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Button } from '@/components/ui/primitives/Button';
 import { GitFork, Check, ChevronDown } from 'lucide-react';
 import { useDropdown } from '@/hooks/useDropdown';
 import {
@@ -21,21 +22,23 @@ export const WorktreeToggle = memo(function WorktreeToggle({
 
   return (
     <div className="relative" ref={dropdownRef}>
-      <button
+      <Button
+        variant="unstyled"
         type="button"
         disabled={disabled}
         onClick={() => setIsOpen(!isOpen)}
-        className="inline-flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-2xs text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-quaternary/30 disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+        className="inline-flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-2xs text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
       >
         <GitFork className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
         <span>Worktree ({worktree ? 'on' : 'off'})</span>
         <ChevronDown className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
-      </button>
+      </Button>
 
       {isOpen && (
         <div className="absolute left-0 top-full z-[60] mt-1 w-32 rounded-xl border border-border bg-surface-secondary/95 py-1 shadow-medium backdrop-blur-xl backdrop-saturate-150 dark:border-border-dark dark:bg-surface-dark-secondary/95 dark:shadow-black/40">
           {[false, true].map((value) => (
-            <button
+            <Button
+              variant="unstyled"
               key={String(value)}
               type="button"
               onClick={() => {
@@ -52,7 +55,7 @@ export const WorktreeToggle = memo(function WorktreeToggle({
                 className={`h-3 w-3 shrink-0 ${worktree === value ? 'opacity-100' : 'opacity-0'}`}
               />
               <span>{value ? 'On' : 'Off'}</span>
-            </button>
+            </Button>
           ))}
         </div>
       )}

--- a/frontend/src/components/editor/editor-view/EmptyState.tsx
+++ b/frontend/src/components/editor/editor-view/EmptyState.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { PanelLeft, FileCode2 } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
 import { cn } from '@/utils/cn';
 
 export interface EmptyStateProps {
@@ -17,13 +18,14 @@ export const EmptyState = memo(function EmptyState({ theme, onToggleFileTree }: 
     >
       {onToggleFileTree && (
         <div className="flex h-9 items-center border-b border-border/50 px-3 dark:border-border-dark/50">
-          <button
+          <Button
+            variant="unstyled"
             onClick={onToggleFileTree}
-            className="shrink-0 rounded-md p-1 text-text-quaternary transition-colors duration-150 hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-quaternary/30 dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+            className="shrink-0 rounded-md p-1 text-text-quaternary transition-colors duration-150 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
             aria-label="Toggle file tree"
           >
             <PanelLeft size={14} />
-          </button>
+          </Button>
         </div>
       )}
       <div className="flex flex-1 flex-col items-center justify-center gap-3">

--- a/frontend/src/components/editor/editor-view/Header.tsx
+++ b/frontend/src/components/editor/editor-view/Header.tsx
@@ -41,19 +41,19 @@ export const Header = memo(function Header({
     <div className="flex h-9 items-center justify-between border-b border-border/50 bg-surface-secondary px-3 dark:border-border-dark/50 dark:bg-surface-dark-secondary">
       <div className="flex min-w-0 items-center gap-2">
         {onToggleFileTree && (
-          <button
+          <Button
+            variant="unstyled"
             onClick={onToggleFileTree}
             className={cn(
               'shrink-0 rounded-md p-1',
               'text-text-quaternary hover:text-text-secondary',
               'dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary',
               'transition-colors duration-150',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-quaternary/30',
             )}
             aria-label="Toggle file tree"
           >
             <PanelLeft size={14} />
-          </button>
+          </Button>
         )}
         <FileIcon name={getFileName(filePath)} className="h-3.5 w-3.5 shrink-0" />
         <span className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-tertiary">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -173,7 +173,8 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
   return (
     <div>
       <div className="group flex items-center gap-1 pb-2 pt-3.5">
-        <button
+        <Button
+          variant="unstyled"
           type="button"
           onClick={() => onToggleCollapse(workspace.id)}
           className="min-w-0 flex-1 text-left"
@@ -181,23 +182,25 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
           <span className="text-2xs font-medium uppercase tracking-wider text-text-quaternary transition-colors duration-200 group-hover:text-text-tertiary dark:text-text-dark-quaternary dark:group-hover:text-text-dark-tertiary">
             {workspace.name}
           </span>
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="unstyled"
           type="button"
           title="New thread"
           onClick={(e) => onNewThread(e, workspace.id)}
           className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
         >
           <SquarePen className="h-3 w-3" />
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="unstyled"
           type="button"
           data-ws-dropdown-trigger
           onClick={(e) => onWorkspaceContextMenu(e, workspace.id)}
           className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
         >
           <MoreHorizontal className="h-3 w-3" />
-        </button>
+        </Button>
       </div>
       {!isCollapsed && (
         <div>
@@ -236,26 +239,29 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
                 </div>
               ))}
               {hasMoreLocalChats && !isChatsExpanded && (
-                <button
+                <Button
+                  variant="unstyled"
                   type="button"
                   onClick={() => setIsChatsExpanded(true)}
                   className="flex w-full items-center gap-1 py-1.5 text-left text-xs text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
                 >
                   Show more ({chats.length - CHATS_PER_WORKSPACE})
                   <ChevronDown className="h-3 w-3" />
-                </button>
+                </Button>
               )}
               {(hasMoreLocalChats || showLoadMore) && isChatsExpanded && (
                 <div className="flex items-center gap-2 py-1.5">
-                  <button
+                  <Button
+                    variant="unstyled"
                     type="button"
                     onClick={() => setIsChatsExpanded(false)}
                     className="text-2xs text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
                   >
                     Show less
-                  </button>
+                  </Button>
                   {showLoadMore && (
-                    <button
+                    <Button
+                      variant="unstyled"
                       type="button"
                       onClick={() => fetchNextPage()}
                       disabled={isFetchingNextPage}
@@ -269,7 +275,7 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
                       ) : (
                         'Load more'
                       )}
-                    </button>
+                    </Button>
                   )}
                 </div>
               )}
@@ -759,7 +765,8 @@ export function Sidebar({
             left: workspaceDropdown.position.left,
           }}
         >
-          <button
+          <Button
+            variant="unstyled"
             type="button"
             onClick={() => {
               const ws = workspaces.find((w) => w.id === workspaceDropdown.workspaceId);
@@ -768,14 +775,15 @@ export function Sidebar({
             className="w-full rounded-md px-2.5 py-1.5 text-left text-xs text-text-secondary transition-colors duration-200 hover:bg-surface-hover dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover"
           >
             Rename
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="unstyled"
             type="button"
             onClick={() => handleDeleteWorkspace(workspaceDropdown.workspaceId)}
             className="w-full rounded-md px-2.5 py-1.5 text-left text-xs text-error-500 transition-colors duration-200 hover:bg-surface-hover dark:text-error-400 dark:hover:bg-surface-dark-hover"
           >
             Delete
-          </button>
+          </Button>
         </div>
       )}
 

--- a/frontend/src/components/layout/SubThreadList.tsx
+++ b/frontend/src/components/layout/SubThreadList.tsx
@@ -34,13 +34,14 @@ export const SubThreadList = memo(function SubThreadList({
     return (
       <div className="relative ml-[11px] mt-0.5 pl-[22px]">
         <div className="absolute bottom-2 left-0 top-0 w-px bg-border-secondary dark:bg-border-dark-secondary" />
-        <button
+        <Button
+          variant="unstyled"
           type="button"
           onClick={() => refetch()}
           className="text-2xs text-text-quaternary transition-colors duration-200 hover:text-text-tertiary dark:text-text-dark-quaternary dark:hover:text-text-dark-tertiary"
         >
           Failed to load · Retry
-        </button>
+        </Button>
       </div>
     );
   }
@@ -74,7 +75,8 @@ export const SubThreadList = memo(function SubThreadList({
               <div className="absolute bottom-1.5 left-0 top-1.5 w-0.5 rounded-full bg-text-primary dark:bg-text-dark-primary" />
             )}
 
-            <button
+            <Button
+              variant="unstyled"
               type="button"
               onClick={() => onSelect(thread.id)}
               title={thread.title}
@@ -91,7 +93,7 @@ export const SubThreadList = memo(function SubThreadList({
               <span className={cn('truncate text-xs', isSelected && 'font-medium')}>
                 {stripMarkdownTitle(thread.title)}
               </span>
-            </button>
+            </Button>
 
             <span
               className={cn(

--- a/frontend/src/components/sandbox/terminal/Container.tsx
+++ b/frontend/src/components/sandbox/terminal/Container.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import type { FC } from 'react';
 import { Plus, X } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
 import { TerminalTab } from './TerminalTab';
 import { cn } from '@/utils/cn';
 
@@ -131,7 +132,8 @@ export const Container: FC<ContainerProps> = ({ sandboxId, chatId, isVisible, pa
         role="tablist"
       >
         {terminals.map((terminal) => (
-          <button
+          <Button
+            variant="unstyled"
             key={terminal.id}
             className={cn(
               'group flex h-full items-center gap-1.5 border-r border-border/30 px-3 font-mono text-2xs transition-colors duration-200 dark:border-border-dark/30',
@@ -157,15 +159,16 @@ export const Container: FC<ContainerProps> = ({ sandboxId, chatId, isVisible, pa
                 <X className="h-2.5 w-2.5" />
               </span>
             )}
-          </button>
+          </Button>
         ))}
-        <button
+        <Button
+          variant="unstyled"
           className="flex h-full items-center px-2 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
           onClick={addTerminal}
           aria-label="Add new terminal"
         >
           <Plus className="h-3 w-3" />
-        </button>
+        </Button>
       </div>
 
       <div className="relative flex-1 overflow-hidden">

--- a/frontend/src/components/ui/AgentToolExpandedModal.tsx
+++ b/frontend/src/components/ui/AgentToolExpandedModal.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, Suspense } from 'react';
+import { Button } from '@/components/ui/primitives/Button';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { ModalHeader } from '@/components/ui/shared/ModalHeader';
 import { Spinner } from '@/components/ui/primitives/Spinner';
@@ -50,11 +51,12 @@ function AgentToolExpandedModal({ agents, initialAgentId, onClose }: AgentToolEx
               const desc = agent.input?.description as string | undefined;
               const isSelected = agent.id === selectedAgent.id;
               return (
-                <button
+                <Button
+                  variant="unstyled"
                   key={agent.id}
                   type="button"
                   onClick={() => setSelectedId(agent.id)}
-                  className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors duration-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-quaternary/30 ${
+                  className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors duration-200 ${
                     isSelected
                       ? 'bg-surface-active dark:bg-surface-dark-active'
                       : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover'
@@ -77,7 +79,7 @@ function AgentToolExpandedModal({ agents, initialAgentId, onClose }: AgentToolEx
                       </div>
                     )}
                   </div>
-                </button>
+                </Button>
               );
             })}
           </div>

--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { Button } from '@/components/ui/primitives/Button';
 import { createPortal } from 'react-dom';
 import {
   MessagesSquare,
@@ -442,13 +443,14 @@ export function CommandMenu() {
       >
         <div className="flex items-center gap-2 border-b border-border/50 px-3 dark:border-border-dark/50">
           {mode === 'files' && (
-            <button
+            <Button
+              variant="unstyled"
               onMouseDown={(e) => e.preventDefault()}
               onClick={() => switchMode('commands')}
               className="shrink-0 rounded-md bg-surface-hover px-1.5 py-0.5 text-2xs font-medium text-text-secondary dark:bg-surface-dark-hover dark:text-text-dark-secondary"
             >
               Files
-            </button>
+            </Button>
           )}
           <Search className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
           <input
@@ -490,7 +492,8 @@ export function CommandMenu() {
                   )}
                   onMouseEnter={() => setActiveIndex(index)}
                 >
-                  <button
+                  <Button
+                    variant="unstyled"
                     id={`file-item-${index}`}
                     role="option"
                     aria-selected={index === activeIndex}
@@ -509,7 +512,7 @@ export function CommandMenu() {
                         {file.path}
                       </span>
                     </span>
-                  </button>
+                  </Button>
                 </div>
               ))}
               {filteredFiles.length === 0 && (
@@ -537,7 +540,8 @@ export function CommandMenu() {
                     )}
                     onMouseEnter={() => setActiveIndex(index)}
                   >
-                    <button
+                    <Button
+                      variant="unstyled"
                       id={`command-item-${cmd.id}`}
                       role="option"
                       aria-selected={index === activeIndex}
@@ -560,7 +564,7 @@ export function CommandMenu() {
                       {isActive && (
                         <span className="h-1.5 w-1.5 rounded-full bg-text-primary dark:bg-text-dark-primary" />
                       )}
-                    </button>
+                    </Button>
                     {!isMobile && cmd.shortcut && (
                       <kbd className="ml-auto shrink-0 font-mono text-2xs text-text-quaternary dark:text-text-dark-quaternary">
                         {formatShortcut(cmd.shortcut)}
@@ -568,22 +572,24 @@ export function CommandMenu() {
                     )}
                     {cmd.type === 'view' && !isMobile && !isActive && (
                       <div className="flex items-center gap-0.5">
-                        <button
+                        <Button
+                          variant="unstyled"
                           onMouseDown={(e) => e.preventDefault()}
                           onClick={() => handleSplit(cmd.id, 'row')}
                           className={splitButtonClass}
                           title="Split right"
                         >
                           <PanelRight className="h-3 w-3" />
-                        </button>
-                        <button
+                        </Button>
+                        <Button
+                          variant="unstyled"
                           onMouseDown={(e) => e.preventDefault()}
                           onClick={() => handleSplit(cmd.id, 'column')}
                           className={splitButtonClass}
                           title="Split down"
                         >
                           <PanelBottom className="h-3 w-3" />
-                        </button>
+                        </Button>
                       </div>
                     )}
                   </div>

--- a/frontend/src/components/ui/MosaicSplitView.tsx
+++ b/frontend/src/components/ui/MosaicSplitView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, ReactNode } from 'react';
+import { Button } from '@/components/ui/primitives/Button';
 import { Mosaic, MosaicWindow } from 'react-mosaic-component';
 import { X, SplitSquareHorizontal } from 'lucide-react';
 import { useUIStore } from '@/store/uiStore';
@@ -45,7 +46,8 @@ export function MosaicSplitView({ mosaicLayout, renderView }: MosaicSplitViewPro
             toolbarControls={
               <div className="flex items-center gap-0.5 pr-0.5">
                 {leaves.length > 1 && (
-                  <button
+                  <Button
+                    variant="unstyled"
                     onClick={() => useUIStore.getState().removeTileFromMosaic(id as ViewType)}
                     className={cn(
                       'flex items-center justify-center',
@@ -58,7 +60,7 @@ export function MosaicSplitView({ mosaicLayout, renderView }: MosaicSplitViewPro
                     title="Close tile"
                   >
                     <X className="h-3 w-3" />
-                  </button>
+                  </Button>
                 )}
               </div>
             }

--- a/frontend/src/components/ui/primitives/Dropdown.tsx
+++ b/frontend/src/components/ui/primitives/Dropdown.tsx
@@ -29,6 +29,8 @@ export interface DropdownProps<T> {
   searchVariant?: 'boxed' | 'underline';
   selectionStyle?: 'check' | 'accent';
   renderFooter?: () => ReactNode;
+  triggerVariant?: 'default' | 'text';
+  dropdownAlign?: 'left' | 'right';
 }
 
 const isGroupedItems = <T,>(
@@ -117,6 +119,8 @@ function DropdownInner<T>({
   searchVariant = 'boxed',
   selectionStyle = 'check',
   renderFooter,
+  triggerVariant = 'default',
+  dropdownAlign = 'left',
 }: DropdownProps<T>) {
   const { isOpen, dropdownRef, setIsOpen } = useDropdown();
   const [searchQuery, setSearchQuery] = useState('');
@@ -155,35 +159,60 @@ function DropdownInner<T>({
       : 'hidden sm:block h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary transition-transform duration-200'
     : 'h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary transition-transform duration-200';
 
+  const triggerLabel = getItemShortLabel ? getItemShortLabel(value) : getItemLabel(value);
+
   return (
     <div className="relative" ref={dropdownRef}>
       <Button
         type="button"
-        onClick={() => !disabled && setIsOpen(!isOpen)}
+        onClick={() => setIsOpen(!isOpen)}
         disabled={disabled}
         variant="unstyled"
         aria-haspopup="listbox"
         aria-expanded={isOpen}
-        className={`flex min-w-0 items-center gap-1.5 rounded-lg px-2.5 py-1.5 transition-colors duration-200 ${isOpen && !disabled ? 'bg-surface-hover dark:bg-surface-dark-hover' : 'hover:bg-surface-hover/60 dark:hover:bg-surface-dark-hover/60'} ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+        className={
+          triggerVariant === 'text'
+            ? `flex min-w-0 items-center gap-1 p-0 text-2xs leading-normal transition-colors duration-200 ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:text-text-primary dark:hover:text-text-dark-primary'} ${isOpen ? 'text-text-primary dark:text-text-dark-primary' : 'text-text-secondary dark:text-text-dark-secondary'}`
+            : `flex min-w-0 items-center gap-1.5 rounded-lg px-2.5 py-1.5 transition-colors duration-200 ${isOpen && !disabled ? 'bg-surface-hover dark:bg-surface-dark-hover' : 'hover:bg-surface-hover/60 dark:hover:bg-surface-dark-hover/60'} ${disabled ? 'cursor-not-allowed opacity-50' : ''}`
+        }
       >
-        {LeftIcon && (
-          <LeftIcon
-            className={cn(
-              'h-3 w-3 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary',
-              !forceCompact && 'sm:hidden',
+        {triggerVariant === 'text' ? (
+          <>
+            {/* Keep the text trigger responsive so the composer row still collapses in split/mobile layouts. */}
+            {showIconOnly && LeftIcon && (
+              <LeftIcon
+                className={cn(
+                  'h-3 w-3 flex-shrink-0 text-current',
+                  forceCompact ? '' : 'sm:hidden',
+                )}
+              />
             )}
-          />
+            <span className={cn(labelClasses, 'text-inherit dark:text-inherit')}>
+              {triggerLabel}
+            </span>
+          </>
+        ) : (
+          <>
+            {LeftIcon && (
+              <LeftIcon
+                className={cn(
+                  'h-3 w-3 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary',
+                  !forceCompact && 'sm:hidden',
+                )}
+              />
+            )}
+            <span className={labelClasses}>{triggerLabel}</span>
+            {!disabled && (
+              <ChevronDown className={`${chevronClasses} ${isOpen ? 'rotate-180' : ''}`} />
+            )}
+          </>
         )}
-        <span className={labelClasses}>
-          {getItemShortLabel ? getItemShortLabel(value) : getItemLabel(value)}
-        </span>
-        {!disabled && <ChevronDown className={`${chevronClasses} ${isOpen ? 'rotate-180' : ''}`} />}
       </Button>
 
       {isOpen && !disabled && (
         <div
           role="listbox"
-          className={`absolute left-0 ${width} z-[60] rounded-xl border border-border bg-surface-secondary/95 shadow-medium backdrop-blur-xl backdrop-saturate-150 dark:border-border-dark dark:bg-surface-dark-secondary/95 dark:shadow-black/40 ${dropdownPosition === 'top' ? 'bottom-full mb-1.5' : 'top-full mt-1.5'}`}
+          className={`absolute ${dropdownAlign === 'right' ? 'right-0' : 'left-0'} ${width} z-[60] rounded-xl border border-border bg-surface-secondary/95 shadow-medium backdrop-blur-xl backdrop-saturate-150 dark:border-border-dark dark:bg-surface-dark-secondary/95 dark:shadow-black/40 ${dropdownPosition === 'top' ? 'bottom-full mb-1.5' : 'top-full mt-1.5'}`}
         >
           {searchable && searchVariant === 'boxed' && (
             <div className="border-b border-border p-1.5 dark:border-border-dark">

--- a/frontend/src/components/ui/primitives/SelectorDot.tsx
+++ b/frontend/src/components/ui/primitives/SelectorDot.tsx
@@ -1,0 +1,7 @@
+export function SelectorDot() {
+  return (
+    <span className="select-none text-2xs text-text-quaternary/40 dark:text-text-dark-quaternary/40">
+      &middot;
+    </span>
+  );
+}

--- a/frontend/src/components/views/DiffView.tsx
+++ b/frontend/src/components/views/DiffView.tsx
@@ -396,7 +396,8 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
               const isRenamed = file.type === 'rename-pure' || file.type === 'rename-changed';
               return (
                 <div key={i}>
-                  <button
+                  <Button
+                    variant="unstyled"
                     type="button"
                     onClick={() => toggleFile(i)}
                     className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors duration-200 hover:bg-surface-hover dark:hover:bg-surface-dark-hover"
@@ -425,7 +426,7 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
                     </span>
                     <FileStatusBadge type={file.type} />
                     <FileStats file={file} />
-                  </button>
+                  </Button>
                   {isExpanded && <FileDiffRenderer file={file} options={options} />}
                 </div>
               );

--- a/frontend/src/components/views/PRReviewView.tsx
+++ b/frontend/src/components/views/PRReviewView.tsx
@@ -8,6 +8,7 @@ import { useUIStore } from '@/store/uiStore';
 import { useGitRemoteUrlQuery } from '@/hooks/queries/useSandboxQueries';
 import { useGitHubPullsQuery, useGitHubPRCommentsQuery } from '@/hooks/queries/useGitHubQueries';
 import { queryKeys } from '@/hooks/queries/queryKeys';
+import { Button } from '@/components/ui/primitives/Button';
 import { cn } from '@/utils/cn';
 import { openExternalUrl } from '@/utils/openExternal';
 
@@ -102,20 +103,22 @@ function PRComments({
             {comment.body}
           </p>
           <div className="mt-1.5 flex gap-1.5">
-            <button
+            <Button
+              variant="unstyled"
               type="button"
               onClick={() => handleFixInThisChat(comment)}
               className="rounded px-2 py-0.5 text-2xs font-medium text-text-secondary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
             >
               Fix in this chat
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="unstyled"
               type="button"
               onClick={() => handleFixInNewChat(comment)}
               className="rounded px-2 py-0.5 text-2xs font-medium text-text-secondary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
             >
               Fix in new chat
-            </button>
+            </Button>
           </div>
         </div>
       ))}
@@ -167,13 +170,14 @@ export const PRReviewView = memo(function PRReviewView() {
             </span>
           )}
         </div>
-        <button
+        <Button
+          variant="unstyled"
           type="button"
           onClick={handleRefresh}
           className="flex h-5 w-5 items-center justify-center rounded text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
         >
           <RefreshCw className="h-3 w-3" />
-        </button>
+        </Button>
       </div>
 
       <div className="flex-1 overflow-y-auto p-3">
@@ -214,7 +218,8 @@ export const PRReviewView = memo(function PRReviewView() {
                   key={pr.number}
                   className="rounded-lg border border-border/50 dark:border-border-dark/50"
                 >
-                  <button
+                  <Button
+                    variant="unstyled"
                     type="button"
                     onClick={() => setExpandedPR(isExpanded ? null : pr.number)}
                     className="flex w-full items-center gap-2.5 p-2.5 text-left transition-colors duration-200 hover:bg-surface-hover dark:hover:bg-surface-dark-hover"
@@ -262,7 +267,7 @@ export const PRReviewView = memo(function PRReviewView() {
                     >
                       GitHub
                     </span>
-                  </button>
+                  </Button>
 
                   {isExpanded && (
                     <div className="border-t border-border/50 px-2.5 pt-2 dark:border-border-dark/50">


### PR DESCRIPTION
## Summary
- Replace all raw `<button>` elements with `<Button variant="unstyled">` across 20+ components for consistent focus-visible and disabled styles
- Redesign message input: move enhance/attach/send buttons inside the input box, relocate selector controls (model, thinking, permission, persona, branch) below with text-only variant and dot separators
- Add `triggerVariant="text"` and `dropdownAlign="right"` support to `Dropdown` primitive
- Add `variant` and `dropdownAlign` props to all selector components (Model, ThinkingMode, PermissionMode, Persona, Branch)
- Create `SelectorDot` component for visual separator between selectors
- Add `onMouseDown preventDefault` to EnhanceButton to preserve textarea selection
- Update CLAUDE.md with UI Primitives convention

## Test plan
- [ ] Verify all buttons retain correct click behavior and visual states (hover, focus-visible, disabled)
- [ ] Test message input layout: enhance, attach, send buttons render inside the input; selectors render below with dot separators
- [ ] Test dropdown alignment with `dropdownAlign="right"` — menus should anchor to the right edge
- [ ] Test text variant selectors show label-only triggers without backgrounds or chevrons
- [ ] Verify persona selector and branch selector conditionally hide when not applicable
- [ ] Test responsive behavior: selectors collapse to icons in split/mobile layouts
- [ ] Verify textarea selection is preserved when clicking the enhance button