### PR TITLE
Keep model selector enabled during streaming

### DIFF
--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -34,7 +34,7 @@ export function InputControls() {
         chatId={state.chatId}
         dropdownPosition={state.dropdownPosition}
         dropdownAlign="right"
-        disabled={state.isLoading || state.isStreaming}
+        disabled={state.isLoading}
         lockedAgentKind={lockedAgentKind}
         variant="text"
       />


### PR DESCRIPTION
## Summary
- Remove `isStreaming` from the model selector's `disabled` condition so users can switch models for queued messages while a response is being streamed

## Test plan
- [ ] Start a chat and send a message that triggers streaming
- [ ] Verify the model selector remains clickable during streaming
- [ ] Switch models while streaming and send a new message — confirm it uses the newly selected model