### PR TITLE
Improve branch selector density and pin current branch

### DIFF
--- a/frontend/src/components/chat/branch-selector/BranchSelector.tsx
+++ b/frontend/src/components/chat/branch-selector/BranchSelector.tsx
@@ -1,7 +1,7 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import toast from 'react-hot-toast';
 import { GitBranch } from 'lucide-react';
-import { Dropdown } from '@/components/ui/primitives/Dropdown';
+import { Dropdown, DropdownItemType } from '@/components/ui/primitives/Dropdown';
 import { useChatContext } from '@/hooks/useChatContext';
 import { useIsSplitMode } from '@/hooks/useIsSplitMode';
 import { useChatStore } from '@/store/chatStore';
@@ -27,17 +27,29 @@ export const BranchSelector = memo(function BranchSelector({
   const { data: branchesData } = useGitBranchesQuery(sandboxId, !!sandboxId, worktreeCwd);
   const checkoutBranch = useCheckoutBranchMutation();
 
+  // Pin current branch at top with a divider separating it from the rest
+  const groupedItems = useMemo<DropdownItemType<string>[]>(() => {
+    if (!branchesData) return [];
+    const current = branchesData.current_branch;
+    const others = branchesData.branches.filter((b) => b !== current);
+    const items: DropdownItemType<string>[] = [{ type: 'item', data: current }];
+    if (others.length > 0) {
+      items.push({ type: 'header', label: 'Branches' });
+      others.forEach((b) => items.push({ type: 'item', data: b }));
+    }
+    return items;
+  }, [branchesData]);
+
   if (!sandboxId || !branchesData?.is_git_repo || branchesData.branches.length === 0) {
     return null;
   }
 
   const currentBranch = branchesData.current_branch;
-  const branches = branchesData.branches;
 
   return (
     <Dropdown
       value={currentBranch}
-      items={branches}
+      items={groupedItems}
       getItemKey={(branch) => branch}
       getItemLabel={(branch) => branch}
       onSelect={(branch) => {
@@ -60,15 +72,16 @@ export const BranchSelector = memo(function BranchSelector({
       }}
       leftIcon={GitBranch}
       getItemShortLabel={(branch) => (branch.length > 16 ? branch.slice(0, 16) + '…' : branch)}
-      width="w-48"
+      width="w-64"
       dropdownPosition={dropdownPosition}
       disabled={disabled || checkoutBranch.isPending}
       compactOnMobile
       forceCompact={isSplitMode}
       triggerVariant={variant}
       dropdownAlign={dropdownAlign}
-      searchable={branches.length >= 6}
+      searchable={branchesData.branches.length >= 6}
       searchPlaceholder="Search branches..."
+      searchVariant="underline"
       itemClassName="font-mono"
     />
   );

--- a/frontend/src/components/chat/workspace-selector/WorkspaceSelector.tsx
+++ b/frontend/src/components/chat/workspace-selector/WorkspaceSelector.tsx
@@ -32,6 +32,7 @@ import { isTauri } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
 
 const VISIBLE_LIMIT = 5;
+const EMPTY_BRANCHES: string[] = [];
 
 type CreationMode = 'none' | 'menu' | 'empty' | 'git';
 
@@ -110,10 +111,20 @@ function WorkspaceItem({
   const checkoutBranch = useCheckoutBranchMutation();
 
   const showBranchSelector = branchesData?.is_git_repo === true;
-  const branches = branchesData?.branches ?? [];
-  const filteredBranches = branchSearch
-    ? branches.filter((b) => b.toLowerCase().includes(branchSearch.toLowerCase()))
-    : branches;
+  const branches = branchesData?.branches ?? EMPTY_BRANCHES;
+
+  // Pin current branch at top so it's always visible without scrolling
+  const currentBranch = branchesData?.current_branch;
+  const sortedBranches = useMemo(() => {
+    const searchLower = branchSearch.toLowerCase();
+    const filtered = branchSearch
+      ? branches.filter((b) => b.toLowerCase().includes(searchLower))
+      : branches;
+    if (!currentBranch) return filtered;
+    const others = filtered.filter((b) => b !== currentBranch);
+    const currentVisible = !branchSearch || currentBranch.toLowerCase().includes(searchLower);
+    return currentVisible ? [currentBranch, ...others] : others;
+  }, [branches, currentBranch, branchSearch]);
 
   return (
     <div>
@@ -209,57 +220,65 @@ function WorkspaceItem({
                     </div>
                   )}
                   <div className="max-h-[10rem] overflow-y-auto">
-                    {filteredBranches.length === 0 ? (
+                    {sortedBranches.length === 0 ? (
                       <p className="px-2 py-2 text-center text-2xs text-text-quaternary dark:text-text-dark-quaternary">
                         No matching branches
                       </p>
                     ) : (
                       <div className="flex flex-col py-0.5">
-                        {filteredBranches.map((branch) => {
+                        {sortedBranches.map((branch, index) => {
                           const isCurrent = branch === branchesData.current_branch;
+                          // Divider after pinned current branch to visually separate it
+                          const showDivider = isCurrent && index === 0 && sortedBranches.length > 1;
                           return (
-                            <Button
-                              variant="unstyled"
-                              key={branch}
-                              type="button"
-                              disabled={checkoutBranch.isPending}
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                if (isCurrent) return;
-                                checkoutBranch.mutate(
-                                  { sandboxId: ws.sandbox_id, branch },
-                                  {
-                                    onSuccess: (data) => {
-                                      if (data.success) {
-                                        toast.success(`Switched to ${branch}`);
-                                      } else {
-                                        toast.error(data.error ?? 'Failed to switch branch');
-                                      }
+                            <div key={branch}>
+                              <Button
+                                variant="unstyled"
+                                type="button"
+                                disabled={checkoutBranch.isPending}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  if (isCurrent) return;
+                                  checkoutBranch.mutate(
+                                    { sandboxId: ws.sandbox_id, branch },
+                                    {
+                                      onSuccess: (data) => {
+                                        if (data.success) {
+                                          toast.success(`Switched to ${branch}`);
+                                        } else {
+                                          toast.error(data.error ?? 'Failed to switch branch');
+                                        }
+                                      },
+                                      onError: (err) => {
+                                        toast.error(
+                                          err instanceof Error
+                                            ? err.message
+                                            : 'Failed to switch branch',
+                                        );
+                                      },
                                     },
-                                    onError: (err) => {
-                                      toast.error(
-                                        err instanceof Error
-                                          ? err.message
-                                          : 'Failed to switch branch',
-                                      );
-                                    },
-                                  },
-                                );
-                              }}
-                              className={cn(
-                                'flex w-full items-center gap-1.5 px-2 py-1 text-left text-2xs transition-colors duration-200 disabled:opacity-50',
-                                isCurrent
-                                  ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
-                                  : 'text-text-secondary hover:bg-surface-hover dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover',
+                                  );
+                                }}
+                                className={cn(
+                                  'flex w-full items-center gap-1.5 px-2 py-1 text-left text-2xs transition-colors duration-200 disabled:opacity-50',
+                                  isCurrent
+                                    ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
+                                    : 'text-text-secondary hover:bg-surface-hover dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover',
+                                )}
+                              >
+                                {isCurrent ? (
+                                  <Check className="h-3 w-3 shrink-0" />
+                                ) : (
+                                  <span className="h-3 w-3 shrink-0" />
+                                )}
+                                <span className="truncate font-mono" title={branch}>
+                                  {branch}
+                                </span>
+                              </Button>
+                              {showDivider && (
+                                <div className="my-0.5 border-t border-border/50 dark:border-border-dark/50" />
                               )}
-                            >
-                              {isCurrent ? (
-                                <Check className="h-3 w-3 shrink-0" />
-                              ) : (
-                                <span className="h-3 w-3 shrink-0" />
-                              )}
-                              <span className="truncate font-mono">{branch}</span>
-                            </Button>
+                            </div>
                           );
                         })}
                       </div>

--- a/frontend/src/components/ui/primitives/Dropdown.tsx
+++ b/frontend/src/components/ui/primitives/Dropdown.tsx
@@ -306,11 +306,12 @@ function DropdownInner<T>({
                       renderItem(item, isSelected)
                     ) : (
                       <span
-                        className={`text-2xs font-medium ${
+                        className={`block truncate text-2xs font-medium ${
                           isSelected
                             ? 'text-text-primary dark:text-text-dark-primary'
                             : 'text-text-secondary dark:text-text-dark-secondary'
                         }`}
+                        title={getItemLabel(item)}
                       >
                         {getItemLabel(item)}
                       </span>


### PR DESCRIPTION
## Summary
- Widen branch dropdown from `w-48` to `w-64` so long branch names display with single-line ellipsis instead of wrapping to multiple lines
- Pin current branch at top with a visual divider in both `BranchSelector` dropdown and `WorkspaceSelector` inline branch list
- Add `truncate` + `title` tooltip to `Dropdown` item labels for consistent overflow handling
- Switch `BranchSelector` search to underline variant for a cleaner, less heavy look

## Test plan
- [ ] Open branch selector dropdown — verify current branch appears first with check mark, followed by a "Branches" header divider, then remaining branches
- [ ] Verify long branch names truncate with ellipsis (not wrap) and show full name on hover
- [ ] Open workspace selector modal — expand branch list on a git workspace, verify current branch is pinned at top with a separator line
- [ ] Search branches in both selectors — verify current branch respects search filter
- [ ] Test in both light and dark mode
- [ ] Test compact/mobile view still works (icon-only trigger)