### PR TITLE
Add OpenCode CLI as a new ACP agent

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,6 +26,12 @@ RUN curl -fsS https://cursor.com/install | bash && \
     cp /root/.local/bin/cursor-agent /usr/local/bin/cursor-agent && \
     chmod +x /usr/local/bin/cursor-agent
 
+# OpenCode CLI — used for the OpenCode ACP server (`opencode acp`). The install
+# script downloads the binary to /root/.opencode/bin.
+RUN curl -fsSL https://opencode.ai/install | bash && \
+    cp /root/.opencode/bin/opencode /usr/local/bin/opencode && \
+    chmod +x /usr/local/bin/opencode
+
 # Install uv package manager
 RUN curl -LsSf https://astral.sh/uv/install.sh | bash
 

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -222,6 +222,1253 @@ MODELS: dict[str, ModelInfo] = {
         "Grok 4.20 Thinking", AgentKind.CURSOR, 200_000
     ),
     "cursor:kimi-k2.5[]": ModelInfo("Kimi K2.5", AgentKind.CURSOR, 262_000),
+    "opencode:opencode/big-pickle": ModelInfo(
+        "Big Pickle (OpenCode)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:opencode/gpt-5-nano": ModelInfo(
+        "GPT-5 Nano (OpenCode)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:opencode/minimax-m2.5-free": ModelInfo(
+        "MiniMax M2.5 Free (OpenCode)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:opencode/nemotron-3-super-free": ModelInfo(
+        "Nemotron 3 Super Free (OpenCode)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:amazon-bedrock/amazon.nova-2-lite-v1:0": ModelInfo(
+        "Nova 2 Lite (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/amazon.nova-lite-v1:0": ModelInfo(
+        "Nova Lite (Amazon Bedrock)", AgentKind.OPENCODE, 300_000
+    ),
+    "opencode:amazon-bedrock/amazon.nova-micro-v1:0": ModelInfo(
+        "Nova Micro (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/amazon.nova-premier-v1:0": ModelInfo(
+        "Nova Premier (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/amazon.nova-pro-v1:0": ModelInfo(
+        "Nova Pro (Amazon Bedrock)", AgentKind.OPENCODE, 300_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-3-5-haiku-20241022-v1:0": ModelInfo(
+        "Claude Haiku 3.5 (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0": ModelInfo(
+        "Claude Sonnet 3.5 (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0": ModelInfo(
+        "Claude Sonnet 3.5 v2 (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0": ModelInfo(
+        "Claude Sonnet 3.7 (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-3-haiku-20240307-v1:0": ModelInfo(
+        "Claude Haiku 3 (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-haiku-4-5-20251001-v1:0": ModelInfo(
+        "Claude Haiku 4.5 (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-opus-4-1-20250805-v1:0": ModelInfo(
+        "Claude Opus 4.1 (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-opus-4-20250514-v1:0": ModelInfo(
+        "Claude Opus 4 (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-opus-4-5-20251101-v1:0": ModelInfo(
+        "Claude Opus 4.5 (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-opus-4-6-v1": ModelInfo(
+        "Claude Opus 4.6 (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-opus-4-7": ModelInfo(
+        "Claude Opus 4.7 (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-sonnet-4-20250514-v1:0": ModelInfo(
+        "Claude Sonnet 4 (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0": ModelInfo(
+        "Claude Sonnet 4.5 (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/anthropic.claude-sonnet-4-6": ModelInfo(
+        "Claude Sonnet 4.6 (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/deepseek.r1-v1:0": ModelInfo(
+        "DeepSeek-R1 (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/deepseek.v3-v1:0": ModelInfo(
+        "DeepSeek-V3.1 (Amazon Bedrock)", AgentKind.OPENCODE, 163_840
+    ),
+    "opencode:amazon-bedrock/deepseek.v3.2": ModelInfo(
+        "DeepSeek-V3.2 (Amazon Bedrock)", AgentKind.OPENCODE, 163_840
+    ),
+    "opencode:amazon-bedrock/eu.anthropic.claude-haiku-4-5-20251001-v1:0": ModelInfo(
+        "Claude Haiku 4.5 (EU) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/eu.anthropic.claude-opus-4-5-20251101-v1:0": ModelInfo(
+        "Claude Opus 4.5 (EU) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/eu.anthropic.claude-opus-4-6-v1": ModelInfo(
+        "Claude Opus 4.6 (EU) (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/eu.anthropic.claude-opus-4-7": ModelInfo(
+        "Claude Opus 4.7 (EU) (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0": ModelInfo(
+        "Claude Sonnet 4 (EU) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0": ModelInfo(
+        "Claude Sonnet 4.5 (EU) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/eu.anthropic.claude-sonnet-4-6": ModelInfo(
+        "Claude Sonnet 4.6 (EU) (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0": ModelInfo(
+        "Claude Haiku 4.5 (Global) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/global.anthropic.claude-opus-4-5-20251101-v1:0": ModelInfo(
+        "Claude Opus 4.5 (Global) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/global.anthropic.claude-opus-4-6-v1": ModelInfo(
+        "Claude Opus 4.6 (Global) (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/global.anthropic.claude-opus-4-7": ModelInfo(
+        "Claude Opus 4.7 (Global) (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/global.anthropic.claude-sonnet-4-20250514-v1:0": ModelInfo(
+        "Claude Sonnet 4 (Global) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0": ModelInfo(
+        "Claude Sonnet 4.5 (Global) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/global.anthropic.claude-sonnet-4-6": ModelInfo(
+        "Claude Sonnet 4.6 (Global) (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/google.gemma-3-12b-it": ModelInfo(
+        "Google Gemma 3 12B (Amazon Bedrock)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:amazon-bedrock/google.gemma-3-27b-it": ModelInfo(
+        "Google Gemma 3 27B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 202_752
+    ),
+    "opencode:amazon-bedrock/google.gemma-3-4b-it": ModelInfo(
+        "Gemma 3 4B IT (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/meta.llama3-1-405b-instruct-v1:0": ModelInfo(
+        "Llama 3.1 405B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/meta.llama3-1-70b-instruct-v1:0": ModelInfo(
+        "Llama 3.1 70B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/meta.llama3-1-8b-instruct-v1:0": ModelInfo(
+        "Llama 3.1 8B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/meta.llama3-2-11b-instruct-v1:0": ModelInfo(
+        "Llama 3.2 11B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/meta.llama3-2-1b-instruct-v1:0": ModelInfo(
+        "Llama 3.2 1B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 131_000
+    ),
+    "opencode:amazon-bedrock/meta.llama3-2-3b-instruct-v1:0": ModelInfo(
+        "Llama 3.2 3B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 131_000
+    ),
+    "opencode:amazon-bedrock/meta.llama3-2-90b-instruct-v1:0": ModelInfo(
+        "Llama 3.2 90B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/meta.llama3-3-70b-instruct-v1:0": ModelInfo(
+        "Llama 3.3 70B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/meta.llama4-maverick-17b-instruct-v1:0": ModelInfo(
+        "Llama 4 Maverick 17B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/meta.llama4-scout-17b-instruct-v1:0": ModelInfo(
+        "Llama 4 Scout 17B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 3_500_000
+    ),
+    "opencode:amazon-bedrock/minimax.minimax-m2": ModelInfo(
+        "MiniMax M2 (Amazon Bedrock)", AgentKind.OPENCODE, 204_608
+    ),
+    "opencode:amazon-bedrock/minimax.minimax-m2.1": ModelInfo(
+        "MiniMax M2.1 (Amazon Bedrock)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:amazon-bedrock/minimax.minimax-m2.5": ModelInfo(
+        "MiniMax M2.5 (Amazon Bedrock)", AgentKind.OPENCODE, 196_608
+    ),
+    "opencode:amazon-bedrock/mistral.devstral-2-123b": ModelInfo(
+        "Devstral 2 123B (Amazon Bedrock)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:amazon-bedrock/mistral.magistral-small-2509": ModelInfo(
+        "Magistral Small 1.2 (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/mistral.ministral-3-14b-instruct": ModelInfo(
+        "Ministral 14B 3.0 (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/mistral.ministral-3-3b-instruct": ModelInfo(
+        "Ministral 3 3B (Amazon Bedrock)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:amazon-bedrock/mistral.ministral-3-8b-instruct": ModelInfo(
+        "Ministral 3 8B (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/mistral.mistral-large-3-675b-instruct": ModelInfo(
+        "Mistral Large 3 (Amazon Bedrock)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:amazon-bedrock/mistral.pixtral-large-2502-v1:0": ModelInfo(
+        "Pixtral Large (25.02) (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/mistral.voxtral-mini-3b-2507": ModelInfo(
+        "Voxtral Mini 3B 2507 (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/mistral.voxtral-small-24b-2507": ModelInfo(
+        "Voxtral Small 24B 2507 (Amazon Bedrock)", AgentKind.OPENCODE, 32_000
+    ),
+    "opencode:amazon-bedrock/moonshot.kimi-k2-thinking": ModelInfo(
+        "Kimi K2 Thinking (Amazon Bedrock)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:amazon-bedrock/moonshotai.kimi-k2.5": ModelInfo(
+        "Kimi K2.5 (Amazon Bedrock)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:amazon-bedrock/nvidia.nemotron-nano-12b-v2": ModelInfo(
+        "NVIDIA Nemotron Nano 12B v2 VL BF16 (Amazon Bedrock)",
+        AgentKind.OPENCODE,
+        128_000,
+    ),
+    "opencode:amazon-bedrock/nvidia.nemotron-nano-3-30b": ModelInfo(
+        "NVIDIA Nemotron Nano 3 30B (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/nvidia.nemotron-nano-9b-v2": ModelInfo(
+        "NVIDIA Nemotron Nano 9B v2 (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/nvidia.nemotron-super-3-120b": ModelInfo(
+        "NVIDIA Nemotron 3 Super 120B A12B (Amazon Bedrock)",
+        AgentKind.OPENCODE,
+        262_144,
+    ),
+    "opencode:amazon-bedrock/openai.gpt-oss-120b-1:0": ModelInfo(
+        "gpt-oss-120b (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/openai.gpt-oss-20b-1:0": ModelInfo(
+        "gpt-oss-20b (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/openai.gpt-oss-safeguard-120b": ModelInfo(
+        "GPT OSS Safeguard 120B (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/openai.gpt-oss-safeguard-20b": ModelInfo(
+        "GPT OSS Safeguard 20B (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:amazon-bedrock/qwen.qwen3-235b-a22b-2507-v1:0": ModelInfo(
+        "Qwen3 235B A22B 2507 (Amazon Bedrock)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:amazon-bedrock/qwen.qwen3-32b-v1:0": ModelInfo(
+        "Qwen3 32B (dense) (Amazon Bedrock)", AgentKind.OPENCODE, 16_384
+    ),
+    "opencode:amazon-bedrock/qwen.qwen3-coder-30b-a3b-v1:0": ModelInfo(
+        "Qwen3 Coder 30B A3B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:amazon-bedrock/qwen.qwen3-coder-480b-a35b-v1:0": ModelInfo(
+        "Qwen3 Coder 480B A35B Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:amazon-bedrock/qwen.qwen3-coder-next": ModelInfo(
+        "Qwen3 Coder Next (Amazon Bedrock)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:amazon-bedrock/qwen.qwen3-next-80b-a3b": ModelInfo(
+        "Qwen/Qwen3-Next-80B-A3B-Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 262_000
+    ),
+    "opencode:amazon-bedrock/qwen.qwen3-vl-235b-a22b": ModelInfo(
+        "Qwen/Qwen3-VL-235B-A22B-Instruct (Amazon Bedrock)", AgentKind.OPENCODE, 262_000
+    ),
+    "opencode:amazon-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0": ModelInfo(
+        "Claude Haiku 4.5 (US) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/us.anthropic.claude-opus-4-1-20250805-v1:0": ModelInfo(
+        "Claude Opus 4.1 (US) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/us.anthropic.claude-opus-4-20250514-v1:0": ModelInfo(
+        "Claude Opus 4 (US) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/us.anthropic.claude-opus-4-5-20251101-v1:0": ModelInfo(
+        "Claude Opus 4.5 (US) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/us.anthropic.claude-opus-4-6-v1": ModelInfo(
+        "Claude Opus 4.6 (US) (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/us.anthropic.claude-opus-4-7": ModelInfo(
+        "Claude Opus 4.7 (US) (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0": ModelInfo(
+        "Claude Sonnet 4 (US) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0": ModelInfo(
+        "Claude Sonnet 4.5 (US) (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/us.anthropic.claude-sonnet-4-6": ModelInfo(
+        "Claude Sonnet 4.6 (US) (Amazon Bedrock)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:amazon-bedrock/writer.palmyra-x4-v1:0": ModelInfo(
+        "Palmyra X4 (Amazon Bedrock)", AgentKind.OPENCODE, 122_880
+    ),
+    "opencode:amazon-bedrock/writer.palmyra-x5-v1:0": ModelInfo(
+        "Palmyra X5 (Amazon Bedrock)", AgentKind.OPENCODE, 1_040_000
+    ),
+    "opencode:amazon-bedrock/zai.glm-4.7": ModelInfo(
+        "GLM-4.7 (Amazon Bedrock)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:amazon-bedrock/zai.glm-4.7-flash": ModelInfo(
+        "GLM-4.7-Flash (Amazon Bedrock)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:amazon-bedrock/zai.glm-5": ModelInfo(
+        "GLM-5 (Amazon Bedrock)", AgentKind.OPENCODE, 202_752
+    ),
+    "opencode:deepseek/deepseek-chat": ModelInfo(
+        "DeepSeek Chat (Deepseek)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:deepseek/deepseek-reasoner": ModelInfo(
+        "DeepSeek Reasoner (Deepseek)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:github-copilot/claude-haiku-4.5": ModelInfo(
+        "Claude Haiku 4.5 (Github Copilot)", AgentKind.OPENCODE, 144_000
+    ),
+    "opencode:github-copilot/claude-opus-4.5": ModelInfo(
+        "Claude Opus 4.5 (Github Copilot)", AgentKind.OPENCODE, 160_000
+    ),
+    "opencode:github-copilot/claude-opus-4.6": ModelInfo(
+        "Claude Opus 4.6 (Github Copilot)", AgentKind.OPENCODE, 144_000
+    ),
+    "opencode:github-copilot/claude-sonnet-4": ModelInfo(
+        "Claude Sonnet 4 (Github Copilot)", AgentKind.OPENCODE, 216_000
+    ),
+    "opencode:github-copilot/claude-sonnet-4.5": ModelInfo(
+        "Claude Sonnet 4.5 (Github Copilot)", AgentKind.OPENCODE, 144_000
+    ),
+    "opencode:github-copilot/claude-sonnet-4.6": ModelInfo(
+        "Claude Sonnet 4.6 (Github Copilot)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:github-copilot/gemini-2.5-pro": ModelInfo(
+        "Gemini 2.5 Pro (Github Copilot)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:github-copilot/gemini-3-flash-preview": ModelInfo(
+        "Gemini 3 Flash (Github Copilot)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:github-copilot/gemini-3.1-pro-preview": ModelInfo(
+        "Gemini 3.1 Pro Preview (Github Copilot)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:github-copilot/gpt-4.1": ModelInfo(
+        "GPT-4.1 (Github Copilot)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:github-copilot/gpt-4o": ModelInfo(
+        "GPT-4o (Github Copilot)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:github-copilot/gpt-5-mini": ModelInfo(
+        "GPT-5-mini (Github Copilot)", AgentKind.OPENCODE, 264_000
+    ),
+    "opencode:github-copilot/gpt-5.2": ModelInfo(
+        "GPT-5.2 (Github Copilot)", AgentKind.OPENCODE, 264_000
+    ),
+    "opencode:github-copilot/gpt-5.2-codex": ModelInfo(
+        "GPT-5.2-Codex (Github Copilot)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:github-copilot/gpt-5.3-codex": ModelInfo(
+        "GPT-5.3-Codex (Github Copilot)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:github-copilot/gpt-5.4": ModelInfo(
+        "GPT-5.4 (Github Copilot)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:github-copilot/gpt-5.4-mini": ModelInfo(
+        "GPT-5.4 Mini (Github Copilot)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:github-copilot/grok-code-fast-1": ModelInfo(
+        "Grok Code Fast 1 (Github Copilot)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:google/gemini-1.5-flash": ModelInfo(
+        "Gemini 1.5 Flash (Google)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:google/gemini-1.5-flash-8b": ModelInfo(
+        "Gemini 1.5 Flash-8B (Google)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:google/gemini-1.5-pro": ModelInfo(
+        "Gemini 1.5 Pro (Google)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:google/gemini-2.0-flash": ModelInfo(
+        "Gemini 2.0 Flash (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.0-flash-lite": ModelInfo(
+        "Gemini 2.0 Flash Lite (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.5-flash": ModelInfo(
+        "Gemini 2.5 Flash (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.5-flash-image": ModelInfo(
+        "Gemini 2.5 Flash Image (Google)", AgentKind.OPENCODE, 32_768
+    ),
+    "opencode:google/gemini-2.5-flash-image-preview": ModelInfo(
+        "Gemini 2.5 Flash Image (Preview) (Google)", AgentKind.OPENCODE, 32_768
+    ),
+    "opencode:google/gemini-2.5-flash-lite": ModelInfo(
+        "Gemini 2.5 Flash Lite (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.5-flash-lite-preview-06-17": ModelInfo(
+        "Gemini 2.5 Flash Lite Preview 06-17 (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.5-flash-lite-preview-09-2025": ModelInfo(
+        "Gemini 2.5 Flash Lite Preview 09-25 (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.5-flash-preview-04-17": ModelInfo(
+        "Gemini 2.5 Flash Preview 04-17 (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.5-flash-preview-05-20": ModelInfo(
+        "Gemini 2.5 Flash Preview 05-20 (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.5-flash-preview-09-2025": ModelInfo(
+        "Gemini 2.5 Flash Preview 09-25 (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.5-flash-preview-tts": ModelInfo(
+        "Gemini 2.5 Flash Preview TTS (Google)", AgentKind.OPENCODE, 8000
+    ),
+    "opencode:google/gemini-2.5-pro": ModelInfo(
+        "Gemini 2.5 Pro (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.5-pro-preview-05-06": ModelInfo(
+        "Gemini 2.5 Pro Preview 05-06 (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.5-pro-preview-06-05": ModelInfo(
+        "Gemini 2.5 Pro Preview 06-05 (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-2.5-pro-preview-tts": ModelInfo(
+        "Gemini 2.5 Pro Preview TTS (Google)", AgentKind.OPENCODE, 8000
+    ),
+    "opencode:google/gemini-3-flash-preview": ModelInfo(
+        "Gemini 3 Flash Preview (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-3-pro-preview": ModelInfo(
+        "Gemini 3 Pro Preview (Google)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:google/gemini-3.1-flash-image-preview": ModelInfo(
+        "Gemini 3.1 Flash Image (Preview) (Google)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:google/gemini-3.1-flash-lite-preview": ModelInfo(
+        "Gemini 3.1 Flash Lite Preview (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-3.1-pro-preview": ModelInfo(
+        "Gemini 3.1 Pro Preview (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-3.1-pro-preview-customtools": ModelInfo(
+        "Gemini 3.1 Pro Preview Custom Tools (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-embedding-001": ModelInfo(
+        "Gemini Embedding 001 (Google)", AgentKind.OPENCODE, 2048
+    ),
+    "opencode:google/gemini-flash-latest": ModelInfo(
+        "Gemini Flash Latest (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-flash-lite-latest": ModelInfo(
+        "Gemini Flash-Lite Latest (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google/gemini-live-2.5-flash": ModelInfo(
+        "Gemini Live 2.5 Flash (Google)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:google/gemini-live-2.5-flash-preview-native-audio": ModelInfo(
+        "Gemini Live 2.5 Flash Preview Native Audio (Google)",
+        AgentKind.OPENCODE,
+        131_072,
+    ),
+    "opencode:google/gemma-3-12b-it": ModelInfo(
+        "Gemma 3 12B (Google)", AgentKind.OPENCODE, 32_768
+    ),
+    "opencode:google/gemma-3-27b-it": ModelInfo(
+        "Gemma 3 27B (Google)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:google/gemma-3-4b-it": ModelInfo(
+        "Gemma 3 4B (Google)", AgentKind.OPENCODE, 32_768
+    ),
+    "opencode:google/gemma-3n-e2b-it": ModelInfo(
+        "Gemma 3n 2B (Google)", AgentKind.OPENCODE, 8192
+    ),
+    "opencode:google/gemma-3n-e4b-it": ModelInfo(
+        "Gemma 3n 4B (Google)", AgentKind.OPENCODE, 8192
+    ),
+    "opencode:google/gemma-4-26b-it": ModelInfo(
+        "Gemma 4 26B (Google)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:google/gemma-4-31b-it": ModelInfo(
+        "Gemma 4 31B (Google)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:google-vertex/deepseek-ai/deepseek-v3.1-maas": ModelInfo(
+        "DeepSeek V3.1 (Google Vertex)", AgentKind.OPENCODE, 163_840
+    ),
+    "opencode:google-vertex/deepseek-ai/deepseek-v3.2-maas": ModelInfo(
+        "DeepSeek V3.2 (Google Vertex)", AgentKind.OPENCODE, 163_840
+    ),
+    "opencode:google-vertex/gemini-2.0-flash": ModelInfo(
+        "Gemini 2.0 Flash (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-2.0-flash-lite": ModelInfo(
+        "Gemini 2.0 Flash Lite (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-2.5-flash": ModelInfo(
+        "Gemini 2.5 Flash (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-2.5-flash-lite": ModelInfo(
+        "Gemini 2.5 Flash Lite (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-2.5-flash-lite-preview-06-17": ModelInfo(
+        "Gemini 2.5 Flash Lite Preview 06-17 (Google Vertex)",
+        AgentKind.OPENCODE,
+        65_536,
+    ),
+    "opencode:google-vertex/gemini-2.5-flash-lite-preview-09-2025": ModelInfo(
+        "Gemini 2.5 Flash Lite Preview 09-25 (Google Vertex)",
+        AgentKind.OPENCODE,
+        1_048_576,
+    ),
+    "opencode:google-vertex/gemini-2.5-flash-preview-04-17": ModelInfo(
+        "Gemini 2.5 Flash Preview 04-17 (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-2.5-flash-preview-05-20": ModelInfo(
+        "Gemini 2.5 Flash Preview 05-20 (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-2.5-flash-preview-09-2025": ModelInfo(
+        "Gemini 2.5 Flash Preview 09-25 (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-2.5-pro": ModelInfo(
+        "Gemini 2.5 Pro (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-2.5-pro-preview-05-06": ModelInfo(
+        "Gemini 2.5 Pro Preview 05-06 (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-2.5-pro-preview-06-05": ModelInfo(
+        "Gemini 2.5 Pro Preview 06-05 (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-3-flash-preview": ModelInfo(
+        "Gemini 3 Flash Preview (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-3-pro-preview": ModelInfo(
+        "Gemini 3 Pro Preview (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-3.1-pro-preview": ModelInfo(
+        "Gemini 3.1 Pro Preview (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-3.1-pro-preview-customtools": ModelInfo(
+        "Gemini 3.1 Pro Preview Custom Tools (Google Vertex)",
+        AgentKind.OPENCODE,
+        1_048_576,
+    ),
+    "opencode:google-vertex/gemini-embedding-001": ModelInfo(
+        "Gemini Embedding 001 (Google Vertex)", AgentKind.OPENCODE, 2048
+    ),
+    "opencode:google-vertex/gemini-flash-latest": ModelInfo(
+        "Gemini Flash Latest (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-flash-lite-latest": ModelInfo(
+        "Gemini Flash-Lite Latest (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/meta/llama-3.3-70b-instruct-maas": ModelInfo(
+        "Llama 3.3 70B Instruct (Google Vertex)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:google-vertex/meta/llama-4-maverick-17b-128e-instruct-maas": ModelInfo(
+        "Llama 4 Maverick 17B 128E Instruct (Google Vertex)",
+        AgentKind.OPENCODE,
+        524_288,
+    ),
+    "opencode:google-vertex/moonshotai/kimi-k2-thinking-maas": ModelInfo(
+        "Kimi K2 Thinking (Google Vertex)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:google-vertex/openai/gpt-oss-120b-maas": ModelInfo(
+        "GPT OSS 120B (Google Vertex)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:google-vertex/openai/gpt-oss-20b-maas": ModelInfo(
+        "GPT OSS 20B (Google Vertex)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:google-vertex/qwen/qwen3-235b-a22b-instruct-2507-maas": ModelInfo(
+        "Qwen3 235B A22B Instruct (Google Vertex)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:google-vertex/zai-org/glm-4.7-maas": ModelInfo(
+        "GLM-4.7 (Google Vertex)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:google-vertex/zai-org/glm-5-maas": ModelInfo(
+        "GLM-5 (Google Vertex)", AgentKind.OPENCODE, 202_752
+    ),
+    "opencode:google-vertex-anthropic/claude-3-5-haiku@20241022": ModelInfo(
+        "Claude Haiku 3.5 (Google Vertex Anthropic)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:google-vertex-anthropic/claude-3-5-sonnet@20241022": ModelInfo(
+        "Claude Sonnet 3.5 v2 (Google Vertex Anthropic)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:google-vertex-anthropic/claude-3-7-sonnet@20250219": ModelInfo(
+        "Claude Sonnet 3.7 (Google Vertex Anthropic)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:google-vertex-anthropic/claude-haiku-4-5@20251001": ModelInfo(
+        "Claude Haiku 4.5 (Google Vertex Anthropic)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:google-vertex-anthropic/claude-opus-4-1@20250805": ModelInfo(
+        "Claude Opus 4.1 (Google Vertex Anthropic)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:google-vertex-anthropic/claude-opus-4-5@20251101": ModelInfo(
+        "Claude Opus 4.5 (Google Vertex Anthropic)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:google-vertex-anthropic/claude-opus-4-6@default": ModelInfo(
+        "Claude Opus 4.6 (Google Vertex Anthropic)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:google-vertex-anthropic/claude-opus-4-7@default": ModelInfo(
+        "Claude Opus 4.7 (Google Vertex Anthropic)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:google-vertex-anthropic/claude-opus-4@20250514": ModelInfo(
+        "Claude Opus 4 (Google Vertex Anthropic)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:google-vertex-anthropic/claude-sonnet-4-5@20250929": ModelInfo(
+        "Claude Sonnet 4.5 (Google Vertex Anthropic)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:google-vertex-anthropic/claude-sonnet-4-6@default": ModelInfo(
+        "Claude Sonnet 4.6 (Google Vertex Anthropic)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:google-vertex-anthropic/claude-sonnet-4@20250514": ModelInfo(
+        "Claude Sonnet 4 (Google Vertex Anthropic)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openai/gpt-5-codex": ModelInfo(
+        "GPT-5-Codex (Openai)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openai/gpt-5.1-codex": ModelInfo(
+        "GPT-5.1 Codex (Openai)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openai/gpt-5.1-codex-max": ModelInfo(
+        "GPT-5.1 Codex Max (Openai)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openai/gpt-5.1-codex-mini": ModelInfo(
+        "GPT-5.1 Codex mini (Openai)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openai/gpt-5.2": ModelInfo(
+        "GPT-5.2 (Openai)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openai/gpt-5.2-codex": ModelInfo(
+        "GPT-5.2 Codex (Openai)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openai/gpt-5.3-codex": ModelInfo(
+        "GPT-5.3 Codex (Openai)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openai/gpt-5.3-codex-spark": ModelInfo(
+        "GPT-5.3 Codex Spark (Openai)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openai/gpt-5.4": ModelInfo(
+        "GPT-5.4 (Openai)", AgentKind.OPENCODE, 1_050_000
+    ),
+    "opencode:openai/gpt-5.4-fast": ModelInfo(
+        "GPT-5.4 Fast (Openai)", AgentKind.OPENCODE, 1_050_000
+    ),
+    "opencode:openai/gpt-5.4-mini": ModelInfo(
+        "GPT-5.4 mini (Openai)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openai/gpt-5.4-mini-fast": ModelInfo(
+        "GPT-5.4 mini Fast (Openai)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/anthropic/claude-3.5-haiku": ModelInfo(
+        "Claude Haiku 3.5 (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/anthropic/claude-3.7-sonnet": ModelInfo(
+        "Claude Sonnet 3.7 (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/anthropic/claude-haiku-4.5": ModelInfo(
+        "Claude Haiku 4.5 (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/anthropic/claude-opus-4": ModelInfo(
+        "Claude Opus 4 (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/anthropic/claude-opus-4.1": ModelInfo(
+        "Claude Opus 4.1 (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/anthropic/claude-opus-4.5": ModelInfo(
+        "Claude Opus 4.5 (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/anthropic/claude-opus-4.6": ModelInfo(
+        "Claude Opus 4.6 (Openrouter)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:openrouter/anthropic/claude-opus-4.7": ModelInfo(
+        "Claude Opus 4.7 (Openrouter)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:openrouter/anthropic/claude-sonnet-4": ModelInfo(
+        "Claude Sonnet 4 (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/anthropic/claude-sonnet-4.5": ModelInfo(
+        "Claude Sonnet 4.5 (Openrouter)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:openrouter/anthropic/claude-sonnet-4.6": ModelInfo(
+        "Claude Sonnet 4.6 (Openrouter)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:openrouter/arcee-ai/trinity-large-preview:free": ModelInfo(
+        "Trinity Large Preview (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/arcee-ai/trinity-large-thinking": ModelInfo(
+        "Trinity Large Thinking (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/black-forest-labs/flux.2-flex": ModelInfo(
+        "FLUX.2 Flex (Openrouter)", AgentKind.OPENCODE, 67_344
+    ),
+    "opencode:openrouter/black-forest-labs/flux.2-klein-4b": ModelInfo(
+        "FLUX.2 Klein 4B (Openrouter)", AgentKind.OPENCODE, 40_960
+    ),
+    "opencode:openrouter/black-forest-labs/flux.2-max": ModelInfo(
+        "FLUX.2 Max (Openrouter)", AgentKind.OPENCODE, 46_864
+    ),
+    "opencode:openrouter/black-forest-labs/flux.2-pro": ModelInfo(
+        "FLUX.2 Pro (Openrouter)", AgentKind.OPENCODE, 46_864
+    ),
+    "opencode:openrouter/bytedance-seed/seedream-4.5": ModelInfo(
+        "Seedream 4.5 (Openrouter)", AgentKind.OPENCODE, 4096
+    ),
+    "opencode:openrouter/cognitivecomputations/dolphin-mistral-24b-venice-edition:free": ModelInfo(
+        "Uncensored (free) (Openrouter)", AgentKind.OPENCODE, 32_768
+    ),
+    "opencode:openrouter/deepseek/deepseek-chat-v3-0324": ModelInfo(
+        "DeepSeek V3 0324 (Openrouter)", AgentKind.OPENCODE, 16_384
+    ),
+    "opencode:openrouter/deepseek/deepseek-chat-v3.1": ModelInfo(
+        "DeepSeek-V3.1 (Openrouter)", AgentKind.OPENCODE, 163_840
+    ),
+    "opencode:openrouter/deepseek/deepseek-r1": ModelInfo(
+        "DeepSeek: R1 (Openrouter)", AgentKind.OPENCODE, 64_000
+    ),
+    "opencode:openrouter/deepseek/deepseek-r1-distill-llama-70b": ModelInfo(
+        "DeepSeek R1 Distill Llama 70B (Openrouter)", AgentKind.OPENCODE, 8192
+    ),
+    "opencode:openrouter/deepseek/deepseek-v3.1-terminus": ModelInfo(
+        "DeepSeek V3.1 Terminus (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/deepseek/deepseek-v3.1-terminus:exacto": ModelInfo(
+        "DeepSeek V3.1 Terminus (exacto) (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/deepseek/deepseek-v3.2": ModelInfo(
+        "DeepSeek V3.2 (Openrouter)", AgentKind.OPENCODE, 163_840
+    ),
+    "opencode:openrouter/deepseek/deepseek-v3.2-speciale": ModelInfo(
+        "DeepSeek V3.2 Speciale (Openrouter)", AgentKind.OPENCODE, 163_840
+    ),
+    "opencode:openrouter/google/gemini-2.0-flash-001": ModelInfo(
+        "Gemini 2.0 Flash (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/google/gemini-2.5-flash": ModelInfo(
+        "Gemini 2.5 Flash (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/google/gemini-2.5-flash-lite": ModelInfo(
+        "Gemini 2.5 Flash Lite (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/google/gemini-2.5-flash-lite-preview-09-2025": ModelInfo(
+        "Gemini 2.5 Flash Lite Preview 09-25 (Openrouter)",
+        AgentKind.OPENCODE,
+        1_048_576,
+    ),
+    "opencode:openrouter/google/gemini-2.5-flash-preview-09-2025": ModelInfo(
+        "Gemini 2.5 Flash Preview 09-25 (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/google/gemini-2.5-pro": ModelInfo(
+        "Gemini 2.5 Pro (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/google/gemini-2.5-pro-preview-05-06": ModelInfo(
+        "Gemini 2.5 Pro Preview 05-06 (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/google/gemini-2.5-pro-preview-06-05": ModelInfo(
+        "Gemini 2.5 Pro Preview 06-05 (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/google/gemini-3-flash-preview": ModelInfo(
+        "Gemini 3 Flash Preview (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/google/gemini-3-pro-preview": ModelInfo(
+        "Gemini 3 Pro Preview (Openrouter)", AgentKind.OPENCODE, 1_050_000
+    ),
+    "opencode:openrouter/google/gemini-3.1-flash-lite-preview": ModelInfo(
+        "Gemini 3.1 Flash Lite Preview (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/google/gemini-3.1-pro-preview": ModelInfo(
+        "Gemini 3.1 Pro Preview (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/google/gemini-3.1-pro-preview-customtools": ModelInfo(
+        "Gemini 3.1 Pro Preview Custom Tools (Openrouter)",
+        AgentKind.OPENCODE,
+        1_048_576,
+    ),
+    "opencode:openrouter/google/gemma-2-9b-it": ModelInfo(
+        "Gemma 2 9B (Openrouter)", AgentKind.OPENCODE, 8192
+    ),
+    "opencode:openrouter/google/gemma-3-12b-it": ModelInfo(
+        "Gemma 3 12B (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/google/gemma-3-12b-it:free": ModelInfo(
+        "Gemma 3 12B (free) (Openrouter)", AgentKind.OPENCODE, 32_768
+    ),
+    "opencode:openrouter/google/gemma-3-27b-it": ModelInfo(
+        "Gemma 3 27B (Openrouter)", AgentKind.OPENCODE, 96_000
+    ),
+    "opencode:openrouter/google/gemma-3-27b-it:free": ModelInfo(
+        "Gemma 3 27B (free) (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/google/gemma-3-4b-it": ModelInfo(
+        "Gemma 3 4B (Openrouter)", AgentKind.OPENCODE, 96_000
+    ),
+    "opencode:openrouter/google/gemma-3-4b-it:free": ModelInfo(
+        "Gemma 3 4B (free) (Openrouter)", AgentKind.OPENCODE, 32_768
+    ),
+    "opencode:openrouter/google/gemma-3n-e2b-it:free": ModelInfo(
+        "Gemma 3n 2B (free) (Openrouter)", AgentKind.OPENCODE, 8192
+    ),
+    "opencode:openrouter/google/gemma-3n-e4b-it": ModelInfo(
+        "Gemma 3n 4B (Openrouter)", AgentKind.OPENCODE, 32_768
+    ),
+    "opencode:openrouter/google/gemma-3n-e4b-it:free": ModelInfo(
+        "Gemma 3n 4B (free) (Openrouter)", AgentKind.OPENCODE, 8192
+    ),
+    "opencode:openrouter/google/gemma-4-26b-a4b-it": ModelInfo(
+        "Gemma 4 26B A4B (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/google/gemma-4-26b-a4b-it:free": ModelInfo(
+        "Gemma 4 26B A4B (free) (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/google/gemma-4-31b-it": ModelInfo(
+        "Gemma 4 31B (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/google/gemma-4-31b-it:free": ModelInfo(
+        "Gemma 4 31B (free) (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/inception/mercury-2": ModelInfo(
+        "Mercury 2 (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/inception/mercury-edit-2": ModelInfo(
+        "Mercury Edit 2 (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/liquid/lfm-2.5-1.2b-instruct:free": ModelInfo(
+        "LFM2.5-1.2B-Instruct (free) (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/liquid/lfm-2.5-1.2b-thinking:free": ModelInfo(
+        "LFM2.5-1.2B-Thinking (free) (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/meta-llama/llama-3.2-11b-vision-instruct": ModelInfo(
+        "Llama 3.2 11B Vision Instruct (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/meta-llama/llama-3.2-3b-instruct:free": ModelInfo(
+        "Llama 3.2 3B Instruct (free) (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/meta-llama/llama-3.3-70b-instruct:free": ModelInfo(
+        "Llama 3.3 70B Instruct (free) (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/minimax/minimax-01": ModelInfo(
+        "MiniMax-01 (Openrouter)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:openrouter/minimax/minimax-m1": ModelInfo(
+        "MiniMax M1 (Openrouter)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:openrouter/minimax/minimax-m2": ModelInfo(
+        "MiniMax M2 (Openrouter)", AgentKind.OPENCODE, 196_600
+    ),
+    "opencode:openrouter/minimax/minimax-m2.1": ModelInfo(
+        "MiniMax M2.1 (Openrouter)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:openrouter/minimax/minimax-m2.5": ModelInfo(
+        "MiniMax M2.5 (Openrouter)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:openrouter/minimax/minimax-m2.5:free": ModelInfo(
+        "MiniMax M2.5 (free) (Openrouter)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:openrouter/minimax/minimax-m2.7": ModelInfo(
+        "MiniMax M2.7 (Openrouter)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:openrouter/mistralai/codestral-2508": ModelInfo(
+        "Codestral 2508 (Openrouter)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:openrouter/mistralai/devstral-2512": ModelInfo(
+        "Devstral 2 2512 (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/mistralai/devstral-medium-2507": ModelInfo(
+        "Devstral Medium (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/mistralai/devstral-small-2505": ModelInfo(
+        "Devstral Small (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/mistralai/devstral-small-2507": ModelInfo(
+        "Devstral Small 1.1 (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/mistralai/mistral-medium-3": ModelInfo(
+        "Mistral Medium 3 (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/mistralai/mistral-medium-3.1": ModelInfo(
+        "Mistral Medium 3.1 (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/mistralai/mistral-small-2603": ModelInfo(
+        "Mistral Small 4 (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/mistralai/mistral-small-3.1-24b-instruct": ModelInfo(
+        "Mistral Small 3.1 24B Instruct (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/mistralai/mistral-small-3.2-24b-instruct": ModelInfo(
+        "Mistral Small 3.2 24B Instruct (Openrouter)", AgentKind.OPENCODE, 96_000
+    ),
+    "opencode:openrouter/moonshotai/kimi-k2": ModelInfo(
+        "Kimi K2 (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/moonshotai/kimi-k2-0905": ModelInfo(
+        "Kimi K2 Instruct 0905 (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/moonshotai/kimi-k2-0905:exacto": ModelInfo(
+        "Kimi K2 Instruct 0905 (exacto) (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/moonshotai/kimi-k2-thinking": ModelInfo(
+        "Kimi K2 Thinking (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/moonshotai/kimi-k2.5": ModelInfo(
+        "Kimi K2.5 (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/nousresearch/hermes-3-llama-3.1-405b:free": ModelInfo(
+        "Hermes 3 405B Instruct (free) (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/nousresearch/hermes-4-405b": ModelInfo(
+        "Hermes 4 405B (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/nousresearch/hermes-4-70b": ModelInfo(
+        "Hermes 4 70B (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/nvidia/nemotron-3-nano-30b-a3b:free": ModelInfo(
+        "Nemotron 3 Nano 30B A3B (free) (Openrouter)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:openrouter/nvidia/nemotron-3-super-120b-a12b": ModelInfo(
+        "Nemotron 3 Super (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/nvidia/nemotron-3-super-120b-a12b:free": ModelInfo(
+        "Nemotron 3 Super (free) (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/nvidia/nemotron-nano-12b-v2-vl:free": ModelInfo(
+        "Nemotron Nano 12B 2 VL (free) (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/nvidia/nemotron-nano-9b-v2": ModelInfo(
+        "nvidia-nemotron-nano-9b-v2 (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/nvidia/nemotron-nano-9b-v2:free": ModelInfo(
+        "Nemotron Nano 9B V2 (free) (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/openai/gpt-4.1": ModelInfo(
+        "GPT-4.1 (Openrouter)", AgentKind.OPENCODE, 1_047_576
+    ),
+    "opencode:openrouter/openai/gpt-4.1-mini": ModelInfo(
+        "GPT-4.1 Mini (Openrouter)", AgentKind.OPENCODE, 1_047_576
+    ),
+    "opencode:openrouter/openai/gpt-4o-mini": ModelInfo(
+        "GPT-4o-mini (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/openai/gpt-5": ModelInfo(
+        "GPT-5 (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5-codex": ModelInfo(
+        "GPT-5 Codex (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5-image": ModelInfo(
+        "GPT-5 Image (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5-mini": ModelInfo(
+        "GPT-5 Mini (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5-nano": ModelInfo(
+        "GPT-5 Nano (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5-pro": ModelInfo(
+        "GPT-5 Pro (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5.1": ModelInfo(
+        "GPT-5.1 (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5.1-chat": ModelInfo(
+        "GPT-5.1 Chat (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/openai/gpt-5.1-codex": ModelInfo(
+        "GPT-5.1-Codex (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5.1-codex-max": ModelInfo(
+        "GPT-5.1-Codex-Max (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5.1-codex-mini": ModelInfo(
+        "GPT-5.1-Codex-Mini (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5.2": ModelInfo(
+        "GPT-5.2 (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5.2-chat": ModelInfo(
+        "GPT-5.2 Chat (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/openai/gpt-5.2-codex": ModelInfo(
+        "GPT-5.2-Codex (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5.2-pro": ModelInfo(
+        "GPT-5.2 Pro (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5.3-codex": ModelInfo(
+        "GPT-5.3-Codex (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5.4": ModelInfo(
+        "GPT-5.4 (Openrouter)", AgentKind.OPENCODE, 1_050_000
+    ),
+    "opencode:openrouter/openai/gpt-5.4-mini": ModelInfo(
+        "GPT-5.4 Mini (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5.4-nano": ModelInfo(
+        "GPT-5.4 Nano (Openrouter)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:openrouter/openai/gpt-5.4-pro": ModelInfo(
+        "GPT-5.4 Pro (Openrouter)", AgentKind.OPENCODE, 1_050_000
+    ),
+    "opencode:openrouter/openai/gpt-oss-120b": ModelInfo(
+        "GPT OSS 120B (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/openai/gpt-oss-120b:exacto": ModelInfo(
+        "GPT OSS 120B (exacto) (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/openai/gpt-oss-120b:free": ModelInfo(
+        "gpt-oss-120b (free) (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/openai/gpt-oss-20b": ModelInfo(
+        "GPT OSS 20B (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/openai/gpt-oss-20b:free": ModelInfo(
+        "gpt-oss-20b (free) (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/openai/gpt-oss-safeguard-20b": ModelInfo(
+        "GPT OSS Safeguard 20B (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/openai/o4-mini": ModelInfo(
+        "o4 Mini (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/openrouter/elephant-alpha": ModelInfo(
+        "Elephant (free) (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/openrouter/free": ModelInfo(
+        "Free Models Router (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/prime-intellect/intellect-3": ModelInfo(
+        "Intellect 3 (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/qwen/qwen-2.5-coder-32b-instruct": ModelInfo(
+        "Qwen2.5 Coder 32B Instruct (Openrouter)", AgentKind.OPENCODE, 32_768
+    ),
+    "opencode:openrouter/qwen/qwen2.5-vl-72b-instruct": ModelInfo(
+        "Qwen2.5 VL 72B Instruct (Openrouter)", AgentKind.OPENCODE, 32_768
+    ),
+    "opencode:openrouter/qwen/qwen3-235b-a22b-07-25": ModelInfo(
+        "Qwen3 235B A22B Instruct 2507 (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/qwen/qwen3-235b-a22b-thinking-2507": ModelInfo(
+        "Qwen3 235B A22B Thinking 2507 (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/qwen/qwen3-30b-a3b-instruct-2507": ModelInfo(
+        "Qwen3 30B A3B Instruct 2507 (Openrouter)", AgentKind.OPENCODE, 262_000
+    ),
+    "opencode:openrouter/qwen/qwen3-30b-a3b-thinking-2507": ModelInfo(
+        "Qwen3 30B A3B Thinking 2507 (Openrouter)", AgentKind.OPENCODE, 262_000
+    ),
+    "opencode:openrouter/qwen/qwen3-coder": ModelInfo(
+        "Qwen3 Coder (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/qwen/qwen3-coder-30b-a3b-instruct": ModelInfo(
+        "Qwen3 Coder 30B A3B Instruct (Openrouter)", AgentKind.OPENCODE, 160_000
+    ),
+    "opencode:openrouter/qwen/qwen3-coder-flash": ModelInfo(
+        "Qwen3 Coder Flash (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/qwen/qwen3-coder:exacto": ModelInfo(
+        "Qwen3 Coder (exacto) (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/qwen/qwen3-max": ModelInfo(
+        "Qwen3 Max (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/qwen/qwen3-next-80b-a3b-instruct": ModelInfo(
+        "Qwen3 Next 80B A3B Instruct (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/qwen/qwen3-next-80b-a3b-thinking": ModelInfo(
+        "Qwen3 Next 80B A3B Thinking (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/qwen/qwen3.5-397b-a17b": ModelInfo(
+        "Qwen3.5 397B A17B (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/qwen/qwen3.5-flash-02-23": ModelInfo(
+        "Qwen: Qwen3.5-Flash (Openrouter)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:openrouter/qwen/qwen3.5-plus-02-15": ModelInfo(
+        "Qwen3.5 Plus 2026-02-15 (Openrouter)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:openrouter/qwen/qwen3.6-plus": ModelInfo(
+        "Qwen3.6 Plus (Openrouter)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:openrouter/sourceful/riverflow-v2-fast-preview": ModelInfo(
+        "Riverflow V2 Fast Preview (Openrouter)", AgentKind.OPENCODE, 8192
+    ),
+    "opencode:openrouter/sourceful/riverflow-v2-max-preview": ModelInfo(
+        "Riverflow V2 Max Preview (Openrouter)", AgentKind.OPENCODE, 8192
+    ),
+    "opencode:openrouter/sourceful/riverflow-v2-standard-preview": ModelInfo(
+        "Riverflow V2 Standard Preview (Openrouter)", AgentKind.OPENCODE, 8192
+    ),
+    "opencode:openrouter/stepfun/step-3.5-flash": ModelInfo(
+        "Step 3.5 Flash (Openrouter)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:openrouter/x-ai/grok-3": ModelInfo(
+        "Grok 3 (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/x-ai/grok-3-beta": ModelInfo(
+        "Grok 3 Beta (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/x-ai/grok-3-mini": ModelInfo(
+        "Grok 3 Mini (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/x-ai/grok-3-mini-beta": ModelInfo(
+        "Grok 3 Mini Beta (Openrouter)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:openrouter/x-ai/grok-4": ModelInfo(
+        "Grok 4 (Openrouter)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:openrouter/x-ai/grok-4-fast": ModelInfo(
+        "Grok 4 Fast (Openrouter)", AgentKind.OPENCODE, 2_000_000
+    ),
+    "opencode:openrouter/x-ai/grok-4.1-fast": ModelInfo(
+        "Grok 4.1 Fast (Openrouter)", AgentKind.OPENCODE, 2_000_000
+    ),
+    "opencode:openrouter/x-ai/grok-4.20-beta": ModelInfo(
+        "Grok 4.20 Beta (Openrouter)", AgentKind.OPENCODE, 2_000_000
+    ),
+    "opencode:openrouter/x-ai/grok-4.20-multi-agent-beta": ModelInfo(
+        "Grok 4.20 Multi - Agent Beta (Openrouter)", AgentKind.OPENCODE, 2_000_000
+    ),
+    "opencode:openrouter/x-ai/grok-code-fast-1": ModelInfo(
+        "Grok Code Fast 1 (Openrouter)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:openrouter/xiaomi/mimo-v2-flash": ModelInfo(
+        "MiMo-V2-Flash (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/xiaomi/mimo-v2-omni": ModelInfo(
+        "MiMo-V2-Omni (Openrouter)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:openrouter/xiaomi/mimo-v2-pro": ModelInfo(
+        "MiMo-V2-Pro (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/z-ai/glm-4.5": ModelInfo(
+        "GLM 4.5 (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/z-ai/glm-4.5-air": ModelInfo(
+        "GLM 4.5 Air (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/z-ai/glm-4.5-air:free": ModelInfo(
+        "GLM 4.5 Air (free) (Openrouter)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:openrouter/z-ai/glm-4.5v": ModelInfo(
+        "GLM 4.5V (Openrouter)", AgentKind.OPENCODE, 64_000
+    ),
+    "opencode:openrouter/z-ai/glm-4.6": ModelInfo(
+        "GLM 4.6 (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/z-ai/glm-4.6:exacto": ModelInfo(
+        "GLM 4.6 (exacto) (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/z-ai/glm-4.7": ModelInfo(
+        "GLM-4.7 (Openrouter)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:openrouter/z-ai/glm-4.7-flash": ModelInfo(
+        "GLM-4.7-Flash (Openrouter)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:openrouter/z-ai/glm-5": ModelInfo(
+        "GLM-5 (Openrouter)", AgentKind.OPENCODE, 202_752
+    ),
+    "opencode:openrouter/z-ai/glm-5-turbo": ModelInfo(
+        "GLM-5-Turbo (Openrouter)", AgentKind.OPENCODE, 202_752
+    ),
+    "opencode:openrouter/z-ai/glm-5.1": ModelInfo(
+        "GLM-5.1 (Openrouter)", AgentKind.OPENCODE, 202_752
+    ),
+    "opencode:perplexity/sonar": ModelInfo(
+        "Sonar (Perplexity)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:perplexity/sonar-deep-research": ModelInfo(
+        "Perplexity Sonar Deep Research (Perplexity)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:perplexity/sonar-pro": ModelInfo(
+        "Sonar Pro (Perplexity)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:perplexity/sonar-reasoning-pro": ModelInfo(
+        "Sonar Reasoning Pro (Perplexity)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:perplexity-agent/anthropic/claude-haiku-4-5": ModelInfo(
+        "Claude Haiku 4.5 (Perplexity Agent)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:perplexity-agent/anthropic/claude-opus-4-5": ModelInfo(
+        "Claude Opus 4.5 (Perplexity Agent)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:perplexity-agent/anthropic/claude-opus-4-6": ModelInfo(
+        "Claude Opus 4.6 (Perplexity Agent)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:perplexity-agent/anthropic/claude-sonnet-4-5": ModelInfo(
+        "Claude Sonnet 4.5 (Perplexity Agent)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:perplexity-agent/anthropic/claude-sonnet-4-6": ModelInfo(
+        "Claude Sonnet 4.6 (Perplexity Agent)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:perplexity-agent/google/gemini-2.5-flash": ModelInfo(
+        "Gemini 2.5 Flash (Perplexity Agent)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:perplexity-agent/google/gemini-2.5-pro": ModelInfo(
+        "Gemini 2.5 Pro (Perplexity Agent)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:perplexity-agent/google/gemini-3-flash-preview": ModelInfo(
+        "Gemini 3 Flash Preview (Perplexity Agent)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:perplexity-agent/google/gemini-3.1-pro-preview": ModelInfo(
+        "Gemini 3.1 Pro Preview (Perplexity Agent)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:perplexity-agent/nvidia/nemotron-3-super-120b-a12b": ModelInfo(
+        "Nemotron 3 Super 120B (Perplexity Agent)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:perplexity-agent/openai/gpt-5-mini": ModelInfo(
+        "GPT-5 Mini (Perplexity Agent)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:perplexity-agent/openai/gpt-5.1": ModelInfo(
+        "GPT-5.1 (Perplexity Agent)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:perplexity-agent/openai/gpt-5.2": ModelInfo(
+        "GPT-5.2 (Perplexity Agent)", AgentKind.OPENCODE, 400_000
+    ),
+    "opencode:perplexity-agent/openai/gpt-5.4": ModelInfo(
+        "GPT-5.4 (Perplexity Agent)", AgentKind.OPENCODE, 1_050_000
+    ),
+    "opencode:perplexity-agent/perplexity/sonar": ModelInfo(
+        "Sonar (Perplexity Agent)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:perplexity-agent/xai/grok-4-1-fast-non-reasoning": ModelInfo(
+        "Grok 4.1 Fast (Non-Reasoning) (Perplexity Agent)",
+        AgentKind.OPENCODE,
+        2_000_000,
+    ),
+    "opencode:zai-coding-plan/glm-4.5": ModelInfo(
+        "GLM-4.5 (Zai Coding Plan)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:zai-coding-plan/glm-4.5-air": ModelInfo(
+        "GLM-4.5-Air (Zai Coding Plan)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:zai-coding-plan/glm-4.5-flash": ModelInfo(
+        "GLM-4.5-Flash (Zai Coding Plan)", AgentKind.OPENCODE, 131_072
+    ),
+    "opencode:zai-coding-plan/glm-4.5v": ModelInfo(
+        "GLM-4.5V (Zai Coding Plan)", AgentKind.OPENCODE, 64_000
+    ),
+    "opencode:zai-coding-plan/glm-4.6": ModelInfo(
+        "GLM-4.6 (Zai Coding Plan)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:zai-coding-plan/glm-4.6v": ModelInfo(
+        "GLM-4.6V (Zai Coding Plan)", AgentKind.OPENCODE, 128_000
+    ),
+    "opencode:zai-coding-plan/glm-4.7": ModelInfo(
+        "GLM-4.7 (Zai Coding Plan)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:zai-coding-plan/glm-4.7-flash": ModelInfo(
+        "GLM-4.7-Flash (Zai Coding Plan)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:zai-coding-plan/glm-4.7-flashx": ModelInfo(
+        "GLM-4.7-FlashX (Zai Coding Plan)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:zai-coding-plan/glm-5": ModelInfo(
+        "GLM-5 (Zai Coding Plan)", AgentKind.OPENCODE, 204_800
+    ),
+    "opencode:zai-coding-plan/glm-5-turbo": ModelInfo(
+        "GLM-5-Turbo (Zai Coding Plan)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:zai-coding-plan/glm-5.1": ModelInfo(
+        "GLM-5.1 (Zai Coding Plan)", AgentKind.OPENCODE, 200_000
+    ),
+    "opencode:zai-coding-plan/glm-5v-turbo": ModelInfo(
+        "glm-5v-turbo (Zai Coding Plan)", AgentKind.OPENCODE, 200_000
+    ),
 }
 
 # Built-in slash commands exposed to the frontend per agent kind.
@@ -389,4 +1636,7 @@ BUILTIN_SLASH_COMMANDS: dict[AgentKind, list[dict[str, str]]] = {
     # Cursor's slash commands live in its TUI client, not the ACP server, so
     # cursor-agent treats them as prompt text rather than commands.
     AgentKind.CURSOR: [],
+    # OpenCode's slash commands live in its TUI; the ACP server surfaces only
+    # user-defined commands, so we rely on runtime discovery.
+    AgentKind.OPENCODE: [],
 }

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -4,6 +4,7 @@ PermissionMode: TypeAlias = Literal[
     "default",
     "acceptEdits",
     "plan",
+    "build",
     "bypassPermissions",
     "agent",
     "autopilot",

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -12,6 +12,7 @@ class AgentKind(str, Enum):
     CODEX = "codex"
     COPILOT = "copilot"
     CURSOR = "cursor"
+    OPENCODE = "opencode"
 
 
 # File types each agent can consume inline in the ACP prompt (base64-embedded as
@@ -25,6 +26,7 @@ NATIVE_FILE_TYPES: dict[AgentKind, frozenset[str]] = {
     AgentKind.CODEX: frozenset({"image"}),
     AgentKind.COPILOT: frozenset({"image"}),
     AgentKind.CURSOR: frozenset({"image"}),
+    AgentKind.OPENCODE: frozenset({"image"}),
 }
 
 
@@ -64,6 +66,10 @@ COPILOT_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
 
 # Cursor CLI exposes three ACP session modes (see https://cursor.com/docs/cli/acp).
 CURSOR_SESSION_MODES = frozenset({"agent", "plan", "ask"})
+
+# OpenCode's built-in primary agents double as ACP session modes; `plan`
+# restricts edits to `.opencode/plans/*.md`, `build` has full tool access.
+OPENCODE_SESSION_MODES = frozenset({"build", "plan"})
 
 
 def coerce_thinking_mode(mode: str | None, valid_modes: frozenset[str]) -> str:
@@ -393,9 +399,65 @@ class CursorAgentAdapter(AgentAdapter):
         return model_id.removeprefix("cursor:")
 
 
+class OpencodeAgentAdapter(AgentAdapter):
+    # OpenCode CLI runs as an ACP server via `opencode acp` and speaks the same
+    # ACP transport as the other adapters. OpenCode's "primary agents" (build,
+    # plan) map to ACP session modes; reasoning effort is controlled per-model
+    # by the underlying provider (opencode itself doesn't expose a uniform
+    # reasoning dial via ACP), so there's no separate thinking-mode control —
+    # the UI's thinking selector is hidden for this adapter.
+
+    def __init__(self) -> None:
+        super().__init__(kind=AgentKind.OPENCODE)
+
+    def build_launch_config(
+        self,
+        *,
+        system_prompt: str | None,
+        system_prompt_is_full_replace: bool,
+        reasoning_effort: str | None,
+        permission_mode: str | None,
+        launch_approval_policy: str | None,
+    ) -> LaunchConfig:
+        return LaunchConfig(binary="opencode", cli_args=["acp"])
+
+    def build_session_config(
+        self,
+        *,
+        system_prompt: str | None,
+        system_prompt_is_full_replace: bool,
+        thinking_mode: str | None,
+        permission_mode: str,
+    ) -> SessionConfig:
+        meta = build_system_prompt_meta(system_prompt, system_prompt_is_full_replace)
+        return SessionConfig(
+            meta=meta,
+            permission=PermissionConfig(
+                session_mode=self.map_session_mode(permission_mode)
+            ),
+        )
+
+    def map_session_mode(self, permission_mode: str) -> str:
+        # Persisted settings may still carry mode strings from a different
+        # previous agent. Default to the restrictive mode (plan) so switching
+        # agents never silently widens permissions — e.g. a chat left in
+        # Codex's read-only mode shouldn't become opencode full-access just
+        # because the string doesn't map.
+        if permission_mode not in OPENCODE_SESSION_MODES:
+            return "plan"
+        return permission_mode
+
+    def map_model_id(self, model_id: str) -> str:
+        # Internal keys use "opencode:" prefix to namespace; opencode expects
+        # the raw provider/model ID (e.g. "openai/gpt-5.4" not
+        # "opencode:openai/gpt-5.4").
+        return model_id.removeprefix("opencode:")
+
+
 AGENT_ADAPTERS: dict[AgentKind, AgentAdapter] = {
     AgentKind.CLAUDE: ClaudeAgentAdapter(),
     AgentKind.CODEX: CodexAgentAdapter(),
     AgentKind.COPILOT: CopilotCliAdapter(),
     AgentKind.CURSOR: CursorAgentAdapter(),
+    AgentKind.OPENCODE: OpencodeAgentAdapter(),
 }

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -29,6 +29,7 @@ from acp.schema import (
 
 from app.models.types import PermissionMode
 from app.models.db_models.enums import ToolStatus
+from app.services.acp.adapters import AgentKind
 from app.services.streaming.types import StreamEvent, StreamEventType, ToolPayload
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,7 @@ VALID_PERMISSION_MODES: set[str] = {
     "default",
     "acceptEdits",
     "plan",
+    "build",
     "bypassPermissions",
     "agent",
     "autopilot",
@@ -57,6 +59,7 @@ PERMISSION_MODE_BY_OPTION_NAME: dict[str, PermissionMode] = {
     "default": "default",
     "accept edits": "acceptEdits",
     "plan": "plan",
+    "build": "build",
     "agent": "agent",
     "bypass permissions": "bypassPermissions",
     "autopilot": "autopilot",
@@ -72,7 +75,8 @@ class AcpClientHandler:
     # permission requests, usage updates). Each method translates the ACP event
     # into a StreamEvent and enqueues it for the SSE layer to forward to the frontend.
 
-    def __init__(self) -> None:
+    def __init__(self, agent_kind: AgentKind) -> None:
+        self.agent_kind = agent_kind
         self.event_queue: asyncio.Queue[StreamEvent | object] = asyncio.Queue()
         self._active_tools: dict[str, ToolPayload] = {}
         self._pending_permissions: dict[str, asyncio.Future[dict[str, Any]]] = {}
@@ -436,15 +440,20 @@ class AcpClientHandler:
             return str(parent_id)
         return None
 
-    @staticmethod
-    def _extract_tool_name(tc: Any) -> str:
+    def _extract_tool_name(self, tc: Any) -> str:
         # Claude embeds the tool name in field_meta.claudeCode.toolName (e.g.
-        # "Read", "Edit"). Codex uses the top-level `kind` field instead (e.g.
-        # "execute", "read", "edit"). Falls back to title for unknown agents.
+        # "Read", "Edit"). OpenCode puts the raw tool name (bash, read, edit,
+        # write, grep, glob, webfetch, task, todowrite, skill, question) in
+        # `title` — its ACP `kind` collapses distinct tools (edit/write/patch
+        # all become "edit"), so title is the only way to distinguish them.
+        # Codex/Copilot/Cursor use the top-level `kind` field.
         meta = getattr(tc, "field_meta", None) or {}
         claude_meta = meta.get("claudeCode", {})
         if tool_name := claude_meta.get("toolName"):
             return str(tool_name)
+        if self.agent_kind == AgentKind.OPENCODE:
+            if title := getattr(tc, "title", None):
+                return str(title)
         kind = getattr(tc, "kind", None)
         if kind:
             return str(kind)
@@ -517,7 +526,14 @@ class AcpClientHandler:
     def _extract_tool_error(cls, tc: ToolCallProgress) -> str:
         if tc.raw_output is not None:
             if isinstance(tc.raw_output, dict):
-                return str(tc.raw_output.get("formatted_output", str(tc.raw_output)))
+                # Codex wraps the error in formatted_output; opencode uses a
+                # top-level `error` string. Fall through to stringifying the
+                # dict only if neither is present.
+                for key in ("formatted_output", "error"):
+                    value = tc.raw_output.get(key)
+                    if value:
+                        return str(value)
+                return str(tc.raw_output)
             return str(tc.raw_output)
         texts = cls._extract_content_texts(tc)
         return "\n".join(texts) if texts else "Tool execution failed"

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -273,7 +273,7 @@ class AcpSession:
 
     @classmethod
     async def create(cls, config: AcpSessionConfig) -> AcpSession:
-        handler = AcpClientHandler()
+        handler = AcpClientHandler(agent_kind=config.agent_kind)
         process = await cls._spawn_process(config)
 
         if process.stdin is None or process.stdout is None:

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -136,6 +136,9 @@ fn spawn_backend(
     let backend_bin = resolve_backend_binary(app_handle);
     let mut backend_path = std::env::var("PATH").unwrap_or_default();
     if let Some(home) = dirs::home_dir() {
+        // OpenCode installs to ~/.opencode/bin on macOS and updates shell rc
+        // files, but the desktop backend gets an explicit PATH from Tauri.
+        backend_path.push_str(&format!(":{}/.opencode/bin", home.display()));
         backend_path.push_str(&format!(":{}/.local/bin", home.display()));
     }
     backend_path.push_str(":/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin");

--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -92,7 +92,12 @@ export const AssistantMessage = memo(function AssistantMessage({
     if (!modelId) return null;
     const model = modelMap.get(modelId);
     if (model?.name) return model.name;
-    return modelId.includes(':') ? modelId.split(':').pop()! : modelId;
+    // Strip only the agent prefix (everything up to and including the first
+    // colon). Using split(':').pop() would drop anything after later colons
+    // — e.g. opencode IDs like `opencode:openrouter/x-ai/grok-4:free` would
+    // become "free" instead of "openrouter/x-ai/grok-4:free".
+    const colonIdx = modelId.indexOf(':');
+    return colonIdx === -1 ? modelId : modelId.slice(colonIdx + 1);
   }, [modelId, modelMap]);
 
   // modelId tells us which agent produced the tool calls embedded in this

--- a/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
@@ -53,7 +53,13 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
   const agentTools = React.useMemo(
     () =>
       segments.reduce<ToolAggregate[]>((acc, seg) => {
-        if (seg.kind === 'tool' && seg.tool.name === 'Agent') acc.push(seg.tool);
+        // Collect subagent-spawning tools across agents so the expand-modal
+        // sibling list works for all of them: Claude's `Agent`, opencode's
+        // `task`. Codex/Copilot/Cursor don't surface subagent spawns as
+        // named tool calls.
+        if (seg.kind === 'tool' && (seg.tool.name === 'Agent' || seg.tool.name === 'task')) {
+          acc.push(seg.tool);
+        }
         return acc;
       }, []),
     [segments],

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -30,7 +30,15 @@ import {
 } from './InputContext';
 import type { InputProps } from './Input';
 import type { MentionItem, SlashCommand } from '@/types/ui.types';
-import { getAgentKindForModelId } from '@/types/chat.types';
+import { getAgentKindForModelId, type AgentKind } from '@/types/chat.types';
+
+// Agents whose ACP servers don't emit UsageUpdate notifications — the context
+// window indicator stays at 0 for these, so we hide it entirely.
+const AGENTS_WITHOUT_USAGE_UPDATE: ReadonlySet<AgentKind> = new Set([
+  'copilot',
+  'cursor',
+  'opencode',
+]);
 
 export function InputProvider({
   message,
@@ -59,10 +67,9 @@ export function InputProvider({
   const agentKind =
     modelMap.get(selectedModelId)?.agent_kind ?? getAgentKindForModelId(selectedModelId);
   // Hide the context-usage indicator for agents whose ACP servers never emit
-  // UsageUpdate notifications (copilot-cli, cursor-agent) — without those
-  // events the value stays 0 and the bar is misleading.
-  const visibleContextUsage =
-    agentKind === 'copilot' || agentKind === 'cursor' ? undefined : contextUsage;
+  // UsageUpdate notifications — without those events the value stays 0 and
+  // the bar is misleading.
+  const visibleContextUsage = AGENTS_WITHOUT_USAGE_UPDATE.has(agentKind) ? undefined : contextUsage;
   const formRef = useRef<HTMLFormElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [previewDismissed, setPreviewDismissed] = useState(false);

--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -8,6 +8,7 @@ import { ClaudeIcon } from '@/components/ui/icons/ClaudeIcon';
 import { CodexIcon } from '@/components/ui/icons/CodexIcon';
 import { CopilotIcon } from '@/components/ui/icons/CopilotIcon';
 import { CursorIcon } from '@/components/ui/icons/CursorIcon';
+import { OpencodeIcon } from '@/components/ui/icons/OpencodeIcon';
 import { formatNumberCompact } from '@/utils/format';
 import type { AgentKind, Model } from '@/types/chat.types';
 
@@ -16,6 +17,7 @@ const AGENT_LABELS: Record<AgentKind, string> = {
   codex: 'Codex',
   copilot: 'Copilot',
   cursor: 'Cursor',
+  opencode: 'OpenCode',
 };
 
 const AGENT_ICONS: Record<AgentKind, ComponentType<SVGProps<SVGSVGElement>>> = {
@@ -23,6 +25,7 @@ const AGENT_ICONS: Record<AgentKind, ComponentType<SVGProps<SVGSVGElement>>> = {
   codex: CodexIcon,
   copilot: CopilotIcon,
   cursor: CursorIcon,
+  opencode: OpencodeIcon,
 };
 
 export interface ModelSelectorProps {

--- a/frontend/src/components/chat/permission-mode-selector/PermissionModeSelector.tsx
+++ b/frontend/src/components/chat/permission-mode-selector/PermissionModeSelector.tsx
@@ -79,11 +79,25 @@ export const CURSOR_PERMISSION_MODES: PermissionModeOption[] = [
   },
 ];
 
+export const OPENCODE_PERMISSION_MODES: PermissionModeOption[] = [
+  {
+    value: 'build',
+    label: 'Build',
+    description: 'Full tool access for development work',
+  },
+  {
+    value: 'plan',
+    label: 'Plan',
+    description: 'Read-only analysis; edits restricted to .opencode/plans/',
+  },
+];
+
 export const MODES_BY_AGENT: Record<AgentKind, PermissionModeOption[]> = {
   claude: CLAUDE_PERMISSION_MODES,
   codex: CODEX_PERMISSION_MODES,
   copilot: COPILOT_PERMISSION_MODES,
   cursor: CURSOR_PERMISSION_MODES,
+  opencode: OPENCODE_PERMISSION_MODES,
 };
 
 const DEFAULT_BY_AGENT: Record<AgentKind, PermissionMode> = {
@@ -91,6 +105,7 @@ const DEFAULT_BY_AGENT: Record<AgentKind, PermissionMode> = {
   codex: 'full-access',
   copilot: 'agent',
   cursor: 'agent',
+  opencode: 'build',
 };
 
 export function coercePermissionModeForAgent(

--- a/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
+++ b/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
@@ -28,16 +28,17 @@ const CODEX_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'xhigh', label: 'XHigh' },
 ];
 
-// Cursor bakes reasoning effort into the model ID itself (e.g. `-low`,
-// `-thinking-high`, `-max`), so it has no separate thinking-mode control.
-// An empty list causes the selector to render nothing.
-const CURSOR_THINKING_MODES: ThinkingModeOption[] = [];
+// Cursor bakes reasoning effort into the model ID; OpenCode delegates to the
+// per-model provider. Neither exposes a uniform thinking-mode dial via ACP,
+// so an empty list hides the selector.
+const EMPTY_THINKING_MODES: ThinkingModeOption[] = [];
 
 export const THINKING_MODES_BY_AGENT: Record<AgentKind, ThinkingModeOption[]> = {
   claude: CLAUDE_THINKING_MODES,
   codex: CODEX_THINKING_MODES,
   copilot: CODEX_THINKING_MODES,
-  cursor: CURSOR_THINKING_MODES,
+  cursor: EMPTY_THINKING_MODES,
+  opencode: EMPTY_THINKING_MODES,
 };
 
 const DEFAULT_BY_AGENT: Record<AgentKind, string> = {
@@ -45,6 +46,7 @@ const DEFAULT_BY_AGENT: Record<AgentKind, string> = {
   codex: 'medium',
   copilot: 'medium',
   cursor: 'medium',
+  opencode: 'medium',
 };
 
 export function coerceThinkingModeForAgent(thinkingMode: string, agentKind: AgentKind): string {

--- a/frontend/src/components/chat/tools/opencode/BashTool.tsx
+++ b/frontend/src/components/chat/tools/opencode/BashTool.tsx
@@ -1,0 +1,53 @@
+import { memo } from 'react';
+import { Terminal } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { TOOL_OUTPUT_PRE_CLASS } from '@/utils/toolStyles';
+import { ToolCard } from '../common/ToolCard';
+import type { OpencodeBashInput, OpencodeOutput } from './opencodePayload';
+
+const ICON = <Terminal className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />;
+
+const BashToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as OpencodeBashInput | undefined;
+  const result = tool.result as OpencodeOutput | undefined;
+
+  const command = input?.command ?? '';
+  const description = input?.description?.trim();
+  const output = result?.output ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        const label = description || command || 'command';
+        switch (status) {
+          case 'completed':
+            return `Ran: ${label}`;
+          case 'failed':
+            return `Failed: ${label}`;
+          default:
+            return `Running: ${label}`;
+        }
+      }}
+      loadingContent="Running command..."
+      error={tool.error}
+    >
+      {(command || output) && (
+        <div className="space-y-1">
+          {command && (
+            <pre className="whitespace-pre-wrap break-all font-mono text-2xs leading-relaxed text-text-secondary dark:text-text-dark-tertiary">
+              <span className="select-none text-text-quaternary dark:text-text-dark-quaternary">
+                ${' '}
+              </span>
+              {command}
+            </pre>
+          )}
+          {output && <pre className={TOOL_OUTPUT_PRE_CLASS}>{output}</pre>}
+        </div>
+      )}
+    </ToolCard>
+  );
+};
+
+export const BashTool = memo(BashToolInner);

--- a/frontend/src/components/chat/tools/opencode/EditTool.tsx
+++ b/frontend/src/components/chat/tools/opencode/EditTool.tsx
@@ -1,0 +1,44 @@
+import { memo } from 'react';
+import { FileEdit } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard';
+import { DiffView } from '../common/DiffView';
+import { OpenInEditorButton } from '../common/OpenInEditorButton';
+import { buildUnifiedDiff } from '../common/buildUnifiedDiff';
+import type { OpencodeEditInput } from './opencodePayload';
+
+const ICON = <FileEdit className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />;
+
+const EditToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as OpencodeEditInput | undefined;
+  const filePath = input?.filePath ?? '';
+  const fileName = filePath ? extractFilename(filePath) : tool.title?.trim() || 'file';
+  const oldText = input?.oldString ?? '';
+  const newText = input?.newString ?? '';
+  const diff = oldText || newText ? buildUnifiedDiff(oldText, newText) : '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Edited ${fileName}`;
+          case 'failed':
+            return `Failed to edit ${fileName}`;
+          default:
+            return `Editing ${fileName}...`;
+        }
+      }}
+      loadingContent="Applying changes..."
+      error={tool.error}
+      actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
+    >
+      {diff && <DiffView diff={diff} />}
+    </ToolCard>
+  );
+};
+
+export const EditTool = memo(EditToolInner);

--- a/frontend/src/components/chat/tools/opencode/GlobTool.tsx
+++ b/frontend/src/components/chat/tools/opencode/GlobTool.tsx
@@ -1,0 +1,50 @@
+import { memo } from 'react';
+import { FolderSearch } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { ToolCard } from '../common/ToolCard';
+import { SearchLoadingDots } from '../common/SearchLoadingDots';
+import { TOOL_OUTPUT_PRE_CLASS } from '@/utils/toolStyles';
+import type { OpencodeGlobInput, OpencodeGlobMetadata, OpencodeOutput } from './opencodePayload';
+
+const ICON = (
+  <FolderSearch className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />
+);
+
+const GlobToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as OpencodeGlobInput | undefined;
+  const result = tool.result as OpencodeOutput | undefined;
+  const metadata = result?.metadata as OpencodeGlobMetadata | undefined;
+
+  const pattern = input?.pattern ?? tool.title?.trim() ?? 'pattern';
+  const count = metadata?.count;
+  const truncated = metadata?.truncated ?? false;
+  const output = result?.output ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed': {
+            if (typeof count !== 'number') return `Globbed "${pattern}"`;
+            const suffix = truncated ? '+' : '';
+            return `Found ${count}${suffix} file${count === 1 ? '' : 's'}`;
+          }
+          case 'failed':
+            return `Glob failed: ${pattern}`;
+          default:
+            return `Matching "${pattern}"...`;
+        }
+      }}
+      loadingContent={<SearchLoadingDots label="Finding files" />}
+      error={tool.error}
+    >
+      {output && typeof count === 'number' && count > 0 && (
+        <pre className={TOOL_OUTPUT_PRE_CLASS}>{output}</pre>
+      )}
+    </ToolCard>
+  );
+};
+
+export const GlobTool = memo(GlobToolInner);

--- a/frontend/src/components/chat/tools/opencode/GrepTool.tsx
+++ b/frontend/src/components/chat/tools/opencode/GrepTool.tsx
@@ -1,0 +1,50 @@
+import { memo } from 'react';
+import { FileSearch } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { ToolCard } from '../common/ToolCard';
+import { SearchLoadingDots } from '../common/SearchLoadingDots';
+import { TOOL_OUTPUT_PRE_CLASS } from '@/utils/toolStyles';
+import type { OpencodeGrepInput, OpencodeGrepMetadata, OpencodeOutput } from './opencodePayload';
+
+const ICON = (
+  <FileSearch className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />
+);
+
+const GrepToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as OpencodeGrepInput | undefined;
+  const result = tool.result as OpencodeOutput | undefined;
+  const metadata = result?.metadata as OpencodeGrepMetadata | undefined;
+
+  const pattern = input?.pattern ?? tool.title?.trim() ?? 'pattern';
+  const matches = metadata?.matches;
+  const truncated = metadata?.truncated ?? false;
+  const output = result?.output ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed': {
+            if (typeof matches !== 'number') return `Searched for "${pattern}"`;
+            const suffix = truncated ? '+' : '';
+            return `Found ${matches}${suffix} match${matches === 1 ? '' : 'es'}`;
+          }
+          case 'failed':
+            return `Search failed: ${pattern}`;
+          default:
+            return `Searching for "${pattern}"...`;
+        }
+      }}
+      loadingContent={<SearchLoadingDots label="Searching files" />}
+      error={tool.error}
+    >
+      {output && typeof matches === 'number' && matches > 0 && (
+        <pre className={TOOL_OUTPUT_PRE_CLASS}>{output}</pre>
+      )}
+    </ToolCard>
+  );
+};
+
+export const GrepTool = memo(GrepToolInner);

--- a/frontend/src/components/chat/tools/opencode/QuestionTool.tsx
+++ b/frontend/src/components/chat/tools/opencode/QuestionTool.tsx
@@ -1,0 +1,62 @@
+import { memo } from 'react';
+import { HelpCircle } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { ToolCard } from '../common/ToolCard';
+import type { OpencodeQuestionInput, OpencodeQuestionOutput } from './opencodePayload';
+
+const ICON = (
+  <HelpCircle className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />
+);
+
+const QuestionToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as OpencodeQuestionInput | undefined;
+  const result = tool.result as OpencodeQuestionOutput | undefined;
+
+  const questions = input?.questions ?? [];
+  const answers = result?.metadata?.answers ?? [];
+  const count = questions.length;
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        const noun = `${count} question${count === 1 ? '' : 's'}`;
+        switch (status) {
+          case 'completed':
+            return `Answered ${noun}`;
+          case 'failed':
+            return `Failed to ask ${noun}`;
+          default:
+            return `Waiting on ${noun}...`;
+        }
+      }}
+      loadingContent="Waiting for answer..."
+      error={tool.error}
+    >
+      {count > 0 && (
+        <div className="space-y-2">
+          {questions.map((q, idx) => {
+            const answer = answers[idx];
+            const answerText = answer && answer.length > 0 ? answer.join(', ') : 'Unanswered';
+            return (
+              <div key={idx} className="space-y-0.5">
+                <div className="text-xs text-text-primary dark:text-text-dark-primary">
+                  {q.question ?? q.header ?? ''}
+                </div>
+                <div className="text-2xs text-text-tertiary dark:text-text-dark-tertiary">
+                  <span className="text-text-quaternary dark:text-text-dark-quaternary">
+                    answer:{' '}
+                  </span>
+                  {answerText}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </ToolCard>
+  );
+};
+
+export const QuestionTool = memo(QuestionToolInner);

--- a/frontend/src/components/chat/tools/opencode/ReadTool.tsx
+++ b/frontend/src/components/chat/tools/opencode/ReadTool.tsx
@@ -1,0 +1,45 @@
+import { memo } from 'react';
+import { FileSearch } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard';
+import { NumberedContent } from '../common/NumberedContent';
+import { OpenInEditorButton } from '../common/OpenInEditorButton';
+import type { OpencodeReadInput, OpencodeOutput } from './opencodePayload';
+
+const ICON = (
+  <FileSearch className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />
+);
+
+const ReadToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as OpencodeReadInput | undefined;
+  const result = tool.result as OpencodeOutput | undefined;
+
+  const filePath = input?.filePath ?? '';
+  const fileName = filePath ? extractFilename(filePath) : tool.title?.trim() || 'file';
+  const content = result?.output ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Read ${fileName}`;
+          case 'failed':
+            return `Failed to read ${fileName}`;
+          default:
+            return `Reading ${fileName}...`;
+        }
+      }}
+      loadingContent="Loading file content..."
+      error={tool.error}
+      actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
+    >
+      {content && <NumberedContent content={content} />}
+    </ToolCard>
+  );
+};
+
+export const ReadTool = memo(ReadToolInner);

--- a/frontend/src/components/chat/tools/opencode/SkillTool.tsx
+++ b/frontend/src/components/chat/tools/opencode/SkillTool.tsx
@@ -1,0 +1,39 @@
+import { memo } from 'react';
+import { Sparkles } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { TOOL_OUTPUT_PRE_CLASS } from '@/utils/toolStyles';
+import { ToolCard } from '../common/ToolCard';
+import type { OpencodeSkillInput, OpencodeOutput } from './opencodePayload';
+
+const ICON = <Sparkles className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />;
+
+const SkillToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as OpencodeSkillInput | undefined;
+  const result = tool.result as OpencodeOutput | undefined;
+
+  const name = input?.name ?? tool.title?.trim() ?? 'skill';
+  const output = result?.output ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Loaded skill: ${name}`;
+          case 'failed':
+            return `Failed to load skill: ${name}`;
+          default:
+            return `Loading skill: ${name}...`;
+        }
+      }}
+      loadingContent="Loading skill..."
+      error={tool.error}
+    >
+      {output && <pre className={TOOL_OUTPUT_PRE_CLASS}>{output}</pre>}
+    </ToolCard>
+  );
+};
+
+export const SkillTool = memo(SkillToolInner);

--- a/frontend/src/components/chat/tools/opencode/TaskTool.tsx
+++ b/frontend/src/components/chat/tools/opencode/TaskTool.tsx
@@ -1,0 +1,128 @@
+import { memo, useMemo, useState, useRef } from 'react';
+import { Bot } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { TOOL_OUTPUT_PRE_CLASS } from '@/utils/toolStyles';
+import { AgentToolsContext } from '@/contexts/AgentToolsContext';
+import { ToolCard } from '../common/ToolCard';
+import { CollapsibleButton } from '../common/CollapsibleButton';
+import { getToolComponent } from '../registry';
+import type { OpencodeTaskInput, OpencodeOutput } from './opencodePayload';
+
+const TaskToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const [promptExpanded, setPromptExpanded] = useState(false);
+  const [resultExpanded, setResultExpanded] = useState(false);
+  const [toolsExpanded, setToolsExpanded] = useState(false);
+  const prevToolIdRef = useRef(tool.id);
+
+  if (prevToolIdRef.current !== tool.id) {
+    prevToolIdRef.current = tool.id;
+    setPromptExpanded(false);
+    setResultExpanded(false);
+    setToolsExpanded(false);
+  }
+
+  const input = tool.input as OpencodeTaskInput | undefined;
+  const result = tool.result as OpencodeOutput | undefined;
+
+  const description = input?.description?.trim() || tool.title?.trim() || '';
+  const agentType = input?.subagent_type?.trim();
+  const prompt = input?.prompt;
+  const output = result?.output?.trim();
+
+  // Scope the sibling context to nested task tools so an expanded view sees
+  // siblings at its own level, not the parent message's top-level list.
+  const childTaskTools = useMemo(
+    () => tool.children.filter((c) => c.name === 'task'),
+    [tool.children],
+  );
+
+  return (
+    <ToolCard
+      icon={<Bot className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />}
+      status={tool.status}
+      title={(status) => {
+        const label = description || agentType || 'agent task';
+        switch (status) {
+          case 'completed':
+            return `Agent: ${label}`;
+          case 'failed':
+            return `Agent failed: ${label}`;
+          default:
+            return `Running agent: ${label}`;
+        }
+      }}
+      loadingContent="Running sub-agent..."
+      error={tool.error}
+    >
+      {(agentType || prompt || output || tool.children.length > 0) && (
+        <div className="space-y-2">
+          {agentType && (
+            <div className="text-2xs text-text-tertiary dark:text-text-dark-tertiary">
+              <span className="text-text-quaternary dark:text-text-dark-quaternary">type: </span>
+              <span className="font-mono">{agentType}</span>
+            </div>
+          )}
+
+          {prompt && (
+            <div className="space-y-2">
+              <CollapsibleButton
+                label="Prompt"
+                isExpanded={promptExpanded}
+                onToggle={() => setPromptExpanded((v) => !v)}
+                fullWidth
+              />
+              {promptExpanded && (
+                <div className="whitespace-pre-wrap break-words rounded bg-black/5 p-2 font-mono text-2xs text-text-secondary dark:bg-white/5 dark:text-text-dark-tertiary">
+                  {prompt}
+                </div>
+              )}
+            </div>
+          )}
+
+          {output && (
+            <div className="space-y-2">
+              <CollapsibleButton
+                label="Result"
+                isExpanded={resultExpanded}
+                onToggle={() => setResultExpanded((v) => !v)}
+                fullWidth
+              />
+              {resultExpanded && <pre className={TOOL_OUTPUT_PRE_CLASS}>{output}</pre>}
+            </div>
+          )}
+
+          {tool.children.length > 0 && (
+            <div className="space-y-2">
+              <CollapsibleButton
+                label="Tools Used"
+                isExpanded={toolsExpanded}
+                onToggle={() => setToolsExpanded((v) => !v)}
+                count={tool.children.length}
+                fullWidth
+              />
+              {toolsExpanded && (
+                <AgentToolsContext value={childTaskTools}>
+                  <div className="space-y-2">
+                    {tool.children.map((childTool) => {
+                      const Component = getToolComponent(childTool.name, 'opencode');
+                      return (
+                        <div
+                          key={childTool.id}
+                          className="border-l border-border pl-2 dark:border-border-dark"
+                        >
+                          <Component tool={childTool} />
+                        </div>
+                      );
+                    })}
+                  </div>
+                </AgentToolsContext>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </ToolCard>
+  );
+};
+
+export const TaskTool = memo(TaskToolInner);

--- a/frontend/src/components/chat/tools/opencode/TodoWriteTool.tsx
+++ b/frontend/src/components/chat/tools/opencode/TodoWriteTool.tsx
@@ -1,0 +1,100 @@
+import { memo } from 'react';
+import { ListTodo, CheckCircle2, Circle, Clock, XCircle } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { ToolCard } from '../common/ToolCard';
+import type { OpencodeTodoInfo, OpencodeTodoWriteInput } from './opencodePayload';
+
+const ICON = <ListTodo className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />;
+
+const STATUS_ICON: Record<NonNullable<OpencodeTodoInfo['status']>, React.ReactNode> = {
+  completed: <CheckCircle2 className="h-4 w-4 text-success-600 dark:text-success-400" />,
+  in_progress: <Clock className="h-4 w-4 text-text-secondary dark:text-text-dark-secondary" />,
+  pending: <Circle className="h-4 w-4 text-text-quaternary dark:text-text-dark-quaternary" />,
+  cancelled: <XCircle className="h-4 w-4 text-text-quaternary dark:text-text-dark-quaternary" />,
+};
+
+const TODO_TEXT_DONE = 'text-xs text-text-tertiary line-through dark:text-text-dark-tertiary';
+const TODO_TEXT_ACTIVE = 'text-xs text-text-primary dark:text-text-dark-primary';
+
+const TodoWriteToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as OpencodeTodoWriteInput | undefined;
+  const todos = input?.todos ?? [];
+
+  const counts = todos.reduce(
+    (acc, t) => {
+      if (t.status === 'completed') acc.completed++;
+      else if (t.status === 'in_progress') acc.inProgress++;
+      else if (t.status === 'pending') acc.pending++;
+      return acc;
+    },
+    { completed: 0, inProgress: 0, pending: 0 },
+  );
+  const total = todos.length;
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Updated todos (${total} item${total !== 1 ? 's' : ''})`;
+          case 'failed':
+            return 'Failed to update todos';
+          default:
+            return 'Updating todos';
+        }
+      }}
+      loadingContent="Updating todo list..."
+      error={tool.error}
+    >
+      {total > 0 && (
+        <div>
+          <div className="mb-2 flex gap-3 text-2xs">
+            {counts.completed > 0 && (
+              <span className="text-success-600 dark:text-success-400">
+                {counts.completed} done
+              </span>
+            )}
+            {counts.inProgress > 0 && (
+              <span className="text-text-secondary dark:text-text-dark-secondary">
+                {counts.inProgress} active
+              </span>
+            )}
+            {counts.pending > 0 && (
+              <span className="text-text-tertiary dark:text-text-dark-tertiary">
+                {counts.pending} pending
+              </span>
+            )}
+          </div>
+          <div className="space-y-1">
+            {todos.map((todo, idx) => {
+              const status = todo.status ?? 'pending';
+              return (
+                <div
+                  key={todo.id ?? `${idx}-${todo.content}`}
+                  className="flex items-center gap-2 rounded-md py-1 transition-colors hover:bg-surface-hover dark:hover:bg-surface-dark-hover"
+                >
+                  <div className="flex-shrink-0">{STATUS_ICON[status]}</div>
+                  <div className="min-w-0 flex-1">
+                    <p
+                      className={
+                        status === 'completed' || status === 'cancelled'
+                          ? TODO_TEXT_DONE
+                          : TODO_TEXT_ACTIVE
+                      }
+                    >
+                      {todo.content}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </ToolCard>
+  );
+};
+
+export const TodoWriteTool = memo(TodoWriteToolInner);

--- a/frontend/src/components/chat/tools/opencode/WebFetchTool.tsx
+++ b/frontend/src/components/chat/tools/opencode/WebFetchTool.tsx
@@ -1,0 +1,50 @@
+import { memo } from 'react';
+import { Globe } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractDomain } from '@/utils/format';
+import { TOOL_OUTPUT_PRE_CLASS } from '@/utils/toolStyles';
+import { ToolCard } from '../common/ToolCard';
+import type { OpencodeWebFetchInput, OpencodeOutput } from './opencodePayload';
+
+const ICON = <Globe className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />;
+
+const WebFetchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as OpencodeWebFetchInput | undefined;
+  const result = tool.result as OpencodeOutput | undefined;
+
+  const url = input?.url ?? '';
+  const domain = extractDomain(url) || url || 'content';
+  const output = result?.output ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Fetched: ${domain}`;
+          case 'failed':
+            return `Failed to fetch: ${domain}`;
+          default:
+            return `Fetching: ${domain}`;
+        }
+      }}
+      loadingContent="Fetching content..."
+      error={tool.error}
+    >
+      {(url || output) && (
+        <div className="space-y-1.5">
+          {url && (
+            <div className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-quaternary">
+              {url}
+            </div>
+          )}
+          {output && <pre className={TOOL_OUTPUT_PRE_CLASS}>{output}</pre>}
+        </div>
+      )}
+    </ToolCard>
+  );
+};
+
+export const WebFetchTool = memo(WebFetchToolInner);

--- a/frontend/src/components/chat/tools/opencode/WriteTool.tsx
+++ b/frontend/src/components/chat/tools/opencode/WriteTool.tsx
@@ -1,0 +1,41 @@
+import { memo } from 'react';
+import { FilePlus } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard';
+import { NumberedContent } from '../common/NumberedContent';
+import { OpenInEditorButton } from '../common/OpenInEditorButton';
+import type { OpencodeWriteInput } from './opencodePayload';
+
+const ICON = <FilePlus className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />;
+
+const WriteToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
+  const input = tool.input as OpencodeWriteInput | undefined;
+  const filePath = input?.filePath ?? '';
+  const fileName = filePath ? extractFilename(filePath) : tool.title?.trim() || 'file';
+  const content = input?.content ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Wrote ${fileName}`;
+          case 'failed':
+            return `Failed to write ${fileName}`;
+          default:
+            return `Writing ${fileName}...`;
+        }
+      }}
+      loadingContent="Writing file..."
+      error={tool.error}
+      actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
+    >
+      {content && <NumberedContent content={content} />}
+    </ToolCard>
+  );
+};
+
+export const WriteTool = memo(WriteToolInner);

--- a/frontend/src/components/chat/tools/opencode/opencodePayload.ts
+++ b/frontend/src/components/chat/tools/opencode/opencodePayload.ts
@@ -1,0 +1,107 @@
+// OpenCode CLI speaks ACP with its raw tool names surfaced in the ACP
+// `title` field (backend extracts it as tool_name for opencode). Tool kinds
+// collapse multiple opencode tools into one ACP kind (e.g. edit/write/patch
+// → "edit"), so renderers key off the tool name rather than the kind.
+//
+// rawOutput is uniform across opencode tools:
+//   { output: string, metadata: Record<string, unknown> }
+// On failure the shape is { error: string, metadata: Record<string, unknown> }.
+// rawInput shapes below mirror opencode's Zod parameter schemas.
+
+export interface OpencodeBashInput {
+  command?: string;
+  timeout?: number;
+  workdir?: string;
+  description?: string;
+}
+
+export interface OpencodeReadInput {
+  filePath?: string;
+  offset?: number;
+  limit?: number;
+}
+
+export interface OpencodeWriteInput {
+  filePath?: string;
+  content?: string;
+}
+
+export interface OpencodeEditInput {
+  filePath?: string;
+  oldString?: string;
+  newString?: string;
+  replaceAll?: boolean;
+}
+
+export interface OpencodeGrepInput {
+  pattern?: string;
+  path?: string;
+  include?: string;
+}
+
+export interface OpencodeGrepMetadata {
+  matches?: number;
+  truncated?: boolean;
+}
+
+export interface OpencodeGlobInput {
+  pattern?: string;
+  path?: string;
+}
+
+export interface OpencodeGlobMetadata {
+  count?: number;
+  truncated?: boolean;
+}
+
+export interface OpencodeWebFetchInput {
+  url?: string;
+  format?: 'text' | 'markdown' | 'html';
+  timeout?: number;
+}
+
+export interface OpencodeTaskInput {
+  description?: string;
+  prompt?: string;
+  subagent_type?: string;
+  task_id?: string;
+  command?: string;
+}
+
+export interface OpencodeTodoInfo {
+  id?: string;
+  content?: string;
+  status?: 'pending' | 'in_progress' | 'completed' | 'cancelled';
+  priority?: 'low' | 'medium' | 'high';
+}
+
+export interface OpencodeTodoWriteInput {
+  todos?: OpencodeTodoInfo[];
+}
+
+export interface OpencodeSkillInput {
+  name?: string;
+}
+
+export interface OpencodeQuestionPrompt {
+  question?: string;
+  header?: string;
+  options?: { label?: string; value?: string }[];
+  multiple?: boolean;
+}
+
+export interface OpencodeQuestionInput {
+  questions?: OpencodeQuestionPrompt[];
+}
+
+export interface OpencodeQuestionOutput {
+  output?: string;
+  error?: string;
+  metadata?: { answers?: string[][] };
+}
+
+export interface OpencodeOutput {
+  output?: string;
+  error?: string;
+  metadata?: Record<string, unknown>;
+}

--- a/frontend/src/components/chat/tools/registry.tsx
+++ b/frontend/src/components/chat/tools/registry.tsx
@@ -25,6 +25,26 @@ const cursorToolLoaders: Record<string, ToolModuleLoader> = {
   edit: () => import('./cursor/EditTool').then((m) => ({ default: m.EditTool })),
 };
 
+// OpenCode uses the raw tool names (bash, read, edit, write, grep, glob,
+// webfetch, task, todowrite, skill, question) rather than ACP kinds — the
+// backend's tool-name extractor picks these out of the ACP `title` field for
+// opencode sessions, since opencode's ACP kinds collapse distinct tools
+// (edit/write/patch all share kind "edit").
+const opencodeToolLoaders: Record<string, ToolModuleLoader> = {
+  bash: () => import('./opencode/BashTool').then((m) => ({ default: m.BashTool })),
+  read: () => import('./opencode/ReadTool').then((m) => ({ default: m.ReadTool })),
+  write: () => import('./opencode/WriteTool').then((m) => ({ default: m.WriteTool })),
+  edit: () => import('./opencode/EditTool').then((m) => ({ default: m.EditTool })),
+  patch: () => import('./opencode/EditTool').then((m) => ({ default: m.EditTool })),
+  grep: () => import('./opencode/GrepTool').then((m) => ({ default: m.GrepTool })),
+  glob: () => import('./opencode/GlobTool').then((m) => ({ default: m.GlobTool })),
+  webfetch: () => import('./opencode/WebFetchTool').then((m) => ({ default: m.WebFetchTool })),
+  task: () => import('./opencode/TaskTool').then((m) => ({ default: m.TaskTool })),
+  todowrite: () => import('./opencode/TodoWriteTool').then((m) => ({ default: m.TodoWriteTool })),
+  skill: () => import('./opencode/SkillTool').then((m) => ({ default: m.SkillTool })),
+  question: () => import('./opencode/QuestionTool').then((m) => ({ default: m.QuestionTool })),
+};
+
 const toolLoaders: Record<string, ToolModuleLoader> = {
   // Claude Code tools
   Agent: () => import('./claude/AgentTool').then((m) => ({ default: m.AgentTool })),
@@ -85,6 +105,10 @@ export const getToolComponent = (toolName: string, agentKind?: AgentKind): ToolC
 
   if (agentKind === 'cursor' && cursorToolLoaders[toolName]) {
     return getOrCreateLazy(`cursor:${toolName}`, cursorToolLoaders[toolName]);
+  }
+
+  if (agentKind === 'opencode' && opencodeToolLoaders[toolName]) {
+    return getOrCreateLazy(`opencode:${toolName}`, opencodeToolLoaders[toolName]);
   }
 
   if (toolLoaders[toolName]) {

--- a/frontend/src/components/ui/icons/OpencodeIcon.tsx
+++ b/frontend/src/components/ui/icons/OpencodeIcon.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from 'react';
+
+export function OpencodeIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 512 512" fill="none" {...props}>
+      <path fill="currentColor" fillOpacity="0.5" d="M320 224V352H192V224H320Z" />
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -25,4 +25,5 @@ export const EMPTY_BUILTIN_COMMANDS: Record<AgentKind, SlashCommand[]> = {
   codex: [],
   copilot: [],
   cursor: [],
+  opencode: [],
 };

--- a/frontend/src/store/chatSettingsStore.ts
+++ b/frontend/src/store/chatSettingsStore.ts
@@ -11,7 +11,8 @@ type PermissionMode =
   | 'auto'
   | 'read-only'
   | 'full-access'
-  | 'ask';
+  | 'ask'
+  | 'build';
 
 const DEFAULT_KEY = '__default__';
 export const DEFAULT_PERMISSION_MODE: PermissionMode = 'bypassPermissions';

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -85,7 +85,7 @@ export interface CreateChatRequest {
   parent_chat_id?: string;
 }
 
-export type AgentKind = 'claude' | 'codex' | 'copilot' | 'cursor';
+export type AgentKind = 'claude' | 'codex' | 'copilot' | 'cursor' | 'opencode';
 
 export interface Model {
   model_id: string;
@@ -109,10 +109,11 @@ export function getAgentKindForModelId(modelId: string | null | undefined): Agen
     return 'claude';
   }
   if (CODEX_MODEL_IDS.has(modelId)) return 'codex';
-  // Copilot and Cursor models use a prefix convention — detect by convention
-  // instead of maintaining a duplicate static set.
+  // Copilot, Cursor, and OpenCode models use a prefix convention — detect by
+  // convention instead of maintaining a duplicate static set.
   if (modelId.startsWith('copilot:')) return 'copilot';
   if (modelId.startsWith('cursor:')) return 'cursor';
+  if (modelId.startsWith('opencode:')) return 'opencode';
   return 'claude';
 }
 

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -63,6 +63,12 @@ RUN . "$NVM_DIR/nvm.sh" && \
 # Cursor CLI (installs `cursor-agent` to ~/.local/bin, which is already on PATH).
 RUN curl -fsS https://cursor.com/install | bash
 
+# OpenCode CLI (installs `opencode` to ~/.opencode/bin; symlink into ~/.local/bin
+# so the ACP binary resolves without modifying PATH).
+RUN curl -fsSL https://opencode.ai/install | bash && \
+    mkdir -p /home/user/.local/bin && \
+    ln -sf /home/user/.opencode/bin/opencode /home/user/.local/bin/opencode
+
 RUN python3 -m pip install --user --upgrade pip && \
     python3 -m pip install --user \
     uv


### PR DESCRIPTION
## Summary
- Integrate the OpenCode CLI (`opencode acp`) as a new ACP agent alongside Claude, Codex, Copilot, and Cursor.
- Add backend `OpencodeAgentAdapter` with `build`/`plan` session modes; extend `AcpClientHandler` to resolve opencode tool names from the ACP `title` field (its `kind` collapses distinct tools) and surface both `formatted_output` and top-level `error` keys from ACP `raw_output`.
- Install the OpenCode binary in both the backend and sandbox Dockerfiles; extend Tauri's backend PATH to include `~/.opencode/bin`.
- Register the opencode catalog (OpenCode-hosted, Bedrock, and many third-party/OpenRouter models) in `backend/app/constants.py`.
- Add 11 opencode tool renderers (Bash, Read, Write, Edit, Grep, Glob, WebFetch, Task, TodoWrite, Skill, Question) plus shared payload types, an `OpencodeIcon`, and wire the agent through model-selector, permission-mode-selector, thinking-mode-selector, input context-usage gating, registry lazy-loaders, and `AgentKind` prefix detection.
- Adjust `AssistantMessage`'s model-name fallback to strip only the agent prefix (preserves IDs containing additional colons, e.g. `opencode:openrouter/x-ai/grok-4:free`).
- Collect opencode's `task` subagent tool in `MessageRenderer` alongside Claude's `Agent` so the sibling-agent expand flow works for both.

## Test plan
- [ ] Desktop app: select an opencode model, start a chat, verify messages stream and tool cards render for bash/read/write/edit/grep/glob/webfetch/task/todowrite/skill/question.
- [ ] Context-usage indicator is hidden for opencode models (no UsageUpdate events).
- [ ] Thinking-mode selector is hidden for opencode; permission-mode selector shows `Build`/`Plan` and the default is `Build`.
- [ ] Switching from a Codex/Claude chat to an opencode model reuses an incompatible permission mode safely (falls back to the restrictive `plan`).
- [ ] Model-name label for `opencode:openrouter/x-ai/grok-4:free` shows `openrouter/x-ai/grok-4:free`, not `free`.
- [ ] Docker backend build installs the opencode binary and `opencode --version` works inside the container.
- [ ] Sandbox build installs the opencode binary and it is reachable on PATH for the user.
- [ ] Subagent expand modal works for `task` tools (opencode) the same way it does for `Agent` (Claude).