### PR TITLE
Migrate raw HTML elements to UI primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,6 @@
 - Expandable content: `transition-all duration-200` with `max-h-*` and `opacity` toggling
 - Dropdowns: `animate-fadeIn` for entry — no scale transforms on buttons
 
-### Button Layout
 ### Layout
 
 - Do not use absolute positioning for layout of sibling elements within a container — use flexbox (`flex`, `justify-between`, `gap-*`); reserve `absolute` for overlays, tooltips, dropdowns, and decorative elements only

--- a/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
+++ b/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
@@ -1,6 +1,7 @@
 import { memo, useState, useCallback, useRef, useEffect } from 'react';
 import { X, Pencil, CornerDownRight, FileText, FileSpreadsheet, Send } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { Input } from '@/components/ui/primitives/Input';
 import { Spinner } from '@/components/ui/primitives/Spinner';
 import { apiClient } from '@/lib/api';
 import { detectFileType } from '@/utils/fileTypes';
@@ -251,8 +252,9 @@ export const QueueMessageCard = memo(function QueueMessageCard({
             </div>
           )}
           {isEditing ? (
-            <input
+            <Input
               ref={inputRef}
+              variant="unstyled"
               type="text"
               value={editContent}
               onChange={(e) => setEditContent(e.target.value)}

--- a/frontend/src/components/chat/github/CreateBranchDialog.tsx
+++ b/frontend/src/components/chat/github/CreateBranchDialog.tsx
@@ -3,6 +3,8 @@ import { GitBranch } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { Button } from '@/components/ui/primitives/Button';
+import { Input } from '@/components/ui/primitives/Input';
+import { Select } from '@/components/ui/primitives/Select';
 import { useChatStore } from '@/store/chatStore';
 import { useGitBranchesQuery, useGitCreateBranchMutation } from '@/hooks/queries/useSandboxQueries';
 
@@ -66,7 +68,8 @@ export function CreateBranchDialog({ onClose }: CreateBranchDialogProps) {
             <label className="mb-1.5 block text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
               Branch name
             </label>
-            <input
+            <Input
+              variant="unstyled"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="feature/my-branch"
@@ -85,10 +88,10 @@ export function CreateBranchDialog({ onClose }: CreateBranchDialogProps) {
             <label className="mb-1.5 block text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
               From
             </label>
-            <select
+            <Select
               value={baseBranch}
               onChange={(e) => setBaseBranch(e.target.value)}
-              className="w-full rounded-lg border border-border/50 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary outline-none transition-colors duration-200 focus:border-border-hover dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:focus:border-border-dark-hover"
+              className="h-8 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary dark:bg-surface-dark-secondary dark:text-text-dark-primary"
             >
               <option value="">
                 Current branch
@@ -99,7 +102,7 @@ export function CreateBranchDialog({ onClose }: CreateBranchDialogProps) {
                   {b}
                 </option>
               ))}
-            </select>
+            </Select>
           </div>
         </div>
       </div>

--- a/frontend/src/components/chat/github/CreateCommitDialog.tsx
+++ b/frontend/src/components/chat/github/CreateCommitDialog.tsx
@@ -3,6 +3,7 @@ import { GitCommitHorizontal, Sparkles } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { Button } from '@/components/ui/primitives/Button';
+import { Textarea } from '@/components/ui/primitives/Textarea';
 import { useChatStore } from '@/store/chatStore';
 import { useChatSessionState } from '@/hooks/useChatSessionContext';
 import { useGitCommitMutation, useGitDiffQuery } from '@/hooks/queries/useSandboxQueries';
@@ -119,11 +120,12 @@ export function CreateCommitDialog({ onClose }: CreateCommitDialogProps) {
               {generateMessage.isPending ? 'Generating...' : 'Generate with AI'}
             </Button>
           </div>
-          <textarea
+          <Textarea
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             placeholder="Describe your changes..."
             rows={5}
+            variant="unstyled"
             className="w-full resize-none rounded-lg border border-border/50 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary outline-none transition-colors duration-200 focus:border-border-hover dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:focus:border-border-dark-hover"
             onKeyDown={(e) => {
               if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {

--- a/frontend/src/components/chat/github/CreatePRDialog.tsx
+++ b/frontend/src/components/chat/github/CreatePRDialog.tsx
@@ -3,6 +3,10 @@ import { ExternalLink, GitPullRequest, Sparkles } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { Button } from '@/components/ui/primitives/Button';
+import { Input } from '@/components/ui/primitives/Input';
+import { Link } from '@/components/ui/primitives/Link';
+import { Select } from '@/components/ui/primitives/Select';
+import { Textarea } from '@/components/ui/primitives/Textarea';
 import { useChatStore } from '@/store/chatStore';
 import { useChatSessionState } from '@/hooks/useChatSessionContext';
 import { sandboxService } from '@/services/sandboxService';
@@ -127,6 +131,9 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
   const diffError = diffData?.error;
   const hasModel = !!selectedModelId.trim();
   const canGenerate = hasDiff && hasModel && !generateDescription.isPending;
+  const titleInputId = 'create-pr-title';
+  const bodyTextareaId = 'create-pr-description';
+  const baseBranchSelectId = 'create-pr-base-branch';
 
   const handleGenerateDescription = async () => {
     if (!diffData?.diff) return;
@@ -185,9 +192,15 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
       toast.success(
         <span>
           Created PR #{result.number}:{' '}
-          <a href={result.html_url} target="_blank" rel="noopener noreferrer" className="underline">
+          <Link
+            href={result.html_url}
+            variant="unstyled"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
             View on GitHub
-          </a>
+          </Link>
         </span>,
         { duration: 6000 },
       );
@@ -259,21 +272,28 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
               </div>
             )}
             <div>
-              <label className="mb-1.5 block text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
+              <label
+                htmlFor={titleInputId}
+                className="mb-1.5 block text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary"
+              >
                 Title
               </label>
-              <input
+              <Input
+                id={titleInputId}
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="PR title"
-                className="w-full rounded-lg border border-border/50 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary outline-none transition-colors duration-200 focus:border-border-hover dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:focus:border-border-dark-hover"
+                className="bg-surface-secondary px-3 py-1.5 text-xs dark:bg-surface-dark-secondary"
                 autoFocus
               />
             </div>
 
             <div>
               <div className="mb-1.5 flex items-center justify-between">
-                <label className="text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
+                <label
+                  htmlFor={bodyTextareaId}
+                  className="text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary"
+                >
                   Description
                 </label>
                 <Button
@@ -300,33 +320,38 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
                   {generateDescription.isPending ? 'Generating...' : 'Generate with AI'}
                 </Button>
               </div>
-              <textarea
+              <Textarea
+                id={bodyTextareaId}
                 value={body}
                 onChange={(e) => {
                   bodyEditedRef.current = true;
                   setBody(e.target.value);
                 }}
                 rows={5}
-                className="w-full resize-none rounded-lg border border-border/50 bg-surface-secondary px-3 py-2 text-xs text-text-primary outline-none transition-colors duration-200 focus:border-border-hover dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:focus:border-border-dark-hover"
+                className="resize-none bg-surface-secondary px-3 py-2 text-xs dark:bg-surface-dark-secondary"
               />
             </div>
 
             <div className="flex gap-3">
               <div className="flex-1">
-                <label className="mb-1.5 block text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
+                <label
+                  htmlFor={baseBranchSelectId}
+                  className="mb-1.5 block text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary"
+                >
                   Base branch
                 </label>
-                <select
+                <Select
+                  id={baseBranchSelectId}
                   value={baseBranch}
                   onChange={(e) => setBaseBranch(e.target.value)}
-                  className="w-full rounded-lg border border-border/50 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary outline-none transition-colors duration-200 focus:border-border-hover dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:focus:border-border-dark-hover"
+                  className="bg-surface-secondary px-3 py-1.5 text-xs dark:bg-surface-dark-secondary"
                 >
                   {sortedBranches.map((b) => (
                     <option key={b} value={b}>
                       {b}
                     </option>
                   ))}
-                </select>
+                </Select>
               </div>
 
               <div className="flex-1">

--- a/frontend/src/components/chat/message-bubble/ThinkingBlock.tsx
+++ b/frontend/src/components/chat/message-bubble/ThinkingBlock.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, memo, type CSSProperties } from 'react';
 import { ChevronRight, Brain } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
 
 const DELAY_0: CSSProperties = { animationDelay: '0ms' };
 const DELAY_150: CSSProperties = { animationDelay: '150ms' };
@@ -28,8 +29,9 @@ const ThinkingBlockInner: React.FC<ThinkingBlockProps> = ({ content, isActiveThi
 
   return (
     <div className="group/thinking">
-      <button
+      <Button
         type="button"
+        variant="unstyled"
         onClick={() => setIsExpanded((prev) => !prev)}
         className="-ml-1 flex items-center gap-1.5 rounded-md px-1 py-0.5 transition-colors duration-150 hover:bg-surface-hover dark:hover:bg-surface-dark-hover"
       >
@@ -61,7 +63,7 @@ const ThinkingBlockInner: React.FC<ThinkingBlockProps> = ({ content, isActiveThi
         <ChevronRight
           className={`h-3 w-3 text-text-quaternary transition-transform duration-200 dark:text-text-dark-quaternary ${isExpanded ? 'rotate-90' : ''}`}
         />
-      </button>
+      </Button>
 
       <div
         className={`overflow-hidden transition-[max-height,opacity] duration-200 ease-in-out ${

--- a/frontend/src/components/chat/message-input/Textarea.tsx
+++ b/frontend/src/components/chat/message-input/Textarea.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { Textarea as PrimitiveTextarea } from '@/components/ui/primitives/Textarea';
 
 const THIN_SCROLLBAR_STYLE: CSSProperties = { scrollbarWidth: 'thin' };
 
@@ -112,8 +113,9 @@ export function Textarea({
   );
 
   return (
-    <textarea
+    <PrimitiveTextarea
       ref={textareaRef}
+      variant="unstyled"
       value={message}
       onChange={handleChange}
       onKeyDown={onKeyDown}

--- a/frontend/src/components/chat/sub-threads/CreateSubThreadDialog.tsx
+++ b/frontend/src/components/chat/sub-threads/CreateSubThreadDialog.tsx
@@ -5,6 +5,8 @@ import toast from 'react-hot-toast';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { Button } from '@/components/ui/primitives/Button';
 import { Dropdown } from '@/components/ui/primitives/Dropdown';
+import { Select } from '@/components/ui/primitives/Select';
+import { Textarea } from '@/components/ui/primitives/Textarea';
 import { ModelSelector } from '@/components/chat/model-selector/ModelSelector';
 import { SlashCommandsPanel } from '@/components/chat/message-input/SlashCommandsPanel';
 import {
@@ -167,10 +169,10 @@ export function CreateSubThreadDialog({ parentChat, onClose }: CreateSubThreadDi
             <label className="mb-1.5 block text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
               Persona
             </label>
-            <select
+            <Select
               value={personaName}
               onChange={(e) => setPersonaName(e.target.value)}
-              className="w-full rounded-lg border border-border/50 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary outline-none transition-colors duration-200 focus:border-border-hover dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:focus:border-border-dark-hover"
+              className="h-8 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary dark:bg-surface-dark-secondary dark:text-text-dark-primary"
             >
               <option value={DEFAULT_PERSONA}>Default</option>
               {personas.map((p) => (
@@ -178,7 +180,7 @@ export function CreateSubThreadDialog({ parentChat, onClose }: CreateSubThreadDi
                   {p.name}
                 </option>
               ))}
-            </select>
+            </Select>
           </div>
 
           <div className="flex items-center gap-2">
@@ -214,8 +216,9 @@ export function CreateSubThreadDialog({ parentChat, onClose }: CreateSubThreadDi
                   onSelect={selectCommand}
                 />
               )}
-              <textarea
+              <Textarea
                 ref={textareaRef}
+                variant="unstyled"
                 value={message}
                 onChange={(e) => setMessage(e.target.value)}
                 onKeyDown={handleSlashKeyDown}

--- a/frontend/src/components/chat/tools/common/OpenInEditorButton.tsx
+++ b/frontend/src/components/chat/tools/common/OpenInEditorButton.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import { ExternalLink } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
 import { useUIStore } from '@/store/uiStore';
 
 export const OpenInEditorButton: React.FC<{ filePath: string }> = ({ filePath }) => (
-  <button
+  <Button
     type="button"
     onClick={() => useUIStore.getState().openFileInEditor(filePath)}
-    className="rounded-sm opacity-0 transition-opacity duration-150 focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-text-quaternary/30 group-hover/tool:opacity-100"
+    variant="unstyled"
+    className="rounded-sm opacity-0 transition-opacity duration-150 focus-visible:opacity-100 group-hover/tool:opacity-100"
     title="Open in editor"
+    aria-label="Open in editor"
   >
     <ExternalLink className="h-3 w-3 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary" />
-  </button>
+  </Button>
 );

--- a/frontend/src/components/chat/tools/common/SourceChip.tsx
+++ b/frontend/src/components/chat/tools/common/SourceChip.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Globe } from 'lucide-react';
+import { Link } from '@/components/ui/primitives/Link';
 
 interface SourceChipProps {
   source: { title: string; url: string };
@@ -19,8 +20,9 @@ export const SourceChip: React.FC<SourceChipProps> = ({ source, index }) => {
   }
 
   return (
-    <a
+    <Link
       href={source.url}
+      variant="unstyled"
       target="_blank"
       rel="noopener noreferrer"
       title={source.title}
@@ -48,6 +50,6 @@ export const SourceChip: React.FC<SourceChipProps> = ({ source, index }) => {
       <span className="text-2xs tabular-nums text-text-quaternary/60 dark:text-text-dark-quaternary/60">
         {index + 1}
       </span>
-    </a>
+    </Link>
   );
 };

--- a/frontend/src/components/chat/workspace-selector/WorkspaceSelector.tsx
+++ b/frontend/src/components/chat/workspace-selector/WorkspaceSelector.tsx
@@ -14,6 +14,7 @@ import {
   Check,
 } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { Input } from '@/components/ui/primitives/Input';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { ModalHeader } from '@/components/ui/shared/ModalHeader';
 import {
@@ -196,7 +197,8 @@ function WorkspaceItem({
                 <>
                   {branches.length >= 6 && (
                     <div className="border-b border-border/50 px-2 py-1 dark:border-border-dark/50">
-                      <input
+                      <Input
+                        variant="unstyled"
                         type="text"
                         value={branchSearch}
                         onChange={(e) => setBranchSearch(e.target.value)}
@@ -513,7 +515,8 @@ export function WorkspaceSelector({
             <div className="px-4 pt-3">
               <div className="relative">
                 <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-quaternary dark:text-text-dark-quaternary" />
-                <input
+                <Input
+                  variant="unstyled"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Search workspaces…"
@@ -562,7 +565,8 @@ export function WorkspaceSelector({
                   <Box className="h-3.5 w-3.5 text-text-quaternary dark:text-text-dark-quaternary" />
                   Empty workspace
                 </div>
-                <input
+                <Input
+                  variant="unstyled"
                   value={emptyName}
                   onChange={(e) => setEmptyName(e.target.value)}
                   onKeyDown={(e) => {
@@ -622,7 +626,8 @@ export function WorkspaceSelector({
                   <>
                     <div className="relative">
                       <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-quaternary dark:text-text-dark-quaternary" />
-                      <input
+                      <Input
+                        variant="unstyled"
                         value={repoSearchQuery}
                         onChange={(e) => setRepoSearchQuery(e.target.value)}
                         placeholder="Search repositories…"
@@ -660,7 +665,8 @@ export function WorkspaceSelector({
                   </>
                 ) : (
                   <>
-                    <input
+                    <Input
+                      variant="unstyled"
                       value={gitUrl}
                       onChange={(e) => setGitUrl(e.target.value)}
                       onKeyDown={(e) => {

--- a/frontend/src/components/editor/file-tree/SearchInput.tsx
+++ b/frontend/src/components/editor/file-tree/SearchInput.tsx
@@ -2,6 +2,7 @@ import { useRef, type ChangeEvent, type KeyboardEvent } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { Search, X } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { Input } from '@/components/ui/primitives/Input';
 import { cn } from '@/utils/cn';
 
 export interface SearchInputProps {
@@ -62,8 +63,9 @@ export function SearchInput({
     <div role="search" className={cn('relative flex items-center', className)}>
       <Search className="pointer-events-none absolute left-2 h-3 w-3 text-text-quaternary dark:text-text-dark-quaternary" />
 
-      <input
+      <Input
         ref={inputRef}
+        variant="unstyled"
         type="text"
         role="searchbox"
         aria-label="Search files"
@@ -80,7 +82,6 @@ export function SearchInput({
           'border border-border/50 dark:border-border-dark/50',
           'rounded-md',
           'focus:border-border-hover focus:outline-none dark:focus:border-border-dark-hover',
-          'focus-visible:ring-1 focus-visible:ring-text-quaternary/30',
           'transition-colors duration-150',
         )}
       />

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { Header, type HeaderProps } from './Header';
 import { TitleBar } from './TitleBar';
+import { Link } from '@/components/ui/primitives/Link';
 import { cn } from '@/utils/cn';
 import { LayoutContext, type LayoutContextValue } from './layoutState';
 import { useUIStore } from '@/store/uiStore';
@@ -61,12 +62,13 @@ export function Layout({
   return (
     <LayoutContext.Provider value={contextValue}>
       <div className={cn('h-viewport flex flex-col', className)}>
-        <a
+        <Link
           href="#main-content"
+          variant="unstyled"
           className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[300] focus:rounded-md focus:bg-surface focus:px-4 focus:py-2 focus:text-sm focus:text-text-primary focus:shadow-strong dark:focus:bg-surface-dark dark:focus:text-text-dark-primary"
         >
           Skip to main content
-        </a>
+        </Link>
         <TitleBar />
         {showHeader && <Header isAuthPage={isAuthPage} />}
 

--- a/frontend/src/components/layout/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar.tsx
@@ -34,7 +34,7 @@ export function TrafficLights() {
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <button
+      <Button
         type="button"
         onClick={handleClose}
         className="group flex h-3 w-3 items-center justify-center rounded-full bg-[#ff5f57] transition-opacity hover:opacity-90"
@@ -50,8 +50,8 @@ export function TrafficLights() {
             />
           </svg>
         )}
-      </button>
-      <button
+      </Button>
+      <Button
         type="button"
         onClick={handleMinimize}
         className="group flex h-3 w-3 items-center justify-center rounded-full bg-[#febc2e] transition-opacity hover:opacity-90"
@@ -62,8 +62,8 @@ export function TrafficLights() {
             <path d="M0.5 1H5.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
           </svg>
         )}
-      </button>
-      <button
+      </Button>
+      <Button
         type="button"
         onClick={handleMaximize}
         className="group flex h-3 w-3 items-center justify-center rounded-full bg-[#28c840] transition-opacity hover:opacity-90"
@@ -80,7 +80,7 @@ export function TrafficLights() {
             />
           </svg>
         )}
-      </button>
+      </Button>
     </div>
   );
 }

--- a/frontend/src/components/settings/inputs/SecretInput.tsx
+++ b/frontend/src/components/settings/inputs/SecretInput.tsx
@@ -1,6 +1,7 @@
 import { Eye, EyeOff } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { Input } from '@/components/ui/primitives/Input';
+import { Link } from '@/components/ui/primitives/Link';
 import { cn } from '@/utils/cn';
 import type { HelperTextLink, HelperTextCode } from '@/types/settings.types';
 
@@ -33,14 +34,15 @@ const renderHelperText = (helperText?: HelperTextLink | HelperTextCode) => {
     return (
       <p className="mt-1.5 break-words text-2xs text-text-quaternary dark:text-text-dark-quaternary">
         {helperText.prefix}{' '}
-        <a
+        <Link
           href={helperText.href}
+          variant="unstyled"
           target="_blank"
           rel="noopener noreferrer"
           className="break-all text-text-primary underline hover:text-text-secondary dark:text-text-dark-primary dark:hover:text-text-dark-secondary"
         >
           {helperText.anchorText}
-        </a>
+        </Link>
       </p>
     );
   }

--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { Button } from '@/components/ui/primitives/Button';
+import { Input } from '@/components/ui/primitives/Input';
 import { createPortal } from 'react-dom';
 import {
   MessagesSquare,
@@ -453,8 +454,9 @@ export function CommandMenu() {
             </Button>
           )}
           <Search className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
-          <input
+          <Input
             ref={inputRef}
+            variant="unstyled"
             value={query}
             onChange={(e) => {
               setQuery(e.target.value);

--- a/frontend/src/components/ui/MarkDown.tsx
+++ b/frontend/src/components/ui/MarkDown.tsx
@@ -5,6 +5,7 @@ import type { Components } from 'react-markdown';
 import type { AnchorHTMLAttributes, HTMLAttributes, ImgHTMLAttributes } from 'react';
 import { AttachmentViewer } from './AttachmentViewer';
 import { Button } from './primitives/Button';
+import { Link } from './primitives/Link';
 import type { MessageAttachment } from '@/types/chat.types';
 import { isImageUrl } from '@/utils/fileTypes';
 
@@ -338,15 +339,16 @@ function MarkDownInner({ content, className = '' }: { content: string; className
         }
 
         return (
-          <a
+          <Link
             href={href}
+            variant="unstyled"
             className="text-text-primary underline transition-colors hover:text-text-secondary dark:text-text-dark-primary dark:hover:text-text-dark-secondary"
             target="_blank"
             rel="noopener noreferrer"
             {...props}
           >
             {children}
-          </a>
+          </Link>
         );
       },
 

--- a/frontend/src/components/ui/primitives/Input.tsx
+++ b/frontend/src/components/ui/primitives/Input.tsx
@@ -18,7 +18,18 @@ export function Input({
   ...props
 }: InputProps) {
   if (variant === 'unstyled') {
-    return <input ref={ref} type={type} className={className} disabled={disabled} {...props} />;
+    return (
+      <input
+        ref={ref}
+        type={type}
+        className={cn(
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-quaternary/30 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        disabled={disabled}
+        {...props}
+      />
+    );
   }
 
   return (

--- a/frontend/src/components/ui/primitives/Link.tsx
+++ b/frontend/src/components/ui/primitives/Link.tsx
@@ -1,0 +1,33 @@
+import { type AnchorHTMLAttributes, type Ref } from 'react';
+import { cn } from '@/utils/cn';
+
+export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  ref?: Ref<HTMLAnchorElement>;
+  variant?: 'default' | 'unstyled';
+}
+
+export function Link({ ref, className, variant = 'default', ...props }: LinkProps) {
+  if (variant === 'unstyled') {
+    return (
+      <a
+        ref={ref}
+        className={cn(
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-quaternary/30',
+          className,
+        )}
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <a
+      ref={ref}
+      className={cn(
+        'text-text-primary underline transition-colors hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-quaternary/30 dark:text-text-dark-primary dark:hover:text-text-dark-secondary',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/primitives/Textarea.tsx
+++ b/frontend/src/components/ui/primitives/Textarea.tsx
@@ -5,9 +5,31 @@ import { baseInputClasses, inputErrorClasses } from './inputStyles';
 export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   ref?: Ref<HTMLTextAreaElement>;
   hasError?: boolean;
+  variant?: 'default' | 'unstyled';
 }
 
-export function Textarea({ ref, className, hasError = false, disabled, ...props }: TextareaProps) {
+export function Textarea({
+  ref,
+  className,
+  hasError = false,
+  disabled,
+  variant = 'default',
+  ...props
+}: TextareaProps) {
+  if (variant === 'unstyled') {
+    return (
+      <textarea
+        ref={ref}
+        className={cn(
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-quaternary/30 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        disabled={disabled}
+        {...props}
+      />
+    );
+  }
+
   return (
     <textarea
       ref={ref}

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/primitives/Button';
 import { FieldMessage } from '@/components/ui/primitives/FieldMessage';
 import { Input } from '@/components/ui/primitives/Input';
 import { Label } from '@/components/ui/primitives/Label';
+import { Link } from '@/components/ui/primitives/Link';
 import { useForgotPasswordMutation } from '@/hooks/queries/useAuthQueries';
 import { useAuthForm } from '@/hooks/useAuthForm';
 import { isValidEmail } from '@/utils/validation';
@@ -101,12 +102,13 @@ export function ForgotPasswordPage() {
               {forgotPasswordMutation.error.message.includes('contact@agentrove.pro') ? (
                 <>
                   Email not found. Please check your email or contact support at{' '}
-                  <a
+                  <Link
                     href="mailto:contact@agentrove.pro"
+                    variant="unstyled"
                     className="underline transition-colors hover:text-error-500 dark:hover:text-error-300"
                   >
                     contact@agentrove.pro
-                  </a>
+                  </Link>
                 </>
               ) : (
                 forgotPasswordMutation.error.message

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -21,6 +21,7 @@ import { useFilesMetadataQuery } from '@/hooks/queries/useSandboxQueries';
 import { useModelSelection } from '@/hooks/queries/useModelQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
 import { ChatProvider } from '@/contexts/ChatContext';
+import { Button } from '@/components/ui/primitives/Button';
 import { buildFileStructureFromSandboxFiles } from '@/utils/file';
 
 const EXAMPLE_PROMPTS = [
@@ -216,14 +217,15 @@ export function LandingPage() {
 
             <div className="mt-4 flex flex-wrap justify-center gap-2 px-4 sm:px-6">
               {EXAMPLE_PROMPTS.map((prompt) => (
-                <button
+                <Button
                   key={prompt}
                   type="button"
+                  variant="unstyled"
                   onClick={() => setMessage(prompt)}
                   className="rounded-lg border border-border/50 px-3 py-2 text-2xs text-text-tertiary transition-colors duration-200 hover:border-border-hover hover:bg-surface-hover hover:text-text-primary dark:border-border-dark/50 dark:text-text-dark-tertiary dark:hover:border-border-dark-hover dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
                 >
                   {prompt}
-                </button>
+                </Button>
               ))}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Add new `Link` primitive component (`components/ui/primitives/Link.tsx`) with `default` and `unstyled` variants
- Add `unstyled` variant to `Textarea` primitive with consistent focus-visible and disabled styles
- Enhance `Input` unstyled variant with focus-visible ring and disabled styles
- Migrate all remaining raw `<input>`, `<textarea>`, `<select>`, `<a>`, and `<button>` elements across 18 components to their corresponding UI primitives (`Input`, `Textarea`, `Select`, `Link`, `Button`)
- Add `htmlFor` attributes to labels in `CreatePRDialog` for accessibility
- Remove duplicate `### Button Layout` heading in CLAUDE.md

## Test plan
- [ ] Verify focus-visible ring appears on all migrated inputs, textareas, links, and buttons
- [ ] Test disabled state styling on inputs and textareas
- [ ] Verify traffic light buttons (close/minimize/maximize) in TitleBar still function
- [ ] Test dialog forms: CreateBranchDialog, CreateCommitDialog, CreatePRDialog, CreateSubThreadDialog
- [ ] Test WorkspaceSelector search inputs and branch search
- [ ] Test CommandMenu search input
- [ ] Test file tree SearchInput
- [ ] Test QueueMessageCard inline editing
- [ ] Test ThinkingBlock expand/collapse
- [ ] Test LandingPage example prompt buttons
- [ ] Verify markdown links render correctly
- [ ] Test SecretInput helper text links
- [ ] Test ForgotPasswordPage error message link