### PR TITLE
Accept "ask" as a valid PermissionMode

### DIFF
--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -10,6 +10,7 @@ PermissionMode: TypeAlias = Literal[
     "auto",
     "read-only",
     "full-access",
+    "ask",
 ]
 
 

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -48,6 +48,7 @@ VALID_PERMISSION_MODES: set[str] = {
     "auto",
     "read-only",
     "full-access",
+    "ask",
 }
 
 # Normalizes human-readable option names (e.g. "Accept Edits") to our


### PR DESCRIPTION
## Summary
- The frontend `PermissionMode` type and the Cursor adapter's `CURSOR_SESSION_MODES` already accepted `"ask"`, but the backend `PermissionMode` Literal (`backend/app/models/types.py`) and the ACP client's `VALID_PERMISSION_MODES` set (`backend/app/services/acp/client.py`) did not.
- Submitting a message while the Cursor agent's permission mode was set to "ask" failed FastAPI's Form validation with a 422. The response body `{"detail": [...]}` was surfaced by `extractErrorMessage` in `frontend/src/lib/api.ts` — since `detail` is an array of objects, it stringified to `[object Object]` in the UI.
- Added `"ask"` to both the Literal and the validation set so ask mode round-trips cleanly.

## Test plan
- [ ] Select the Cursor agent, set permission mode to "Ask", send a message — the request should succeed (no 422, no `[object Object]`).
- [ ] Verify the other permission modes (default / acceptEdits / plan / bypassPermissions / agent / autopilot / auto / read-only / full-access) still work.
- [ ] When the Cursor agent asks for permission during a turn in ask mode, the approval footer renders the options and resolves correctly.