### PR TITLE
Sync branch UI with HEAD on focus and agent turn end

### DIFF
--- a/frontend/src/hooks/queries/useSandboxQueries.ts
+++ b/frontend/src/hooks/queries/useSandboxQueries.ts
@@ -105,8 +105,10 @@ export const useGitBranchesQuery = (
     queryKey: queryKeys.sandbox.gitBranches(sandboxId, cwd),
     queryFn: () => sandboxService.getGitBranches(sandboxId, cwd),
     enabled: !!sandboxId && enabled,
-    // Branch lists change infrequently, and branch-changing mutations already invalidate this query.
-    staleTime: 300_000,
+    // Branches can change out-of-band (terminal `git checkout`, external tools), so refetch on
+    // window focus with a short stale window to pick those up without aggressive polling.
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
   });
 };
 

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -598,6 +598,11 @@ export function useStreamCallbacks({
         queryClient.removeQueries({
           queryKey: ['sandbox', currentChat.sandbox_id, 'file-content'],
         });
+        // Agent may have switched/created a branch during the turn (e.g. `git checkout -b`),
+        // so refresh the branch list to keep the UI in sync with HEAD.
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.sandbox.gitBranchesAll(currentChat.sandbox_id),
+        });
       }
 
       timerIdsRef.current.forEach(clearTimeout);


### PR DESCRIPTION
## Summary
- Branch list no longer goes stale when the branch changes outside UI mutations (terminal `git checkout`, agent-run `git checkout -b`, external tools).
- `useGitBranchesQuery` now uses `staleTime: 30s` + `refetchOnWindowFocus: true` so tabbing back from the terminal refreshes HEAD.
- `onComplete` in `useStreamCallbacks` invalidates `gitBranchesAll` for the active sandbox when a stream finishes, so agent-driven branch switches show up immediately.

## Test plan
- [ ] In the terminal, run `git checkout -b test-branch`, tab back to the app, and confirm the branch selector updates.
- [ ] Ask the agent to create a new branch and confirm the selector reflects it when the turn ends.
- [ ] Cancelling a turn does not trigger an extra branch refetch (block is gated on `!isCancelled`).
- [ ] Existing checkout/create/push/pull mutations still invalidate branches as before.