### PR TITLE
Lighten user avatar background in light mode

### DIFF
--- a/frontend/src/components/chat/message-bubble/MessageAvatars.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageAvatars.tsx
@@ -15,7 +15,7 @@ export const UserAvatarCircle = memo(
       <div
         className={cn(
           sizeClasses,
-          'rounded-full bg-surface-active dark:bg-surface-dark-hover',
+          'rounded-full bg-surface-hover dark:bg-surface-dark-hover',
           'flex items-center justify-center text-2xs font-medium text-text-secondary dark:text-text-dark-secondary',
           'transition-all duration-200',
         )}


### PR DESCRIPTION
## Summary
- Switch the sidebar user avatar's light-mode background from `surface-active` (#d8d8d8) to `surface-hover` (#e0e0e0) so the profile circle reads as a subtler, lighter tone.
- Dark mode is unchanged.

## Test plan
- [ ] Open the app in light mode and confirm the profile avatar in the sidebar footer looks lighter and still reads against the surrounding surface.
- [ ] Toggle to dark mode and confirm no visual change.