### PR TITLE
Let users favorite models so they surface first in the selector

### DIFF
--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -1,7 +1,10 @@
 import { memo, useEffect, useMemo, ComponentType, SVGProps } from 'react';
+import { Star } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
 import { Dropdown } from '@/components/ui/primitives/Dropdown';
 import type { DropdownItemType } from '@/components/ui/primitives/Dropdown';
 import { useAuthStore } from '@/store/authStore';
+import { useModelStore } from '@/store/modelStore';
 import { useModelSelection } from '@/hooks/queries/useModelQueries';
 import { useIsSplitMode } from '@/hooks/useIsSplitMode';
 import { ClaudeIcon } from '@/components/ui/icons/ClaudeIcon';
@@ -9,8 +12,11 @@ import { CodexIcon } from '@/components/ui/icons/CodexIcon';
 import { CopilotIcon } from '@/components/ui/icons/CopilotIcon';
 import { CursorIcon } from '@/components/ui/icons/CursorIcon';
 import { OpencodeIcon } from '@/components/ui/icons/OpencodeIcon';
+import { cn } from '@/utils/cn';
 import { formatNumberCompact } from '@/utils/format';
 import type { AgentKind, Model } from '@/types/chat.types';
+
+const FAVORITES_LABEL = 'Favorites';
 
 const AGENT_LABELS: Record<AgentKind, string> = {
   claude: 'Claude',
@@ -54,21 +60,35 @@ export const ModelSelector = memo(function ModelSelector({
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const isSplitMode = useIsSplitMode();
   const { models, isLoading } = useModelSelection({ enabled: isAuthenticated, chatId });
+  const favoriteModelIds = useModelStore((state) => state.favoriteModelIds);
 
   const filteredModels = useMemo(
     () => (lockedAgentKind ? models.filter((m) => m.agent_kind === lockedAgentKind) : models),
     [models, lockedAgentKind],
   );
 
+  const favoriteIdSet = useMemo(() => new Set(favoriteModelIds), [favoriteModelIds]);
+
   const groupedItems = useMemo(() => {
+    const items: DropdownItemType<Model>[] = [];
+    // Favorites ordered by when each model was starred, not alphabetically.
+    const modelById = new Map(filteredModels.map((m) => [m.model_id, m]));
+    const favoriteModels = favoriteModelIds
+      .map((id) => modelById.get(id))
+      .filter((m): m is Model => m !== undefined);
+    if (favoriteModels.length > 0) {
+      items.push({ type: 'header', label: FAVORITES_LABEL });
+      favoriteModels.forEach((model) => items.push({ type: 'item', data: model }));
+    }
+
     const groups = new Map<AgentKind, Model[]>();
     filteredModels.forEach((model) => {
+      if (favoriteIdSet.has(model.model_id)) return;
       const list = groups.get(model.agent_kind) ?? [];
       list.push(model);
       groups.set(model.agent_kind, list);
     });
 
-    const items: DropdownItemType<Model>[] = [];
     groups.forEach((agentModels, kind) => {
       items.push({ type: 'header', label: AGENT_LABELS[kind] ?? kind });
       agentModels.forEach((model) => {
@@ -76,7 +96,7 @@ export const ModelSelector = memo(function ModelSelector({
       });
     });
     return items;
-  }, [filteredModels]);
+  }, [filteredModels, favoriteModelIds, favoriteIdSet]);
 
   const selectedModel = filteredModels.find((m) => m.model_id === selectedModelId);
 
@@ -124,20 +144,53 @@ export const ModelSelector = memo(function ModelSelector({
       selectionStyle="accent"
       triggerVariant={variant}
       dropdownAlign={dropdownAlign}
-      renderItem={(model, isSelected) => (
-        <div className="flex items-center justify-between gap-2">
-          <span
-            className={`truncate text-2xs font-medium ${isSelected ? 'text-text-primary dark:text-text-dark-primary' : 'text-text-secondary dark:text-text-dark-secondary'}`}
-          >
-            {model.name}
-          </span>
-          {model.context_window != null && model.context_window > 0 && (
-            <span className="flex-shrink-0 rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs font-medium text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
-              {formatNumberCompact(model.context_window)}
+      renderItem={(model, isSelected) => {
+        const isFavorite = favoriteIdSet.has(model.model_id);
+        return (
+          <div className="flex items-center gap-2">
+            <span
+              className={cn(
+                'min-w-0 flex-1 truncate text-2xs font-medium',
+                isSelected
+                  ? 'text-text-primary dark:text-text-dark-primary'
+                  : 'text-text-secondary dark:text-text-dark-secondary',
+              )}
+            >
+              {model.name}
             </span>
-          )}
-        </div>
-      )}
+            {model.context_window != null && model.context_window > 0 && (
+              <span className="flex-shrink-0 rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs font-medium text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
+                {formatNumberCompact(model.context_window)}
+              </span>
+            )}
+            <Button
+              type="button"
+              variant="unstyled"
+              aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+              aria-pressed={isFavorite}
+              onClick={(event) => {
+                // Stop the row's onClick from selecting the model when the star is clicked.
+                event.stopPropagation();
+                useModelStore.getState().toggleFavoriteModel(model.model_id);
+              }}
+              onKeyDown={(event) => {
+                // Keep the row's Enter/Space handler from firing in addition to this button's.
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.stopPropagation();
+                }
+              }}
+              className={cn(
+                'flex flex-shrink-0 items-center justify-center rounded-md p-0.5 transition-colors duration-150',
+                isFavorite
+                  ? 'text-text-primary dark:text-text-dark-primary'
+                  : 'text-text-quaternary hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
+              )}
+            >
+              <Star className={cn('h-3 w-3', isFavorite && 'fill-current')} />
+            </Button>
+          </div>
+        );
+      }}
     />
   );
 });

--- a/frontend/src/components/ui/primitives/SelectItem.tsx
+++ b/frontend/src/components/ui/primitives/SelectItem.tsx
@@ -1,5 +1,4 @@
-import { memo, ReactNode } from 'react';
-import { Button } from '@/components/ui/primitives/Button';
+import { memo, KeyboardEvent, ReactNode } from 'react';
 import { cn } from '@/utils/cn';
 
 interface SelectItemProps {
@@ -11,13 +10,23 @@ interface SelectItemProps {
 }
 
 function SelectItemInner({ isSelected, onSelect, className, children, role }: SelectItemProps) {
+  // Rendered as a div (not a button) so renderItem can nest secondary interactive controls
+  // like a favorite toggle — nesting interactive elements inside a <button> is invalid.
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelect();
+    }
+  };
   return (
-    <Button
-      onClick={onSelect}
-      variant="unstyled"
+    <div
       role={role}
+      tabIndex={0}
+      aria-selected={isSelected}
+      onClick={onSelect}
+      onKeyDown={handleKeyDown}
       className={cn(
-        'w-full rounded-lg px-2 py-1.5 text-left transition-colors duration-150',
+        'w-full cursor-pointer rounded-lg px-2 py-1.5 text-left transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-quaternary/30',
         isSelected
           ? 'bg-surface-hover/80 dark:bg-surface-dark-hover/80'
           : 'hover:bg-surface-hover/50 active:bg-surface-hover/70 dark:hover:bg-surface-dark-hover/50 dark:active:bg-surface-dark-hover/70',
@@ -25,7 +34,7 @@ function SelectItemInner({ isSelected, onSelect, className, children, role }: Se
       )}
     >
       {children}
-    </Button>
+    </div>
   );
 }
 

--- a/frontend/src/store/modelStore.ts
+++ b/frontend/src/store/modelStore.ts
@@ -6,6 +6,7 @@ export const useModelStore = create<ModelSelectionState>()(
   persist(
     (set, get) => ({
       modelByChat: {},
+      favoriteModelIds: [],
       selectModel: (chatId: string, modelId: string) => {
         const trimmedId = modelId?.trim();
         if (trimmedId && get().modelByChat[chatId] !== trimmedId) {
@@ -13,6 +14,16 @@ export const useModelStore = create<ModelSelectionState>()(
             modelByChat: { ...state.modelByChat, [chatId]: trimmedId },
           }));
         }
+      },
+      toggleFavoriteModel: (modelId: string) => {
+        set((state) => {
+          const exists = state.favoriteModelIds.includes(modelId);
+          return {
+            favoriteModelIds: exists
+              ? state.favoriteModelIds.filter((id) => id !== modelId)
+              : [...state.favoriteModelIds, modelId],
+          };
+        });
       },
     }),
     { name: 'model-storage' },

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -23,7 +23,9 @@ export interface ThemeState {
 
 export interface ModelSelectionState {
   modelByChat: Record<string, string>;
+  favoriteModelIds: string[];
   selectModel: (chatId: string, modelId: string) => void;
+  toggleFavoriteModel: (modelId: string) => void;
 }
 
 export type ViewType = 'agent' | 'diff' | 'editor' | 'prReview' | 'terminal' | 'secrets';


### PR DESCRIPTION
## Summary
- Adds a star toggle to each row in the model selector; favorited models appear in a pinned **Favorites** group above the per-provider groups (Claude, Codex, Copilot, Cursor, OpenCode).
- Persists favorites locally via the existing `model-storage` Zustand slice (`favoriteModelIds: string[]`, `toggleFavoriteModel`).
- Converts `SelectItem` from a `<button>` to a `<div role="option" tabIndex={0}>` so the favorite button can nest inside each row without invalid interactive nesting, and so row keyboard activation (Enter/Space) stays intact.
- Favorite button uses the `Button` primitive with `variant="unstyled"`, is tab-reachable, exposes `aria-pressed`, and `stopPropagation`s Enter/Space so it doesn't also trigger row selection.

## Test plan
- [ ] Open the model selector and star a model — it jumps to a new **Favorites** section at the top.
- [ ] Unstar from the Favorites section — model returns to its provider group.
- [ ] Reload the page — favorites persist (localStorage key `model-storage`).
- [ ] Tab through the open dropdown — focus reaches each row and each star button; Enter/Space on a row selects; Enter/Space on a star toggles without selecting.
- [ ] Screen reader announces `aria-pressed` state on the star and `aria-selected` on the row.
- [ ] Search filter still works across both Favorites and provider groups.
- [ ] Verify other `Dropdown` consumers (agent selector, permission selector, thinking selector, theme picker) still work — same `SelectItem` primitive change.