### PR TITLE
Fix blue focus outline on chat sidebar dropdown

### DIFF
--- a/frontend/src/components/layout/ChatDropdown.tsx
+++ b/frontend/src/components/layout/ChatDropdown.tsx
@@ -51,7 +51,7 @@ export const ChatDropdown = memo(function ChatDropdown({
         'fixed w-32',
         'bg-surface dark:bg-surface-dark',
         'border border-border dark:border-border-dark',
-        'z-50 overflow-hidden rounded-lg shadow-medium',
+        'z-50 overflow-hidden rounded-lg shadow-medium focus:outline-none',
       )}
       style={{
         top: `${position.top}px`,


### PR DESCRIPTION
## Summary
- The `ChatDropdown` div is programmatically focused on mount for keyboard navigation but was missing `focus:outline-none`, causing the browser's default blue focus outline to appear when clicking the 3-dot menu on sidebar chat items
- Added `focus:outline-none` to suppress the unwanted outline

## Test plan
- [ ] Click the 3-dot menu on a chat sidebar item and verify no blue border appears
- [ ] Verify keyboard navigation (Escape to close) still works