### PR TITLE
Redesign permission approval UI

### DIFF
--- a/frontend/src/components/chat/tools/ToolPermissionInline.tsx
+++ b/frontend/src/components/chat/tools/ToolPermissionInline.tsx
@@ -1,14 +1,114 @@
-import { ShieldAlert } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { ChevronRight, Folder, ShieldAlert } from 'lucide-react';
 import { LazyMarkDown } from '@/components/ui/LazyMarkDown';
+import { Button } from '@/components/ui/primitives/Button';
 import type { PermissionRequest } from '@/types/chat.types';
 import { PermissionApprovalButtons } from '@/components/ui/shared/ApprovalFooter';
 import { filterOptions } from '@/utils/permissionStorage';
+import { cn } from '@/utils/cn';
+import { formatResult } from '@/utils/format';
 
-function formatValue(value: unknown): string {
-  if (value === null || value === undefined) return 'null';
+const HEADLINE_KEYS = new Set(['reason', 'description']);
+const COMMAND_KEYS = new Set(['command', 'cmd']);
+const CWD_KEYS = new Set(['cwd', 'working_directory']);
+const SHELL_WRAPPER_FLAGS = new Set(['-lc', '-lic', '-c']);
+// Conservative "safe" charset — anything outside it (whitespace, shell
+// metacharacters like ; | & > < $ ` * ? ( ) ~ \, embedded quotes, etc.) gets
+// POSIX single-quoted so the rendered command is lossless and can't parse
+// as a different shell invocation than the tool will actually execute.
+const SHELL_SAFE_ARG_RE = /^[-A-Za-z0-9_./=:@%+,]+$/;
+// Match only POSIX shell executables (bare or absolute path). Prevents the
+// wrapper unwrap from misrepresenting non-shell invocations like
+// `python -c 'print(1)'` — those must render in full so the user approves
+// the real interpreter, not just the script body.
+const SHELL_BASENAME_RE = /(?:^|\/)(sh|bash|zsh|dash|ksh|fish)$/;
+// Diagnostic identifiers (call_id, turn_id, request_id, …) get collapsed
+// behind "Show details"; everything else — including provider scope metadata
+// like proposed_execpolicy_amendment — stays visible so the user can see the
+// full breadth of what they're approving.
+const DIAGNOSTIC_KEY_RE = /(?:^|_)id$/;
+
+interface ExtractedFields {
+  headline: string | null;
+  command: string | null;
+  cwd: string | null;
+  meta: Array<[string, unknown]>;
+  diagnostics: Array<[string, unknown]>;
+}
+
+function extractFields(input: Record<string, unknown>): ExtractedFields {
+  let headline: string | null = null;
+  let command: string | null = null;
+  let cwd: string | null = null;
+  const meta: Array<[string, unknown]> = [];
+  const diagnostics: Array<[string, unknown]> = [];
+
+  for (const [key, value] of Object.entries(input)) {
+    const lower = key.toLowerCase();
+    if (headline === null && HEADLINE_KEYS.has(lower) && typeof value === 'string') {
+      headline = value;
+      continue;
+    }
+    if (command === null && COMMAND_KEYS.has(lower)) {
+      const formatted = formatShellCommand(value);
+      if (formatted !== null) {
+        command = formatted;
+        continue;
+      }
+    }
+    if (cwd === null && CWD_KEYS.has(lower) && typeof value === 'string') {
+      cwd = value;
+      continue;
+    }
+    if (DIAGNOSTIC_KEY_RE.test(lower)) {
+      diagnostics.push([key, value]);
+    } else {
+      meta.push([key, value]);
+    }
+  }
+
+  return { headline, command, cwd, meta, diagnostics };
+}
+
+function formatShellCommand(value: unknown): string | null {
   if (typeof value === 'string') return value;
-  if (typeof value === 'boolean' || typeof value === 'number') return String(value);
-  return JSON.stringify(value, null, 2);
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const arr = value.map(String);
+  // Only unwrap when arr[0] is an actual shell — otherwise we'd hide the real
+  // interpreter (python, node, rsync, …) behind a `-c`/`-lc`/`-lic` flag that
+  // those tools also accept but with different semantics.
+  if (arr.length === 3 && SHELL_WRAPPER_FLAGS.has(arr[1]) && SHELL_BASENAME_RE.test(arr[0])) {
+    return arr[2];
+  }
+  return arr.map(shellQuote).join(' ');
+}
+
+function shellQuote(arg: string): string {
+  if (arg === '') return "''";
+  if (SHELL_SAFE_ARG_RE.test(arg)) return arg;
+  // POSIX: close the single-quoted span, emit an escaped literal quote, reopen.
+  return "'" + arg.replace(/'/g, "'\\''") + "'";
+}
+
+interface DetailsListProps {
+  details: Array<[string, unknown]>;
+}
+
+function DetailsList({ details }: DetailsListProps) {
+  return (
+    <div className="space-y-2">
+      {details.map(([key, value]) => (
+        <div key={key} className="space-y-0.5">
+          <div className="text-2xs font-medium uppercase tracking-wider text-text-tertiary dark:text-text-dark-tertiary">
+            {key}
+          </div>
+          <div className="overflow-auto rounded-md bg-black/5 px-2 py-1.5 text-xs text-text-primary dark:bg-white/5 dark:text-text-dark-primary">
+            <LazyMarkDown content={formatResult(value)} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 interface ToolPermissionInlineProps {
@@ -26,48 +126,94 @@ export function ToolPermissionInline({
   isLoading = false,
   error = null,
 }: ToolPermissionInlineProps) {
+  const [showDetails, setShowDetails] = useState(false);
+  const prevRequestIdRef = useRef<string | null>(null);
+
+  // Reset the disclosure when a new permission request arrives — the
+  // component stays mounted across requests in the chat UI, so without this
+  // an expanded section from a prior request would leak into the next one.
+  const currentRequestId = request?.request_id ?? null;
+  if (prevRequestIdRef.current !== currentRequestId) {
+    prevRequestIdRef.current = currentRequestId;
+    if (showDetails) setShowDetails(false);
+  }
+
   if (!request || request.tool_name === 'ExitPlanMode') return null;
 
-  const hasParams = request.tool_input && Object.keys(request.tool_input).length > 0;
+  const fields = extractFields(request.tool_input ?? {});
+
   const allowOptions = filterOptions(request.options, 'allow');
   const rejectOptions = filterOptions(request.options, 'reject');
+  const hasStructured = fields.headline !== null || fields.command !== null;
+  const hasAnyContent =
+    hasStructured || fields.cwd !== null || fields.meta.length > 0 || fields.diagnostics.length > 0;
+  const needsMetaTopMargin = hasStructured || fields.cwd !== null;
 
   return (
     <div className="overflow-hidden rounded-lg border border-border/50 bg-surface-tertiary dark:border-border-dark/50 dark:bg-surface-dark-tertiary">
-      <div className="flex h-9 items-center justify-between border-b border-border/50 px-3 dark:border-border-dark/50">
-        <div className="flex items-center gap-2">
-          <div className="rounded-md bg-black/5 p-1 dark:bg-white/5">
-            <ShieldAlert className="h-3.5 w-3.5 text-text-tertiary dark:text-text-dark-tertiary" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <span className="text-xs font-medium text-text-primary dark:text-text-dark-primary">
-              Permission Required
-            </span>
-            <span className="ml-2 text-2xs text-text-secondary dark:text-text-dark-secondary">
-              Tool:{' '}
-              <code className="rounded bg-black/5 px-1 py-0.5 font-mono dark:bg-white/5">
-                {request.tool_name}
-              </code>
-            </span>
-          </div>
+      <div className="flex h-9 items-center gap-2 border-b border-border/50 px-3 dark:border-border-dark/50">
+        <div className="rounded-md bg-black/5 p-1 dark:bg-white/5">
+          <ShieldAlert className="h-3.5 w-3.5 text-text-tertiary dark:text-text-dark-tertiary" />
         </div>
+        <span className="text-xs font-medium text-text-primary dark:text-text-dark-primary">
+          Permission required
+        </span>
+        <code className="ml-auto rounded bg-black/5 px-1.5 py-0.5 font-mono text-2xs text-text-secondary dark:bg-white/5 dark:text-text-dark-secondary">
+          {request.tool_name}
+        </code>
       </div>
 
       <div className="max-h-[50vh] overflow-y-auto p-3">
-        {hasParams ? (
-          <div className="space-y-2">
-            {Object.entries(request.tool_input).map(([key, value]) => (
-              <div key={key} className="space-y-0.5">
-                <div className="text-2xs font-medium uppercase tracking-wider text-text-tertiary dark:text-text-dark-tertiary">
-                  {key}
-                </div>
-                <div className="overflow-auto rounded-md bg-black/5 px-2 py-1.5 text-xs text-text-primary dark:bg-white/5 dark:text-text-dark-primary">
-                  <LazyMarkDown content={formatValue(value)} />
-                </div>
-              </div>
-            ))}
+        {fields.headline && (
+          <div className="mb-3 text-xs leading-relaxed text-text-primary dark:text-text-dark-primary">
+            {fields.headline}
           </div>
-        ) : (
+        )}
+        {fields.command && (
+          <div className="overflow-x-auto rounded-md bg-black/5 px-2.5 py-2 dark:bg-white/5">
+            <code className="whitespace-pre font-mono text-xs text-text-primary dark:text-text-dark-primary">
+              <span className="mr-2 select-none text-text-quaternary dark:text-text-dark-quaternary">
+                $
+              </span>
+              {fields.command}
+            </code>
+          </div>
+        )}
+        {fields.cwd && (
+          <div className="mt-2 flex items-center gap-1.5 font-mono text-2xs text-text-tertiary dark:text-text-dark-tertiary">
+            <Folder className="h-3 w-3 flex-shrink-0" />
+            <span className="truncate">{fields.cwd}</span>
+          </div>
+        )}
+        {fields.meta.length > 0 && (
+          <div className={cn(needsMetaTopMargin && 'mt-3')}>
+            <DetailsList details={fields.meta} />
+          </div>
+        )}
+        {fields.diagnostics.length > 0 && (
+          <>
+            <Button
+              variant="unstyled"
+              type="button"
+              onClick={() => setShowDetails((v) => !v)}
+              className="mt-3 flex items-center gap-1 rounded-md text-2xs text-text-tertiary transition-colors hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+            >
+              <ChevronRight
+                className={cn(
+                  'h-3 w-3 transition-transform duration-150',
+                  showDetails && 'rotate-90',
+                )}
+              />
+              {showDetails ? 'Hide details' : 'Show details'}
+            </Button>
+            {showDetails && (
+              <div className="mt-2">
+                <DetailsList details={fields.diagnostics} />
+              </div>
+            )}
+          </>
+        )}
+        {!hasAnyContent && (
           <p className="text-center text-xs italic text-text-tertiary dark:text-text-dark-tertiary">
             No parameters
           </p>

--- a/frontend/src/components/ui/shared/ApprovalFooter.tsx
+++ b/frontend/src/components/ui/shared/ApprovalFooter.tsx
@@ -1,6 +1,19 @@
-import { CheckCircle, XCircle, AlertCircle } from 'lucide-react';
+import { AlertCircle, Check, CheckCircle, X, XCircle } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { cn } from '@/utils/cn';
 import type { PermissionOption } from '@/types/chat.types';
+
+// Generic, agent-agnostic subtitles keyed by option kind — reinforces the
+// server-provided title with a plain-English outcome line.
+const KIND_SUBTITLES: Record<PermissionOption['kind'], string> = {
+  allow_once: 'Proceed with this request.',
+  allow_always: "Allow and don't ask again.",
+  reject_once: 'Reject this request.',
+  reject_always: "Reject and don't ask again.",
+};
+
+const ALLOW_PRIORITY: PermissionOption['kind'][] = ['allow_once', 'allow_always'];
+const REJECT_PRIORITY: PermissionOption['kind'][] = ['reject_once', 'reject_always'];
 
 interface PermissionApprovalButtonsProps {
   allowOptions: PermissionOption[];
@@ -19,59 +32,145 @@ export function PermissionApprovalButtons({
   isLoading,
   error,
 }: PermissionApprovalButtonsProps) {
+  const sortedAllow = sortByPriority(allowOptions, ALLOW_PRIORITY);
+  const sortedReject = sortByPriority(rejectOptions, REJECT_PRIORITY);
+  // Only show "Allow" / "Reject" group labels when the user has to choose
+  // between multiple options in a group; a single-option footer (e.g. plan
+  // mode) doesn't need the extra visual grouping.
+  const showGroupLabels = sortedAllow.length + sortedReject.length > 2;
+  const primaryAllowId = sortedAllow[0]?.option_id ?? null;
+
   return (
-    <div className="border-t border-border/50 px-3 py-2 dark:border-border-dark/50">
+    <div className="border-t border-border/50 p-2 dark:border-border-dark/50">
       {error && (
-        <div className="mb-2 flex items-center gap-2 text-2xs text-error-600 dark:text-error-400">
+        <div className="mb-2 flex items-center gap-2 px-1 text-2xs text-error-600 dark:text-error-400">
           <AlertCircle className="h-3 w-3 flex-shrink-0" />
           <span>{error}</span>
         </div>
       )}
-      <div className="flex flex-col gap-1.5">
-        {allowOptions
-          .filter((opt) => opt.kind === 'allow_once')
-          .map((opt) => (
-            <Button
+
+      {sortedAllow.length > 0 && (
+        <>
+          {showGroupLabels && <GroupLabel kind="allow" />}
+          {sortedAllow.map((opt) => (
+            <OptionRow
               key={opt.option_id}
+              option={opt}
+              isPrimary={opt.option_id === primaryAllowId}
               onClick={() => onApprove(opt.option_id)}
-              variant="primary"
-              size="sm"
-              className="w-full justify-center"
               disabled={isLoading}
-            >
-              <CheckCircle className="h-3.5 w-3.5 flex-shrink-0" />
-              {opt.name}
-            </Button>
+            />
           ))}
-        {allowOptions
-          .filter((opt) => opt.kind !== 'allow_once')
-          .map((opt) => (
-            <Button
+        </>
+      )}
+
+      {sortedAllow.length > 0 && sortedReject.length > 0 && (
+        <div className="mx-2 my-1 h-px bg-border/50 dark:bg-border-dark/50" />
+      )}
+
+      {sortedReject.length > 0 && (
+        <>
+          {showGroupLabels && <GroupLabel kind="reject" />}
+          {sortedReject.map((opt) => (
+            <OptionRow
               key={opt.option_id}
-              onClick={() => onApprove(opt.option_id)}
-              variant="secondary"
-              size="sm"
-              className="w-full justify-center"
+              option={opt}
+              isPrimary={false}
+              onClick={() => onReject(opt.option_id)}
               disabled={isLoading}
-            >
-              <CheckCircle className="h-3.5 w-3.5 flex-shrink-0" />
-              {opt.name}
-            </Button>
+            />
           ))}
-        {rejectOptions.map((opt) => (
-          <Button
-            key={opt.option_id}
-            onClick={() => onReject(opt.option_id)}
-            variant="ghost"
-            size="sm"
-            className="w-full justify-center"
-            disabled={isLoading}
-          >
-            <XCircle className="h-3.5 w-3.5 flex-shrink-0" />
-            {opt.name}
-          </Button>
-        ))}
-      </div>
+        </>
+      )}
     </div>
+  );
+}
+
+function sortByPriority(
+  options: PermissionOption[],
+  priority: PermissionOption['kind'][],
+): PermissionOption[] {
+  return [...options].sort((a, b) => {
+    const ai = priority.indexOf(a.kind);
+    const bi = priority.indexOf(b.kind);
+    return (ai === -1 ? Infinity : ai) - (bi === -1 ? Infinity : bi);
+  });
+}
+
+interface GroupLabelProps {
+  kind: 'allow' | 'reject';
+}
+
+function GroupLabel({ kind }: GroupLabelProps) {
+  const Icon = kind === 'allow' ? Check : X;
+  return (
+    <div className="flex items-center gap-1.5 px-2 pb-1 pt-1.5 text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
+      <Icon className="h-2.5 w-2.5" />
+      {kind === 'allow' ? 'Allow' : 'Reject'}
+    </div>
+  );
+}
+
+interface OptionRowProps {
+  option: PermissionOption;
+  isPrimary: boolean;
+  onClick: () => void;
+  disabled: boolean;
+}
+
+function OptionRow({ option, isPrimary, onClick, disabled }: OptionRowProps) {
+  const Icon = option.kind.startsWith('allow') ? CheckCircle : XCircle;
+  const subtitle = KIND_SUBTITLES[option.kind];
+
+  return (
+    <Button
+      variant="unstyled"
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={option.name}
+      className={cn(
+        'mb-0.5 flex w-full items-start gap-2.5 rounded-lg border p-2.5 text-left transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-60',
+        isPrimary
+          ? 'border-text-primary bg-text-primary text-surface hover:bg-text-secondary dark:border-text-dark-primary dark:bg-text-dark-primary dark:text-surface-dark dark:hover:bg-text-dark-secondary'
+          : 'border-transparent hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+      )}
+    >
+      <div
+        className={cn(
+          'mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md',
+          isPrimary ? 'bg-white/10 dark:bg-black/10' : 'bg-black/5 dark:bg-white/5',
+        )}
+      >
+        <Icon
+          className={cn(
+            'h-3.5 w-3.5',
+            isPrimary
+              ? 'text-surface dark:text-surface-dark'
+              : 'text-text-tertiary dark:text-text-dark-tertiary',
+          )}
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div
+          className={cn(
+            'text-xs font-medium leading-snug',
+            !isPrimary && 'text-text-primary dark:text-text-dark-primary',
+          )}
+        >
+          {option.name}
+        </div>
+        <div
+          className={cn(
+            'mt-0.5 text-2xs leading-snug',
+            isPrimary
+              ? 'text-surface/60 dark:text-surface-dark/60'
+              : 'text-text-tertiary dark:text-text-dark-tertiary',
+          )}
+        >
+          {subtitle}
+        </div>
+      </div>
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- Extract structured fields (headline, command, cwd) from `tool_input` in `ToolPermissionInline` for readable, scannable display instead of a flat key/value dump.
- POSIX-quote array-form shell commands and conservatively unwrap `bash -lc '<cmd>'` invocations so the rendered command is lossless and matches what the tool actually runs.
- Collapse diagnostic identifiers (`*_id`) behind a "Show details" disclosure; reset the disclosure when a new request arrives.
- Restyle `ApprovalFooter` with a primary allow button, optional "Allow" / "Reject" group labels, per-option subtitles, and consistent icon treatment so the recommended action is unambiguous.

## Test plan
- [ ] Trigger a tool permission request with a shell `Bash` command and verify it renders as `$ <command>` with the wrapper flag unwrapped.
- [ ] Trigger a permission request with a non-shell array command (e.g. `python -c ...`) and verify it renders in full without unwrapping.
- [ ] Verify `reason` / `description` renders as a headline above the command, `cwd` renders with a folder icon, and `*_id` fields stay hidden until "Show details" is clicked.
- [ ] Verify the disclosure collapses automatically when a new permission request replaces the current one.
- [ ] Verify the approval footer: primary allow button styling, allow/reject group labels appear only when there are more than 2 options total, and single-option footers (e.g. ExitPlanMode elsewhere) look correct.
- [ ] Check light and dark mode.