### PR TITLE
Add discard changes support to diff view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,309 +2,322 @@
 
 ## Project Context
 
-- The `frontend/backend-sidecar/` directory is a build artifact — never edit files there; all backend source lives in `backend/`
-- Open-source, self-hosted application — designed for single-user or small-team use, not enterprise scale
-- Runs as a single API instance (no distributed workers, no multi-replica coordination)
-- Do not introduce distributed-system patterns (distributed locks, cross-instance heartbeats, consensus protocols) — prefer simple in-process state (e.g., in-memory sets/dicts, asyncio tasks)
-- Use Redis for pub/sub and caching only, not as a task broker or distributed coordination layer
-- Background work runs as asyncio tasks in the API process — no separate worker services
-- Treat per-user request handling as effectively sequential for reviews and refactors: do not flag bugs that only appear under overlapping concurrent requests (retries, double-submit, multi-tab) unless the task explicitly asks for concurrency hardening
-- ACP `field_meta` (`_meta`) is extensibility metadata that agents are not required to read — do not use it to pass user-facing data (alternative instructions, form answers) that agents need to act on; if the ACP schema has no first-class field for a concept, the feature cannot be reliably implemented through metadata alone
+- `frontend/backend-sidecar/` is a build artifact — never edit; all backend source lives in `backend/`
+- Open-source self-hosted app for single-user / small-team use — single API instance, no distributed workers or multi-replica coordination
+- No distributed-system patterns (distributed locks, cross-instance heartbeats, consensus) — prefer in-process state (in-memory sets/dicts, asyncio tasks)
+- Redis is for pub/sub and caching only — not a task broker or coordination layer
+- Background work runs as asyncio tasks in the API process
+- Treat per-user request handling as effectively sequential — don't flag bugs that only appear under overlapping concurrent requests (retries, double-submit, multi-tab) unless the task explicitly asks for concurrency hardening
+- ACP `field_meta` (`_meta`) is extensibility metadata agents aren't required to read — don't use it for user-facing data (alt instructions, form answers); if ACP has no first-class field for a concept, it can't be reliably done through metadata
 
 ## SQLAlchemy Model Conventions
 
-- Always add `server_default=` when using `default=` - the `default` only applies in Python/ORM, while `server_default` ensures the database has the default value for raw SQL inserts
-- Always specify `nullable=True` or `nullable=False` explicitly
-- Always add max length to String fields (e.g., `String(64)` not just `String`)
-- Use `DateTime(timezone=True)` for all datetime fields for consistency
-- Don't add `index=True` on FK columns if a composite index starting with that column already exists (composite indexes can serve single-column lookups)
+- Always pair `default=` with `server_default=` — `default` only applies in Python/ORM
+- Always specify `nullable=True|False` explicitly
+- Always set max length on String fields (e.g., `String(64)`)
+- Use `DateTime(timezone=True)` for all datetime fields
+- Don't add `index=True` on an FK if a composite index already starts with that column
 
 ## Migration Workflow
 
