### PR TITLE
Fix image upload failing on host sandbox provider

### DIFF
--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -85,9 +85,11 @@ class StorageService:
         if sandbox_id:
             # Attachments are advertised to the agent as readable from the
             # sandbox, so fail the upload if the sandbox copy is unavailable.
-            sandbox_file_path = f"/home/user/{unique_filename}"
+            # Pass a relative filename so both providers handle it — Docker
+            # normalises it under /home/user/, Host resolves against the
+            # workspace root (absolute paths are rejected by Host).
             await self.sandbox_service.provider.write_file(
-                sandbox_id=sandbox_id, path=sandbox_file_path, content=contents
+                sandbox_id=sandbox_id, path=unique_filename, content=contents
             )
 
         return {


### PR DESCRIPTION
## Summary
- `StorageService.save_file` passed an absolute `/home/user/{filename}` path to `provider.write_file`. The Docker provider accepted it, but `LocalHostProvider._resolve_path` rejects absolute paths and raised `SandboxException("Path must be relative")`, so image uploads failed on host-mode sandboxes.
- Pass the relative filename instead — Docker's `_normalize_path` still places it under `/home/user/`, and Host resolves it against the workspace root.

## Test plan
- [ ] On a host-sandbox workspace, upload an image in a chat message and confirm no "Path must be relative" error
- [ ] On a Docker-sandbox workspace, upload an image and confirm the file still lands at `/home/user/{filename}` inside the container and the agent can read it