### PR TITLE
Preview uploaded images in a lightbox

### DIFF
--- a/frontend/src/components/ui/AttachmentViewer.tsx
+++ b/frontend/src/components/ui/AttachmentViewer.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/utils/cn';
 import { apiClient } from '@/lib/api';
 import { fetchAttachmentBlob, downloadAttachmentFile } from '@/utils/file';
 import { isBrowserObjectUrl } from '@/utils/attachmentUrl';
+import { ImagePreviewModal } from './ImagePreviewModal';
 
 interface AttachmentViewerProps {
   attachments: MessageAttachment[];
@@ -25,6 +26,7 @@ interface ImageState {
 interface ThumbnailWrapperProps {
   attachment: MessageAttachment;
   onDownload: (url: string, filename: string) => void;
+  onPreview?: () => void;
   children: ReactNode;
 }
 
@@ -88,11 +90,36 @@ const LoadingProgressOverlay = memo(function LoadingProgressOverlay() {
 const downloadButtonClass =
   'h-5 w-5 rounded-full bg-black/60 text-white shadow-md backdrop-blur-sm hover:bg-black/70 focus-visible:ring-white/70';
 
-function ThumbnailWrapper({ attachment, onDownload, children }: ThumbnailWrapperProps) {
+const DEFAULT_IMAGE_STATE: ImageState = { isLoading: true, error: false, imageSrc: '' };
+
+function ThumbnailWrapper({ attachment, onDownload, onPreview, children }: ThumbnailWrapperProps) {
   const filename = attachment.filename || getDefaultFilename(attachment.file_type, 0);
+  const isInteractive = Boolean(onPreview);
 
   return (
-    <div className="group/thumbnail relative">
+    <div
+      className={cn(
+        'group/thumbnail relative rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-quaternary/30',
+        isInteractive && 'cursor-zoom-in',
+      )}
+      onClick={onPreview}
+      onKeyDown={
+        isInteractive
+          ? (e) => {
+              // Only react to keys on the wrapper itself — avoid double-firing when the nested
+              // download button is focused and the user presses Enter/Space on it.
+              if (e.target !== e.currentTarget) return;
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onPreview?.();
+              }
+            }
+          : undefined
+      }
+      role={isInteractive ? 'button' : undefined}
+      tabIndex={isInteractive ? 0 : undefined}
+      aria-label={isInteractive ? `Preview ${filename}` : undefined}
+    >
       {children}
       <div className="absolute right-1 top-1 opacity-0 transition-opacity group-hover/thumbnail:opacity-100">
         <Button
@@ -100,9 +127,8 @@ function ThumbnailWrapper({ attachment, onDownload, children }: ThumbnailWrapper
           size="icon"
           variant="ghost"
           onClick={(e) => {
-            if (attachment.file_type === 'image') {
-              e.stopPropagation();
-            }
+            // Stop propagation so the wrapper's preview click handler (images) doesn't fire.
+            e.stopPropagation();
             onDownload(attachment.file_url, filename);
           }}
           className={cn('p-0', downloadButtonClass)}
@@ -170,7 +196,7 @@ function ImageThumbnail({
         <img
           src={state.imageSrc}
           alt={filename}
-          className="block h-10 w-10 cursor-default rounded object-cover"
+          className="block h-10 w-10 rounded object-cover"
           loading="lazy"
         />
         {isUploading && <LoadingProgressOverlay />}
@@ -183,6 +209,8 @@ function ImageThumbnail({
 
 function AttachmentViewerInner({ attachments, uploadingAttachmentIds }: AttachmentViewerProps) {
   const [imageStates, setImageStates] = useState<Record<string, ImageState>>({});
+  // Index into imageAttachments of the image currently shown in the lightbox; null means closed.
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const loadedIdsRef = useRef<Set<string>>(new Set());
   const ownedObjectUrlsRef = useRef<Set<string>>(new Set());
   const uploadingIdSet = useMemo(
@@ -204,10 +232,16 @@ function AttachmentViewerInner({ attachments, uploadingAttachmentIds }: Attachme
     () => attachments.filter((a) => a.file_type === 'image'),
     [attachments],
   );
+  const imageIndexMap = useMemo(
+    () => new Map(imageAttachments.map((a, i) => [a.id, i])),
+    [imageAttachments],
+  );
   const imageIdKey = useMemo(
     () => imageAttachments.map((a) => a.id).join('\0'),
     [imageAttachments],
   );
+
+  const handleClosePreview = useCallback(() => setPreviewIndex(null), []);
 
   useEffect(() => {
     if (imageAttachments.length === 0) return;
@@ -293,48 +327,61 @@ function AttachmentViewerInner({ attachments, uploadingAttachmentIds }: Attachme
   }
 
   return (
-    <div className="flex flex-wrap gap-1.5">
-      {attachments.map((attachment, index) => {
-        const isUploadingAttachment = uploadingIdSet.has(attachment.id);
+    <>
+      <div className="flex flex-wrap gap-1.5">
+        {attachments.map((attachment, index) => {
+          const isUploadingAttachment = uploadingIdSet.has(attachment.id);
 
-        if (attachment.file_type === 'image') {
-          const state = imageStates[attachment.id] || {
-            isLoading: true,
-            error: false,
-            imageSrc: '',
-          };
+          if (attachment.file_type === 'image') {
+            const state = imageStates[attachment.id] || DEFAULT_IMAGE_STATE;
+            // Preview is only meaningful once the image has finished loading successfully —
+            // don't open the lightbox on a still-loading or errored thumbnail.
+            const canPreview = !isUploadingAttachment && !state.isLoading && !state.error;
+            // Safe non-null: every 'image' attachment is in imageAttachments, so the map always has it.
+            const imageIndex = imageIndexMap.get(attachment.id)!;
 
-          return (
-            <ThumbnailWrapper
-              key={attachment.id}
-              attachment={attachment}
-              onDownload={handleDownload}
-            >
-              <ImageThumbnail
+            return (
+              <ThumbnailWrapper
+                key={attachment.id}
                 attachment={attachment}
-                state={state}
-                index={index}
-                isUploading={isUploadingAttachment}
-              />
-            </ThumbnailWrapper>
-          );
-        }
+                onDownload={handleDownload}
+                onPreview={canPreview ? () => setPreviewIndex(imageIndex) : undefined}
+              >
+                <ImageThumbnail
+                  attachment={attachment}
+                  state={state}
+                  index={index}
+                  isUploading={isUploadingAttachment}
+                />
+              </ThumbnailWrapper>
+            );
+          }
 
-        if (attachment.file_type === 'pdf' || attachment.file_type === 'xlsx') {
-          return (
-            <ThumbnailWrapper
-              key={attachment.id}
-              attachment={attachment}
-              onDownload={handleDownload}
-            >
-              <IconThumbnail attachment={attachment} isLoading={isUploadingAttachment} />
-            </ThumbnailWrapper>
-          );
-        }
+          if (attachment.file_type === 'pdf' || attachment.file_type === 'xlsx') {
+            return (
+              <ThumbnailWrapper
+                key={attachment.id}
+                attachment={attachment}
+                onDownload={handleDownload}
+              >
+                <IconThumbnail attachment={attachment} isLoading={isUploadingAttachment} />
+              </ThumbnailWrapper>
+            );
+          }
 
-        return null;
-      })}
-    </div>
+          return null;
+        })}
+      </div>
+      <ImagePreviewModal
+        isOpen={previewIndex !== null}
+        onClose={handleClosePreview}
+        attachments={imageAttachments}
+        imageStates={imageStates}
+        currentIndex={previewIndex ?? 0}
+        onIndexChange={setPreviewIndex}
+        onDownload={handleDownload}
+      />
+    </>
   );
 }
 

--- a/frontend/src/components/ui/ImagePreviewModal.tsx
+++ b/frontend/src/components/ui/ImagePreviewModal.tsx
@@ -1,0 +1,140 @@
+import { memo, useEffect } from 'react';
+import { ChevronLeft, ChevronRight, Download, X } from 'lucide-react';
+import type { MessageAttachment } from '@/types/chat.types';
+import { BaseModal } from './shared/BaseModal';
+import { Button } from './primitives/Button';
+import { Spinner } from './primitives/Spinner';
+
+interface ImageState {
+  isLoading: boolean;
+  error: boolean;
+  imageSrc: string;
+}
+
+interface ImagePreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  attachments: MessageAttachment[];
+  imageStates: Record<string, ImageState>;
+  currentIndex: number;
+  onIndexChange: (index: number) => void;
+  onDownload: (url: string, filename: string) => void;
+}
+
+const navButtonClass =
+  'absolute top-1/2 -translate-y-1/2 rounded-full bg-black/50 p-2 text-white backdrop-blur-sm transition-colors duration-200 hover:bg-black/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70';
+
+function ImagePreviewModalInner({
+  isOpen,
+  onClose,
+  attachments,
+  imageStates,
+  currentIndex,
+  onIndexChange,
+  onDownload,
+}: ImagePreviewModalProps) {
+  const total = attachments.length;
+  const hasMultiple = total > 1;
+  const current = attachments[currentIndex];
+  const goPrev = () => onIndexChange((currentIndex - 1 + total) % total);
+  const goNext = () => onIndexChange((currentIndex + 1) % total);
+
+  useEffect(() => {
+    if (!isOpen || !hasMultiple) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') goPrev();
+      else if (e.key === 'ArrowRight') goNext();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+    // goPrev/goNext are fresh closures each render; currentIndex changing is what matters.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, hasMultiple, currentIndex, total, onIndexChange]);
+
+  if (!isOpen || !current) return null;
+
+  const state = imageStates[current.id];
+  const filename = current.filename || `image-${currentIndex + 1}`;
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="4xl"
+      ariaLabel={`Image preview: ${filename}`}
+    >
+      <div className="flex items-center justify-between border-b border-border/50 px-4 py-2.5 dark:border-border-dark/50">
+        <div className="flex min-w-0 items-center gap-2">
+          <p className="truncate text-xs font-medium text-text-primary dark:text-text-dark-primary">
+            {filename}
+          </p>
+          {hasMultiple && (
+            <span className="shrink-0 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+              {currentIndex + 1} / {total}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            onClick={() => onDownload(current.file_url, filename)}
+            aria-label="Download image"
+          >
+            <Download className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            onClick={onClose}
+            aria-label="Close preview"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+      <div className="relative flex min-h-[60vh] items-center justify-center bg-surface-secondary dark:bg-surface-dark-secondary">
+        {state?.isLoading && <Spinner size="md" className="text-text-tertiary" />}
+        {state?.error && (
+          <p className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
+            Failed to load image
+          </p>
+        )}
+        {state?.imageSrc && !state.error && (
+          <img
+            key={current.id}
+            src={state.imageSrc}
+            alt={filename}
+            className="max-h-[80vh] max-w-full object-contain"
+          />
+        )}
+        {hasMultiple && (
+          <>
+            <Button
+              type="button"
+              variant="unstyled"
+              onClick={goPrev}
+              className={`${navButtonClass} left-3`}
+              aria-label="Previous image"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="unstyled"
+              onClick={goNext}
+              className={`${navButtonClass} right-3`}
+              aria-label="Next image"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </>
+        )}
+      </div>
+    </BaseModal>
+  );
+}
+
+export const ImagePreviewModal = memo(ImagePreviewModalInner);


### PR DESCRIPTION
## Summary
- Clicking an image thumbnail in a chat message now opens a full-size preview modal; previously only download-on-hover was available.
- Lightbox shows the filename, a download action, and a close action; when a message has multiple images, chevron buttons and `ArrowLeft` / `ArrowRight` keys cycle through them.
- Reuses the blob URLs already cached by `AttachmentViewer.imageStates`, so the preview doesn't re-fetch.
- Preview is disabled for still-loading, errored, or uploading thumbnails.
- PDFs and XLSX attachments keep their existing download-only behavior.

## Test plan
- [ ] Upload a single image, send the message, click the thumbnail — modal opens with the image, filename, download button, and close button.
- [ ] Upload multiple images in one message — thumbnails render, clicking any opens the modal at the correct index, chevrons and arrow keys cycle.
- [ ] Hover an image thumbnail and click the download button — download fires, preview does **not** open.
- [ ] `Escape` closes the modal; clicking the backdrop closes the modal.
- [ ] Keyboard-only: tab to a thumbnail, press Enter — preview opens; ring focus is visible.
- [ ] PDF/XLSX thumbnails still show only the hover download button.
- [ ] Try previewing a slow-loading image — thumbnail shows spinner, preview click is no-op until it finishes loading.
- [ ] Dark mode renders correctly (header, backdrop, nav buttons).