### PR TITLE
Close file tree by default and focus selected file on open

### DIFF
--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -5,7 +5,9 @@ import { Tree } from '../file-tree/Tree';
 import { View } from '../editor-view/View';
 import type { FileStructure } from '@/types/file-system.types';
 import { cn } from '@/utils/cn';
+import { getAncestorFolderPaths } from '@/utils/file';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { useMountEffect } from '@/hooks/useMountEffect';
 
 export interface CodeViewProps {
   files: FileStructure[];
@@ -22,6 +24,17 @@ export interface CodeViewProps {
   onRefresh?: () => void;
   isRefreshing?: boolean;
 }
+
+const scrollSelectedFileIntoView = (container: HTMLElement | null, path: string) => {
+  if (!container) return;
+  // Two rAFs: first for React to flush folder-expansion state, second for the layout to settle.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const el = container.querySelector<HTMLElement>(`[data-file-path="${CSS.escape(path)}"]`);
+      el?.scrollIntoView({ block: 'center' });
+    });
+  });
+};
 
 export const CodeView = memo(function CodeView({
   files,
@@ -42,7 +55,18 @@ export const CodeView = memo(function CodeView({
   const isMobile = useIsMobile();
   const [showMobileTree, setShowMobileTree] = useState(false);
   const fileTreePanelRef = useRef<ImperativePanelHandle>(null);
-  const [isFileTreeCollapsed, setIsFileTreeCollapsed] = useState(false);
+  const fileTreeContainerRef = useRef<HTMLDivElement>(null);
+  const [isFileTreeCollapsed, setIsFileTreeCollapsed] = useState(true);
+
+  useMountEffect(() => {
+    // Sync the flag with the panel's actual restored state: autoSaveId can override defaultSize,
+    // so a returning user's saved-expanded layout would otherwise leave isFileTreeCollapsed=true
+    // and desync the View's toggle button from reality.
+    const panel = fileTreePanelRef.current;
+    if (panel && !panel.isCollapsed()) {
+      setIsFileTreeCollapsed(false);
+    }
+  });
 
   const handleToggleFileTree = useCallback(() => {
     const panel = fileTreePanelRef.current;
@@ -53,6 +77,22 @@ export const CodeView = memo(function CodeView({
       panel.collapse();
     }
   }, []);
+
+  const handleFileTreeExpand = useCallback(() => {
+    setIsFileTreeCollapsed(false);
+    if (!selectedFile || selectedFile.type !== 'file') return;
+
+    // Expand any collapsed ancestor folders so the selected file renders in the DOM before scrolling.
+    // Editor.tsx normalizes expandedFolders so unknown paths default to `true`; `=== false` matches
+    // only explicitly-collapsed folders and avoids toggling implicit-true defaults closed.
+    for (const ancestorPath of getAncestorFolderPaths(selectedFile.path)) {
+      if (expandedFolders[ancestorPath] === false) {
+        toggleFolder(ancestorPath);
+      }
+    }
+
+    scrollSelectedFileIntoView(fileTreeContainerRef.current, selectedFile.path);
+  }, [selectedFile, expandedFolders, toggleFolder]);
 
   const handleMobileFileSelect = useCallback(
     (file: FileStructure | null) => {
@@ -119,15 +159,16 @@ export const CodeView = memo(function CodeView({
       <PanelGroup direction="horizontal" autoSaveId="code-view-layout">
         <Panel
           ref={fileTreePanelRef}
-          defaultSize={20}
+          defaultSize={0}
           minSize={15}
           maxSize={40}
           collapsible
           collapsedSize={0}
           onCollapse={() => setIsFileTreeCollapsed(true)}
-          onExpand={() => setIsFileTreeCollapsed(false)}
+          onExpand={handleFileTreeExpand}
         >
           <div
+            ref={fileTreeContainerRef}
             className={`h-full overflow-hidden border-r border-border dark:border-border-dark ${backgroundClass}`}
           >
             <Tree

--- a/frontend/src/components/editor/file-tree/Item.tsx
+++ b/frontend/src/components/editor/file-tree/Item.tsx
@@ -39,6 +39,7 @@ export const Item = memo(function Item({ item, level, searchQuery = '', matchedP
       <Button
         onClick={handleClick}
         variant="unstyled"
+        data-file-path={item.path}
         className={cn(
           'flex w-full items-center gap-1 px-1.5 py-[3px] text-left',
           'rounded-md transition-colors duration-150',

--- a/frontend/src/hooks/useFileTreeSearch.ts
+++ b/frontend/src/hooks/useFileTreeSearch.ts
@@ -1,6 +1,6 @@
 import { useDeferredValue, useMemo } from 'react';
 import type { FileStructure } from '@/types/file-system.types';
-import { traverseFileStructure, getFileName } from '@/utils/file';
+import { traverseFileStructure, getFileName, getAncestorFolderPaths } from '@/utils/file';
 import { fuzzySearch } from '@/utils/fuzzySearch';
 
 interface FileItem {
@@ -38,14 +38,8 @@ const getFoldersToExpand = (matchedFiles: FileItem[]): Record<string, boolean> =
   const foldersToExpand: Record<string, boolean> = {};
 
   matchedFiles.forEach((file) => {
-    const pathParts = file.path.split('/');
-
-    // Build all parent paths (excluding the file itself)
-    for (let i = 1; i < pathParts.length; i++) {
-      const folderPath = pathParts.slice(0, i).join('/');
-      if (folderPath) {
-        foldersToExpand[folderPath] = true;
-      }
+    for (const folderPath of getAncestorFolderPaths(file.path)) {
+      foldersToExpand[folderPath] = true;
     }
   });
 

--- a/frontend/src/utils/file.ts
+++ b/frontend/src/utils/file.ts
@@ -69,6 +69,19 @@ export function getFileName(path: string): string {
   return parts[parts.length - 1];
 }
 
+export function getAncestorFolderPaths(path: string): string[] {
+  const segments = path.split('/');
+  const ancestors: string[] = [];
+  let prefix = '';
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i];
+    if (!segment) continue;
+    prefix = prefix ? `${prefix}/${segment}` : segment;
+    ancestors.push(prefix);
+  }
+  return ancestors;
+}
+
 export function findFileInStructure(
   items: FileStructure[],
   path: string,


### PR DESCRIPTION
## Summary
- File tree panel now starts collapsed on fresh sessions (`defaultSize={0}`); existing users' `autoSaveId`-persisted layout is preserved.
- When the panel is opened, any collapsed ancestor folders of the currently selected file are expanded and the file is scrolled into view (`block: 'center'`).
- Added `useMountEffect` sync so the `isFileTreeCollapsed` flag matches the panel's actually-restored state — avoids desyncing the `View`'s toggle button for returning users.
- Extracted `getAncestorFolderPaths` into `utils/file.ts` and reused it from `useFileTreeSearch` to deduplicate ancestor-path logic.
- Added a `data-file-path` attribute on tree items so the selected row can be queried for `scrollIntoView`.

## Test plan
- [ ] Fresh session (clear `code-view-layout` from localStorage): open the editor and confirm the file tree is collapsed by default.
- [ ] With the tree collapsed, click the toggle button in the editor `Header` or `EmptyState` and confirm the tree expands.
- [ ] Open a deeply-nested file, close the tree, reopen it — confirm the file's ancestor folders are expanded and the file row is scrolled into view.
- [ ] Manually collapse an ancestor folder, close the tree, reopen — confirm that ancestor re-expands.
- [ ] Returning user with a previously-expanded saved layout: confirm the tree stays open on reload and the `View` doesn't render a redundant toggle button.
- [ ] File tree search still auto-expands ancestor folders for matched files (regression check on `useFileTreeSearch`).
- [ ] Mobile breakpoint still opens the tree in an overlay as before.