### PR TITLE
Skip GitHub token injection in desktop mode

### DIFF
--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -396,7 +396,8 @@ class AgentService:
     ) -> AcpSessionConfig:
         env: dict[str, str] = {}
 
-        if user_settings.github_personal_access_token:
+        # Skip in desktop mode — host git credentials handle auth natively
+        if user_settings.github_personal_access_token and not settings.DESKTOP_MODE:
             env["GITHUB_TOKEN"] = user_settings.github_personal_access_token
             env["GIT_ASKPASS"] = SANDBOX_GIT_ASKPASS_PATH
         if settings.GIT_AUTHOR_NAME and settings.GIT_AUTHOR_EMAIL:

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -45,7 +45,9 @@ class SandboxService:
         if custom_env_vars:
             for ev in custom_env_vars:
                 envs[ev["key"]] = ev["value"]
-        if github_token:
+        # Desktop mode uses the host's native git credentials; only inject
+        # token-based auth inside Docker containers.
+        if github_token and not settings.DESKTOP_MODE:
             envs["GITHUB_TOKEN"] = github_token
             envs["GIT_ASKPASS"] = str(SANDBOX_GIT_ASKPASS_PATH)
         return envs

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -58,6 +58,14 @@ class WorkspaceService(BaseDbService[Workspace]):
         user_workspace_dir = (self._base_dir / str(user.id)).resolve()
         user_workspace_dir.mkdir(parents=True, exist_ok=True)
 
+        # Desktop mode uses the host's native git credentials; token-based
+        # auth is only needed inside Docker containers.
+        github_token: str | None = (
+            None
+            if settings.DESKTOP_MODE
+            else user_settings.github_personal_access_token
+        )
+
         if data.source_type == "git":
             if not data.git_url:
                 raise WorkspaceException(
@@ -69,7 +77,7 @@ class WorkspaceService(BaseDbService[Workspace]):
             workspace_path = await self._clone_git_workspace(
                 user_workspace_dir,
                 normalized_url,
-                github_token=user_settings.github_personal_access_token,
+                github_token=github_token,
             )
             source_url = normalized_url
         elif data.source_type == "local":
@@ -97,7 +105,7 @@ class WorkspaceService(BaseDbService[Workspace]):
         resolved_provider = data.sandbox_provider or user_settings.sandbox_provider
         env_vars = SandboxService.build_env_vars(
             user_settings.custom_env_vars,
-            user_settings.github_personal_access_token,
+            github_token,
         )
         provider = SandboxProvider.create_provider(
             SandboxProviderType(resolved_provider),
@@ -111,7 +119,7 @@ class WorkspaceService(BaseDbService[Workspace]):
 
         await sandbox_service.initialize_sandbox(
             sandbox_id=sandbox_id,
-            has_github_token=bool(user_settings.github_personal_access_token),
+            has_github_token=bool(github_token),
             auto_compact_disabled=user_settings.auto_compact_disabled,
             attribution_disabled=user_settings.attribution_disabled,
         )


### PR DESCRIPTION
## Summary
- Skip `GITHUB_TOKEN` / `GIT_ASKPASS` env var injection in desktop mode across agent, sandbox, and workspace services
- Desktop mode runs on the host where native git credentials (SSH keys, credential helpers, `.netrc`) handle authentication — token-based askpass injection is only needed inside Docker containers
- Compute the effective token once in `WorkspaceService.create_workspace` and reuse across clone, `build_env_vars`, and `initialize_sandbox`

## Test plan
- [ ] Verify Docker-mode workspaces with a GitHub PAT can still clone private repos
- [ ] Verify desktop-mode workspaces clone using host git credentials without injecting `GITHUB_TOKEN`
- [ ] Verify agent sessions in desktop mode do not set `GITHUB_TOKEN` or `GIT_ASKPASS` env vars