### PR TITLE
Refactor skills to be per-agent with simplified path resolution

### DIFF
--- a/backend/app/api/endpoints/skills.py
+++ b/backend/app/api/endpoints/skills.py
@@ -18,37 +18,31 @@ async def list_skills(
     return skill_service.list_all()
 
 
-@router.get("/{skill_name}/files", response_model=SkillFilesResponse)
+@router.get("/{source}/{skill_name}/files", response_model=SkillFilesResponse)
 async def get_skill_files(
+    source: str,
     skill_name: str,
     current_user: User = Depends(get_current_user),
     skill_service: SkillService = Depends(get_skill_service),
 ) -> SkillFilesResponse:
     try:
-        skill_service.validate_exact_sanitized_name(skill_name)
-        files = skill_service.get_files(skill_name)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        files = skill_service.get_files(source, skill_name)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
     return SkillFilesResponse(name=skill_name, files=files)
 
 
-@router.put("/{skill_name}", response_model=CustomSkillDict)
+@router.put("/{source}/{skill_name}", response_model=CustomSkillDict)
 async def update_skill(
+    source: str,
     skill_name: str,
     request: SkillUpdateRequest,
     current_user: User = Depends(get_current_user),
     skill_service: SkillService = Depends(get_skill_service),
 ) -> CustomSkillDict:
     try:
-        skill_service.validate_exact_sanitized_name(skill_name)
-        files_data: list[dict[str, str | bool]] = [
-            {"path": file.path, "content": file.content, "is_binary": file.is_binary}
-            for file in request.files
-        ]
-        return skill_service.update(skill_name, files_data)
+        return skill_service.update(source, skill_name, request.files)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except FileNotFoundError as exc:

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -1,5 +1,3 @@
-import os
-from pathlib import Path
 from typing import Final, NamedTuple
 
 from app.core.config import get_settings
@@ -13,25 +11,6 @@ class ModelInfo(NamedTuple):
     agent_kind: AgentKind
     context_window: int | None
 
-
-CLAUDE_DIR: Final[Path] = (
-    Path(d) if (d := os.environ.get("CLAUDE_CONFIG_DIR")) else Path.home() / ".claude"
-)
-CODEX_DIR: Final[Path] = (
-    Path(d) if (d := os.environ.get("CODEX_HOME")) else Path.home() / ".codex"
-)
-CLAUDE_SKILLS_DIR: Final[Path] = (
-    CLAUDE_DIR if settings.DESKTOP_MODE else Path(settings.STORAGE_PATH) / ".claude"
-) / "skills"
-CODEX_SKILLS_DIR: Final[Path] = (
-    CODEX_DIR if settings.DESKTOP_MODE else Path(settings.STORAGE_PATH) / ".codex"
-) / "skills"
-COPILOT_DIR: Final[Path] = (
-    Path(d) if (d := os.environ.get("COPILOT_HOME")) else Path.home() / ".copilot"
-)
-COPILOT_SKILLS_DIR: Final[Path] = (
-    COPILOT_DIR if settings.DESKTOP_MODE else Path(settings.STORAGE_PATH) / ".copilot"
-) / "skills"
 
 REDIS_KEY_CHAT_STREAM_LIVE: Final[str] = "chat:{chat_id}:stream:live"
 REDIS_KEY_USER_SETTINGS: Final[str] = "user_settings:{user_id}"
@@ -126,9 +105,6 @@ SANDBOX_BINARY_EXTENSIONS: Final[set[str]] = {
 
 SANDBOX_HOME_DIR: Final[str] = "/home/user"
 SANDBOX_WORKSPACE_DIR: Final[str] = "/home/user/workspace"
-SANDBOX_CLAUDE_DIR: Final[str] = "/home/user/.claude"
-SANDBOX_CODEX_DIR: Final[str] = "/home/user/.codex"
-SANDBOX_COPILOT_DIR: Final[str] = "/home/user/.copilot"
 SANDBOX_CLAUDE_JSON_PATH: Final[str] = "/home/user/.claude.json"
 SANDBOX_GIT_ASKPASS_PATH: Final[str] = "/home/user/.git-askpass.sh"
 

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -41,7 +41,7 @@ def get_refresh_token_service() -> RefreshTokenService:
 
 
 def get_skill_service() -> SkillService:
-    return SkillService(base_paths=SkillService.get_default_base_paths())
+    return SkillService()
 
 
 async def get_github_token(

--- a/backend/app/models/schemas/skills.py
+++ b/backend/app/models/schemas/skills.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, Field
 
 class SkillFileEntry(BaseModel):
     path: str = Field(..., max_length=4096)
-    content: str
+    content: str = Field(..., max_length=10_000_000)
     is_binary: bool = False
 
 

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -1,58 +1,58 @@
 import base64
 import json
 import logging
-import re
 import shutil
 import stat as stat_module
 import tempfile
 from pathlib import Path
 
-from app.constants import (
-    CLAUDE_DIR,
-    CLAUDE_SKILLS_DIR,
-    CODEX_SKILLS_DIR,
-    COPILOT_SKILLS_DIR,
-    SANDBOX_CLAUDE_DIR,
-    SANDBOX_CODEX_DIR,
-    SANDBOX_COPILOT_DIR,
-)
-from app.models.types import (
-    CustomSkillDict,
-    EnabledResourceInfo,
-    YamlMetadata,
-)
+from app.core.config import get_settings
+from app.models.schemas.skills import SkillFileEntry
+from app.models.types import CustomSkillDict
+from app.services.acp.adapters import AgentKind
 from app.utils.yaml_parser import YAMLParser
 
 logger = logging.getLogger(__name__)
+settings = get_settings()
 
-SKILL_SANDBOX_DIRS = (SANDBOX_CLAUDE_DIR, SANDBOX_CODEX_DIR, SANDBOX_COPILOT_DIR)
-SKILL_SOURCE_BY_DIR: dict[str, str] = {".codex": "codex", ".copilot": "copilot"}
-SKILL_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-_]*$")
+SKILL_MD_FILENAME = "SKILL.md"
 
 
 class SkillService:
-    def __init__(
-        self,
-        base_paths: tuple[Path, ...],
-    ) -> None:
-        self.skills_base_paths = base_paths
+    def __init__(self, workspace_path: Path | None = None) -> None:
+        self.paths_by_source = self._build_paths_by_source(workspace_path)
 
     @staticmethod
-    def get_default_base_paths() -> tuple[Path, ...]:
-        return (
-            CLAUDE_SKILLS_DIR,
-            CODEX_SKILLS_DIR,
-            COPILOT_SKILLS_DIR,
-            *SkillService._get_plugin_skill_paths(),
+    def _build_paths_by_source(workspace_path: Path | None) -> dict[str, list[Path]]:
+        # Desktop mode reads from the user's home dir, server mode from STORAGE_PATH
+        base = Path.home() if settings.DESKTOP_MODE else Path(settings.STORAGE_PATH)
+        # Agents that support the shared .agents/skills directory (Vercel skills ecosystem)
+        agents_dir_kinds = {AgentKind.CODEX, AgentKind.COPILOT}
+        result: dict[str, list[Path]] = {}
+        for kind in AgentKind:
+            paths: list[Path] = []
+            # Workspace-local paths first so they take priority over globals
+            if workspace_path:
+                paths.append(workspace_path / f".{kind.value}" / "skills")
+                if kind in agents_dir_kinds:
+                    paths.append(workspace_path / ".agents" / "skills")
+            paths.append(base / f".{kind.value}" / "skills")
+            if kind in agents_dir_kinds:
+                paths.append(base / ".agents" / "skills")
+            result[kind.value] = paths
+        # Claude plugins can also bundle skills
+        result[AgentKind.CLAUDE.value].extend(
+            SkillService._get_claude_plugin_skill_paths()
         )
+        return result
 
     @staticmethod
-    def _get_plugin_skill_paths() -> list[Path]:
-        # Cross-reference settings.json (enabled flags) with installed_plugins.json
-        # (install paths) to avoid walking the entire plugin cache directory tree.
-        plugins_dir = CLAUDE_DIR / "plugins"
-        settings_path = CLAUDE_DIR / "settings.json"
-        installed_path = plugins_dir / "installed_plugins.json"
+    def _get_claude_plugin_skill_paths() -> list[Path]:
+        # Claude-specific: cross-reference ~/.claude/settings.json (enabled flags)
+        # with installed_plugins.json (install paths) to discover plugin-bundled skills.
+        claude_dir = Path.home() / ".claude"
+        settings_path = claude_dir / "settings.json"
+        installed_path = claude_dir / "plugins" / "installed_plugins.json"
         if not settings_path.is_file() or not installed_path.is_file():
             return []
         try:
@@ -81,18 +81,6 @@ class SkillService:
         return paths
 
     @staticmethod
-    def _get_skill_source(base_path: Path) -> str:
-        return SKILL_SOURCE_BY_DIR.get(base_path.parent.name, "claude")
-
-    @staticmethod
-    def _find_skill_md(skill_dir: Path) -> Path | None:
-        # Skills follow the CLI's canonical filename; lowercase variants are not supported.
-        skill_md = skill_dir / "SKILL.md"
-        if skill_md.exists():
-            return skill_md
-        return None
-
-    @staticmethod
     def _compute_dir_stats(directory: Path) -> tuple[int, int]:
         file_count = 0
         total_size = 0
@@ -106,98 +94,79 @@ class SkillService:
                 total_size += st.st_size
         return file_count, total_size
 
-    @staticmethod
-    def validate_exact_sanitized_name(name: str) -> None:
-        if not SKILL_NAME_RE.fullmatch(name):
-            raise ValueError("Invalid skill name format")
-
-    @staticmethod
-    def _parse_skill_metadata(content: str) -> YamlMetadata:
-        metadata = YAMLParser.parse(content)
-        name = metadata.get("name")
-        description = metadata.get("description")
-        if not isinstance(name, str) or not name.strip():
-            raise ValueError("YAML frontmatter must include 'name'")
-        if not isinstance(description, str):
-            raise ValueError("YAML frontmatter must include 'description'")
-        return metadata
-
-    def _validate_skill_dir(self, skill_dir: Path) -> tuple[YamlMetadata, int, int]:
-        skill_md = self._find_skill_md(skill_dir)
-        if not skill_md:
-            raise ValueError("Skill directory must contain a SKILL.md file")
-        try:
-            skill_content = skill_md.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError) as exc:
-            raise ValueError("SKILL.md must be valid UTF-8 text") from exc
-        metadata = self._parse_skill_metadata(skill_content)
-        file_count, total_size = self._compute_dir_stats(skill_dir)
-        return metadata, file_count, total_size
-
-    def _find_skill_dir(self, skill_name: str) -> Path | None:
-        for base_path in self.skills_base_paths:
+    def _find_skill_dir(self, source: str, skill_name: str) -> Path | None:
+        for base_path in self.paths_by_source.get(source, []):
             skill_dir = base_path / skill_name
-            if skill_dir.is_dir() and self._find_skill_md(skill_dir):
+            if skill_dir.is_dir() and (skill_dir / SKILL_MD_FILENAME).exists():
                 return skill_dir
         return None
 
     def list_all(self) -> list[CustomSkillDict]:
         skills: list[CustomSkillDict] = []
-        seen_skill_names: set[str] = set()
-        for base_path in self.skills_base_paths:
-            if not base_path.is_dir():
-                continue
-            for entry in base_path.iterdir():
-                if not entry.is_dir() or entry.name in seen_skill_names:
+        for source, paths in self.paths_by_source.items():
+            seen_names: set[str] = set()
+            for base_path in paths:
+                if not base_path.is_dir():
                     continue
-                skill_md = self._find_skill_md(entry)
-                if not skill_md:
-                    continue
-                try:
-                    content = skill_md.read_text(encoding="utf-8")
-                except (OSError, UnicodeDecodeError):
-                    continue
-                try:
-                    metadata = YAMLParser.parse(content)
-                except ValueError:
-                    metadata = {}
-                file_count, total_size = self._compute_dir_stats(entry)
-                skills.append(
-                    {
-                        "name": entry.name,
-                        "description": str(metadata.get("description", "")),
-                        "size_bytes": total_size,
-                        "file_count": file_count,
-                        "source": self._get_skill_source(base_path),
-                    }
-                )
-                seen_skill_names.add(entry.name)
+                for entry in base_path.iterdir():
+                    if not entry.is_dir() or entry.name in seen_names:
+                        continue
+                    skill_md = entry / SKILL_MD_FILENAME
+                    if not skill_md.exists():
+                        continue
+                    try:
+                        content = skill_md.read_text(encoding="utf-8")
+                    except (OSError, UnicodeDecodeError):
+                        continue
+                    try:
+                        metadata = YAMLParser.parse(content)
+                    except ValueError:
+                        metadata = {}
+                    file_count, total_size = self._compute_dir_stats(entry)
+                    skills.append(
+                        {
+                            "name": entry.name,
+                            "description": str(metadata.get("description", "")),
+                            "size_bytes": total_size,
+                            "file_count": file_count,
+                            "source": source,
+                        }
+                    )
+                    seen_names.add(entry.name)
         return skills
 
-    def get_files(self, skill_name: str) -> list[dict[str, str | bool]]:
-        skill_dir = self._find_skill_dir(skill_name)
+    def get_files(self, source: str, skill_name: str) -> list[SkillFileEntry]:
+        # Text files are returned as-is, binary files as base64-encoded strings.
+        skill_dir = self._find_skill_dir(source, skill_name)
         if skill_dir is None:
             raise FileNotFoundError(f"Skill '{skill_name}' not found")
 
-        files: list[dict[str, str | bool]] = []
+        files: list[SkillFileEntry] = []
         for file_path in sorted(skill_dir.rglob("*")):
             if not file_path.is_file():
                 continue
             rel_path = str(file_path.relative_to(skill_dir))
             try:
                 content = file_path.read_text(encoding="utf-8")
-                files.append({"path": rel_path, "content": content, "is_binary": False})
+                files.append(
+                    SkillFileEntry(path=rel_path, content=content, is_binary=False)
+                )
             except UnicodeDecodeError:
                 encoded = base64.b64encode(file_path.read_bytes()).decode("ascii")
-                files.append({"path": rel_path, "content": encoded, "is_binary": True})
+                files.append(
+                    SkillFileEntry(path=rel_path, content=encoded, is_binary=True)
+                )
         return files
 
     def update(
         self,
+        source: str,
         skill_name: str,
-        files: list[dict[str, str | bool]],
+        files: list[SkillFileEntry],
     ) -> CustomSkillDict:
-        skill_dir = self._find_skill_dir(skill_name)
+        # Atomic update: writes to a temp dir first, validates SKILL.md metadata,
+        # then replaces the original so the skill is untouched if validation fails.
+        skill_dir = self._find_skill_dir(source, skill_name)
         if skill_dir is None:
             raise FileNotFoundError(f"Skill '{skill_name}' not found")
 
@@ -207,22 +176,19 @@ class SkillService:
             tmp_dir_resolved = tmp_dir.resolve()
 
             for entry in files:
-                rel_path = str(entry["path"])
-                dest = (tmp_dir / rel_path).resolve()
+                dest = (tmp_dir / entry.path).resolve()
                 if not dest.is_relative_to(tmp_dir_resolved):
-                    raise ValueError(f"Invalid file path: {rel_path}")
+                    raise ValueError(f"Invalid file path: {entry.path}")
                 dest.parent.mkdir(parents=True, exist_ok=True)
-                if bool(entry.get("is_binary")):
-                    dest.write_bytes(base64.b64decode(str(entry["content"])))
+                if entry.is_binary:
+                    dest.write_bytes(base64.b64decode(entry.content))
                 else:
-                    dest.write_text(str(entry["content"]), encoding="utf-8")
+                    dest.write_text(entry.content, encoding="utf-8")
 
-            metadata, file_count, total_size = self._validate_skill_dir(tmp_dir)
-            new_name = str(metadata.get("name", "")).strip()
-            if new_name != skill_name:
-                raise ValueError(
-                    "Cannot rename a skill via edit. Keep the YAML name unchanged."
-                )
+            metadata = YAMLParser.parse(
+                (tmp_dir / SKILL_MD_FILENAME).read_text(encoding="utf-8")
+            )
+            file_count, total_size = self._compute_dir_stats(tmp_dir)
 
             shutil.rmtree(skill_dir)
             shutil.copytree(tmp_dir, skill_dir)
@@ -232,31 +198,5 @@ class SkillService:
             "description": str(metadata.get("description", "")),
             "size_bytes": total_size,
             "file_count": file_count,
-            "source": self._get_skill_source(skill_dir.parent),
+            "source": source,
         }
-
-    def get_all_skill_paths(self) -> list[EnabledResourceInfo]:
-        resources: list[EnabledResourceInfo] = []
-        seen_skill_names: set[str] = set()
-        for base_path in self.skills_base_paths:
-            if not base_path.is_dir():
-                continue
-            for entry in base_path.iterdir():
-                if not entry.is_dir() or entry.name in seen_skill_names:
-                    continue
-                if not self._find_skill_md(entry):
-                    continue
-                resources.append({"name": entry.name, "path": str(entry)})
-                seen_skill_names.add(entry.name)
-        return resources
-
-    @staticmethod
-    def format_for_sandbox(
-        skill_name: str,
-        rel_path: str,
-        file_bytes: bytes,
-    ) -> list[tuple[str, bytes]]:
-        return [
-            (f"{sd}/skills/{skill_name}/{rel_path}", file_bytes)
-            for sd in SKILL_SANDBOX_DIRS
-        ]

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -261,14 +261,7 @@ class WorkspaceService(BaseDbService[Workspace]):
     ) -> WorkspaceResources:
         workspace = await self.get_workspace(workspace_id, user)
         workspace_path = Path(workspace.workspace_path)
