### PR TITLE
Fix UI primitive migration regressions (traffic lights, input focus ring)

### DIFF
--- a/frontend/src/components/layout/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar.tsx
@@ -36,6 +36,7 @@ export function TrafficLights() {
     >
       <Button
         type="button"
+        variant="unstyled"
         onClick={handleClose}
         className="group flex h-3 w-3 items-center justify-center rounded-full bg-[#ff5f57] transition-opacity hover:opacity-90"
         aria-label="Close window"
@@ -53,6 +54,7 @@ export function TrafficLights() {
       </Button>
       <Button
         type="button"
+        variant="unstyled"
         onClick={handleMinimize}
         className="group flex h-3 w-3 items-center justify-center rounded-full bg-[#febc2e] transition-opacity hover:opacity-90"
         aria-label="Minimize window"
@@ -65,6 +67,7 @@ export function TrafficLights() {
       </Button>
       <Button
         type="button"
+        variant="unstyled"
         onClick={handleMaximize}
         className="group flex h-3 w-3 items-center justify-center rounded-full bg-[#28c840] transition-opacity hover:opacity-90"
         aria-label="Maximize window"

--- a/frontend/src/components/ui/primitives/Input.tsx
+++ b/frontend/src/components/ui/primitives/Input.tsx
@@ -23,7 +23,7 @@ export function Input({
         ref={ref}
         type={type}
         className={cn(
-          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-quaternary/30 disabled:cursor-not-allowed disabled:opacity-50',
+          'focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         disabled={disabled}

--- a/frontend/src/components/ui/primitives/Textarea.tsx
+++ b/frontend/src/components/ui/primitives/Textarea.tsx
@@ -21,7 +21,7 @@ export function Textarea({
       <textarea
         ref={ref}
         className={cn(
-          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-text-quaternary/30 disabled:cursor-not-allowed disabled:opacity-50',
+          'focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         disabled={disabled}


### PR DESCRIPTION
## Summary
- Add `variant="unstyled"` to TrafficLights buttons — the migration to `Button` primitive defaulted to `primary` variant, which added `h-10 rounded-lg px-4` styles that broke the custom `h-3 w-3 rounded-full` traffic light sizing
- Remove `focus-visible:ring-1` from unstyled `Input` and `Textarea` variants — the focus ring created an unwanted border around the chat input textarea; unstyled variants should defer all visual styling to the consumer's `className`

## Test plan
- [ ] Verify traffic light buttons (close/minimize/maximize) render at correct 12px size
- [ ] Verify chat input textarea has no visible border/ring when focused
- [ ] Verify unstyled Input components (e.g., file tree search) have no unwanted focus ring