### PR TITLE
Fix file tree reads in Docker sandboxes

### DIFF
--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -161,7 +161,7 @@ class AcpSession:
             file_path = att.get("file_path")
             if not isinstance(file_path, str) or not file_path:
                 continue
-            sandbox_path = SANDBOX_HOME_DIR + "/" + Path(file_path).name
+            sandbox_path = SANDBOX_WORKSPACE_DIR + "/" + Path(file_path).name
             filename = att.get("filename")
             label = (
                 filename

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -16,6 +16,7 @@ from app.constants import (
     SANDBOX_BINARY_EXTENSIONS,
     SANDBOX_DEFAULT_COMMAND_TIMEOUT,
     SANDBOX_HOME_DIR,
+    SANDBOX_WORKSPACE_DIR,
     TERMINAL_TYPE,
 )
 from app.services.exceptions import SandboxException
@@ -54,14 +55,18 @@ class LocalDockerProvider(SandboxProvider):
         self._docker: aiodocker.Docker | None = None
 
     @staticmethod
-    def _normalize_path(file_path: str, base: str = SANDBOX_HOME_DIR) -> str:
-        # Convert a relative or absolute path into an absolute container path
-        # under the base directory — Docker's tar APIs (get_archive/put_archive)
-        # require absolute paths.
+    def _normalize_path(file_path: str, base: str = SANDBOX_WORKSPACE_DIR) -> str:
+        # Convert a relative or absolute path into an absolute container path —
+        # Docker's tar APIs (get_archive/put_archive) require absolute paths.
+        # Base defaults to the workspace dir because that's where list_files
+        # roots, so relative paths from the file tree (e.g. ".worktrees/.../foo")
+        # must resolve under /home/user/workspace, not /home/user.
         path = PurePosixPath(file_path)
         if path.is_absolute():
             path_str = str(path)
-            if path_str.startswith(base):
+            # Preserve any absolute path already under /home/user/ (covers both
+            # workspace paths and sibling home-dir paths like /home/user/.bashrc).
+            if path_str.startswith(SANDBOX_HOME_DIR):
                 return posixpath.normpath(path_str)
             return posixpath.normpath(f"{base}{path}")
         return posixpath.normpath(f"{base}/{path}")

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -85,9 +85,8 @@ class StorageService:
         if sandbox_id:
             # Attachments are advertised to the agent as readable from the
             # sandbox, so fail the upload if the sandbox copy is unavailable.
-            # Pass a relative filename so both providers handle it — Docker
-            # normalises it under /home/user/, Host resolves against the
-            # workspace root (absolute paths are rejected by Host).
+            # Pass a relative filename so both providers resolve it under the
+            # workspace dir (absolute paths are rejected by Host).
             await self.sandbox_service.provider.write_file(
                 sandbox_id=sandbox_id, path=unique_filename, content=contents
             )


### PR DESCRIPTION
## Summary
- `list_files` roots `git ls-files` at `/home/user/workspace`, but `_normalize_path` still defaulted to `/home/user`, so every relative path from the file tree resolved to the wrong container location (404). Most visible when a listed file sat under `.worktrees/...`.
- Change `_normalize_path` default base to `SANDBOX_WORKSPACE_DIR` and preserve any absolute path already under `/home/user/` (including sibling home-dir paths like `/home/user/.bashrc`).
- Update attachment prompt note to `/home/user/workspace/{filename}` to match where Docker now writes attachments — aligns with existing host-provider behavior.

## Test plan
- [ ] In Docker mode, open a workspace pointed at a local dir containing `.worktrees/...` and confirm clicking files in the file tree loads their contents.
- [ ] Click a plain workspace file (e.g. `backend/app/main.py`) and confirm it loads.
- [ ] Edit and save a file from the editor; confirm the update lands at the workspace path.
- [ ] Upload an image attachment and confirm the agent can reference it at the advertised `/home/user/workspace/{filename}` path.