### PR TITLE
Hide context-usage indicator for Cursor agent

### DIFF
--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -58,7 +58,11 @@ export function InputProvider({
   const modelMap = useModelMap();
   const agentKind =
     modelMap.get(selectedModelId)?.agent_kind ?? getAgentKindForModelId(selectedModelId);
-  const visibleContextUsage = agentKind === 'copilot' ? undefined : contextUsage;
+  // Hide the context-usage indicator for agents whose ACP servers never emit
+  // UsageUpdate notifications (copilot-cli, cursor-agent) — without those
+  // events the value stays 0 and the bar is misleading.
+  const visibleContextUsage =
+    agentKind === 'copilot' || agentKind === 'cursor' ? undefined : contextUsage;
   const formRef = useRef<HTMLFormElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [previewDismissed, setPreviewDismissed] = useState(false);


### PR DESCRIPTION
## Summary
- Extend the existing copilot gate in `InputProvider.tsx` to also hide the context-usage indicator for the Cursor agent.
- Empirical ACP probe of all four agent binaries confirmed only `claude-agent-acp` and `codex-acp` emit `session/update` notifications with `sessionUpdate: "usage_update"`. `copilot --acp --stdio` and `cursor-agent acp` emit none — neither in notifications nor in the `session/prompt` response — so the indicator was pinned at 0% and misleading.

## Test plan
- [ ] Open a chat using a Cursor model and confirm the context-usage indicator is no longer rendered in the message input.
- [ ] Open a chat using a Copilot model and confirm it remains hidden (unchanged).
- [ ] Open a chat using a Claude model and confirm the indicator still renders and updates as usage_update events arrive.
- [ ] Open a chat using a Codex model and confirm the indicator still renders.