-- Do not create migration files manually; generate them via Alembic autogenerate first
-- Manual edits to generated Alembic migrations are allowed when necessary for correctness
-- Run Alembic migration commands inside the Docker backend container (not on host)
+- Generate migrations via Alembic autogenerate (don't write them by hand); manual edits to generated migrations are fine when needed for correctness
+- Run Alembic commands inside the Docker backend container (not on host)
 
 ## Code Style
 
-- Always choose the smallest, simplest fix that solves the problem — do not refactor, restructure, or add abstractions as part of a bug fix; if a one-line guard or a single conditional handles it, prefer that over reworking control flow
-- Do not optimize for no regressions or long-term resilience unless explicitly requested — favor simple, direct changes over defensive scaffolding
-- Do not build elaborate rollback/state-restoration logic for failure paths — in a single-user app, a simple log + best-effort recovery (e.g., re-queue the item) is sufficient; do not save/restore every field, delete orphaned rows, or revert intermediate state changes
-- Do not add resource cleanup (`try/finally` with `.cleanup()`, `.close()`) for short-lived provider/client objects in a single-user app — lazy clients (e.g., `aiodocker.Docker`) are created infrequently and GC handles them; only add explicit cleanup when the object is long-lived or pooled
-- Do not add pre-flight compatibility checks that gate an operation when a natural fallback already exists — if the operation can't proceed, let it fall through to the existing path (e.g., normal queue processing) instead of adding branching to detect and re-route
-- Validate at the boundary, not at every layer — if a value is validated on entry (e.g., API endpoint checks that a path exists), do not re-validate the same condition in downstream functions that receive the already-validated value
-- Prefer the simplest collection operation that achieves the goal — use `list.insert(0, item)` instead of a sorted-insertion loop when ordering doesn't meaningfully matter
-- Keep `try/except` blocks narrow — only wrap the code that needs the specific recovery action (e.g., requeue after a pop), not the entire function body; code that can safely propagate exceptions should stay outside the `try`
-- Narrow `except` clauses to specific exception types — never `except Exception` when the actual failure modes are known (e.g., `except (KeyError, SomeLibError)` not `except Exception`)
-- Do not translate exceptions across boundaries just to change the type — if an upstream function already raises a meaningful error, let it propagate; only catch-and-wrap when the caller genuinely needs a different status code or error shape that the original doesn't provide
-- Do not handle hypothetical input shapes — if you have evidence of the actual data format (logs, tests, type definitions), write code for that format only; do not add branches for types or structures you have not observed
-- Do not use Python's `str.format()` or f-strings to interpolate untrusted/user-provided content that may contain `{` or `}` characters (e.g., code diffs, source code snippets, JSON) — use string concatenation or `string.Template` instead
-- Add `Field(max_length=...)` to all `str` fields on Pydantic request models — bare `str` allows unbounded payloads; also add `min_length=1` when empty strings are invalid
-- Do not instantiate services directly in FastAPI route handlers — add a factory function in `deps.py` and inject via `Depends()`; route files should not import `SessionLocal`
-- Never use docstrings (`"""..."""`) — always use inline `#` comments instead when a comment is needed
-- Always add inline `#` comments for non-obvious logic, implicit conventions, design decisions, or anything that isn't clear from the code alone — treat this as mandatory for new and modified code, not optional; comment the *why*, never the *what*
-- Do not delete existing comments without asking first — they may capture context that isn't obvious from the code
-- Let the code speak for itself - use clear variable/function names instead of comments
-- Do not use decorative section comments (e.g., `# ── Section ──────`) — code structure should be self-evident from class/method organization
-- Place comments inside methods and classes, not above them — a comment describing a method belongs as the first line inside the method body, not on the line before `def`/`async def`
-- Method-level comments should explain the *why* and *context*, not just restate the method name — describe the purpose, who uses it, and any non-obvious behavior (e.g., "Catch-up mechanism for SSE reconnection: when a client reconnects it sends the last seq it saw, and this method pages through persisted events so nothing is missed before switching to live pub/sub")
-- Example — no comment needed (self-explanatory): `user_dir.mkdir(parents=True, exist_ok=True)`
-- Example — comment needed (non-obvious why): `# Read from the API host, not the sandbox — sandbox containers don't have the user's global git config`
-- Example — bad method comment (terse, restates the name): `# Yield persisted events after a given seq`
-- Example — good method comment (explains why and context): `# Catch-up mechanism for SSE reconnection: when a client reconnects (network blip, page refresh) it sends the last seq it saw, and this method pages through all persisted events after that seq so the client doesn't miss anything before switching to live Redis pub/sub.`
-- Avoid no-op pass-through wrappers (e.g., a function that only calls another function with identical args/return)
-- If a wrapper exists, it must add concrete value (validation, transformation, error handling, compatibility boundary, or stable public API surface)
-- Prefer direct imports/calls over indirection when behavior is unchanged
-- Do not create a new utility file for a single constant or one-line expression duplicated across only 2 call sites — inline duplication is cheaper than a new file plus two imports when no existing utility module is a natural home; only extract when there are 3+ call sites or an obvious existing file fits
-- Do not call private methods (`_method`) from outside the file where they are defined; if cross-file usage is needed, make the method public and rename it accordingly
-- Do not define helper functions in endpoint files — endpoint files should only contain route handlers; no-op exception-translation wrappers (e.g., `_raise_foo_http_exception`) should be inlined at each call site, reusable access-check or service-construction helpers should be moved to `deps.py` as `Depends()` dependencies, and pure utility functions should be moved to `utils/`
-- When a caller passes a value to a function that already stores/registers it internally, do not call a second function to store/register the same value again — one code path, one registration
-- Do not use inline imports; only allow inline imports when required to avoid circular imports and no cleaner module-level import structure exists
-- Strong typing only: do not use `# type: ignore`, `# pyright: ignore`, `# noqa` to silence typing/import issues; fix the types/usages directly (if absolutely unavoidable, document why in the PR description)
-- Do not define nested/inline functions; use module-level functions for standalone functions (e.g., endpoints) and class methods for classes — if a helper is only used by a class, it must be a method (or static method) on that class, not a module-level function
-- Do not add backward compatibility paths, fallback paths, or legacy shims unless explicitly requested
-- Do not create type aliases that add no semantic value (e.g., `StreamKind = str`) — use the base type directly
-- Module-level constants must be placed at the top of the file, immediately after imports and logger/settings initialization — never between classes or functions
-- Prefer simple env-var/config-based solutions over runtime introspection — e.g., use a `HOST_STORAGE_PATH` env var to map container paths to host paths instead of inspecting Docker container mounts at runtime
-- When two methods in the same class share the same lifecycle (one always calls the other), do not duplicate work in the caller that the callee already performs — let the callee handle it once
-- When refactoring code that has `try/catch/finally` blocks, preserve cleanup logic in `finally` — do not move cleanup after an `await` without wrapping it in `try/finally`, or it will be skipped on failure
-- When extracting a shared utility from multiple callers with slightly different semantics, verify behavioral equivalence for every caller — especially for edge-case inputs like `null`, `undefined`, `0`, and empty strings
-- When accepting a caller-provided options/config object and spreading it into a builder, use `Omit<>` to exclude keys the factory controls — prevents silent shadowing at the type level instead of runtime `_ignored` destructuring
-- When a function receives an optional targeting parameter (e.g., `cwd`, `workspace_id`) and the value is provided but invalid, raise an error — do not silently fall back to a default target, as this causes the operation to succeed against the wrong resource
-- When adding new operations in a domain where existing operations already accept a context/targeting parameter (e.g., `cwd` for worktree paths), propagate that parameter through all new operations in the same chain — backend endpoint, frontend service, React Query hook, and UI component
-- When multiple endpoints share the same parameter validation (e.g., token presence check), extract it into a FastAPI dependency that raises on failure and returns the validated value — do not duplicate the check inline in each endpoint
-- Do not extract a shared React hook when callers must add `useCallback`/`useMemo` wrappers that the inline version did not need — the per-call-site ceremony can exceed the duplication it removes
-- When closing, cleaning up, or tearing down multiple independent resources in a loop, use `asyncio.gather(*[...], return_exceptions=True)` instead of sequential awaits — serializing I/O across independent resources wastes time, especially during shutdown or idle cleanup
-- When catching a `ServiceException` subclass at the API boundary to produce an `HTTPException`, use `exc.status_code` from the exception — do not hardcode a status code constant (e.g., `HTTP_500`) that shadows the exception's own classification
-- When a backend Pydantic response model field has a default value, the corresponding frontend TypeScript type must mark it as required — the API always includes it in responses, so optional markers are incorrect
-- Do not use `TypedDict` with `total=False` when all keys are always present in every construction site — use `total=True` (the default) so the type checker can verify direct key access is safe
-- Do not create standalone functions that only wrap a single dict lookup with a default — inline `DICT[key].field` or `DICT.get(key)` at the call site; if the data structure is a plain tuple, use a `NamedTuple` for self-documenting field access instead of adding accessor functions
-- Do not introduce a new frontend type/interface when an existing one has the same shape — reuse the existing type directly, even across module boundaries
-- When defining an abstract method signature during a refactor, verify every parameter receives a meaningful value from all call sites — do not carry forward parameters from the old design that become dead in the new interface (e.g., always hardcoded to `None`)
-- Do not create inline dict literals for identity mappings (where every key maps to itself) — use a `set`/`frozenset` membership check instead, hoisted to a module-level constant
-- In JSX conditionals with numeric values, use explicit checks (`value != null && value > 0`) instead of truthy checks (`value && ...`) — numeric `0` is falsy but renders as text in React
+### Minimalism
+- Choose the smallest fix — don't refactor, restructure, or add abstractions as part of a bug fix; prefer a one-line guard over reworked control flow
+- Don't optimize for "no regressions" or long-term resilience unless asked — favor simple, direct changes over defensive scaffolding
+- Don't build elaborate rollback/state-restoration for failure paths — log + best-effort recovery (e.g., re-queue) is sufficient; don't save/restore every field, delete orphaned rows, or revert intermediate changes
+- Don't add resource cleanup (`try/finally` with `.cleanup()`, `.close()`) for short-lived provider/client objects — GC handles lazy clients (e.g., `aiodocker.Docker`); only add cleanup for long-lived or pooled objects
+- Don't add pre-flight compatibility checks when a natural fallback exists — let it fall through to the existing path instead of branching to re-route
+- Validate at the boundary only — if an API endpoint checks a value, downstream functions receiving it shouldn't re-validate
+- Prefer the simplest collection op (e.g., `list.insert(0, item)` over a sorted-insertion loop when order doesn't matter)
+- Don't add backward-compat paths, fallback paths, or legacy shims unless asked
+- Don't create type aliases with no semantic value (e.g., `StreamKind = str`)
+- Don't handle hypothetical input shapes — code for the format you've observed (logs, tests, types), not branches for unseen structures
+- Avoid no-op pass-through wrappers; wrappers must add concrete value (validation, transformation, error handling, compatibility boundary, stable public API); prefer direct imports/calls otherwise
+- Don't extract a utility file for a single constant/expression duplicated across only 2 call sites — inline until 3+ sites or an existing file fits naturally
+- Don't create standalone functions that only wrap a single dict lookup with a default — inline `DICT[key].field` or `DICT.get(key)`; for tuples, use a `NamedTuple` instead of accessor functions
+- Don't create inline dict literals for identity mappings — use a module-level `frozenset` membership check
+
+### Exceptions
+- Keep `try/except` narrow — wrap only the code needing the specific recovery; code that can safely propagate should stay outside the `try`
+- Narrow `except` clauses to specific types — never `except Exception` when failure modes are known
+- Don't translate exceptions across boundaries just to change the type — let meaningful upstream errors propagate; catch-and-wrap only when the caller needs a different status/shape
+- When catching a `ServiceException` subclass at the API boundary, use `exc.status_code` — don't hardcode a status that shadows the exception's classification
+- When a function receives an optional targeting parameter (e.g., `cwd`, `workspace_id`) and the value is invalid, raise — don't silently fall back to a default target
+
+### Input & Security
+- Don't use Python `str.format()` or f-strings to interpolate untrusted content that may contain `{`/`}` (diffs, code, JSON) — use concatenation or `string.Template`
+- Add `Field(max_length=...)` to all `str` fields on Pydantic request models; add `min_length=1` when empty is invalid
+
+### FastAPI
+- Don't instantiate services in route handlers — add a factory in `deps.py` and inject via `Depends()`; route files shouldn't import `SessionLocal`
+- Don't define helper functions in endpoint files — endpoint files contain only route handlers. Inline no-op exception-translation wrappers at the call site; move reusable access/service helpers to `deps.py`; move pure utilities to `utils/`
+- When multiple endpoints share parameter validation (e.g., token presence), extract a FastAPI dependency that raises on failure and returns the validated value — don't duplicate inline
+
+### Imports, Typing, Structure
+- No inline imports unless needed to break a circular import
+- Strong typing only — no `# type: ignore`, `# pyright: ignore`, `# noqa` to silence typing/import issues; fix types directly (document in PR if truly unavoidable)
+- Don't define nested/inline functions — use module-level functions or class methods (static/instance); a helper only used by a class must be a method on it
+- Module-level constants go at the top of the file, right after imports/logger/settings — never between classes or functions
+- Don't call private methods (`_method`) across files; make them public (and rename) if cross-file use is needed
+- Don't use `TypedDict` with `total=False` when all keys are always present — use `total=True`
+- When a Pydantic response model field has a default, the corresponding frontend TypeScript type must mark it required — the API always sends it
+- Don't introduce a new frontend type when an existing one has the same shape — reuse directly across modules
+- When defining an abstract method signature during a refactor, verify every parameter gets a meaningful value from all call sites — don't carry forward parameters that are always hardcoded to `None`
+
+### Comments
+- Never use docstrings (`"""..."""`) — always use inline `#` comments
+- Always comment non-obvious logic, implicit conventions, design decisions — mandatory for new/modified code; comment the *why*, never the *what*
+- Don't delete existing comments without asking — they may capture context not obvious from the code
+- Prefer clear names over comments when the code is self-explanatory
+- No decorative section comments (e.g., `# ── Section ──────`) — code structure should be self-evident
+- Place comments inside methods/classes, not above them — a method comment is the first line inside the body
+- Method comments explain *why* and *context* (who uses it, non-obvious behavior), not just restate the name
+- Good: `# Read from the API host, not the sandbox — sandbox containers don't have the user's global git config`
+- Good method comment: `# Catch-up for SSE reconnection: when a client reconnects it sends last seen seq; this pages persisted events after that seq before switching to live pub/sub.`
+- Bad method comment (restates name): `# Yield persisted events after a given seq`
+- Example needing no comment: `user_dir.mkdir(parents=True, exist_ok=True)`
+
+### Cross-cutting gotchas
+- When two methods in the same class share a lifecycle (one always calls the other), don't duplicate work in the caller that the callee already performs
+- When refactoring code with `try/catch/finally`, preserve cleanup in `finally` — don't move cleanup after an `await` without wrapping in `try/finally`
+- When extracting a shared utility from multiple callers with slightly different semantics, verify equivalence for every caller — especially edge-case inputs (`null`, `undefined`, `0`, `""`)
+- When spreading a caller-provided options object into a builder, use `Omit<>` to exclude keys the factory controls — prevents silent shadowing at the type level (not runtime `_ignored` destructuring)
+- When a caller passes a value to a function that already stores/registers it, don't call a second function to store/register it again
+- When adding new operations in a domain that already accepts a context/targeting parameter (e.g., `cwd` for worktree paths), propagate it through the full chain — backend endpoint, frontend service, React Query hook, UI component
+- Don't extract a shared React hook when callers must add `useCallback`/`useMemo` wrappers that the inline version didn't need
+- When closing/tearing down multiple independent resources in a loop, use `asyncio.gather(*[...], return_exceptions=True)` — don't serialize independent I/O
+- Prefer env-var/config solutions over runtime introspection (e.g., `HOST_STORAGE_PATH` to map container→host paths, not inspecting Docker mounts at runtime)
+- In JSX conditionals with numeric values, use explicit checks (`value != null && value > 0`) — not truthy checks, since `0` renders as text in React
+- In shell command chains, use `&&` to gate dependent steps and wrap independent cleanup in `{ ...; }` when exit status must reflect earlier failures — a bare `;` lets later commands mask upstream failures
+- When a shell/CLI command interpolates a path, confirm the cwd matches the path's basis — mixing repo-root-relative pathspecs with a nested cwd (or vice versa) silently scopes operations wrong
+- When adding a bulk variant of a per-item operation, mirror every edge case the per-item version handles (initial state, missing ref, newly-added vs tracked entries) — don't ship only the happy path
 
 ## Naming Conventions
 
-- Method names should describe intent, not mechanism (`_consume_stream` not `_iterate_events`, `_complete_stream` not `_finalize`)
-- Be concrete, not vague (`_save_final_snapshot` not `_persist_final_state`, `_close_redis` not `_cleanup_redis`)
-- Keep names short when meaning is preserved (`_try_create_checkpoint` not `_create_checkpoint_if_needed`, `_prune_done_tasks` not `_prune_finished_background_tasks`)
+- Method names describe intent, not mechanism (`_consume_stream` not `_iterate_events`)
+- Be concrete, not vague (`_save_final_snapshot` not `_persist_final_state`; `_close_redis` not `_cleanup_redis`)
+- Keep names short when meaning holds (`_try_create_checkpoint` not `_create_checkpoint_if_needed`)
 - Don't put implementation details in public method names (`execute_chat` not `execute_chat_with_managed_resources`)
-- Use consistent terminology within a module — don't mix synonyms (e.g., pick "cancel" or "revoke", not both)
-- Do not prefix module-level constants with `_` — leading underscores are for private class methods and instance variables only, not for constants or classes
+- Use consistent terminology within a module — don't mix synonyms (pick "cancel" or "revoke", not both)
+- Don't prefix module-level constants with `_` — leading underscores are for private class methods/instance vars only
 
 ## Module Organization
 
-- Keep logic in the module where it belongs — factory methods go on the class they construct (e.g., `Chat.from_dict`, `SandboxService.create_for_user`), not in unrelated callers
-- Group related free functions into a class with static methods rather than leaving them as loose module-level functions (e.g., `StreamEnvelope.build()` + `StreamEnvelope.sanitize_payload()` instead of separate `build_envelope()` + `redact_for_audit()`)
-- Prefer one data structure over two when one can serve both purposes — don't add a second dict/set to handle an edge case that can be folded into the primary structure; if a property can be derived from existing data (e.g., checking `path.is_relative_to(base_dir)` instead of tracking a separate `managed` set), derive it
-- Do not create multiple overlapping data containers for the same concept — if fields are shared across dataclasses, consolidate into one
-- **`utils/`** is for stateless, pure functions only — parsing, formatting, string building, validation. No I/O, no database access, no service dependencies, no HTTP concerns (`HTTPException`). Raise `ValueError` for invalid input, let callers translate to the appropriate exception type.
-- **`services/`** is for stateful, I/O-bound business logic — database queries, API calls, sandbox commands. Services are instantiated with dependencies (`session_factory`, providers) and injected via `Depends()`. Raise domain exceptions (`SandboxException`, `ChatException`, etc.).
-- **`core/deps.py`** is for FastAPI dependency injection wiring — instantiate services, validate access, translate domain exceptions to `HTTPException` at the boundary.
-- **`core/security.py`** is for authentication and authorization — token validation, password hashing, encryption, and WebSocket auth handshake.
-- If a function does I/O or depends on a service, it does not belong in `utils/` — move it to the appropriate service class or `core/` module
-- When a service accumulates responsibilities from two distinct domains, extract the secondary domain into its own service — e.g., git operations belong in `GitService` (not `SandboxService`), with `GitService` depending on `SandboxService` for command execution
-- Endpoint files must contain only route handlers — all business logic (command building, output parsing, branching decisions) belongs in the service layer; endpoints handle HTTP concerns (request validation, response formatting, exception translation) only
-- Place class definitions (including `NamedTuple` and `TypedDict`) at the top of the file after imports — never between constant declarations
+- Keep logic in the module where it belongs — factory methods go on the class they construct (e.g., `Chat.from_dict`, `SandboxService.create_for_user`)
+- Group related free functions into a class with static methods (e.g., `StreamEnvelope.build()` + `StreamEnvelope.sanitize_payload()` instead of two loose module functions)
+- Prefer one data structure over two when one serves both purposes — derive properties from existing data (e.g., `path.is_relative_to(base_dir)`) instead of tracking a parallel set; don't maintain overlapping containers for the same concept
+- **`utils/`** — stateless pure functions only (parsing, formatting, validation). No I/O, DB, services, or HTTP concerns. Raise `ValueError`; let callers translate.
+- **`services/`** — stateful I/O-bound business logic (DB, API calls, sandbox commands). Instantiated with dependencies, injected via `Depends()`. Raise domain exceptions (`SandboxException`, `ChatException`, ...).
+- **`core/deps.py`** — FastAPI DI wiring; instantiate services, validate access, translate domain exceptions to `HTTPException` at the boundary.
+- **`core/security.py`** — auth/authz (token validation, password hashing, encryption, WebSocket auth handshake).
+- If a function does I/O or depends on a service, it doesn't belong in `utils/` — move it to a service class or `core/`
+- When a service accumulates responsibilities from two distinct domains, extract the secondary into its own service (e.g., `GitService` split out from `SandboxService`, with `GitService` depending on `SandboxService` for command execution)
+- Endpoint files contain only route handlers — all business logic (command building, output parsing, branching) belongs in services; endpoints handle HTTP concerns (validation, response formatting, exception translation)
+- Place class definitions (including `NamedTuple`/`TypedDict`) at the top of the file after imports — never between constants
 
 ## Frontend Component Architecture
 
 ### React Version
-- Project uses React 19 — use `use()` instead of `useContext()`, pass `ref` as a regular prop instead of `forwardRef`
+- React 19 — use `use()` instead of `useContext()`; pass `ref` as a regular prop instead of `forwardRef`
 
 ### UI Primitives
-- Never use raw HTML interactive elements (`<button>`, `<input>`, `<select>`, `<a>`) when a corresponding UI primitive exists in `components/ui/primitives/` — use `Button`, `Input`, etc. instead; for fully custom styling, use `variant="unstyled"` which still provides consistent focus-visible and disabled styles automatically; do not duplicate those built-in styles in `className`
+- Never use raw HTML interactive elements (`<button>`, `<input>`, `<select>`, `<a>`) when a primitive exists in `components/ui/primitives/` — use `Button`, `Input`, etc.; for fully custom styling use `variant="unstyled"` (keeps focus-visible and disabled styles); don't duplicate those built-in styles in `className`
 
 ### Composition Patterns
-- Avoid boolean prop proliferation — don't add `isX`, `showX`, `hideX` boolean props to customize component behavior; use composition instead
+- Avoid boolean prop proliferation (`isX`, `showX`, `hideX`) — use composition instead
 - When a component exceeds ~10 props or has 3+ boolean flags, refactor to a context provider + compound components
-- Use the `state / actions` context interface pattern: define a context with `{ state: StateType; actions: ActionsType }` so UI components consume a generic interface, not a specific implementation
-- Context definitions go in a separate `*Definition.ts` file (e.g., `ChatSessionContextDefinition.ts`), providers in a `*Context.tsx` or `*Provider.tsx` file, and consumer hooks in `hooks/use*.ts`
-- Consumer hooks must use React 19 `use()` and throw if context is null (see `useChatSessionContext.ts` pattern)
-- Provider values must be wrapped in `useMemo` to prevent unnecessary re-renders
+- Use the `state / actions` context interface pattern: `{ state: StateType; actions: ActionsType }` so UI consumes a generic interface
+- Context definitions go in `*Definition.ts`, providers in `*Context.tsx` / `*Provider.tsx`, consumer hooks in `hooks/use*.ts`
+- Consumer hooks use React 19 `use()` and throw if context is null (see `useChatSessionContext.ts`)
+- Provider values must be `useMemo`'d to prevent unnecessary re-renders
 
 ### Provider Pattern for Complex Components
-- When a component has extensive internal hook logic (file handling, suggestions, mutations), lift that logic into a dedicated `*Provider.tsx` that wraps children with context
-- The outer component keeps its prop-based API for backward compatibility, internally wrapping `<Provider {...props}><Layout /></Provider>`
-- Sub-components read from context via `use*Context()` hooks instead of receiving props from the parent
-- Reference implementations: `InputProvider.tsx` (wraps Input internals), `ChatSessionProvider` (wraps Chat session state), `FileTreeProvider` (wraps file tree state)
+- When a component has extensive internal hook logic (file handling, suggestions, mutations), lift it into a `*Provider.tsx` that wraps children with context
+- Outer component keeps its prop-based API; internally wrap `<Provider {...props}><Layout /></Provider>`
+- Sub-components read from context via `use*Context()` hooks
+- References: `InputProvider.tsx`, `ChatSessionProvider`, `FileTreeProvider`
 
 ### No Fallback Patterns in Context Interfaces
-- Context interface fields must not be optional (`?`) when the provider always supplies them — optional markers on always-provided fields are legacy shims
-- Do not add nullability guards (`value && doSomething()`) on context values that are guaranteed by the provider — these are leftover prop-era checks
-- Do not add `?? null` / `?? false` / `?? []` coercions in the provider unless the upstream source genuinely returns `undefined` and the context type requires a concrete value — if the types already match, pass directly
+- Context interface fields must not be optional (`?`) when the provider always supplies them
+- Don't add nullability guards (`value && doSomething()`) on context values guaranteed by the provider
+- Don't add `?? null` / `?? false` / `?? []` coercions in the provider unless the upstream genuinely returns `undefined` and the context type requires a concrete value
 
 ### Existing Context Hierarchy
 - `ChatProvider` (`contexts/ChatContext.tsx`) — static chat metadata: `chatId`, `sandboxId`, `fileStructure`, `customAgents`, `customSlashCommands`, `customPrompts`
 - `ChatSessionProvider` (`contexts/ChatSessionContext.tsx`) — dynamic chat session state: messages, streaming, loading, permissions, input message, model selection
-- `InputProvider` (`components/chat/message-input/InputProvider.tsx`) — input-specific internal state: file handling, drag-and-drop, suggestions, enhancement, submit logic
+- `InputProvider` (`components/chat/message-input/InputProvider.tsx`) — input internals: file handling, drag-and-drop, suggestions, enhancement, submit logic
 - `LayoutContext` (`components/layout/layoutState.tsx`) — sidebar state
-- `FileTreeProvider` (`components/editor/file-tree/FileTreeProvider.tsx`) — file tree selection and expansion state
+- `FileTreeProvider` (`components/editor/file-tree/FileTreeProvider.tsx`) — file tree selection/expansion state
 
 ### Responsive Awareness
-- Before removing a UI element, check if it serves a responsive or functional role beyond its visual purpose — icons often double as compact-mode fallbacks (`compactOnMobile`), and labels may be the only visible element at certain breakpoints
+- Before removing a UI element, check whether it serves a responsive/functional role beyond its visual purpose — icons often double as compact-mode fallbacks (`compactOnMobile`); labels may be the only visible element at some breakpoints
 
 ### File Placement
-- When extracting non-component code (contexts, utils, hooks) from a component file, place it in the project's canonical folder for that type (`contexts/`, `utils/`, `hooks/`) — do not leave it next to the component it was extracted from
-- The `components/chat/tools/` directory is exclusively for tool components (one per tool type) — helper modals, dialogs, and detail views triggered by tools belong in `components/chat/` or a relevant feature folder, not in `tools/`
-- Shared UI components used by 2+ feature areas belong in `components/ui/shared/` — do not place them loose in a feature folder just because the first consumer lives there
+- When extracting non-component code (contexts, utils, hooks) from a component file, place it in the canonical folder (`contexts/`, `utils/`, `hooks/`) — don't leave it next to the component
+- `components/chat/tools/` is exclusively for tool components (one per tool type) — helper modals/dialogs/detail views belong in `components/chat/` or a relevant feature folder
+- Shared UI used by 2+ feature areas belongs in `components/ui/shared/` — don't leave it in a feature folder just because the first consumer lives there
 
 ### Event Handler Signatures
-- Never pass a callback directly to `onClick` (or similar event props) when the callback expects domain-typed arguments — always wrap in an arrow function: `onClick={() => handler(value)}` not `onClick={handler}` — React will pass the event object as the first argument, silently corrupting typed parameters
+- Never pass a callback directly to `onClick` (or similar) when it expects domain-typed args — wrap in an arrow: `onClick={() => handler(value)}`, not `onClick={handler}` (React passes the event as the first arg)
 
 ### useEffect Discipline
-- Never place hooks (`useState`, `useCallback`, `useMemo`, `useEffect`) after conditional early returns in a component — React requires hooks to be called in the same order on every render; move all hooks above any `return` statements
-- Never call `useEffect` directly for mount-only effects — use `useMountEffect()` from `hooks/useMountEffect.ts` (`useEffect(fn, [])` wrapper) to make intent explicit and enable lint enforcement
-- Never use `useEffect` to derive state from other state or props — if state is always computable from existing values, use inline computation or `useMemo`; `useEffect(() => setX(f(y)), [y])` causes an unnecessary extra render cycle
-- When state must reset on a prop/ID change, use a ref-based render check instead of `useEffect` — pattern: `const prevRef = useRef(prop); if (prevRef.current !== prop) { prevRef.current = prop; setState(initial); }` — this runs synchronously during render and avoids the effect-induced double render
-- Distinguish "derived state" from "form state initialization" — if local state is a copy of server data that the user then edits independently (e.g., secrets form, settings form), syncing it via `useEffect` on query data change is the correct pattern; do not convert these to inline derivation, as the local state intentionally diverges from the source
-- `useEffect` cleanup closures must not rely on hook-scoped utilities that close over the current entity ID (e.g., `updateMessageInCache` scoped to the rendered `chatId`) when the cleanup may serve sessions from a different entity — use refs or the underlying API directly (e.g., `queryClient.setQueryData` with `session.chatId`) to target the correct entity
+- Never place hooks (`useState`, `useCallback`, `useMemo`, `useEffect`) after conditional early returns — hooks must be called in the same order every render
+- Never call `useEffect` directly for mount-only effects — use `useMountEffect()` from `hooks/useMountEffect.ts`
+- Never use `useEffect` to derive state from other state/props — use inline computation or `useMemo`; `useEffect(() => setX(f(y)), [y])` causes an extra render cycle
+- When state must reset on a prop/ID change, use a ref-based render check: `const prevRef = useRef(prop); if (prevRef.current !== prop) { prevRef.current = prop; setState(initial); }` — runs synchronously, avoids double render
+- Distinguish "derived state" from "form state init" — if local state is a copy of server data the user then edits independently (secrets form, settings form), syncing via `useEffect` on query data change is correct; don't convert these to inline derivation
+- `useEffect` cleanup closures must not rely on hook-scoped utilities that close over the current entity ID (e.g., `updateMessageInCache` scoped to the rendered `chatId`) when cleanup may serve sessions from a different entity — use refs or the underlying API (e.g., `queryClient.setQueryData` with `session.chatId`)
 
 ### Component Variants
-- Create explicit variant components instead of one component with many boolean modes (e.g., `ThreadComposer`, `EditComposer` instead of `<Composer isThread isEditing />`)
-- Use `children` for composing static structure; use render props only when the parent needs to pass data back to the child (e.g., `renderItem` in lists)
+- Create explicit variant components instead of one with many boolean modes (e.g., `ThreadComposer`, `EditComposer` instead of `<Composer isThread isEditing />`)
+- Use `children` for composing static structure; render props only when the parent needs data back from the child (e.g., `renderItem` in lists)
+
+### Action Gating
+- When a React Query uses `placeholderData` / `keepPreviousData`, gate destructive actions derived from that data on `!isPlaceholderData` so they can't fire against rows from a previous query
+- Gate action buttons on backend capability, not UI rendering state — a bulk action that doesn't depend on per-row parsing shouldn't disappear when the list fails to parse; hide only the affordances that genuinely require rendered rows
 
 ## Frontend Performance Conventions
 
 ### Bundle Size
-- Do not create barrel/index.ts files — import directly from the source file (e.g., `from '@/components/layout/Layout'` not `from '@/components/layout'`)
-- Heavy libraries must use dynamic `import()`, never static imports at module level — applies to: `xlsx`, `jszip`, `xterm`, `@monaco-editor/react`, `react-vnc`, `qrcode`, `dompurify`, `mermaid`
-- For heavy React components, use `React.lazy()` + `<Suspense>` (e.g., Monaco Editor in dialogs, VncScreen)
-- For heavy libraries used inside hooks/effects, use `await import('lib')` inside the async function where the library is consumed
-- Audit `package.json` periodically for unused dependencies — remove any package with zero imports in `src/`
+- No barrel/index.ts files — import directly from the source (e.g., `from '@/components/layout/Layout'`)
+- Heavy libraries must use dynamic `import()`, never static: `xlsx`, `jszip`, `xterm`, `@monaco-editor/react`, `react-vnc`, `qrcode`, `dompurify`, `mermaid`
+- Heavy React components: `React.lazy()` + `<Suspense>` (e.g., Monaco in dialogs, VncScreen)
+- Heavy libraries used in hooks/effects: `await import('lib')` inside the async function
+- Audit `package.json` periodically for unused deps — remove any package with zero imports in `src/`
 
 ### Async-to-Sync Migration Safety
-- When converting synchronous code (useMemo, inline expressions) to async (useEffect + useState with dynamic imports), always clear the previous state at the top of the effect before the async work begins — otherwise users see stale data from the previous input while the new async result loads
+- When converting sync (useMemo/inline) to async (useEffect + useState with dynamic imports), clear the previous state at the top of the effect before async work — otherwise users see stale data while the new result loads
 - Pattern: `useEffect(() => { setState(initial); if (!input) return; let cancelled = false; (async () => { ... })(); return () => { cancelled = true; }; }, [input])`
 
 ### Re-render Optimization
-- Zustand selectors for action functions (used only in callbacks, not in JSX) must use `useStore.getState().action()` at the call site instead of subscribing with `useStore((s) => s.action)` — subscriptions cause re-renders when the store updates
-- Do not wrap Zustand store `set(...)` calls in `startTransition` inside store definitions/actions; use normal synchronous `set` in stores, and only use `startTransition` from React components/hooks when needed
-- Zustand selectors passed to `useStore(...)` must return stable references; never create new objects/arrays/`Set`/`Map` inside the selector. Subscribe to stable slices and derive new collections with `useMemo`
-- Use `Set` instead of arrays for membership checks in render loops — wrap with `useMemo(() => new Set(arr), [arr])` and use `.has()` instead of `.includes()`
-- Do not wrap trivial expressions in `useMemo` (e.g., `useMemo(() => x || [], [x])`) — use direct expressions (`x ?? []`)
-- When query keys include optional dimensions (e.g., `cwd`), add a separate prefix key without the optional dimension for broad invalidation (e.g., `gitBranchesAll: (id) => ['sandbox', id, 'git-branches']` alongside `gitBranches: (id, cwd?) => ['sandbox', id, 'git-branches', cwd]`) — invalidation with `undefined` in the key array does not prefix-match real values
-- Hoist regex patterns to module-level constants — never create RegExp inside loops or frequently-called functions
-- Prefer single-pass iteration (`.reduce()`) over chained `.filter().map()` in render paths
-- When reordering a function call to run earlier in a per-event hot path (e.g., stream envelope processing), gate the call with the cheapest possible condition check at the call site — avoid paying function-call overhead for the 99% of events that will just early-return
-- Keep `useEffect` for external system subscriptions and DOM side effects — keyboard shortcuts, resize observers, WebSocket lifecycle, scroll-into-view, and focus management require post-render timing and cleanup; do not convert these to ref-based render checks
-- When unifying components with variant-specific features, gate Zustand selectors to return a stable value for variants that don't use the subscribed state — e.g., `useStore((s) => needsFeature ? s.value : false)` — to avoid unnecessary re-renders
+- Zustand action selectors used only in callbacks: use `useStore.getState().action()` at the call site — don't subscribe via `useStore((s) => s.action)`
+- Don't wrap Zustand `set(...)` in `startTransition` inside store definitions — use synchronous `set`; `startTransition` belongs in components/hooks
+- Zustand selectors must return stable references — never create new objects/arrays/`Set`/`Map` inside the selector; subscribe to stable slices and derive with `useMemo`
+- Use `Set` for membership checks in render loops — `useMemo(() => new Set(arr), [arr])` + `.has()` instead of `.includes()`
+- Don't wrap trivial expressions in `useMemo` (e.g., `useMemo(() => x || [], [x])`) — use `x ?? []`
+- When query keys include optional dimensions (e.g., `cwd`), add a separate prefix key without the optional dimension for broad invalidation (e.g., `gitBranchesAll: (id) => ['sandbox', id, 'git-branches']` alongside `gitBranches: (id, cwd?) => ['sandbox', id, 'git-branches', cwd]`) — invalidation with `undefined` doesn't prefix-match real values
+- Hoist regex patterns to module-level constants — never create `RegExp` inside loops/frequently-called functions
+- Prefer single-pass `.reduce()` over chained `.filter().map()` in render paths
+- When reordering a function call earlier in a per-event hot path (e.g., stream envelope processing), gate it with the cheapest condition at the call site — don't pay call overhead for the 99% that would early-return
+- Keep `useEffect` for external system subscriptions and DOM side effects — keyboard shortcuts, resize observers, WebSocket lifecycle, scroll-into-view, focus management need post-render timing and cleanup; don't convert these to ref-based render checks
+- When unifying components with variant-specific features, gate Zustand selectors to return a stable value for variants that don't use that state (e.g., `useStore((s) => needsFeature ? s.value : false)`)
+- When invalidating a React Query key built from an identifier (paths, IDs, slugs), verify the format matches consumers' — cwd-relative vs workspace-root-relative paths miss each other, especially in worktree/nested-cwd setups; when formats can diverge, invalidate a prefix key (e.g., `fileContentAll`)
 
 ### Async Patterns
-- Use `Promise.all()` for independent async operations (e.g., multiple `queryClient.invalidateQueries()` calls)
-- When dynamically importing multiple libraries in the same function, parallelize with `Promise.all([import('a'), import('b')])`
-- When discarding a promise with `void`, attach `.catch()` to prevent silent error swallowing — `void fn().catch(err => console.error(err))`
+- Use `Promise.all()` for independent async ops (e.g., multiple `queryClient.invalidateQueries()` calls)
+- When dynamically importing multiple libraries in the same function, parallelize: `Promise.all([import('a'), import('b')])`
+- When discarding a promise with `void`, attach `.catch()` — `void fn().catch(err => console.error(err))`
 
 ## Frontend UI/UX Guidelines
 
 ### Design Philosophy
-- Fully monochrome aesthetic — no brand/blue accent colors in structural UI
-- Clean, minimal, and refined — prefer subtlety over visual weight
-- Every element should feel quiet and intentional
-- When multiple visual approaches are viable for a UI element (connector styles, layout patterns, color choices), present visual mockups to the user for selection before writing implementation code — avoids repeated code iterations
+- Fully monochrome — no brand/blue accent colors in structural UI
+- Clean, minimal, refined — subtle over visually heavy; every element should feel quiet and intentional
+- When multiple visual approaches are viable (connector styles, layout, color), present visual mockups for selection before implementation
 
 ### Color Palette
-- Always refer to `frontend/tailwind.config.js` for defined colors
-- Never hardcode hex codes or use default Tailwind colors (`bg-gray-100`, `text-blue-600`, etc.)
+- Refer to `frontend/tailwind.config.js` for defined colors
+- Never hardcode hex or default Tailwind colors (`bg-gray-100`, `text-blue-600`, ...)
 - Every light color class must have a `dark:` counterpart
-- Surface tokens: `surface-primary`, `surface-secondary` (most used), `surface-tertiary`, `surface-hover`, `surface-active` — dark variants are `surface-dark-*`
-- Border tokens: `border-border` (default), `border-border-secondary`, `border-border-hover` — dark variants are `border-border-dark-*` — prefer `border-border/50` and `dark:border-border-dark/50` for subtle borders
-- Text tokens: `text-text-primary`, `text-text-secondary`, `text-text-tertiary`, `text-text-quaternary` — dark variants are `text-text-dark-*`
-- **Never use `brand-*` colors for buttons, switches, highlights, focus rings, or structural elements** — the UI is fully monochrome
+- Surface tokens: `surface-primary`, `surface-secondary` (most used), `surface-tertiary`, `surface-hover`, `surface-active` — dark variants `surface-dark-*`
+- Border tokens: `border-border` (default), `border-border-secondary`, `border-border-hover` — dark `border-border-dark-*`; prefer `border-border/50` + `dark:border-border-dark/50` for subtle borders
+- Text tokens: `text-text-primary`, `text-text-secondary`, `text-text-tertiary`, `text-text-quaternary` — dark `text-text-dark-*`
+- **Never use `brand-*` for buttons, switches, highlights, focus rings, or structural elements** — UI is fully monochrome
 - Primary buttons: `bg-text-primary text-surface` / `dark:bg-text-dark-primary dark:text-surface-dark` (inverted text/surface)
 - Switches/toggles: `bg-text-primary` when checked, `bg-surface-tertiary` when unchecked
 - Focus rings: `ring-text-quaternary/30` — never `ring-brand-*`
 - Search highlights: `bg-surface-active` / `dark:bg-surface-dark-hover` — never `bg-brand-*`
 - Selected/active states: `bg-surface-active` / `dark:bg-surface-dark-active` — never `bg-brand-*`
-- Semantic colors (`success`, `error`, `warning`, `info`) are only for status indicators, not layout
-- Do not use semantic colors (`error-*`, `warning-*`, `success-*`) for interactive button backgrounds — use monochrome surface tokens; semantic colors are for status badges and text indicators only
-- Every `dark:text-*` / `dark:bg-*` class must have a corresponding light-mode class — never rely on browser defaults or inherited color for one mode while explicitly setting the other
-- Use opacity modifiers sparingly for glassmorphism (`/50`, `/30` are common) — white/black only as opacity overlays (`bg-white/5`, `bg-black/50`), never solid
-- Do not use opacity below /30 for structural lines (connectors, tree branches, dividers) — at /20 or lower, lines become invisible against surface backgrounds; use /50 minimum or full opacity for elements that must be clearly visible
+- Semantic colors (`success`, `error`, `warning`, `info`) are for status indicators only, not layout; don't use `error-*` / `warning-*` / `success-*` for interactive button backgrounds
+- Every `dark:text-*` / `dark:bg-*` must have a corresponding light-mode class — never rely on inherited color for one mode while explicitly setting the other
+- Use opacity sparingly for glassmorphism (`/50`, `/30`); white/black only as opacity overlays (`bg-white/5`, `bg-black/50`), never solid
+- Don't use opacity below `/30` for structural lines (connectors, tree branches, dividers) — use `/50` minimum or full opacity for elements that must stay visible
 
 ### Typography
-- `text-xs` is the default for most UI, `text-sm` for primary inputs, `text-2xs` for meta-data and section headers, `text-lg` for dialog titles only — avoid `text-base` and larger in dense UI
-- `font-medium` is the standard for emphasis — use `font-semibold` only for page titles (`text-xl`) and section headers — avoid `font-bold` except for special display elements like auth codes
+- `text-xs` default, `text-sm` for primary inputs, `text-2xs` for meta/section headers, `text-lg` for dialog titles only — avoid `text-base`+ in dense UI
+- `font-medium` for standard emphasis; `font-semibold` only for page titles (`text-xl`) and section headers; avoid `font-bold` except special display (auth codes)
 - Form labels: `text-xs text-text-secondary` — no icons next to labels
-- Section headers in panels: `text-2xs font-medium uppercase tracking-wider text-text-quaternary`
-- Use `font-mono` for code snippets, URIs, package names, env vars, file paths, and technical identifiers — pair with `text-xs` or `text-2xs`
+- Panel section headers: `text-2xs font-medium uppercase tracking-wider text-text-quaternary`
+- `font-mono` for code, URIs, package names, env vars, file paths, technical IDs — pair with `text-xs` or `text-2xs`
 
 ### Borders & Radius
-- Standard border pattern: `border border-border/50 dark:border-border-dark/50` for most containers — use full opacity `border-border dark:border-border-dark` only for prominent dividers
-- Radius hierarchy: `rounded-md` for small elements (buttons, inputs), `rounded-lg` for standard containers and cards (most common), `rounded-xl` for prominent cards and dropdowns, `rounded-2xl` for overlays — button sizes follow `sm: rounded-md`, `md: rounded-lg`, `lg: rounded-xl`
-- Shadow hierarchy: `shadow-sm` for interactive elements, `shadow-medium` for dropdowns and panels, `shadow-strong` for modals — use `backdrop-blur-xl` with `bg-*/95` for frosted glass dropdowns
-- Do not use custom shadow tokens (`shadow-soft`, `shadow-harsh`, etc.) — use only the defined hierarchy: `shadow-sm`, `shadow-medium`, `shadow-strong`
+- Standard border: `border border-border/50 dark:border-border-dark/50`; full opacity only for prominent dividers
+- Radius: `rounded-md` small (buttons, inputs), `rounded-lg` standard containers/cards, `rounded-xl` prominent cards/dropdowns, `rounded-2xl` overlays; button sizes follow `sm: rounded-md`, `md: rounded-lg`, `lg: rounded-xl`
+- Shadows: `shadow-sm` interactive, `shadow-medium` dropdowns/panels, `shadow-strong` modals; use `backdrop-blur-xl` + `bg-*/95` for frosted dropdowns
+- No custom shadow tokens (`shadow-soft`, `shadow-harsh`) — only `shadow-sm` / `shadow-medium` / `shadow-strong`
 
 ### Icons
-- Default icon size is `h-3.5 w-3.5` for toolbars, action buttons, and small controls
-- Use `h-4 w-4` for message actions and form controls
-- Use `h-3 w-3` for text-adjacent icons, badges, and close buttons
-- Use `h-5 w-5` or `h-6 w-6` for empty states and status indicators — never `h-16 w-16` or larger
-- Icon color is `text-text-tertiary` / `dark:text-text-dark-tertiary` by default, `text-text-primary` on hover/active
+- Default `h-3.5 w-3.5` for toolbars/action buttons/small controls
+- `h-4 w-4` for message actions and form controls
+- `h-3 w-3` for text-adjacent icons, badges, close buttons
+- `h-5 w-5` or `h-6 w-6` for empty states/status indicators — never `h-16 w-16`+
+- Color: `text-text-tertiary` / `dark:text-text-dark-tertiary` default, `text-text-primary` on hover/active
 - Toolbar dropdown selectors (model, thinking, permission): text-only labels with chevrons, no left icons
 - Loading spinners: `text-text-quaternary` / `dark:text-text-dark-quaternary` — never brand colors
-- Do not generate SVG path data from memory — fetch official brand icon SVGs from authoritative sources (e.g., Simple Icons, brand asset pages) and use the exact path data
+- Don't generate SVG path data from memory — fetch official brand icon SVGs from authoritative sources (Simple Icons, brand asset pages)
 
 ### Panel Headers
-- Standardized `h-9` height with `px-3` padding
-- File paths and technical labels: `font-mono text-2xs`
+- `h-9` height with `px-3` padding
+- File paths / technical labels: `font-mono text-2xs`
 - Section labels: `text-2xs font-medium uppercase tracking-wider text-text-quaternary`
-- Icon buttons in headers: `h-3 w-3` icons, no background, hover with `text-text-primary`
+- Icon buttons: `h-3 w-3`, no background, hover `text-text-primary`
 
 ### Animations & Transitions
-- Use CSS keyframe animations via Tailwind (`animate-fade-in`, `animate-fade-in-up`, `animate-dot-pulse`, etc.) for enter/state transitions — do not use `framer-motion` or other JS animation libraries
-- Use `transition-colors duration-200` for hover/focus, `transition-all duration-300` for complex state changes like drag-and-drop
-- Use `transition-[padding] duration-500 ease-in-out` for sidebar/layout animations
-- Loading states: `animate-spin` for circular spinner icons only (e.g., `Loader2`), `animate-pulse` for non-circular icons used as loading indicators and skeletons, `animate-bounce` with staggered `animationDelay` for dot loaders
-- Expandable content: `transition-all duration-200` with `max-h-*` and `opacity` toggling
-- Dropdowns: `animate-fadeIn` for entry — no scale transforms on buttons
+- Use CSS keyframe animations via Tailwind (`animate-fade-in`, `animate-fade-in-up`, `animate-dot-pulse`) — no `framer-motion` or other JS animation libs
+- `transition-colors duration-200` for hover/focus; `transition-all duration-300` for complex state changes (drag-and-drop)
+- `transition-[padding] duration-500 ease-in-out` for sidebar/layout animations
+- Loading: `animate-spin` for circular spinners only (`Loader2`); `animate-pulse` for non-circular loading icons and skeletons; `animate-bounce` with staggered `animationDelay` for dot loaders
+- Expandable content: `transition-all duration-200` with `max-h-*` + `opacity` toggling
+- Dropdowns: `animate-fadeIn` — no scale transforms on buttons
 
 ### Layout
-
-- Do not use absolute positioning for layout of sibling elements within a container — use flexbox (`flex`, `justify-between`, `gap-*`); reserve `absolute` for overlays, tooltips, dropdowns, and decorative elements only
-- When action buttons have variable-length or long text labels, stack them vertically (`flex-col`) at full width instead of placing them in a horizontal row — horizontal layouts break awkwardly when text wraps or buttons have uneven widths
-- When nesting child items under parent items in lists (e.g., sub-threads), always maintain visible indentation — do not align child text flush with parent text; use connector lines or visual indicators for nesting cues, but indentation is the primary hierarchy signal
+- Don't use absolute positioning for sibling layout — use flexbox (`flex`, `justify-between`, `gap-*`); reserve `absolute` for overlays, tooltips, dropdowns, decorative elements
+- When action buttons have variable-length or long labels, stack vertically (`flex-col`) at full width — horizontal rows break awkwardly with wrapped/uneven widths
+- When nesting child items under parents (e.g., sub-threads), always maintain visible indentation — don't align child text flush with parent; connector lines/visual cues supplement but indentation is the primary hierarchy signal
 
 ## Code Review Guidelines
 
 ### What to fix
 - Bugs that break user-visible behavior (wrong event ordering, dropped messages, stale UI state)
-- Correctness issues where the code silently continues into a broken state (e.g., swallowing an error that leaves client/server out of sync)
-- Missing TTLs or expiry on Redis keys that can leak forever
+- Correctness issues that silently continue into broken state (e.g., swallowed errors leaving client/server out of sync)
+- Missing TTL/expiry on Redis keys that can leak forever
 - Dead code left behind by the change (unused imports, unreachable branches, orphaned constants)
 
 ### What to skip
-- Orphaned DB rows from unlikely failure paths — in a single-user app, a stray empty message row is harmless; do not add delete-rollback logic
-- Concurrency edge cases (double-submit, multi-tab races, overlapping requests) — unless the task explicitly asks for concurrency hardening
-- Hypothetical compatibility mismatches — if a natural fallback already handles the case (e.g., normal queue processing), do not add pre-flight checks to detect and re-route
-- State-restoration rollback for failure paths — a simple log + best-effort recovery (re-queue) is sufficient; do not save/restore every field or revert intermediate changes
+- Orphaned DB rows from unlikely failure paths — a stray empty message row is harmless in a single-user app; don't add delete-rollback logic
+- Concurrency edge cases (double-submit, multi-tab races, overlapping requests) unless the task explicitly asks for concurrency hardening
+- Hypothetical compatibility mismatches when a natural fallback already handles the case — don't add pre-flight checks to detect/re-route
+- State-restoration rollback for failure paths — log + best-effort recovery (re-queue) is sufficient
 
 ### Callback closure analysis
 - When reviewing React hooks, event handlers, or async stream callbacks, verify which render created the callback before concluding what props/state it closes over
-- Do not infer a closure bug from a helper being parameterized by the current prop/state value unless you have traced where the callback instance was created, where it was stored, and which instance is invoked later
-- For callbacks stored outside React render flow (refs, Zustand stores, event listeners, stream registries, service singletons), treat them as snapshots of the render that created them — they do not automatically track the currently visible screen or latest hook inputs
-- Before flagging cross-chat, cross-screen, or cross-context state contamination in the frontend, trace the full lifecycle: callback creation site, captured values, storage location, update path, and invocation site
-- Prefer concrete callback lifecycle traces over static closure assumptions when hooks interact with long-lived stores, subscriptions, or external event sources
+- Don't infer a closure bug from a helper being parameterized by the current prop/state value unless you've traced creation site, storage, and which instance is invoked later
+- Callbacks stored outside React render flow (refs, Zustand stores, event listeners, stream registries, service singletons) are snapshots of the render that created them — they don't track the currently visible screen or latest hook inputs
+- Before flagging cross-chat/cross-screen/cross-context state contamination, trace the full lifecycle: creation site, captured values, storage location, update path, invocation site
+- Prefer concrete lifecycle traces over static closure assumptions when hooks interact with long-lived stores, subscriptions, or external event sources
 
 ### Failure-path control flow
-- When reviewing error handling, trace the exact path an exception takes through `except`, `raise`, and `return` boundaries before concluding that later code is affected
-- Do not flag success-path classification logic as buggy unless you have verified that execution can still reach it after the failure
-- In async call chains, follow the failure across helper methods and outer handlers all the way to the final state write before reporting misclassification bugs
+- When reviewing error handling, trace the exact path an exception takes through `except`, `raise`, and `return` boundaries before concluding later code is affected
+- Don't flag success-path classification logic as buggy unless you've verified execution can still reach it after the failure
+- In async call chains, follow the failure across helper methods and outer handlers all the way to the final state write before reporting misclassification
 - Before raising a finding about status handling, verify which exact lines run next after the failure
 
 ### Complexity test
-Before flagging or fixing an issue, ask: "If this fails, does the user lose data or get stuck?" If the answer is no (e.g., an orphaned row, a briefly stale UI element), skip it. If the answer is yes (e.g., a queued message is silently dropped, the stream appears frozen), fix it.
+Ask: "If this fails, does the user lose data or get stuck?" If no (orphaned row, briefly stale UI), skip. If yes (queued message silently dropped, stream appears frozen), fix.
 
 ## Verification
 
-- Do not run tests, lints, type checks, or any similar verification commands unless explicitly asked
+- Don't run tests, lints, type checks, or similar verification commands unless explicitly asked
 
 ## Completion Quality Gate
 
-- Do not leave dead code behind. If a change makes code unused, remove it in the same task (unused functions, exports, imports, constants, types, files, and stale wrappers).
-- Every task must include a final dead-code sweep across touched areas and any newly created files.
-- Before finishing, verify all newly created or modified code paths:
-  - Confirm new symbols are referenced (or intentionally public and documented).
-  - Confirm replaced symbols were removed and references updated.
-- If something is intentionally left unused for compatibility, state that explicitly in the final summary.
+- No dead code left behind — remove unused functions, exports, imports, constants, types, files, and stale wrappers in the same task
+- Every task includes a final dead-code sweep across touched areas and new files
+- Before finishing, verify new/modified paths:
+  - New symbols are referenced (or intentionally public and documented)
+  - Replaced symbols are removed and references updated
+- If something is intentionally left unused for compatibility, state that explicitly in the final summary

--- a/backend/app/api/endpoints/sandbox.py
+++ b/backend/app/api/endpoints/sandbox.py
@@ -26,6 +26,7 @@ from app.models.schemas.sandbox import (
     GitCreateBranchResponse,
     GitDiffResponse,
     GitRemoteUrlResponse,
+    GitRestoreFileRequest,
     SandboxFilesMetadataResponse,
     SearchResponse,
     UpdateFileRequest,
@@ -280,6 +281,38 @@ async def git_commit(
 ) -> GitCommandResponse:
     try:
         return await git_service.commit(sandbox_id, request.message, request.cwd)
+    except (ValueError, SandboxException) as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.post("/{sandbox_id}/git/restore-file", response_model=GitCommandResponse)
+async def git_restore_file(
+    request: GitRestoreFileRequest,
+    sandbox_id: str = Depends(validate_sandbox_ownership),
+    git_service: GitService = Depends(get_git_service),
+) -> GitCommandResponse:
+    try:
+        return await git_service.restore_file(
+            sandbox_id, request.file_path, request.old_path, request.cwd
+        )
+    except (ValueError, SandboxException) as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.post("/{sandbox_id}/git/restore-all", response_model=GitCommandResponse)
+async def git_restore_all(
+    sandbox_id: str = Depends(validate_sandbox_ownership),
+    git_service: GitService = Depends(get_git_service),
+    cwd: str | None = Query(None),
+) -> GitCommandResponse:
+    try:
+        return await git_service.restore_all(sandbox_id, cwd)
     except (ValueError, SandboxException) as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/models/schemas/sandbox.py
+++ b/backend/app/models/schemas/sandbox.py
@@ -85,6 +85,13 @@ class GitCommitRequest(BaseModel):
     cwd: str | None = None
 
 
+class GitRestoreFileRequest(BaseModel):
+    file_path: str = Field(..., min_length=1, max_length=4096)
+    # Pre-rename path, when the change is a rename; None otherwise.
+    old_path: str | None = Field(default=None, min_length=1, max_length=4096)
+    cwd: str | None = None
+
+
 class GitCommandResponse(BaseModel):
     success: bool
     output: str

--- a/backend/app/services/git.py
+++ b/backend/app/services/git.py
@@ -1,4 +1,6 @@
 import re
+import shlex
+from string import Template
 from typing import Literal
 
 from app.models.schemas.sandbox import (
@@ -17,6 +19,114 @@ GITHUB_REMOTE_RE = re.compile(
     r"(?:https?://github\.com/|git@github\.com:)([^/]+)/([^/]+?)(?:\.git)?$"
 )
 
+GIT_IS_REPO_CMD = "git rev-parse --is-inside-work-tree 2>/dev/null"
+GIT_CURRENT_BRANCH_CMD = "git rev-parse --abbrev-ref HEAD 2>/dev/null"
+GIT_PUSH_CMD = "git push -u origin HEAD"
+GIT_PULL_CMD = "git pull"
+GIT_REMOTE_URL_CMD = "git remote get-url origin 2>/dev/null"
+# Detached HEAD (e.g. checking out a tag/SHA) — revert to the previous branch
+# so the UI always has a named branch to display.
+GIT_CHECKOUT_PREV_CMD = "git checkout - 2>/dev/null"
+
+# Segmented with explicit markers so one exec result can be parsed
+# deterministically without depending on `git branch` output formatting.
+GIT_LIST_BRANCHES_CMD = (
+    "git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 2; "
+    "git rev-parse --abbrev-ref HEAD 2>/dev/null; "
+    "printf '__BRANCHES_LOCAL__\\n'; "
+    "git for-each-ref --format='%(refname:short)' refs/heads; "
+    "printf '__BRANCHES_REMOTE__\\n'; "
+    "git for-each-ref --format='%(refname:short)' refs/remotes/origin"
+)
+
+GIT_CHECKOUT_TEMPLATE = Template("git checkout '$branch' 2>&1")
+GIT_CHECKOUT_FROM_REMOTE_TEMPLATE = Template(
+    "git checkout -b '$branch' 'origin/$branch' 2>&1"
+)
+GIT_COMMIT_TEMPLATE = Template("git add -A && git commit -m $msg")
+# $base expands to either "" or " '<base_branch>'" so a single template covers
+# both the "create from current HEAD" and "create from base" call shapes.
+GIT_CREATE_BRANCH_TEMPLATE = Template("git checkout -b '$name'$base 2>&1")
+GIT_CREATE_BRANCH_FROM_REMOTE_TEMPLATE = Template(
+    "git checkout -b '$name' 'origin/$base' 2>&1"
+)
+
+# Idempotent: a previous attempt may have created the worktree but failed to
+# persist it; the dir-exists check lets us skip `git worktree add` instead of
+# failing on a duplicate branch or path.
+GIT_WORKTREE_ADD_TEMPLATE = Template(
+    "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && "
+    "if [ -e '$worktree_dir/.git' ]; then echo 'exists'; exit 0; fi && "
+    "mkdir -p '$base_worktrees_dir' && "
+    "git worktree add '$worktree_dir' -b '$branch_name' 2>&1"
+)
+
+GIT_DIFF_STAGED_TEMPLATE = Template("git diff$ctx --cached 2>/dev/null")
+GIT_DIFF_UNSTAGED_TEMPLATE = Template("git diff$ctx 2>/dev/null;$untracked")
+# "all" mode: try `git diff HEAD` first (combined staged+unstaged in one pass);
+# falls back to separate staged + unstaged when HEAD doesn't exist (initial
+# commit).
+GIT_DIFF_ALL_TEMPLATE = Template(
+    "{ git diff$ctx HEAD 2>/dev/null"
+    " || { git diff$ctx --cached 2>/dev/null; git diff$ctx 2>/dev/null; }; };"
+    "$untracked"
+)
+GIT_UNTRACKED_DIFF_TEMPLATE = Template(
+    " git ls-files --others --exclude-standard -z"
+    " | xargs -0 -I{} git diff$ctx --no-index -- /dev/null {} 2>/dev/null"
+)
+# Diff HEAD against the merge-base with the default branch. Default branch is
+# detected via the remote HEAD symref, falling back to main/master/develop/
+# trunk. Exits 2 when no base can be determined so the caller can surface a
+# distinct error. `$$` escapes literal `$` (shell vars and command subs) so
+# `string.Template` only substitutes the `$ctx` placeholder.
+GIT_DIFF_BRANCH_TEMPLATE = Template(
+    "base=$$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/||');"
+    " [ -z \"$$base\" ] && base=$$(git branch -r 2>/dev/null | grep -oE 'origin/(main|master|develop|trunk)' | head -1 | tr -d ' ');"
+    ' [ -z "$$base" ] && for b in main master develop trunk; do'
+    " git rev-parse --verify $$b >/dev/null 2>&1 && base=$$b && break; done;"
+    ' if [ -z "$$base" ]; then exit 2; fi;'
+    ' merge_base=$$(git merge-base "$$base" HEAD 2>/dev/null || echo "$$base");'
+    ' git diff$ctx "$$merge_base" HEAD 2>/dev/null'
+)
+
+# Diff pathspecs are repo-root-relative and `git clean -fd` only cleans below
+# the current directory, so restore commands hop to the repo root before
+# running to keep pathspecs resolving and clean sweeps workspace-wide.
+GIT_CD_REPO_ROOT = 'cd "$(git rev-parse --show-toplevel)" && '
+
+# `git reset --hard` (not `git checkout HEAD -- .`) is required so newly-added
+# files drop out of the index and become untracked for `git clean` to sweep.
+# Initial repo has no HEAD to reset to, so we empty the index directly and let
+# `git clean` do the same job. Gitignored files (.env, etc.) are preserved.
+RESTORE_ALL_CMD = (
+    GIT_CD_REPO_ROOT + "if git rev-parse --verify HEAD >/dev/null 2>&1; then "
+    "git reset --hard HEAD && git clean -fd; "
+    "else "
+    "git rm --cached -rf --ignore-unmatch -q . >/dev/null 2>&1; "
+    "git clean -fd; "
+    "fi"
+)
+
+# Rename: restore the original path, drop the new one. Cleanup of `new` is
+# gated on the checkout of `old` with `&&` — not `;` — so a failed checkout
+# (old_path not in HEAD) doesn't silently turn a committed rename into a
+# fresh deletion.
+RESTORE_RENAME_TEMPLATE = Template(
+    "git checkout HEAD -- $op && { git reset -- $fp >/dev/null 2>&1; rm -f -- $fp; }"
+)
+
+# Branch on HEAD membership: `git checkout HEAD --` fails for paths not in
+# HEAD, so untracked/new-staged files need an unstage + rm instead.
+RESTORE_FILE_TEMPLATE = Template(
+    "if git cat-file -e HEAD:$fp 2>/dev/null; then "
+    "git checkout HEAD -- $fp; "
+    "else "
+    "git reset -- $fp >/dev/null 2>&1; "
+    "rm -f -- $fp; "
+    "fi"
+)
+
 
 class GitService:
     def __init__(self, sandbox_service: SandboxService) -> None:
@@ -32,7 +142,7 @@ class GitService:
         cd_prefix = git_cd_prefix(cwd)
         check = await self.sandbox_service.execute_command(
             sandbox_id,
-            f"{cd_prefix}git rev-parse --is-inside-work-tree 2>/dev/null",
+            f"{cd_prefix}{GIT_IS_REPO_CMD}",
         )
         if check.exit_code != 0:
             return GitDiffResponse(diff="", has_changes=False, is_git_repo=False)
@@ -40,38 +150,18 @@ class GitService:
         # Large context window so the patch includes the entire file,
         # enabling full-file diff view
         ctx = " -U99999" if full_context else ""
-
-        untracked_diff = (
-            " git ls-files --others --exclude-standard -z"
-            f" | xargs -0 -I{{}} git diff{ctx} --no-index -- /dev/null {{}} 2>/dev/null"
-        )
+        untracked_diff = GIT_UNTRACKED_DIFF_TEMPLATE.substitute(ctx=ctx)
 
         if mode == "branch":
-            # Diff current HEAD against the merge-base with the default branch.
-            # Detect default branch via the remote HEAD symref, falling back
-            # to main/master.
-            cmd = (
-                "base=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/||');"
-                " [ -z \"$base\" ] && base=$(git branch -r 2>/dev/null | grep -oE 'origin/(main|master|develop|trunk)' | head -1 | tr -d ' ');"
-                ' [ -z "$base" ] && for b in main master develop trunk; do'
-                " git rev-parse --verify $b >/dev/null 2>&1 && base=$b && break; done;"
-                ' if [ -z "$base" ]; then exit 2; fi;'
-                ' merge_base=$(git merge-base "$base" HEAD 2>/dev/null || echo "$base");'
-                f' git diff{ctx} "$merge_base" HEAD 2>/dev/null'
-            )
+            cmd = GIT_DIFF_BRANCH_TEMPLATE.substitute(ctx=ctx)
         elif mode == "staged":
-            cmd = f"git diff{ctx} --cached 2>/dev/null"
+            cmd = GIT_DIFF_STAGED_TEMPLATE.substitute(ctx=ctx)
         elif mode == "unstaged":
-            cmd = f"git diff{ctx} 2>/dev/null;{untracked_diff}"
-        else:
-            # "all" mode: try `git diff HEAD` first (combined staged+unstaged
-            # in one pass); falls back to separate staged + unstaged when HEAD
-            # doesn't exist (initial commit).
-            cmd = (
-                f"{{ git diff{ctx} HEAD 2>/dev/null"
-                f" || {{ git diff{ctx} --cached 2>/dev/null; git diff{ctx} 2>/dev/null; }}; }};"
-                f"{untracked_diff}"
+            cmd = GIT_DIFF_UNSTAGED_TEMPLATE.substitute(
+                ctx=ctx, untracked=untracked_diff
             )
+        else:
+            cmd = GIT_DIFF_ALL_TEMPLATE.substitute(ctx=ctx, untracked=untracked_diff)
 
         result = await self.sandbox_service.execute_command(
             sandbox_id, f"{cd_prefix}{cmd}"
@@ -101,14 +191,7 @@ class GitService:
         cd_prefix = git_cd_prefix(cwd)
         result = await self.sandbox_service.provider.execute_command(
             sandbox_id,
-            (
-                f"{cd_prefix}git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 2; "
-                "git rev-parse --abbrev-ref HEAD 2>/dev/null; "
-                "printf '__BRANCHES_LOCAL__\\n'; "
-                "git for-each-ref --format='%(refname:short)' refs/heads; "
-                "printf '__BRANCHES_REMOTE__\\n'; "
-                "git for-each-ref --format='%(refname:short)' refs/remotes/origin"
-            ),
+            f"{cd_prefix}{GIT_LIST_BRANCHES_CMD}",
         )
         if result.exit_code != 0:
             return GitBranchesResponse(
@@ -120,9 +203,6 @@ class GitService:
             local_marker = lines.index("__BRANCHES_LOCAL__")
             remote_marker = lines.index("__BRANCHES_REMOTE__")
         except ValueError:
-            # The shell output is segmented with explicit markers so we can
-            # parse one exec result deterministically instead of depending on
-            # `git branch` formatting.
             raise SandboxException("Failed to parse git branches output")
         current_branch = "\n".join(lines[:local_marker]).strip()
 
@@ -161,13 +241,13 @@ class GitService:
 
         result = await self.sandbox_service.execute_command(
             sandbox_id,
-            f"{cd_prefix}git checkout '{branch}' 2>&1",
+            f"{cd_prefix}{GIT_CHECKOUT_TEMPLATE.substitute(branch=branch)}",
         )
         if result.exit_code != 0:
             # Branch might only exist as a remote tracking branch
             result = await self.sandbox_service.execute_command(
                 sandbox_id,
-                f"{cd_prefix}git checkout -b '{branch}' 'origin/{branch}' 2>&1",
+                f"{cd_prefix}{GIT_CHECKOUT_FROM_REMOTE_TEMPLATE.substitute(branch=branch)}",
             )
 
         if result.exit_code != 0:
@@ -179,15 +259,13 @@ class GitService:
 
         head_result = await self.sandbox_service.execute_command(
             sandbox_id,
-            f"{cd_prefix}git rev-parse --abbrev-ref HEAD 2>/dev/null",
+            f"{cd_prefix}{GIT_CURRENT_BRANCH_CMD}",
         )
         current = head_result.stdout.strip()
         if current == "HEAD":
-            # Detached HEAD (e.g. checking out a tag or SHA) — revert to the
-            # previous branch so the UI always has a named branch to display
             await self.sandbox_service.execute_command(
                 sandbox_id,
-                f"{cd_prefix}git checkout - 2>/dev/null",
+                f"{cd_prefix}{GIT_CHECKOUT_PREV_CMD}",
             )
             return GitCheckoutResponse(
                 success=False,
@@ -202,7 +280,6 @@ class GitService:
         command: str,
         cwd: str | None = None,
     ) -> GitCommandResponse:
-        # Execute a simple git command and return success/failure with output.
         cd_prefix = git_cd_prefix(cwd)
         result = await self.sandbox_service.execute_command(
             sandbox_id,
@@ -217,20 +294,41 @@ class GitService:
         return GitCommandResponse(success=True, output=result.stdout.strip())
 
     async def push(self, sandbox_id: str, cwd: str | None = None) -> GitCommandResponse:
-        return await self.run_command(sandbox_id, "git push -u origin HEAD", cwd)
+        return await self.run_command(sandbox_id, GIT_PUSH_CMD, cwd)
 
     async def pull(self, sandbox_id: str, cwd: str | None = None) -> GitCommandResponse:
-        return await self.run_command(sandbox_id, "git pull", cwd)
+        return await self.run_command(sandbox_id, GIT_PULL_CMD, cwd)
 
     async def commit(
         self, sandbox_id: str, message: str, cwd: str | None = None
     ) -> GitCommandResponse:
-        # Shell-escape single quotes so the commit message can contain
-        # apostrophes
-        msg = message.replace("'", "'\\''")
-        return await self.run_command(
-            sandbox_id, f"git add -A && git commit -m '{msg}'", cwd
-        )
+        cmd = GIT_COMMIT_TEMPLATE.substitute(msg=shlex.quote(message))
+        return await self.run_command(sandbox_id, cmd, cwd)
+
+    async def restore_file(
+        self,
+        sandbox_id: str,
+        file_path: str,
+        old_path: str | None = None,
+        cwd: str | None = None,
+    ) -> GitCommandResponse:
+        self._validate_relative_path(file_path)
+        if old_path:
+            self._validate_relative_path(old_path)
+        fp = shlex.quote(file_path)
+        if old_path and old_path != file_path:
+            op = shlex.quote(old_path)
+            tail = RESTORE_RENAME_TEMPLATE.substitute(fp=fp, op=op)
+        else:
+            tail = RESTORE_FILE_TEMPLATE.substitute(fp=fp)
+        return await self.run_command(sandbox_id, GIT_CD_REPO_ROOT + tail, cwd)
+
+    async def restore_all(
+        self,
+        sandbox_id: str,
+        cwd: str | None = None,
+    ) -> GitCommandResponse:
+        return await self.run_command(sandbox_id, RESTORE_ALL_CMD, cwd)
 
     async def create_branch(
         self,
@@ -247,13 +345,16 @@ class GitService:
         base = f" '{base_branch}'" if base_branch else ""
         result = await self.sandbox_service.execute_command(
             sandbox_id,
-            f"{cd_prefix}git checkout -b '{name}'{base} 2>&1",
+            f"{cd_prefix}{GIT_CREATE_BRANCH_TEMPLATE.substitute(name=name, base=base)}",
         )
         if result.exit_code != 0 and base_branch:
             # Base branch might only exist as a remote tracking branch
+            remote_cmd = GIT_CREATE_BRANCH_FROM_REMOTE_TEMPLATE.substitute(
+                name=name, base=base_branch
+            )
             result = await self.sandbox_service.execute_command(
                 sandbox_id,
-                f"{cd_prefix}git checkout -b '{name}' 'origin/{base_branch}' 2>&1",
+                f"{cd_prefix}{remote_cmd}",
             )
         if result.exit_code != 0:
             return GitCreateBranchResponse(
@@ -264,7 +365,7 @@ class GitService:
 
         head_result = await self.sandbox_service.execute_command(
             sandbox_id,
-            f"{cd_prefix}git rev-parse --abbrev-ref HEAD 2>/dev/null",
+            f"{cd_prefix}{GIT_CURRENT_BRANCH_CMD}",
         )
         return GitCreateBranchResponse(
             success=True,
@@ -279,7 +380,7 @@ class GitService:
         cd_prefix = git_cd_prefix(cwd)
         result = await self.sandbox_service.execute_command(
             sandbox_id,
-            f"{cd_prefix}git remote get-url origin 2>/dev/null",
+            f"{cd_prefix}{GIT_REMOTE_URL_CMD}",
         )
         if result.exit_code != 0:
             raise SandboxException("No git remote origin found", status_code=404)
@@ -310,16 +411,11 @@ class GitService:
         short_id = chat_id[:8]
         worktree_dir = f"{base_cwd}/.worktrees/{short_id}"
         branch_name = f"worktree-{short_id}"
-        # Idempotent: if a previous attempt created the worktree but the DB
-        # persist failed, the directory already exists. Check first so we
-        # don't fail on a duplicate branch/path from git worktree add.
         cd_prefix = git_cd_prefix(base_cwd)
-        cmd = (
-            f"{cd_prefix}"
-            f"git rev-parse --is-inside-work-tree >/dev/null 2>&1 && "
-            f"if [ -e '{worktree_dir}/.git' ]; then echo 'exists'; exit 0; fi && "
-            f"mkdir -p '{base_cwd}/.worktrees' && "
-            f"git worktree add '{worktree_dir}' -b '{branch_name}' 2>&1"
+        cmd = cd_prefix + GIT_WORKTREE_ADD_TEMPLATE.substitute(
+            worktree_dir=worktree_dir,
+            base_worktrees_dir=f"{base_cwd}/.worktrees",
+            branch_name=branch_name,
         )
         # Local git operation — no user secrets needed, so bypass
         # SandboxService.execute_command and call the provider directly.
@@ -343,3 +439,18 @@ class GitService:
             or name.startswith("-")
         ):
             raise ValueError(f"Invalid {label} name")
+
+    @staticmethod
+    def _validate_relative_path(path: str) -> None:
+        # Defense-in-depth against shell interpolation escape even after the
+        # `--` separator: reject absolutes (escape cwd), `..` (escape repo),
+        # `-` prefix (option injection), and newlines/NULs (command chaining).
+        if (
+            not path
+            or path.startswith("/")
+            or path.startswith("-")
+            or ".." in path.split("/")
+            or "\n" in path
+            or "\x00" in path
+        ):
+            raise ValueError("Invalid file path")

--- a/frontend/src/components/views/DiffView.tsx
+++ b/frontend/src/components/views/DiffView.tsx
@@ -1,12 +1,27 @@
 import { memo, useMemo, useState, useEffect, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import toast from 'react-hot-toast';
 import { useToggleSet } from '@/hooks/useToggleSet';
-import { AlertCircle, ChevronRight, GitCompareArrows, RotateCcw } from 'lucide-react';
+import {
+  AlertCircle,
+  ChevronRight,
+  ChevronsUpDown,
+  GitCompareArrows,
+  MoreHorizontal,
+  RotateCcw,
+  Undo2,
+} from 'lucide-react';
 import { FileIcon } from '@/components/editor/file-tree/FileIcon';
 import { Button } from '@/components/ui/primitives/Button';
 import { SegmentedControl } from '@/components/ui/primitives/SegmentedControl';
 import { Spinner } from '@/components/ui/primitives/Spinner';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { ErrorBoundary } from '@/components/ui/ErrorBoundary';
-import { useGitDiffQuery } from '@/hooks/queries/useSandboxQueries';
+import {
+  useGitDiffQuery,
+  useGitRestoreAllMutation,
+  useGitRestoreFileMutation,
+} from '@/hooks/queries/useSandboxQueries';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import type { FileDiffMetadata, FileContents } from '@pierre/diffs';
 import type { DiffMode } from '@/types/sandbox.types';
@@ -47,6 +62,11 @@ const STATUS_COLORS: Record<string, string> = {
   'rename-changed':
     'bg-warning-600/15 text-warning-600 dark:bg-warning-400/15 dark:text-warning-400',
 };
+
+const MENU_ITEM_CLASS =
+  'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-text-secondary transition-colors duration-200 hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover';
+
+const isRenameFileType = (type?: string) => type === 'rename-pure' || type === 'rename-changed';
 
 // Extract old/new file contents from a full-context parsed diff. The hunk lines
 // include trailing '\n' (from parsePatchFiles's SPLIT_WITH_NEWLINES split), so
@@ -153,7 +173,7 @@ function FileStats({ file }: { file: FileDiffMetadata }) {
   if (additions === 0 && deletions === 0) return null;
 
   return (
-    <span className="ml-auto flex shrink-0 items-center gap-1.5 font-mono text-2xs">
+    <span className="flex shrink-0 items-center gap-1.5 pr-3 font-mono text-2xs">
       {additions > 0 && (
         <span className="text-success-600 dark:text-success-400">+{additions}</span>
       )}
@@ -191,13 +211,92 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
   const [parsingDone, setParsingDone] = useState(false);
   const [mode, setMode] = useState<DiffMode>('all');
   const [diffStyle, setDiffStyle] = useState<'unified' | 'split'>('unified');
+  const [discardTarget, setDiscardTarget] = useState<FileDiffMetadata | null>(null);
+  const [discardAllOpen, setDiscardAllOpen] = useState(false);
 
   const {
     data: diffData,
     isFetching,
     isError,
+    isPlaceholderData,
     refetch,
   } = useGitDiffQuery(sandboxId, mode, true, cwd, { enabled: !!sandboxId });
+
+  const restoreFile = useGitRestoreFileMutation();
+  const restoreAll = useGitRestoreAllMutation();
+
+  // Portal + fixed-position menu — the toolbar's `overflow-x-auto` creates a
+  // clip region on both axes (per CSS spec), so an absolute-positioned menu
+  // inside it gets hidden. Portaling to <body> with fixed coords escapes it.
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuPanelRef = useRef<HTMLDivElement>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuPos, setMenuPos] = useState({ top: 0, right: 0 });
+
+  const toggleMenu = useCallback(() => {
+    if (menuOpen) {
+      setMenuOpen(false);
+      return;
+    }
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    setMenuPos({ top: rect.bottom + 6, right: window.innerWidth - rect.right });
+    setMenuOpen(true);
+  }, [menuOpen]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (menuPanelRef.current?.contains(target)) return;
+      setMenuOpen(false);
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [menuOpen]);
+
+  const handleDiscard = useCallback(async () => {
+    if (!sandboxId || !discardTarget) return;
+    const file = discardTarget;
+    try {
+      const result = await restoreFile.mutateAsync({
+        sandboxId,
+        filePath: file.name,
+        oldPath: isRenameFileType(file.type) ? file.prevName : undefined,
+        cwd,
+      });
+      if (result.success) {
+        toast.success('Changes discarded');
+      } else {
+        toast.error(result.error || 'Failed to discard changes');
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to discard changes');
+    }
+  }, [sandboxId, discardTarget, cwd, restoreFile]);
+
+  const handleDiscardAll = useCallback(async () => {
+    if (!sandboxId) return;
+    try {
+      const result = await restoreAll.mutateAsync({ sandboxId, cwd });
+      if (result.success) {
+        toast.success('All changes discarded');
+      } else {
+        toast.error(result.error || 'Failed to discard all changes');
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to discard all changes');
+    }
+  }, [sandboxId, cwd, restoreAll]);
 
   const diffContent = diffData?.diff ?? '';
   const prevFileNamesRef = useRef<string>('');
@@ -271,6 +370,13 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
   const hasChanges = diffData?.has_changes ?? false;
   const diffError = diffData?.error ?? null;
   const showFiles = !isLoading && !isError && isGitRepo && hasChanges && parsedFiles.length > 0;
+  // Discard restores against HEAD, which only matches what the user sees in
+  // `all` mode. In staged/unstaged it would wipe the other side too, and in
+  // branch mode it wouldn't touch the committed diff at all.
+  // `!isPlaceholderData` guards the window where `keepPreviousData` still
+  // shows rows from the previous mode while the `all`-mode fetch is pending.
+  const canDiscardAll =
+    !isLoading && !isError && isGitRepo && hasChanges && mode === 'all' && !isPlaceholderData;
 
   return (
     <div className="flex h-full w-full flex-col bg-surface-secondary dark:bg-surface-dark-secondary">
@@ -297,17 +403,63 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
 
         <div className="min-w-0 flex-1" />
 
-        {showFiles && (
+        {(showFiles || canDiscardAll) && (
           <>
             <Button
-              onClick={toggleAll}
+              ref={triggerRef}
+              onClick={toggleMenu}
               variant="unstyled"
-              className="shrink-0 whitespace-nowrap text-2xs text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
-              title={allExpanded ? 'Collapse all' : 'Expand all'}
-              aria-label={allExpanded ? 'Collapse all' : 'Expand all'}
+              className="shrink-0 rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+              title="More actions"
+              aria-label="More actions"
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
             >
-              {allExpanded ? 'Collapse all' : 'Expand all'}
+              <MoreHorizontal className="h-3 w-3" />
             </Button>
+            {menuOpen &&
+              createPortal(
+                <div
+                  ref={menuPanelRef}
+                  role="menu"
+                  style={{ top: menuPos.top, right: menuPos.right }}
+                  className="fixed z-50 min-w-[180px] animate-fade-in space-y-px rounded-xl border border-border bg-surface-secondary/95 p-1 shadow-medium backdrop-blur-xl backdrop-saturate-150 dark:border-border-dark dark:bg-surface-dark-secondary/95"
+                >
+                  {showFiles && (
+                    <Button
+                      variant="unstyled"
+                      role="menuitem"
+                      onClick={() => {
+                        toggleAll();
+                        setMenuOpen(false);
+                      }}
+                      className={MENU_ITEM_CLASS}
+                    >
+                      <ChevronsUpDown className="h-3 w-3 text-text-tertiary dark:text-text-dark-tertiary" />
+                      {allExpanded ? 'Collapse all files' : 'Expand all files'}
+                    </Button>
+                  )}
+                  {showFiles && canDiscardAll && (
+                    <div className="my-1 h-px bg-border/50 dark:bg-border-dark/50" />
+                  )}
+                  {canDiscardAll && (
+                    <Button
+                      variant="unstyled"
+                      role="menuitem"
+                      disabled={restoreAll.isPending}
+                      onClick={() => {
+                        setDiscardAllOpen(true);
+                        setMenuOpen(false);
+                      }}
+                      className={MENU_ITEM_CLASS}
+                    >
+                      <Undo2 className="h-3 w-3 text-text-tertiary dark:text-text-dark-tertiary" />
+                      Discard all changes
+                    </Button>
+                  )}
+                </div>,
+                document.body,
+              )}
             <div className="h-3 w-px shrink-0 bg-border/50 dark:bg-border-dark/50" />
           </>
         )}
@@ -375,40 +527,55 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
           <div className="divide-y divide-border/30 dark:divide-border-dark/30">
             {parsedFiles.map((file, i) => {
               const isExpanded = expandedFiles.has(i);
-              const isRenamed = file.type === 'rename-pure' || file.type === 'rename-changed';
+              const isRenamed = isRenameFileType(file.type);
               return (
                 <div key={i}>
-                  <Button
-                    variant="unstyled"
-                    type="button"
-                    onClick={() => toggleFile(i)}
-                    className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors duration-200 hover:bg-surface-hover dark:hover:bg-surface-dark-hover"
-                  >
-                    <ChevronRight
-                      className={cn(
-                        'h-3 w-3 shrink-0 text-text-quaternary transition-transform duration-200 dark:text-text-dark-quaternary',
-                        isExpanded && 'rotate-90',
-                      )}
-                    />
-                    <FileIcon name={file.name} className="h-3 w-3" />
-                    <span className="min-w-0 truncate font-mono text-2xs text-text-secondary dark:text-text-dark-secondary">
-                      {isRenamed && file.prevName ? (
-                        <>
-                          <span className="text-text-quaternary dark:text-text-dark-quaternary">
-                            {file.prevName}
-                          </span>
-                          <span className="mx-1 text-text-quaternary dark:text-text-dark-quaternary">
-                            &rarr;
-                          </span>
-                          {file.name}
-                        </>
-                      ) : (
-                        file.name
-                      )}
-                    </span>
-                    <FileStatusBadge type={file.type} />
+                  <div className="group flex w-full items-center transition-colors duration-200 hover:bg-surface-hover dark:hover:bg-surface-dark-hover">
+                    <Button
+                      variant="unstyled"
+                      type="button"
+                      onClick={() => toggleFile(i)}
+                      className="flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left"
+                    >
+                      <ChevronRight
+                        className={cn(
+                          'h-3 w-3 shrink-0 text-text-quaternary transition-transform duration-200 dark:text-text-dark-quaternary',
+                          isExpanded && 'rotate-90',
+                        )}
+                      />
+                      <FileIcon name={file.name} className="h-3 w-3" />
+                      <span className="min-w-0 truncate font-mono text-2xs text-text-secondary dark:text-text-dark-secondary">
+                        {isRenamed && file.prevName ? (
+                          <>
+                            <span className="text-text-quaternary dark:text-text-dark-quaternary">
+                              {file.prevName}
+                            </span>
+                            <span className="mx-1 text-text-quaternary dark:text-text-dark-quaternary">
+                              &rarr;
+                            </span>
+                            {file.name}
+                          </>
+                        ) : (
+                          file.name
+                        )}
+                      </span>
+                      <FileStatusBadge type={file.type} />
+                    </Button>
+                    {canDiscardAll && (
+                      <Button
+                        variant="unstyled"
+                        type="button"
+                        onClick={() => setDiscardTarget(file)}
+                        disabled={restoreFile.isPending}
+                        className="mr-1 shrink-0 rounded-md p-1 text-text-quaternary opacity-0 transition-opacity duration-200 hover:text-text-primary focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-50 group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+                        title="Discard changes"
+                        aria-label={`Discard changes for ${file.name}`}
+                      >
+                        <Undo2 className="h-3 w-3" />
+                      </Button>
+                    )}
                     <FileStats file={file} />
-                  </Button>
+                  </div>
                   {isExpanded && <FileDiffRenderer file={file} options={options} />}
                 </div>
               );
@@ -444,6 +611,28 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
             </div>
           )}
       </div>
+
+      <ConfirmDialog
+        isOpen={discardTarget !== null}
+        onClose={() => setDiscardTarget(null)}
+        onConfirm={handleDiscard}
+        title="Discard changes?"
+        message={
+          discardTarget
+            ? `All changes to ${discardTarget.name} will be reverted to the last committed version. This cannot be undone.`
+            : ''
+        }
+        confirmLabel="Discard"
+      />
+
+      <ConfirmDialog
+        isOpen={discardAllOpen}
+        onClose={() => setDiscardAllOpen(false)}
+        onConfirm={handleDiscardAll}
+        title="Discard all changes?"
+        message="All modified, staged, and untracked files in the workspace will be reverted to the last committed version. This cannot be undone."
+        confirmLabel="Discard all"
+      />
     </div>
   );
 });

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -14,6 +14,7 @@ export const queryKeys = {
   sandbox: {
     fileContent: (sandboxId?: string, filePath?: string) =>
       ['sandbox', sandboxId, 'file-content', filePath] as const,
+    fileContentAll: (sandboxId?: string) => ['sandbox', sandboxId, 'file-content'] as const,
     filesMetadata: (sandboxId?: string) => ['sandbox', sandboxId, 'files-metadata'] as const,
     secrets: (sandboxId?: string) => ['sandbox', sandboxId, 'secrets'] as const,
     gitDiff: (

--- a/frontend/src/hooks/queries/useSandboxQueries.ts
+++ b/frontend/src/hooks/queries/useSandboxQueries.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
-import type { UseQueryOptions } from '@tanstack/react-query';
+import type { QueryClient, UseQueryOptions } from '@tanstack/react-query';
 import { sandboxService } from '@/services/sandboxService';
 import type {
   DiffMode,
@@ -229,6 +229,40 @@ export const useSearchInFilesQuery = (
     ...options,
   });
 };
+
+// Diff paths are cwd-relative while the editor caches workspace-root-relative
+// paths (e.g. `.worktrees/<id>/src/App.tsx`), so targeting a specific
+// `fileContent` key would miss worktree entries. Invalidate the whole
+// file-content space under this sandbox instead.
+const invalidateAfterGitRestore = (queryClient: QueryClient, sandboxId: string) =>
+  Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitDiffAll(sandboxId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.filesMetadata(sandboxId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.fileContentAll(sandboxId) }),
+  ]);
+
+export const useGitRestoreFileMutation = createMutation<
+  GitCommitResult,
+  Error,
+  { sandboxId: string; filePath: string; oldPath?: string; cwd?: string }
+>(
+  ({ sandboxId, filePath, oldPath, cwd }) =>
+    sandboxService.gitRestoreFile(sandboxId, filePath, oldPath, cwd),
+  async (queryClient, _data, variables) => {
+    await invalidateAfterGitRestore(queryClient, variables.sandboxId);
+  },
+);
+
+export const useGitRestoreAllMutation = createMutation<
+  GitCommitResult,
+  Error,
+  { sandboxId: string; cwd?: string }
+>(
+  ({ sandboxId, cwd }) => sandboxService.gitRestoreAll(sandboxId, cwd),
+  async (queryClient, _data, variables) => {
+    await invalidateAfterGitRestore(queryClient, variables.sandboxId);
+  },
+);
 
 export const useGitCreateBranchMutation = createMutation<
   GitCreateBranchResult,

--- a/frontend/src/services/sandboxService.ts
+++ b/frontend/src/services/sandboxService.ts
@@ -208,6 +208,40 @@ async function gitPull(sandboxId: string, cwd?: string): Promise<GitPushPullResu
   });
 }
 
+async function gitRestoreFile(
+  sandboxId: string,
+  filePath: string,
+  oldPath?: string,
+  cwd?: string,
+): Promise<GitCommitResult> {
+  validateRequired(sandboxId, 'Sandbox ID');
+  validateRequired(filePath, 'File path');
+
+  return serviceCall(async () => {
+    const response = await apiClient.post<GitCommitResult>(
+      `/sandbox/${sandboxId}/git/restore-file`,
+      {
+        file_path: filePath,
+        old_path: oldPath ?? null,
+        cwd: cwd ?? null,
+      },
+    );
+    return ensureResponse(response, 'Restore file failed');
+  });
+}
+
+async function gitRestoreAll(sandboxId: string, cwd?: string): Promise<GitCommitResult> {
+  validateRequired(sandboxId, 'Sandbox ID');
+
+  return serviceCall(async () => {
+    const qs = buildQueryString({ cwd });
+    const response = await apiClient.post<GitCommitResult>(
+      `/sandbox/${sandboxId}/git/restore-all${qs}`,
+    );
+    return ensureResponse(response, 'Restore all failed');
+  });
+}
+
 async function gitCreateBranch(
   sandboxId: string,
   name: string,
@@ -273,6 +307,8 @@ export const sandboxService = {
   gitPush,
   gitPull,
   gitCreateBranch,
+  gitRestoreFile,
+  gitRestoreAll,
   getGitRemoteUrl,
   searchInFiles,
 };


### PR DESCRIPTION
## Summary
- Adds per-file and "discard all" actions in the diff view via a kebab menu (Expand all + Discard all changes), portaled to escape the toolbar's overflow clipping.
- New backend endpoints `POST /git/restore-file` and `POST /git/restore-all` handle initial repos (no HEAD), nested cwd, renames, newly-staged files, and worktrees; all git shell commands extracted to module-level constants.
- React Query cache invalidation uses prefix keys to cover worktree path mismatches.
- CLAUDE.md updated with learnings from this work (shell chaining, cwd/pathspec, action gating on `isPlaceholderData`, cache key format matching, etc.).

## Test plan
- [ ] Initial repo (no HEAD): discard all wipes newly-staged files and untracked files.
- [ ] Repo with commits: per-file discard reverts tracked changes, including renames.
- [ ] Worktree/nested cwd: discard targets the correct workspace.
- [ ] Diff mode gating: discard actions appear only in \`all\` mode, not \`staged\`/\`unstaged\`/\`branch\`.
- [ ] Binary-only diffs: "Discard all" remains accessible; per-file button hidden when no rows parsed.
- [ ] Kebab menu: opens/closes correctly, escapes toolbar overflow clipping, click-outside dismisses.