### PR TITLE
Add "New thread" option to command menu

### DIFF
--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/primitives/Input';
 import { createPortal } from 'react-dom';
 import {
   MessagesSquare,
+  MessageSquarePlus,
   Code,
   SquareTerminal,
   KeyRound,
@@ -25,6 +26,7 @@ import {
   File,
 } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { useNavigate, type NavigateFunction } from 'react-router-dom';
 import { useUIStore } from '@/store/uiStore';
 import { useChatStore } from '@/store/chatStore';
 import { useQueryClient, type QueryClient } from '@tanstack/react-query';
@@ -84,6 +86,7 @@ const VIEW_COMMANDS: ViewCommandItem[] = [
 ];
 
 const ACTION_COMMANDS: ActionCommandItem[] = [
+  { type: 'action', id: 'new-thread', label: 'New thread', icon: MessageSquarePlus, shortcut: 'w' },
   { type: 'action', id: 'new-sub-thread', label: 'New sub-thread', icon: GitBranch, shortcut: 'n' },
   {
     type: 'action',
@@ -209,7 +212,12 @@ function executeGitRemoteCommand(
     .catch(() => toast.error(`${label} failed`));
 }
 
-export function executeCommand(cmd: CommandItem, queryClient: QueryClient, toggle: boolean) {
+export function executeCommand(
+  cmd: CommandItem,
+  queryClient: QueryClient,
+  navigate: NavigateFunction,
+  toggle: boolean,
+) {
   const ui = useUIStore.getState();
 
   if (cmd.type === 'view') {
@@ -219,6 +227,8 @@ export function executeCommand(cmd: CommandItem, queryClient: QueryClient, toggl
     } else {
       ui.handleViewClick(cmd.id, true);
     }
+  } else if (cmd.id === 'new-thread') {
+    navigate('/');
   } else if (cmd.id === 'new-sub-thread') {
     const chat = useChatStore.getState().currentChat;
     if (!chat || chat.parent_chat_id) {
@@ -285,6 +295,7 @@ export function CommandMenu() {
   const activeLeaves = useActiveViews();
   const activeLeafSet = useMemo(() => new Set(activeLeaves), [activeLeaves]);
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const { fileStructure } = useChatContext();
 
   const flatFiles = useMemo(() => flattenFiles(fileStructure), [fileStructure]);
@@ -338,10 +349,10 @@ export function CommandMenu() {
 
   const handleSelectItem = useCallback(
     (cmd: CommandItem) => {
-      executeCommand(cmd, queryClient, false);
+      executeCommand(cmd, queryClient, navigate, false);
       close();
     },
-    [close, queryClient],
+    [close, queryClient, navigate],
   );
 
   const handleSelectFile = useCallback(

--- a/frontend/src/hooks/useCommandMenu.ts
+++ b/frontend/src/hooks/useCommandMenu.ts
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useUIStore } from '@/store/uiStore';
 import { useQueryClient } from '@tanstack/react-query';
@@ -11,6 +12,7 @@ function isEmbeddedEditor(target: EventTarget | null): boolean {
 
 export function useCommandMenu() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   useMountEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -34,7 +36,7 @@ export function useCommandMenu() {
       if (cmd.hideOnMobile && window.innerWidth < MOBILE_BREAKPOINT) return;
 
       e.preventDefault();
-      executeCommand(cmd, queryClient, true);
+      executeCommand(cmd, queryClient, navigate, true);
     };
 
     window.addEventListener('keydown', handleKeyDown, { capture: true });


### PR DESCRIPTION
## Summary
- Adds a `New thread` entry to the command menu (icon `MessageSquarePlus`, shortcut `⌘⇧W` / `Ctrl⇧W`) that navigates to `/` to start a fresh thread from anywhere.
- Threads `navigate` through `executeCommand` (same pattern as `queryClient`) so both the menu UI and the keyboard-shortcut hook can perform client-side navigation without a full page reload.

## Test plan
- [ ] Open the command menu (`⌘⇧P`) from a chat page, select "New thread", confirm redirect to landing page.
- [ ] From a chat page, press `⌘⇧W` directly and confirm redirect to landing page.
- [ ] Confirm existing commands (new sub-thread, create commit, theme toggles, etc.) still work.
- [ ] Confirm the shortcut does not fire inside Monaco/xterm embedded editors.