### PR TITLE
Improve DiffView header UX

### DIFF
--- a/frontend/src/components/ui/primitives/SegmentedControl.tsx
+++ b/frontend/src/components/ui/primitives/SegmentedControl.tsx
@@ -1,5 +1,21 @@
-import { useRef, useLayoutEffect, useCallback, useState, type ReactNode } from 'react';
+import { useRef, useLayoutEffect, useCallback, useMemo, useState, type ReactNode } from 'react';
 import { cn } from '@/utils/cn';
+
+type SegmentSize = 'sm' | 'md';
+
+const SIZE_CLASSES: Record<SegmentSize, { container: string; indicator: string; button: string }> =
+  {
+    sm: {
+      container: 'rounded-md',
+      indicator: 'rounded-[5px]',
+      button: 'rounded-[5px] px-2.5 py-1 text-2xs',
+    },
+    md: {
+      container: 'rounded-lg',
+      indicator: 'rounded-[7px]',
+      button: 'rounded-[7px] px-3.5 py-1.5 text-xs',
+    },
+  };
 
 export interface SegmentOption<T extends string = string> {
   value: T;
@@ -11,6 +27,7 @@ export interface SegmentedControlProps<T extends string = string> {
   options: SegmentOption<T>[];
   value: T;
   onChange: (value: T) => void;
+  size?: SegmentSize;
   className?: string;
 }
 
@@ -18,6 +35,7 @@ export function SegmentedControl<T extends string = string>({
   options,
   value,
   onChange,
+  size = 'md',
   className,
 }: SegmentedControlProps<T>) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -58,20 +76,69 @@ export function SegmentedControl<T extends string = string>({
     return () => observer.disconnect();
   }, [updateIndicator]);
 
+  const enabledIndices = useMemo(
+    () =>
+      options.reduce<number[]>((acc, o, i) => {
+        if (!o.disabled) acc.push(i);
+        return acc;
+      }, []),
+    [options],
+  );
+
+  // Roving tabindex: arrow keys move focus+selection, only active item is tabbable
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, currentIndex: number) => {
+      const pos = enabledIndices.indexOf(currentIndex);
+      if (pos < 0) return;
+
+      let nextIndex: number | undefined;
+
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        nextIndex = enabledIndices[(pos + 1) % enabledIndices.length];
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        nextIndex = enabledIndices[(pos - 1 + enabledIndices.length) % enabledIndices.length];
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        nextIndex = enabledIndices[0];
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        nextIndex = enabledIndices[enabledIndices.length - 1];
+      }
+
+      if (nextIndex != null) {
+        onChange(options[nextIndex].value);
+        const buttons = containerRef.current?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+        buttons?.[nextIndex]?.focus();
+      }
+    },
+    [enabledIndices, options, onChange],
+  );
+
+  // Active option if enabled, otherwise first enabled option — ensures at least
+  // one button stays tabbable even when value is stale or the selected option is disabled
+  const activeIdx = options.findIndex((o) => o.value === value && !o.disabled);
+  const tabbableIdx = activeIdx >= 0 ? activeIdx : options.findIndex((o) => !o.disabled);
+
   return (
     <div
       ref={containerRef}
       className={cn(
-        'relative inline-flex rounded-lg border border-border bg-surface-tertiary dark:border-border-dark dark:bg-surface-dark-secondary',
+        'relative inline-flex border border-border bg-surface-tertiary dark:border-border-dark dark:bg-surface-dark-secondary',
+        SIZE_CLASSES[size].container,
         className,
       )}
       role="radiogroup"
     >
       <span
-        className="absolute left-0 top-0 rounded-[7px] bg-surface-secondary shadow-sm transition-[transform,width,height] duration-300 ease-out dark:bg-surface-dark-hover"
+        className={cn(
+          'absolute left-0 top-0 bg-surface-secondary shadow-sm transition-[transform,width,height] duration-300 ease-out dark:bg-surface-dark-hover',
+          SIZE_CLASSES[size].indicator,
+        )}
         style={indicatorStyle}
       />
-      {options.map((option) => {
+      {options.map((option, index) => {
         const isActive = value === option.value;
         return (
           <button
@@ -79,10 +146,13 @@ export function SegmentedControl<T extends string = string>({
             type="button"
             role="radio"
             aria-checked={isActive}
+            tabIndex={index === tabbableIdx ? 0 : -1}
             disabled={option.disabled}
             onClick={() => !option.disabled && onChange(option.value)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
             className={cn(
-              'relative z-10 rounded-[7px] px-3.5 py-1.5 text-xs font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-quaternary/30',
+              'relative z-10 font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-quaternary/30',
+              SIZE_CLASSES[size].button,
               isActive
                 ? 'text-text-primary dark:text-text-dark-primary'
                 : 'text-text-quaternary hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary',

--- a/frontend/src/components/views/DiffView.tsx
+++ b/frontend/src/components/views/DiffView.tsx
@@ -1,18 +1,9 @@
 import { memo, useMemo, useState, useEffect, useCallback, useRef } from 'react';
 import { useToggleSet } from '@/hooks/useToggleSet';
-import {
-  AlertCircle,
-  ChevronRight,
-  ChevronsDownUp,
-  ChevronsUpDown,
-  Columns2,
-  GitCompareArrows,
-  Rows2,
-  RotateCcw,
-} from 'lucide-react';
+import { AlertCircle, ChevronRight, GitCompareArrows, RotateCcw } from 'lucide-react';
 import { FileIcon } from '@/components/editor/file-tree/FileIcon';
 import { Button } from '@/components/ui/primitives/Button';
-import { Dropdown } from '@/components/ui/primitives/Dropdown';
+import { SegmentedControl } from '@/components/ui/primitives/SegmentedControl';
 import { Spinner } from '@/components/ui/primitives/Spinner';
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary';
 import { useGitDiffQuery } from '@/hooks/queries/useSandboxQueries';
@@ -23,16 +14,20 @@ import { cn } from '@/utils/cn';
 
 const DIFF_THEMES = { dark: 'pierre-dark', light: 'pierre-light' } as const;
 
-const DIFF_MODES: DiffMode[] = ['all', 'staged', 'unstaged', 'branch'];
-const DIFF_MODE_LABELS: Record<DiffMode, string> = {
-  all: 'Uncommitted',
-  staged: 'Staged',
-  unstaged: 'Unstaged',
-  branch: 'Branch',
-};
+const DIFF_MODE_OPTIONS = [
+  { value: 'all', label: 'All' },
+  { value: 'staged', label: 'Staged' },
+  { value: 'unstaged', label: 'Unstaged' },
+  { value: 'branch', label: 'Branch' },
+] satisfies { value: DiffMode; label: string }[];
+
+const DIFF_STYLE_OPTIONS = [
+  { value: 'unified', label: 'Unified' },
+  { value: 'split', label: 'Split' },
+] satisfies { value: 'unified' | 'split'; label: string }[];
 
 const DIFF_EMPTY_LABELS: Record<DiffMode, string> = {
-  all: 'No uncommitted changes',
+  all: 'No changes',
   staged: 'No staged changes',
   unstaged: 'No unstaged changes',
   branch: 'No changes from base branch',
@@ -279,11 +274,11 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
 
   return (
     <div className="flex h-full w-full flex-col bg-surface-secondary dark:bg-surface-dark-secondary">
-      <div className="flex h-9 items-center gap-1 border-b border-border/50 px-3 dark:border-border-dark/50">
+      <div className="flex h-9 items-center gap-1.5 overflow-x-auto border-b border-border/50 px-3 [scrollbar-width:none] dark:border-border-dark/50 [&::-webkit-scrollbar]:hidden">
         <Button
           onClick={() => refetch()}
           variant="unstyled"
-          className="rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+          className="shrink-0 rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
           title="Refresh diff"
           aria-label="Refresh diff"
         >
@@ -292,51 +287,38 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
           />
         </Button>
 
-        <Dropdown
+        <SegmentedControl
+          options={DIFF_MODE_OPTIONS}
           value={mode}
-          items={DIFF_MODES}
-          getItemKey={(m) => m}
-          getItemLabel={(m) => DIFF_MODE_LABELS[m]}
-          onSelect={setMode}
-          width="w-32"
+          onChange={setMode}
+          size="sm"
+          className="shrink-0"
         />
 
-        <div className="flex-1" />
+        <div className="min-w-0 flex-1" />
 
         {showFiles && (
           <>
-            <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-              {parsedFiles.length} file{parsedFiles.length !== 1 ? 's' : ''}
-            </span>
             <Button
               onClick={toggleAll}
               variant="unstyled"
-              className="rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+              className="shrink-0 whitespace-nowrap text-2xs text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
               title={allExpanded ? 'Collapse all' : 'Expand all'}
               aria-label={allExpanded ? 'Collapse all' : 'Expand all'}
             >
-              {allExpanded ? (
-                <ChevronsDownUp className="h-3 w-3" />
-              ) : (
-                <ChevronsUpDown className="h-3 w-3" />
-              )}
+              {allExpanded ? 'Collapse all' : 'Expand all'}
             </Button>
+            <div className="h-3 w-px shrink-0 bg-border/50 dark:bg-border-dark/50" />
           </>
         )}
 
-        <Button
-          onClick={() => setDiffStyle(diffStyle === 'unified' ? 'split' : 'unified')}
-          variant="unstyled"
-          className="rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
-          title={diffStyle === 'unified' ? 'Split view' : 'Unified view'}
-          aria-label={diffStyle === 'unified' ? 'Split view' : 'Unified view'}
-        >
-          {diffStyle === 'unified' ? (
-            <Columns2 className="h-3 w-3" />
-          ) : (
-            <Rows2 className="h-3 w-3" />
-          )}
-        </Button>
+        <SegmentedControl
+          options={DIFF_STYLE_OPTIONS}
+          value={diffStyle}
+          onChange={setDiffStyle}
+          size="sm"
+          className="shrink-0"
+        />
       </div>
 
       <div className="relative min-h-0 flex-1 overflow-auto">


### PR DESCRIPTION
## Summary
- Replace cryptic icon-only buttons in the DiffView header with self-documenting controls: mode selector and view toggle use `SegmentedControl`, expand/collapse uses a text button
- Add `sm` size variant to `SegmentedControl` for compact toolbar use
- Add proper radiogroup keyboard accessibility to `SegmentedControl` (roving tabindex with stale-value fallback, arrow/Home/End navigation)
- Add overflow handling for narrow panes via hidden-scrollbar horizontal scroll

## Test plan
- [ ] Verify DiffView header renders correctly in both light and dark mode
- [ ] Switch between All/Staged/Unstaged/Branch modes via click and keyboard (arrow keys)
- [ ] Toggle between Unified/Split view
- [ ] Click Expand all / Collapse all and verify text toggles
- [ ] Narrow the DiffView pane and verify controls remain accessible via horizontal scroll
- [ ] Tab into the segmented controls and verify only one button per control is in the tab order
- [ ] Verify arrow keys wrap around and skip disabled options (if any)