### PR TITLE
Add Copilot tool renderers and route tools by agent kind

### DIFF
--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -2,7 +2,11 @@ import { memo, useMemo } from 'react';
 import { UserMessageContent, AssistantMessageContent } from './MessageContent';
 import { MessageActions } from './MessageActions';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
-import type { AssistantStreamEvent, MessageAttachment } from '@/types/chat.types';
+import {
+  getAgentKindForModelId,
+  type AssistantStreamEvent,
+  type MessageAttachment,
+} from '@/types/chat.types';
 import { Tooltip } from '@/components/ui/Tooltip';
 import { formatRelativeTime, formatFullTimestamp } from '@/utils/date';
 import { useChatContext } from '@/hooks/useChatContext';
@@ -91,6 +95,11 @@ export const AssistantMessage = memo(function AssistantMessage({
     return modelId.includes(':') ? modelId.split(':').pop()! : modelId;
   }, [modelId, modelMap]);
 
+  // modelId tells us which agent produced the tool calls embedded in this
+  // message, so tool renderers can handle per-agent rawInput shape variations
+  // (e.g. Copilot's apply_patch vs. Codex's structured changes).
+  const agentKind = modelId ? getAgentKindForModelId(modelId) : undefined;
+
   return (
     <div className="group px-4 py-1.5 sm:px-6 sm:py-2">
       <div className="flex items-start">
@@ -103,6 +112,7 @@ export const AssistantMessage = memo(function AssistantMessage({
               chatId={chatId}
               isLastBotMessage={isLastBotMessage}
               onSuggestionSelect={onSuggestionSelect}
+              agentKind={agentKind}
             />
           </div>
 

--- a/frontend/src/components/chat/message-bubble/MessageContent.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageContent.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { MessageRenderer } from './MessageRenderer';
-import type { AssistantStreamEvent, MessageAttachment } from '@/types/chat.types';
+import type { AgentKind, AssistantStreamEvent, MessageAttachment } from '@/types/chat.types';
 import { MessageAttachments } from './MessageAttachments';
 
 interface SharedContentProps {
@@ -37,6 +37,7 @@ export const UserMessageContent = memo(function UserMessageContent({
 interface AssistantMessageContentProps extends SharedContentProps {
   isLastBotMessage?: boolean;
   onSuggestionSelect?: (suggestion: string) => void;
+  agentKind?: AgentKind;
 }
 
 export const AssistantMessageContent = memo(function AssistantMessageContent({
@@ -46,6 +47,7 @@ export const AssistantMessageContent = memo(function AssistantMessageContent({
   chatId,
   isLastBotMessage,
   onSuggestionSelect,
+  agentKind,
 }: AssistantMessageContentProps) {
   return (
     <div className="space-y-4">
@@ -55,6 +57,7 @@ export const AssistantMessageContent = memo(function AssistantMessageContent({
         chatId={chatId}
         isLastBotMessage={isLastBotMessage}
         onSuggestionSelect={onSuggestionSelect}
+        agentKind={agentKind}
       />
 
       <MessageAttachments attachments={attachments} className="mt-3" />

--- a/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
@@ -5,7 +5,7 @@ import { PromptSuggestions } from './PromptSuggestions';
 import { getToolComponent } from '@/components/chat/tools/registry';
 import { buildSegments } from './segmentBuilder';
 import { AgentToolsContext } from '@/contexts/AgentToolsContext';
-import type { AssistantStreamEvent } from '@/types/chat.types';
+import type { AgentKind, AssistantStreamEvent } from '@/types/chat.types';
 import type { ToolAggregate } from '@/types/tools.types';
 import { Spinner } from '@/components/ui/primitives/Spinner';
 
@@ -16,6 +16,7 @@ interface MessageRendererProps {
   chatId?: string;
   isLastBotMessage?: boolean;
   onSuggestionSelect?: (suggestion: string) => void;
+  agentKind?: AgentKind;
 }
 
 const MessageRendererInner: React.FC<MessageRendererProps> = ({
@@ -25,6 +26,7 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
   chatId,
   isLastBotMessage = false,
   onSuggestionSelect,
+  agentKind,
 }) => {
   const { segments, activeThinkingIndex } = React.useMemo(() => {
     const builtSegments = buildSegments(events);
@@ -82,7 +84,7 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
               );
             }
             case 'tool': {
-              const Component = getToolComponent(segment.tool.name);
+              const Component = getToolComponent(segment.tool.name, agentKind);
               return (
                 <div key={segment.id} className="mb-2 mt-1">
                   <Suspense

--- a/frontend/src/components/chat/tools/claude/FileOperationTool.tsx
+++ b/frontend/src/components/chat/tools/claude/FileOperationTool.tsx
@@ -5,7 +5,14 @@ import type { LucideIcon } from 'lucide-react';
 import type { ToolAggregate } from '@/types/tools.types';
 import type { ToolComponent } from '@/types/ui.types';
 import { ToolCard } from '../common/ToolCard';
+import { NumberedContent } from '../common/NumberedContent';
 import { OpenInEditorButton } from '../common/OpenInEditorButton';
+
+// Claude's Read output embeds real line numbers before each line. The
+// separator has shifted between agent versions: older builds used "→"
+// (U+2192), newer builds use a tab. Handle both so we use the real line
+// numbers instead of the array index.
+const CLAUDE_READ_LINE_PREFIX = /^\s*(\d+)(?:→|\t)/;
 
 interface FileOperationToolProps {
   tool: ToolAggregate;
@@ -132,27 +139,7 @@ const FileOperationToolInner: React.FC<FileOperationToolProps> = ({ tool, varian
     if (variant === 'read') {
       const content = normalizeContent(tool.result);
       if (!content || tool.status !== 'completed') return null;
-
-      const lines = content.split('\n');
-      return (
-        <div className="max-h-48 overflow-auto font-mono text-2xs leading-relaxed">
-          {lines.map((line: string, idx: number) => {
-            const match = line.match(/^\s*(\d+)→/);
-            const lineNum = match ? match[1] : String(idx + 1);
-            const lineContent = line.replace(/^\s*\d+→/, '');
-            return (
-              <div key={idx} className="flex">
-                <span className="w-8 flex-shrink-0 select-none pr-2 text-right text-text-quaternary dark:text-text-dark-quaternary">
-                  {lineNum}
-                </span>
-                <span className="whitespace-pre text-text-tertiary dark:text-text-dark-tertiary">
-                  {lineContent || '\u00A0'}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-      );
+      return <NumberedContent content={content} prefixPattern={CLAUDE_READ_LINE_PREFIX} />;
     }
 
     if (variant === 'edit') {
@@ -165,22 +152,7 @@ const FileOperationToolInner: React.FC<FileOperationToolProps> = ({ tool, varian
 
     const content = typeof tool.input?.content === 'string' ? tool.input.content : '';
     if (!content) return null;
-
-    const lines = content.split('\n');
-    return (
-      <div className="max-h-48 overflow-auto font-mono text-2xs leading-relaxed">
-        {lines.map((line: string, idx: number) => (
-          <div key={idx} className="flex">
-            <span className="w-8 flex-shrink-0 select-none pr-2 text-right text-text-quaternary dark:text-text-dark-quaternary">
-              {idx + 1}
-            </span>
-            <span className="whitespace-pre text-text-tertiary dark:text-text-dark-tertiary">
-              {line || '\u00A0'}
-            </span>
-          </div>
-        ))}
-      </div>
-    );
+    return <NumberedContent content={content} />;
   };
 
   const hasContent =

--- a/frontend/src/components/chat/tools/codex/ReadTool.tsx
+++ b/frontend/src/components/chat/tools/codex/ReadTool.tsx
@@ -3,6 +3,7 @@ import { FileSearch } from 'lucide-react';
 import type { ToolAggregate } from '@/types/tools.types';
 import { extractFilename } from '@/utils/format';
 import { ToolCard } from '../common/ToolCard';
+import { NumberedContent } from '../common/NumberedContent';
 import { OpenInEditorButton } from '../common/OpenInEditorButton';
 import {
   type ShellLikeInput,
@@ -46,20 +47,7 @@ const ReadToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
             </div>
           )}
           {renderCommand(command)}
-          {content && (
-            <div className="max-h-48 overflow-auto font-mono text-2xs leading-relaxed">
-              {content.split('\n').map((line, idx) => (
-                <div key={idx} className="flex">
-                  <span className="w-8 flex-shrink-0 select-none pr-2 text-right text-text-quaternary dark:text-text-dark-quaternary">
-                    {idx + 1}
-                  </span>
-                  <span className="whitespace-pre text-text-tertiary dark:text-text-dark-tertiary">
-                    {line || '\u00A0'}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
+          {content && <NumberedContent content={content} />}
         </div>
       )}
     </ToolCard>

--- a/frontend/src/components/chat/tools/common/DiffView.tsx
+++ b/frontend/src/components/chat/tools/common/DiffView.tsx
@@ -1,0 +1,53 @@
+import { memo, useMemo } from 'react';
+
+const DiffLine: React.FC<{ line: string }> = ({ line }) => {
+  const isAdded = line.startsWith('+') && !line.startsWith('+++');
+  const isRemoved = line.startsWith('-') && !line.startsWith('---');
+  const isHunkHeader =
+    line.startsWith('@@') || line.startsWith('diff ') || line.startsWith('index ');
+  const isFileHeader = line.startsWith('+++') || line.startsWith('---');
+
+  if (isHunkHeader || isFileHeader) {
+    return <div className="text-text-quaternary dark:text-text-dark-quaternary">{line}</div>;
+  }
+
+  return (
+    <div className="flex">
+      <span
+        className={`w-4 flex-shrink-0 select-none text-center ${
+          isRemoved
+            ? 'text-error-600/40 dark:text-error-400/40'
+            : isAdded
+              ? 'text-success-600/40 dark:text-success-400/40'
+              : 'text-transparent'
+        }`}
+      >
+        {isRemoved ? '−' : isAdded ? '+' : ' '}
+      </span>
+      <span
+        className={`whitespace-pre ${
+          isRemoved
+            ? 'text-text-quaternary line-through dark:text-text-dark-quaternary'
+            : isAdded
+              ? 'text-text-secondary dark:text-text-dark-secondary'
+              : 'text-text-tertiary dark:text-text-dark-tertiary'
+        }`}
+      >
+        {line.slice(1) || '\u00A0'}
+      </span>
+    </div>
+  );
+};
+
+const DiffViewInner: React.FC<{ diff: string }> = ({ diff }) => {
+  const lines = useMemo(() => diff.split('\n').filter((l) => l.length > 0), [diff]);
+  return (
+    <div className="max-h-48 overflow-auto font-mono text-2xs leading-relaxed">
+      {lines.map((line, idx) => (
+        <DiffLine key={idx} line={line} />
+      ))}
+    </div>
+  );
+};
+
+export const DiffView = memo(DiffViewInner);

--- a/frontend/src/components/chat/tools/common/NumberedContent.tsx
+++ b/frontend/src/components/chat/tools/common/NumberedContent.tsx
@@ -1,0 +1,46 @@
+import { memo, useMemo } from 'react';
+
+interface NumberedContentProps {
+  content: string;
+  // When provided, capture group 1 supplies the displayed line number and the
+  // full match is stripped from the rendered content. Lets us reuse the same
+  // gutter renderer for agents whose read output already embeds line numbers
+  // (Claude: "N→" / "N\t", Copilot-via-Claude: "N. ") alongside raw content.
+  prefixPattern?: RegExp;
+}
+
+interface ParsedLine {
+  lineNum: string;
+  text: string;
+}
+
+const NumberedContentInner: React.FC<NumberedContentProps> = ({ content, prefixPattern }) => {
+  const lines = useMemo<ParsedLine[]>(
+    () =>
+      content.split('\n').map((line, idx) => {
+        if (prefixPattern) {
+          const match = line.match(prefixPattern);
+          if (match) return { lineNum: match[1], text: line.slice(match[0].length) };
+        }
+        return { lineNum: String(idx + 1), text: line };
+      }),
+    [content, prefixPattern],
+  );
+
+  return (
+    <div className="max-h-48 overflow-auto font-mono text-2xs leading-relaxed">
+      {lines.map((line, idx) => (
+        <div key={idx} className="flex">
+          <span className="w-8 flex-shrink-0 select-none pr-2 text-right text-text-quaternary dark:text-text-dark-quaternary">
+            {line.lineNum}
+          </span>
+          <span className="whitespace-pre text-text-tertiary dark:text-text-dark-tertiary">
+            {line.text || '\u00A0'}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const NumberedContent = memo(NumberedContentInner);

--- a/frontend/src/components/chat/tools/copilot/AgentTool.tsx
+++ b/frontend/src/components/chat/tools/copilot/AgentTool.tsx
@@ -1,0 +1,112 @@
+import { memo, useState, useRef } from 'react';
+import { Bot } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { TOOL_OUTPUT_PRE_CLASS } from '@/utils/toolStyles';
+import { extractResultText } from '@/utils/agentTool';
+import { ToolCard } from '../common/ToolCard';
+import { CollapsibleButton } from '../common/CollapsibleButton';
+import type { CopilotToolOutput } from './copilotPayload';
+
+interface CopilotAgentInput {
+  description?: string;
+  agent_type?: string;
+  name?: string;
+  prompt?: string;
+}
+
+const AgentToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const [promptExpanded, setPromptExpanded] = useState(false);
+  const [resultExpanded, setResultExpanded] = useState(false);
+  const prevToolIdRef = useRef(tool.id);
+
+  if (prevToolIdRef.current !== tool.id) {
+    prevToolIdRef.current = tool.id;
+    setPromptExpanded(false);
+    setResultExpanded(false);
+  }
+
+  const input = tool.input as CopilotAgentInput | undefined;
+  const output = tool.result as CopilotToolOutput | undefined;
+  const description = input?.description?.trim() || tool.title?.trim() || '';
+  const agentType = input?.agent_type?.trim();
+  const agentName = input?.name?.trim();
+  const prompt = input?.prompt;
+  // `output.content` is the sub-agent's summary text; fall back to the Claude
+  // tool utility which handles other structured result shapes.
+  const result = output?.content?.trim() || extractResultText(tool.result);
+
+  return (
+    <ToolCard
+      icon={<Bot className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />}
+      status={tool.status}
+      title={(status) => {
+        const label = description || agentName || agentType || 'agent task';
+        switch (status) {
+          case 'completed':
+            return `Agent: ${label}`;
+          case 'failed':
+            return `Agent failed: ${label}`;
+          default:
+            return `Running agent: ${label}`;
+        }
+      }}
+      loadingContent="Running sub-agent..."
+      error={tool.error}
+    >
+      {(agentType || agentName || prompt || result) && (
+        <div className="space-y-2">
+          {(agentType || agentName) && (
+            <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-2xs text-text-tertiary dark:text-text-dark-tertiary">
+              {agentType && (
+                <span>
+                  <span className="text-text-quaternary dark:text-text-dark-quaternary">
+                    type:{' '}
+                  </span>
+                  <span className="font-mono">{agentType}</span>
+                </span>
+              )}
+              {agentName && (
+                <span>
+                  <span className="text-text-quaternary dark:text-text-dark-quaternary">
+                    name:{' '}
+                  </span>
+                  <span className="font-mono">{agentName}</span>
+                </span>
+              )}
+            </div>
+          )}
+
+          {prompt && (
+            <div className="space-y-2">
+              <CollapsibleButton
+                label="Prompt"
+                isExpanded={promptExpanded}
+                onToggle={() => setPromptExpanded((v) => !v)}
+                fullWidth
+              />
+              {promptExpanded && (
+                <div className="whitespace-pre-wrap break-words rounded bg-black/5 p-2 font-mono text-2xs text-text-secondary dark:bg-white/5 dark:text-text-dark-tertiary">
+                  {prompt}
+                </div>
+              )}
+            </div>
+          )}
+
+          {result && (
+            <div className="space-y-2">
+              <CollapsibleButton
+                label="Result"
+                isExpanded={resultExpanded}
+                onToggle={() => setResultExpanded((v) => !v)}
+                fullWidth
+              />
+              {resultExpanded && <pre className={TOOL_OUTPUT_PRE_CLASS}>{result}</pre>}
+            </div>
+          )}
+        </div>
+      )}
+    </ToolCard>
+  );
+};
+
+export const AgentTool = memo(AgentToolInner);

--- a/frontend/src/components/chat/tools/copilot/EditTool.tsx
+++ b/frontend/src/components/chat/tools/copilot/EditTool.tsx
@@ -1,0 +1,116 @@
+import { memo, useMemo } from 'react';
+import { FileEdit, FilePlus, FileMinus } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard';
+import { DiffView } from '../common/DiffView';
+import { NumberedContent } from '../common/NumberedContent';
+import { OpenInEditorButton } from '../common/OpenInEditorButton';
+import type { CopilotEditInput, CopilotToolOutput } from './copilotPayload';
+
+type EditOp = 'add' | 'update' | 'delete';
+
+interface ParsedEdit {
+  op: EditOp;
+  path: string;
+}
+
+const APPLY_PATCH_HEADERS: Array<{ op: EditOp; regex: RegExp }> = [
+  { op: 'add', regex: /^\*\*\* Add File: (.+)$/m },
+  { op: 'update', regex: /^\*\*\* Update File: (.+)$/m },
+  { op: 'delete', regex: /^\*\*\* Delete File: (.+)$/m },
+];
+
+const parseApplyPatch = (patch: string): ParsedEdit | null => {
+  for (const { op, regex } of APPLY_PATCH_HEADERS) {
+    const match = patch.match(regex);
+    if (match) return { op, path: match[1].trim() };
+  }
+  return null;
+};
+
+const identifyEdit = (input: CopilotEditInput | undefined): ParsedEdit => {
+  if (!input) return { op: 'update', path: '' };
+  if (typeof input.raw === 'string') {
+    return parseApplyPatch(input.raw) ?? { op: 'update', path: '' };
+  }
+  if (typeof input.file_text === 'string') {
+    return { op: 'add', path: input.path ?? '' };
+  }
+  return { op: 'update', path: input.path ?? '' };
+};
+
+const buildStrReplaceDiff = (oldStr: string, newStr: string): string => {
+  const removed = oldStr.split('\n').map((l) => `-${l}`);
+  const added = newStr.split('\n').map((l) => `+${l}`);
+  return [...removed, ...added].join('\n');
+};
+
+const ICON_BY_OP: Record<EditOp, React.ReactNode> = {
+  add: <FilePlus className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />,
+  delete: <FileMinus className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />,
+  update: <FileEdit className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />,
+};
+
+const PendingPreview: React.FC<{ input: CopilotEditInput; op: EditOp }> = ({ input, op }) => {
+  if (typeof input.raw === 'string') {
+    return <DiffView diff={input.raw} />;
+  }
+  if (op === 'add' && typeof input.file_text === 'string') {
+    return <NumberedContent content={input.file_text} />;
+  }
+  if (typeof input.old_str === 'string' || typeof input.new_str === 'string') {
+    return <DiffView diff={buildStrReplaceDiff(input.old_str ?? '', input.new_str ?? '')} />;
+  }
+  return null;
+};
+
+const EditToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as CopilotEditInput | undefined;
+  const result = tool.result as CopilotToolOutput | undefined;
+
+  const parsed = useMemo(() => identifyEdit(input), [input]);
+  const filePath = parsed.path;
+  const fileName = filePath ? extractFilename(filePath) : 'file';
+  const diff = result?.detailedContent ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON_BY_OP[parsed.op]}
+      status={tool.status}
+      title={(status) => {
+        const { label, verb } =
+          parsed.op === 'add'
+            ? { label: 'Created', verb: 'Creating' }
+            : parsed.op === 'delete'
+              ? { label: 'Deleted', verb: 'Deleting' }
+              : { label: 'Edited', verb: 'Editing' };
+        switch (status) {
+          case 'completed':
+            return `${label} ${fileName}`;
+          case 'failed':
+            return `Failed to ${verb.toLowerCase()} ${fileName}`;
+          default:
+            return `${verb} ${fileName}`;
+        }
+      }}
+      loadingContent={
+        parsed.op === 'add'
+          ? 'Creating file...'
+          : parsed.op === 'delete'
+            ? 'Removing file...'
+            : 'Applying changes...'
+      }
+      error={tool.error}
+      actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
+    >
+      {diff ? (
+        <DiffView diff={diff} />
+      ) : input ? (
+        <PendingPreview input={input} op={parsed.op} />
+      ) : null}
+    </ToolCard>
+  );
+};
+
+export const EditTool = memo(EditToolInner);

--- a/frontend/src/components/chat/tools/copilot/ExecuteTool.tsx
+++ b/frontend/src/components/chat/tools/copilot/ExecuteTool.tsx
@@ -1,0 +1,53 @@
+import { memo } from 'react';
+import { Terminal } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { TOOL_OUTPUT_PRE_CLASS } from '@/utils/toolStyles';
+import { ToolCard } from '../common/ToolCard';
+import type { CopilotExecuteInput, CopilotToolOutput } from './copilotPayload';
+
+const ICON = <Terminal className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />;
+
+const ExecuteToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as CopilotExecuteInput | undefined;
+  const result = tool.result as CopilotToolOutput | undefined;
+
+  const command = input?.command ?? '';
+  const description = input?.description?.trim();
+  const output = result?.content ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        const label = description || command || 'command';
+        switch (status) {
+          case 'completed':
+            return `Ran: ${label}`;
+          case 'failed':
+            return `Failed: ${label}`;
+          default:
+            return `Running: ${label}`;
+        }
+      }}
+      loadingContent="Running command..."
+      error={tool.error}
+    >
+      {(command || output) && (
+        <div className="space-y-1">
+          {command && (
+            <pre className="whitespace-pre-wrap break-all font-mono text-2xs leading-relaxed text-text-secondary dark:text-text-dark-tertiary">
+              <span className="select-none text-text-quaternary dark:text-text-dark-quaternary">
+                ${' '}
+              </span>
+              {command}
+            </pre>
+          )}
+          {output && <pre className={TOOL_OUTPUT_PRE_CLASS}>{output}</pre>}
+        </div>
+      )}
+    </ToolCard>
+  );
+};
+
+export const ExecuteTool = memo(ExecuteToolInner);

--- a/frontend/src/components/chat/tools/copilot/FetchTool.tsx
+++ b/frontend/src/components/chat/tools/copilot/FetchTool.tsx
@@ -1,0 +1,50 @@
+import { memo } from 'react';
+import { Globe } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractDomain } from '@/utils/format';
+import { TOOL_OUTPUT_PRE_CLASS } from '@/utils/toolStyles';
+import { ToolCard } from '../common/ToolCard';
+import type { CopilotFetchInput, CopilotToolOutput } from './copilotPayload';
+
+const ICON = <Globe className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />;
+
+const FetchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as CopilotFetchInput | undefined;
+  const result = tool.result as CopilotToolOutput | undefined;
+
+  const url = input?.url ?? '';
+  const domain = extractDomain(url) || url || 'content';
+  const output = result?.content ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Fetched: ${domain}`;
+          case 'failed':
+            return `Failed to fetch: ${domain}`;
+          default:
+            return `Fetching: ${domain}`;
+        }
+      }}
+      loadingContent="Fetching content..."
+      error={tool.error}
+    >
+      {(url || output) && (
+        <div className="space-y-1.5">
+          {url && (
+            <div className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-quaternary">
+              {url}
+            </div>
+          )}
+          {output && <pre className={TOOL_OUTPUT_PRE_CLASS}>{output}</pre>}
+        </div>
+      )}
+    </ToolCard>
+  );
+};
+
+export const FetchTool = memo(FetchToolInner);

--- a/frontend/src/components/chat/tools/copilot/ReadTool.tsx
+++ b/frontend/src/components/chat/tools/copilot/ReadTool.tsx
@@ -1,0 +1,75 @@
+import { memo } from 'react';
+import { FileSearch, FolderSearch } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard';
+import { NumberedContent } from '../common/NumberedContent';
+import { OpenInEditorButton } from '../common/OpenInEditorButton';
+import type { CopilotReadInput, CopilotToolOutput } from './copilotPayload';
+
+// Copilot-via-Claude models prefix each line with "N. "; GPT models return raw
+// content and we fall back to the array index in NumberedContent.
+const LINE_NUMBER_PREFIX = /^(\d+)\.\s?/;
+
+const ReadToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as CopilotReadInput | undefined;
+  const result = tool.result as CopilotToolOutput | undefined;
+
+  // Copilot uses a single `read` kind for file/dir views and glob searches;
+  // the `pattern` field is the discriminator.
+  const isGlob = typeof input?.pattern === 'string' && input.pattern.length > 0;
+  const path = input?.path ?? '';
+  const pattern = input?.pattern ?? '';
+  const content = result?.content ?? '';
+  const fileLabel = path ? extractFilename(path) : 'file';
+
+  const icon = isGlob ? (
+    <FolderSearch className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />
+  ) : (
+    <FileSearch className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />
+  );
+
+  return (
+    <ToolCard
+      icon={icon}
+      status={tool.status}
+      title={(status) => {
+        if (isGlob) {
+          const label = path ? `'${pattern}' in ${path}` : `'${pattern}'`;
+          switch (status) {
+            case 'completed':
+              return `Found ${label}`;
+            case 'failed':
+              return `Search failed: ${label}`;
+            default:
+              return `Searching ${label}`;
+          }
+        }
+        switch (status) {
+          case 'completed':
+            return `Read ${fileLabel}`;
+          case 'failed':
+            return `Failed to read ${fileLabel}`;
+          default:
+            return `Reading ${fileLabel}`;
+        }
+      }}
+      loadingContent={isGlob ? 'Searching...' : 'Loading file content...'}
+      error={tool.error}
+      actions={!isGlob && path ? <OpenInEditorButton filePath={path} /> : null}
+    >
+      {(path || pattern || content) && (
+        <div className="space-y-1.5">
+          {path && !isGlob && (
+            <div className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-quaternary">
+              {path}
+            </div>
+          )}
+          {content && <NumberedContent content={content} prefixPattern={LINE_NUMBER_PREFIX} />}
+        </div>
+      )}
+    </ToolCard>
+  );
+};
+
+export const ReadTool = memo(ReadToolInner);

--- a/frontend/src/components/chat/tools/copilot/copilotPayload.ts
+++ b/frontend/src/components/chat/tools/copilot/copilotPayload.ts
@@ -1,0 +1,36 @@
+export interface CopilotExecuteInput {
+  command?: string;
+  commands?: string[];
+  description?: string;
+  initial_wait?: number;
+}
+
+export interface CopilotReadInput {
+  path?: string;
+  view_range?: [number, number];
+  pattern?: string;
+}
+
+// Copilot's `edit` rawInput varies by underlying model:
+//   - GPT family: a single patch string wrapped by the backend into {raw: "<patch>"}
+//   - Claude family (create): {path, file_text}
+//   - Claude family (str_replace): {path, old_str, new_str}
+// rawOutput is consistent across models: {content, detailedContent}.
+// detailedContent is always a unified diff so editing UIs can render one shape.
+export interface CopilotEditInput {
+  raw?: string;
+  path?: string;
+  file_text?: string;
+  old_str?: string;
+  new_str?: string;
+}
+
+export interface CopilotFetchInput {
+  url?: string;
+  max_length?: number;
+}
+
+export interface CopilotToolOutput {
+  content?: string;
+  detailedContent?: string;
+}

--- a/frontend/src/components/chat/tools/registry.tsx
+++ b/frontend/src/components/chat/tools/registry.tsx
@@ -1,5 +1,6 @@
 import { lazy } from 'react';
 import type { ToolComponent } from '@/types/ui.types';
+import type { AgentKind } from '@/types/chat.types';
 type ToolModuleLoader = () => Promise<{ default: ToolComponent }>;
 
 const toLazy = (loader: ToolModuleLoader): ToolComponent =>
@@ -7,6 +8,15 @@ const toLazy = (loader: ToolModuleLoader): ToolComponent =>
 
 const codexShellLoader: ToolModuleLoader = () =>
   import('./codex/ShellTool').then((m) => ({ default: m.ShellTool }));
+
+const copilotToolLoaders: Record<string, ToolModuleLoader> = {
+  execute: () => import('./copilot/ExecuteTool').then((m) => ({ default: m.ExecuteTool })),
+  read: () => import('./copilot/ReadTool').then((m) => ({ default: m.ReadTool })),
+  edit: () => import('./copilot/EditTool').then((m) => ({ default: m.EditTool })),
+  fetch: () => import('./copilot/FetchTool').then((m) => ({ default: m.FetchTool })),
+  // Copilot uses `kind: "other"` for sub-agent invocations.
+  other: () => import('./copilot/AgentTool').then((m) => ({ default: m.AgentTool })),
+};
 
 const toolLoaders: Record<string, ToolModuleLoader> = {
   // Claude Code tools
@@ -57,7 +67,14 @@ const getOrCreateLazy = (key: string, loader: ToolModuleLoader) => {
   return component;
 };
 
-export const getToolComponent = (toolName: string): ToolComponent => {
+export const getToolComponent = (toolName: string, agentKind?: AgentKind): ToolComponent => {
+  // Copilot shares lowercase ACP kinds (execute/read/edit/fetch) with Codex but
+  // emits different rawInput shapes, so route Copilot tools to their own
+  // renderers before falling through to the Codex/Claude table.
+  if (agentKind === 'copilot' && copilotToolLoaders[toolName]) {
+    return getOrCreateLazy(`copilot:${toolName}`, copilotToolLoaders[toolName]);
+  }
+
   if (toolLoaders[toolName]) {
     return getOrCreateLazy(toolName, toolLoaders[toolName]);
   }


### PR DESCRIPTION
## Summary
- Fix desktop app crash when Copilot requests permission — Copilot's `execute` rawInput sends `command` as a string, which broke Codex's `ShellTool` (`args.join(' ')` TypeError)
- Add dedicated Copilot tool renderers under `components/chat/tools/copilot/` for `execute`, `read`, `edit`, `fetch`, and `other` (sub-agent) ACP kinds, handling both GPT and Claude model shape variations (apply_patch string vs. `{path, file_text}` create vs. `{path, old_str, new_str}` str_replace)
- Thread `agentKind` through `Message` → `MessageContent` → `MessageRenderer` → `getToolComponent` so the registry can route per-agent; Copilot uses `modelId` via existing `getAgentKindForModelId`
- Extract shared `DiffView` and `NumberedContent` components into `tools/common/`; replace inline duplicates in `copilot/EditTool`, `copilot/ReadTool`, `claude/FileOperationTool` (Read + Write variants), and `codex/ReadTool`
- Fix Claude `Read` tool double-numbering: its line-prefix separator changed from `N→` (older agent) to `N\t` (newer agent); the regex now matches both

## Test plan
- [ ] Copilot chat: trigger a shell command that asks for permission — verify the tool card renders and the approval modal appears (previously crashed the app)
- [ ] Copilot chat: request file creation / edit / delete with both a GPT model and a Claude model; verify the diff renders for all three rawInput shapes
- [ ] Copilot chat: trigger a file/dir read and a glob search; verify Read tool uses different icon/title and strips `N. ` line prefixes
- [ ] Copilot chat: trigger a fetch; verify domain and content render
- [ ] Copilot chat: invoke a sub-agent (`kind: "other"`); verify dedicated AgentTool renders with agent_type, name, collapsible prompt, and result
- [ ] Claude chat: read a file; verify no double line numbers (fix for the `N\t` prefix bug)
- [ ] Codex chat: regression check — shell/read/edit/fetch tools still render as before