### PR TITLE
Skip sandbox writes for natively-embedded attachments

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -18,6 +18,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sse_starlette.sse import EventSourceResponse
 
 from app.constants import (
+    MODELS,
     REDIS_KEY_CHAT_CONTEXT_USAGE,
 )
 from app.prompts.system_prompt import DEFAULT_PERSONA_NAME
@@ -445,11 +446,13 @@ async def queue_message(
     if files:
         ws_sandbox = ChatService.sandbox_for_workspace(chat.workspace)
         file_storage = StorageService(ws_sandbox)
+        agent_kind = MODELS[model_id].agent_kind
         attachments = list(
             await asyncio.gather(
                 *[
                     file_storage.save_file(
                         file,
+                        agent_kind=agent_kind,
                         sandbox_id=chat.workspace.sandbox_id,
                         user_id=str(current_user.id),
                     )

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -14,6 +14,20 @@ class AgentKind(str, Enum):
     CURSOR = "cursor"
 
 
+# File types each agent can consume inline in the ACP prompt (base64-embedded as
+# ImageContentBlock/EmbeddedResourceContentBlock). For these, the agent never
+# reads from the sandbox path, so a sandbox-side copy of the upload is dead data.
+# Copilot advertises ACP `embeddedContext: true` but routes to multiple backend
+# models (Claude, GPT, etc.) — PDF parsing depends on the runtime model, so we
+# stay conservative and only declare image as guaranteed-inline for Copilot.
+NATIVE_FILE_TYPES: dict[AgentKind, frozenset[str]] = {
+    AgentKind.CLAUDE: frozenset({"image", "pdf"}),
+    AgentKind.CODEX: frozenset({"image"}),
+    AgentKind.COPILOT: frozenset({"image"}),
+    AgentKind.CURSOR: frozenset({"image"}),
+}
+
+
 # Claude uses MAX_THINKING_TOKENS env var (not a CLI arg) to cap the
 # extended-thinking budget. These map the UI's named tiers to token counts.
 THINKING_MODE_TOKENS: dict[str, int] = {

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -23,7 +23,12 @@ from acp.schema import (
 
 from app.constants import SANDBOX_HOME_DIR, SANDBOX_WORKSPACE_DIR, TERMINAL_TYPE
 from app.core.config import get_settings
-from app.services.acp.adapters import AGENT_ADAPTERS, AgentKind, LaunchConfig
+from app.services.acp.adapters import (
+    AGENT_ADAPTERS,
+    NATIVE_FILE_TYPES,
+    AgentKind,
+    LaunchConfig,
+)
 from app.services.acp.client import AcpClientHandler
 from app.services.sandbox_providers import SandboxProviderType
 from app.services.sandbox_providers.docker_provider import (
@@ -53,15 +58,6 @@ NON_IMAGE_MIME: dict[str, str] = {
 }
 
 EMPTY_FROZENSET: frozenset[str] = frozenset()
-
-# File types each agent can consume natively in the ACP prompt —
-# no sandbox-path note needed for these since the content is inline.
-NATIVE_FILE_TYPES: dict[AgentKind, frozenset[str]] = {
-    AgentKind.CLAUDE: frozenset({"image", "pdf"}),
-    AgentKind.CODEX: frozenset({"image"}),
-    AgentKind.COPILOT: frozenset({"image", "pdf"}),
-    AgentKind.CURSOR: frozenset({"image"}),
-}
 
 
 @dataclass

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -776,11 +776,13 @@ class ChatService(BaseDbService[Chat]):
         attachments: list[MessageAttachmentDict] | None = None
         if request.attached_files:
             file_storage = StorageService(ws_sandbox)
+            agent_kind = MODELS[request.model_id].agent_kind
             attachments = list(
                 await asyncio.gather(
                     *[
                         file_storage.save_file(
                             file,
+                            agent_kind=agent_kind,
                             sandbox_id=chat.workspace.sandbox_id,
                             user_id=str(current_user.id),
                         )

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -6,6 +6,7 @@ from fastapi import UploadFile
 
 from app.core.config import get_settings
 from app.models.types import MessageAttachmentDict
+from app.services.acp.adapters import NATIVE_FILE_TYPES, AgentKind
 from app.services.exceptions import StorageException
 from app.services.sandbox import SandboxService
 from app.utils.attachment_urls import AttachmentURL
@@ -26,6 +27,7 @@ class StorageService:
     async def save_file(
         self,
         file: UploadFile,
+        agent_kind: AgentKind,
         sandbox_id: str | None = None,
         attachment_id: str | None = None,
         user_id: str | None = None,
@@ -82,9 +84,12 @@ class StorageService:
         else:
             file_url = AttachmentURL.build_temp_preview_url(relative_file_path)
 
-        if sandbox_id:
+        if sandbox_id and file_type not in NATIVE_FILE_TYPES[agent_kind]:
             # Attachments are advertised to the agent as readable from the
             # sandbox, so fail the upload if the sandbox copy is unavailable.
+            # Skip the write when the agent consumes this file type inline
+            # (base64-embedded in the ACP prompt) — the sandbox copy would be
+            # dead data and, in desktop mode, would pollute the user's workspace.
             # Pass a relative filename so both providers resolve it under the
             # workspace dir (absolute paths are rejected by Host).
             await self.sandbox_service.provider.write_file(


### PR DESCRIPTION
## Summary
- Images (all agents) and PDFs (Claude) are base64-embedded inline in the ACP prompt, so copying them into the sandbox workspace is dead data — and in desktop mode it pollutes the user's project directory.
- Thread `agent_kind` through `StorageService.save_file` and skip the sandbox write when the file type is natively consumed by the agent. xlsx and non-native PDFs still get written so the agent can reference them by workspace path in `<user_attachments>`.
- Move `NATIVE_FILE_TYPES` from `acp/session.py` to `acp/adapters.py` so `storage.py` can use it without pulling in heavy ACP modules.
- Flip Copilot from `{image, pdf}` to `{image}`: Copilot CLI routes to multiple backend models and the ACP `embeddedContext` capability flag doesn't actually prove PDF parsing (Codex advertises it too). Conservative choice avoids silently dropping PDFs on non-PDF-capable backends.

## Test plan
- [ ] Upload an image in a Claude chat; confirm no file lands in the workspace but the agent still sees the image inline.
- [ ] Upload a PDF in a Claude chat; confirm sandbox write is skipped and the agent reads the PDF inline.
- [ ] Upload a PDF in a Codex/Copilot/Cursor chat; confirm the file is written to the sandbox and the agent gets a `<user_attachments>` path reference.
- [ ] Upload an xlsx in any chat; confirm it's written to the sandbox and referenced via `<user_attachments>`.
- [ ] In desktop mode (`LocalHostProvider`), verify image uploads no longer appear in the user's workspace directory.