-        # Include both workspace-local and global skill directories
-        skill_service = SkillService(
-            base_paths=(
-                workspace_path / ".claude" / "skills",
-                workspace_path / ".codex" / "skills",
-                *SkillService.get_default_base_paths(),
-            )
-        )
+        skill_service = SkillService(workspace_path=workspace_path)
 
         return await asyncio.to_thread(self._build_workspace_resources, skill_service)
 

--- a/frontend/src/components/settings/dialogs/SkillEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/SkillEditDialog.tsx
@@ -75,7 +75,7 @@ export const SkillEditDialog: React.FC<SkillEditDialogProps> = ({
 
     let cancelled = false;
     void skillService
-      .getSkillFiles(skill.name)
+      .getSkillFiles(skill.source, skill.name)
       .then((loaded) => {
         if (cancelled) return;
         setFiles(loaded);
@@ -149,7 +149,7 @@ export const SkillEditDialog: React.FC<SkillEditDialogProps> = ({
         const modified = modifiedFiles.get(file.path);
         return modified === undefined ? file : { ...file, content: modified };
       });
-      await skillService.updateSkill(skill.name, JSON.stringify(merged));
+      await skillService.updateSkill(skill.source, skill.name, merged);
       await onSaved();
       onClose();
       toast.success('Skill updated');

--- a/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
@@ -48,7 +48,7 @@ export const SkillsSettingsTab: React.FC<SkillsSettingsTabProps> = ({
         <div className="space-y-2">
           {items.map((skill) => (
             <div
-              key={skill.name}
+              key={`${skill.source}/${skill.name}`}
               className="rounded-lg border border-border/50 px-4 py-3 dark:border-border-dark/50"
             >
               <div className="flex items-start justify-between gap-3">

--- a/frontend/src/services/skillService.ts
+++ b/frontend/src/services/skillService.ts
@@ -21,24 +21,29 @@ interface SkillFilesResponse {
   files: SkillFileEntry[];
 }
 
-async function getSkillFiles(skillName: string): Promise<SkillFileEntry[]> {
+async function getSkillFiles(source: string, skillName: string): Promise<SkillFileEntry[]> {
+  validateRequired(source, 'Source');
   validateRequired(skillName, 'Skill name');
 
   return withAuth(async () => {
-    const response = await apiClient.get<SkillFilesResponse>(`/skills/${skillName}/files`);
+    const response = await apiClient.get<SkillFilesResponse>(
+      `/skills/${source}/${skillName}/files`,
+    );
     const data = ensureResponse(response, 'Failed to fetch skill files');
     return data.files;
   });
 }
 
-async function updateSkill(skillName: string, filesJson: string): Promise<CustomSkill> {
+async function updateSkill(
+  source: string,
+  skillName: string,
+  files: SkillFileEntry[],
+): Promise<CustomSkill> {
+  validateRequired(source, 'Source');
   validateRequired(skillName, 'Skill name');
-  validateRequired(filesJson, 'Files');
-
-  const files: SkillFileEntry[] = JSON.parse(filesJson);
 
   return withAuth(async () => {
-    const response = await apiClient.put<CustomSkill>(`/skills/${skillName}`, { files });
+    const response = await apiClient.put<CustomSkill>(`/skills/${source}/${skillName}`, { files });
     return ensureResponse(response, 'Failed to update skill');
   });
 }


### PR DESCRIPTION
## Summary
- Refactor SkillService to treat skills as per-agent (claude/codex/copilot) instead of deduplicating across agents — same skill name in different agent dirs now shows as separate entries
- Simplify path resolution: derive skill paths from settings instead of 9 constants in constants.py
- Add `.agents/skills` support for codex and copilot (Vercel skills ecosystem)
- Remove dead code: `format_for_sandbox`, `get_all_skill_paths`, sandbox dir constants
- Use typed `SkillFileEntry` throughout instead of untyped dicts, remove JSON stringify/parse roundtrip in frontend
- API routes now include source: `GET/PUT /skills/{source}/{skill_name}`

## Test plan
- [ ] Verify skills list shows skills grouped by agent source
- [ ] Verify editing a skill works with source in the URL path
- [ ] Verify workspace resources still include workspace-local skills
- [ ] Verify `.agents/skills` directory is discovered for codex and copilot