### PR TITLE
Remove unused sandbox dep from WorkspaceService

### DIFF
--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -158,11 +158,9 @@ def get_git_service(
 
 
 async def get_workspace_service(
-    sandbox_service: SandboxService = Depends(get_sandbox_service),
     user_service: UserService = Depends(get_user_service),
 ) -> WorkspaceService:
     return WorkspaceService(
-        sandbox_service,
         user_service,
         session_factory=SessionLocal,
     )

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -45,12 +45,10 @@ GIT_CLONE_TIMEOUT_SECONDS = 180
 class WorkspaceService(BaseDbService[Workspace]):
     def __init__(
         self,
-        sandbox_service: SandboxService,
         user_service: UserService,
         session_factory: SessionFactoryType | None = None,
     ) -> None:
         super().__init__(session_factory)
-        self.sandbox_service = sandbox_service
         self.user_service = user_service
         self._base_dir = (Path(settings.STORAGE_PATH) / WORKSPACES_DIR_NAME).resolve()
         self._base_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- `WorkspaceService` stored `sandbox_service` but never used it — `create_workspace` builds its own `SandboxService` inline with the correct `workspace_path`.
- The unused dep chained `get_workspace_service` → `get_sandbox_service`, forcing every workspace endpoint (list/get/create/update/delete) to construct a provider up-front.
- For the host provider, that fails with `ValueError: workspace_path is required for host provider` when the URL has no `sandbox_id` (list/create/etc.).

## Test plan
- [ ] Create a workspace with host provider configured
- [ ] List workspaces with host provider configured
- [ ] Confirm sandbox-scoped endpoints (files, git, secrets) still work