### PR TITLE
Abort in-flight chat request when Stop pressed during loading

### DIFF
--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -226,7 +226,11 @@ export function useChatStreaming({
     return () => unsubscribe();
   }, [chatId]);
 
-  const { sendMessage, handleMessageSend: handleMessageSendAction } = useMessageActions({
+  const {
+    sendMessage,
+    handleMessageSend: handleMessageSendAction,
+    cancelPendingStart,
+  } = useMessageActions({
     chatId,
     selectedModelId,
     permissionMode,
@@ -266,6 +270,13 @@ export function useChatStreaming({
     replayStream,
   });
 
+  const markStreamIdleAfterAbort = useCallback(() => {
+    setStreamState('idle');
+    setCurrentMessageId(null);
+    setWasAborted(true);
+    setPendingUserMessageId(null);
+  }, [setPendingUserMessageId]);
+
   // Sends stop requests for one or all active streams in the current chat.
   // Immediately marks the UI as idle (optimistic) and tracks pending stops
   // so incoming envelopes for the stopping stream are ignored.
@@ -285,10 +296,7 @@ export function useChatStreaming({
         });
       }
       pendingStopRef.current = pendingIds;
-      setStreamState('idle');
-      setCurrentMessageId(null);
-      setWasAborted(true);
-      setPendingUserMessageId(null);
+      markStreamIdleAfterAbort();
 
       const results = await Promise.allSettled(stopPromises);
       let anyFailed = false;
@@ -302,7 +310,7 @@ export function useChatStreaming({
         pendingStopRef.current.clear();
       }
     },
-    [chatId, setPendingUserMessageId, stopStream],
+    [chatId, markStreamIdleAfterAbort, stopStream],
   );
 
   useEffect(() => {
@@ -310,9 +318,15 @@ export function useChatStreaming({
   }, [currentMessageId]);
 
   const handleStop = useCallback(() => {
+    if (streamState === 'loading') {
+      cancelPendingStart();
+      markStreamIdleAfterAbort();
+      clearInput();
+      return;
+    }
     void stopActiveStreams(currentMessageIdRef.current || undefined);
     clearInput();
-  }, [stopActiveStreams, clearInput]);
+  }, [cancelPendingStart, clearInput, markStreamIdleAfterAbort, stopActiveStreams, streamState]);
 
   useMountEffect(() => {
     cleanupExpiredPdfBlobs();

--- a/frontend/src/hooks/useMessageActions.ts
+++ b/frontend/src/hooks/useMessageActions.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import toast from 'react-hot-toast';
 import { logger } from '@/utils/logger';
 import { createAttachmentsFromFiles } from '@/utils/message';
@@ -31,7 +31,7 @@ interface UseMessageActionsParams {
   setWasAborted: (aborted: boolean) => void;
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
   addMessageToCache: (message: Message, userMessage?: Message) => void;
-  startStream: (request: ChatRequest) => Promise<string>;
+  startStream: (request: ChatRequest, signal?: AbortSignal) => Promise<string>;
   storeBlobUrl: (file: File, url: string) => void;
   setPendingUserMessageId: (id: string | null) => void;
   isLoading: boolean;
@@ -69,6 +69,7 @@ export function useMessageActions({
 }: UseMessageActionsParams) {
   const { personas } = useChatContext();
   const modelMap = useModelMap();
+  const pendingStartControllerRef = useRef<AbortController | null>(null);
 
   const sendMessage = useCallback(
     async (
@@ -92,6 +93,9 @@ export function useMessageActions({
       if (filesToSend && filesToSend.length > 0 && userMessage?.id) {
         setPendingUserMessageId(userMessage.id);
       }
+
+      const startController = new AbortController();
+      pendingStartControllerRef.current = startController;
 
       try {
         const personaKey = chatId ?? DEFAULT_CHAT_SETTINGS_KEY;
@@ -118,7 +122,8 @@ export function useMessageActions({
           selected_persona_name: validPersona,
         };
 
-        const messageId = await startStream(request);
+        const messageId = await startStream(request, startController.signal);
+        pendingStartControllerRef.current = null;
 
         setCurrentMessageId(messageId);
         setStreamState('streaming');
@@ -148,8 +153,15 @@ export function useMessageActions({
         });
         addMessageToCache(initialMessage, userMessage);
       } catch (streamStartError) {
+        pendingStartControllerRef.current = null;
         setPendingUserMessageId(null);
         setStreamState('idle');
+        // The service layer wraps abort errors inconsistently (direct ServiceError
+        // pre-check vs. wrapped DOMException mid-fetch), so trust the controller
+        // signal as the authoritative source of "did we cancel this".
+        if (startController.signal.aborted) {
+          return;
+        }
         const error =
           streamStartError instanceof Error
             ? streamStartError
@@ -176,6 +188,13 @@ export function useMessageActions({
       setPendingUserMessageId,
     ],
   );
+
+  const cancelPendingStart = useCallback(() => {
+    // Loading-state stop has no stream/message ID yet, so abort the in-flight
+    // start request directly instead of going through the post-registration stop path.
+    pendingStartControllerRef.current?.abort();
+    pendingStartControllerRef.current = null;
+  }, []);
 
   const handleMessageSend = useCallback(
     async (inputMessage: string, inputFiles: File[]) => {
@@ -242,5 +261,6 @@ export function useMessageActions({
   return {
     sendMessage,
     handleMessageSend,
+    cancelPendingStart,
   };
 }

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -193,7 +193,7 @@ interface UseStreamCallbacksResult {
   ) => void;
   onError: (error: Error, messageId?: string, streamId?: string) => void;
   onQueueProcess: (data: QueueProcessingData) => void;
-  startStream: (request: StreamOptions['request']) => Promise<string>;
+  startStream: (request: StreamOptions['request'], signal?: AbortSignal) => Promise<string>;
   replayStream: (messageId: string, afterSeq?: number) => Promise<string>;
   stopStream: (messageId: string) => Promise<void>;
   updateMessageInCache: ReturnType<typeof useMessageCache>['updateMessageInCache'];
@@ -782,23 +782,27 @@ export function useStreamCallbacks({
       : null;
   }, [chatId, onEnvelope, onComplete, onError, onQueueProcess]);
 
-  const startStream = useCallback(async (request: StreamOptions['request']): Promise<string> => {
-    const currentOptions = optionsRef.current;
-    if (!currentOptions) {
-      throw new Error('Stream options not available');
-    }
+  const startStream = useCallback(
+    async (request: StreamOptions['request'], signal?: AbortSignal): Promise<string> => {
+      const currentOptions = optionsRef.current;
+      if (!currentOptions) {
+        throw new Error('Stream options not available');
+      }
 
-    const streamOptions: StreamOptions = {
-      chatId: currentOptions.chatId,
-      request,
-      onEnvelope: currentOptions.onEnvelope,
-      onComplete: currentOptions.onComplete,
-      onError: currentOptions.onError,
-      onQueueProcess: currentOptions.onQueueProcess,
-    };
+      const streamOptions: StreamOptions = {
+        chatId: currentOptions.chatId,
+        request,
+        signal,
+        onEnvelope: currentOptions.onEnvelope,
+        onComplete: currentOptions.onComplete,
+        onError: currentOptions.onError,
+        onQueueProcess: currentOptions.onQueueProcess,
+      };
 
-    return streamService.startStream(streamOptions);
-  }, []);
+      return streamService.startStream(streamOptions);
+    },
+    [],
+  );
 
   const replayStream = useCallback(
     async (messageId: string, afterSeq?: number): Promise<string> => {

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -10,6 +10,7 @@ import { chatStorage } from '@/utils/storage';
 export interface StreamOptions {
   chatId: string;
   request: ChatRequest;
+  signal?: AbortSignal;
   onEnvelope?: (envelope: StreamEnvelope) => void;
   onComplete?: (
     messageId?: string,
@@ -245,7 +246,10 @@ class StreamService {
     const streamId = crypto.randomUUID();
 
     try {
-      const { source, messageId } = await chatService.createCompletion(options.request);
+      const { source, messageId } = await chatService.createCompletion(
+        options.request,
+        options.signal,
+      );
 
       const activeStream: ActiveStream = {
         id: streamId,


### PR DESCRIPTION
## Summary
- Thread an `AbortSignal` through `useMessageActions` → `useStreamCallbacks` → `streamService` → `chatService.createCompletion` so the POST request that opens a stream can be cancelled.
- When the user hits Stop while `streamState === 'loading'` (before the stream has a message ID), abort the in-flight controller and reset UI state directly instead of going through the message-targeted stop path.
- Trust `controller.signal.aborted` inside the catch rather than string-matching the wrapped error — `BaseService.handleServiceError` wraps mid-fetch `DOMException` `AbortError` into a generic `ServiceError`, which the previous `error.name === 'AbortError' || error.message === 'Request aborted'` check failed to recognize.
- Extract a shared `markStreamIdleAfterAbort` helper in `useChatStreaming` to remove the duplicated 4-state reset block between `handleStop` (loading branch) and `stopActiveStreams`.

## Test plan
- [ ] Send a message, immediately press Stop before the assistant bubble appears → UI returns to idle with no toast error and no lingering request in DevTools Network.
- [ ] Send a message, wait for streaming to begin, then press Stop → existing behavior unchanged (stream is stopped via server DELETE, UI returns to idle).
- [ ] Press Stop when nothing is running → no-op (no crash, no toast).
- [ ] Network-throttle the POST so Stop is pressed after request sends but before response → request is cancelled, no error toast shown.