### PR TITLE
Fix New thread button contrast in light mode

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -632,7 +632,7 @@ export function Sidebar({
           <Button
             onClick={handleNewChat}
             variant="unstyled"
-            className="flex w-full items-center justify-center gap-2.5 rounded-lg bg-surface-tertiary/50 px-2 py-2 text-[13px] font-medium text-text-secondary transition-colors duration-200 hover:bg-surface-tertiary hover:text-text-primary dark:bg-surface-dark-tertiary/50 dark:text-text-dark-secondary dark:hover:bg-surface-dark-tertiary dark:hover:text-text-dark-primary"
+            className="flex w-full items-center justify-center gap-2.5 rounded-lg bg-surface-tertiary px-2 py-2 text-[13px] font-medium text-text-secondary transition-colors duration-200 hover:bg-surface-tertiary hover:text-text-primary dark:bg-surface-dark-tertiary/50 dark:text-text-dark-secondary dark:hover:bg-surface-dark-tertiary dark:hover:text-text-dark-primary"
           >
             <Plus className="h-3.5 w-3.5" />
             New thread


### PR DESCRIPTION
## Summary
- Remove 50% opacity from the light-mode background of the "New thread" button in the sidebar
- `bg-surface-tertiary/50` → `bg-surface-tertiary` so the button is visible against the white sidebar background
- Dark mode kept at `/50` as it already has sufficient perceptual contrast

## Test plan
- [ ] Verify the "New thread" button is visibly distinct in light mode
- [ ] Verify the button still looks subtle and consistent in dark mode
- [ ] Verify hover state still works correctly in both modes