### PR TITLE
Add skills support for Cursor agent

### DIFF
--- a/backend/app/models/schemas/workspace.py
+++ b/backend/app/models/schemas/workspace.py
@@ -11,6 +11,7 @@ class CustomSkill(BaseModel):
     size_bytes: int
     file_count: int
     source: str
+    read_only: bool
 
 
 class BuiltinSlashCommand(BaseModel):

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -24,6 +24,7 @@ class CustomSkillDict(TypedDict):
     size_bytes: int
     file_count: int
     source: str
+    read_only: bool
 
 
 class PersonaDict(TypedDict):

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -20,15 +20,20 @@ SKILL_MD_FILENAME = "SKILL.md"
 
 class SkillService:
     def __init__(self, workspace_path: Path | None = None) -> None:
-        self.paths_by_source = self._build_paths_by_source(workspace_path)
+        self.paths_by_source, self.readonly_paths = self._build_paths_by_source(
+            workspace_path
+        )
 
     @staticmethod
-    def _build_paths_by_source(workspace_path: Path | None) -> dict[str, list[Path]]:
+    def _build_paths_by_source(
+        workspace_path: Path | None,
+    ) -> tuple[dict[str, list[Path]], set[Path]]:
         # Desktop mode reads from the user's home dir, server mode from STORAGE_PATH
         base = Path.home() if settings.DESKTOP_MODE else Path(settings.STORAGE_PATH)
         # Agents that support the shared .agents/skills directory (Vercel skills ecosystem)
-        agents_dir_kinds = {AgentKind.CODEX, AgentKind.COPILOT}
+        agents_dir_kinds = {AgentKind.CODEX, AgentKind.COPILOT, AgentKind.CURSOR}
         result: dict[str, list[Path]] = {}
+        readonly_paths: set[Path] = set()
         for kind in AgentKind:
             paths: list[Path] = []
             # Workspace-local paths first so they take priority over globals
@@ -40,11 +45,17 @@ class SkillService:
             if kind in agents_dir_kinds:
                 paths.append(base / ".agents" / "skills")
             result[kind.value] = paths
+        # Cursor CLI ships built-in skills at ~/.cursor/skills-cursor/ and manages
+        # that directory automatically (updates overwrite user edits), so we
+        # surface those skills but flag them read-only.
+        cursor_builtin = base / ".cursor" / "skills-cursor"
+        result[AgentKind.CURSOR.value].append(cursor_builtin)
+        readonly_paths.add(cursor_builtin)
         # Claude plugins can also bundle skills
         result[AgentKind.CLAUDE.value].extend(
             SkillService._get_claude_plugin_skill_paths()
         )
-        return result
+        return result, readonly_paths
 
     @staticmethod
     def _get_claude_plugin_skill_paths() -> list[Path]:
@@ -108,6 +119,7 @@ class SkillService:
             for base_path in paths:
                 if not base_path.is_dir():
                     continue
+                is_readonly = base_path in self.readonly_paths
                 for entry in base_path.iterdir():
                     if not entry.is_dir() or entry.name in seen_names:
                         continue
@@ -130,6 +142,7 @@ class SkillService:
                             "size_bytes": total_size,
                             "file_count": file_count,
                             "source": source,
+                            "read_only": is_readonly,
                         }
                     )
                     seen_names.add(entry.name)
@@ -170,6 +183,11 @@ class SkillService:
         if skill_dir is None:
             raise FileNotFoundError(f"Skill '{skill_name}' not found")
 
+        # Reject edits under CLI-managed directories (e.g. ~/.cursor/skills-cursor)
+        # where an external tool would silently overwrite user changes.
+        if skill_dir.parent in self.readonly_paths:
+            raise ValueError(f"Skill '{skill_name}' is read-only and cannot be edited")
+
         with tempfile.TemporaryDirectory() as tmp_dir_str:
             tmp_dir = Path(tmp_dir_str) / skill_name
             tmp_dir.mkdir()
@@ -199,4 +217,5 @@ class SkillService:
             "size_bytes": total_size,
             "file_count": file_count,
             "source": source,
+            "read_only": skill_dir.parent in self.readonly_paths,
         }

--- a/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
@@ -33,7 +33,7 @@ export const SkillsSettingsTab: React.FC<SkillsSettingsTabProps> = ({
           Skills
         </h2>
         <p className="mt-1 text-xs text-text-tertiary dark:text-text-dark-tertiary">
-          Skills installed via the Claude or Codex CLI are shown here.
+          Skills installed via the Claude, Codex, Copilot, or Cursor CLI are shown here.
         </p>
       </div>
 
@@ -60,6 +60,11 @@ export const SkillsSettingsTab: React.FC<SkillsSettingsTabProps> = ({
                     <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
                       {skill.source}
                     </span>
+                    {skill.read_only && (
+                      <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
+                        built-in
+                      </span>
+                    )}
                   </div>
                   {skill.description && (
                     <p className="mb-2 text-xs text-text-tertiary dark:text-text-dark-tertiary">
@@ -74,16 +79,18 @@ export const SkillsSettingsTab: React.FC<SkillsSettingsTabProps> = ({
                     <span>{formatBytes(skill.size_bytes)}</span>
                   </div>
                 </div>
-                <Button
-                  type="button"
-                  onClick={() => setEditingSkill(skill)}
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 text-text-quaternary hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
-                  aria-label={`Edit ${skill.name}`}
-                >
-                  <Edit2 className="h-3.5 w-3.5" />
-                </Button>
+                {!skill.read_only && (
+                  <Button
+                    type="button"
+                    onClick={() => setEditingSkill(skill)}
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-text-quaternary hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+                    aria-label={`Edit ${skill.name}`}
+                  >
+                    <Edit2 className="h-3.5 w-3.5" />
+                  </Button>
+                )}
               </div>
             </div>
           ))}

--- a/frontend/src/types/user.types.ts
+++ b/frontend/src/types/user.types.ts
@@ -24,6 +24,7 @@ export interface CustomSkill {
   size_bytes: number;
   file_count: number;
   source: string;
+  read_only: boolean;
 }
 
 export interface Persona {


### PR DESCRIPTION
## Summary
- Add Cursor to the shared `.agents/skills/` ecosystem (Vercel skills convention) so skills installed there show up under Cursor alongside Codex and Copilot
- Surface Cursor's CLI-managed built-in skills at `~/.cursor/skills-cursor/` with a new `read_only` flag (editing is rejected server-side because Cursor overwrites that directory on updates)
- Update Skills settings UI to mention all four agents, show a "built-in" badge, and hide the edit button for read-only skills

## Test plan
- [ ] With Cursor CLI installed, open Settings → Skills and confirm bundled skills (e.g. `create-skill`, `shell`, `canvas`) appear with a `cursor` source badge and a `built-in` badge
- [ ] Confirm the edit button is hidden for read-only skills
- [ ] Drop a user-authored skill at `~/.cursor/skills/my-skill/SKILL.md` and confirm it appears without the `built-in` badge and is editable
- [ ] Attempt to PUT `/api/skills/cursor/<built-in-name>` and confirm a 400 is returned
- [ ] Add a skill under a workspace's `.agents/skills/` and confirm it appears under Cursor (as well as Codex/Copilot)