### PR TITLE
docs: expand README feature coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentrove
 
-Self-hosted AI coding workspace for Claude Code and Codex, using ACP adapters to run agents inside per-workspace sandboxes with chat, editor, terminal, and git tooling.
+Self-hosted AI coding workspace for Claude Code, Codex, Copilot, Cursor, and OpenCode, using ACP adapters to run agents inside per-workspace sandboxes with chat, editor, terminal, and git tooling.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
@@ -21,8 +21,8 @@ Join the [Discord server](https://discord.gg/HvkJU8dcBA).
 
 ## Why Agentrove
 
-- Run Claude Code and Codex from one self-hosted interface
-- Launch both agent runtimes through ACP adapters
+- Run multiple coding-agent runtimes from one self-hosted interface
+- Launch agent runtimes through ACP adapters
 - Keep each project in its own Docker or host sandbox
 - Work in chat, editor, terminal, diff, secrets, and PR review views side by side
 - Organize work by workspace, then branch into sub-threads when a task needs its own track
@@ -46,21 +46,27 @@ Agentrove launches agents through ACP adapters:
 - **Codex** via `codex-acp` + Codex CLI
 - **Copilot** via `copilot --acp --stdio`
 - **Cursor** via `cursor-agent acp`
+- **OpenCode** via OpenCode ACP-compatible models and tool streams
 
 ## Key Features
 
-- Claude and Codex in the same UI with per-chat model selection
-- ACP-based agent runtime integration for both Claude and Codex
+- Claude, Codex, Copilot, Cursor, and OpenCode in the same UI with per-chat model selection
+- ACP-based agent runtime integration with agent-specific tool rendering
 - Agent-specific permission modes and reasoning/thinking controls
 - Workspace-based project organization with per-workspace sandboxes
+- Workspace creation from an empty directory, git clone, or an existing local folder
 - Docker and host sandbox providers
 - Built-in editor, terminal, diff, secrets, and PR review panels
-- Git helpers for branches, pull, push, commit generation, PR description generation, and PR creation
-- Streaming chat sessions with resumable SSE events and explicit cancellation
-- Sub-threads for branching work from an existing chat
+- File mentions, built-in slash commands, custom skills, and prompt enhancement in the composer
+- File attachments with inline preview support for images, PDFs, and spreadsheets
+- Streaming chat sessions with resumable SSE events, explicit cancellation, queued follow-up messages, and permission prompts
+- Sub-threads for branching work from an existing chat, plus chat pinning
 - Optional git worktree mode for isolated implementation per chat
+- Git helpers for branches, checkout, pull, push, commit generation, PR description generation, PR creation, and diff restore flows
+- GitHub integration for repository lookup, pull request review, comments, collaborators, and reviewer selection
 - Workspace resources for custom skills and built-in slash commands
 - User-configurable personas, custom instructions, custom env vars, notifications, and sandbox defaults
+- Built-in authentication flows for signup, login, refresh, logout, password reset, and optional email verification
 - Web app and macOS desktop app
 
 ## Workspaces
@@ -94,6 +100,9 @@ Current model families exposed by the backend:
 
 - **Claude**: `sonnet[1m]`, `opus[1m]`, `haiku`
 - **Codex**: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`
+- **Copilot**: Claude and GPT model variants exposed through Copilot ACP
+- **Cursor**: Cursor composer, GPT, Claude, Gemini, Grok, and other Cursor ACP model variants
+- **OpenCode**: OpenCode-hosted and provider-backed ACP model variants
 
 Agent-specific controls:
 
@@ -101,6 +110,8 @@ Agent-specific controls:
 - **Codex permission modes**: `default`, `read-only`, `full-access`
 - **Claude thinking modes**: `low`, `medium`, `high`, `max`
 - **Codex reasoning modes**: `low`, `medium`, `high`, `xhigh`
+
+The UI also adapts tool rendering per runtime, so Claude, Codex, Copilot, Cursor, and OpenCode tool calls are shown with agent-specific formatting instead of a single generic event viewer.
 
 ## Settings Surface
 
@@ -117,8 +128,13 @@ General settings include:
 - GitHub personal access token
 - Default sandbox provider
 - Notification toggle
-- Auto-compact toggle
-- Attribution toggle
+
+Workspace resources and settings together let you:
+
+- Add and edit custom skills
+- Define reusable personas with custom system prompts
+- Inject custom environment variables into agent runs
+- Add account-level custom instructions applied to chats
 
 ## Quick Start (Web)
 
@@ -148,6 +164,8 @@ docker compose up -d
 ```
 
 Open [http://localhost:3000](http://localhost:3000).
+
+The web app includes built-in auth screens for sign up, login, password reset, and email verification when verification is enabled in config.
 
 ### Stop and logs
 
@@ -214,6 +232,7 @@ The backend and sandbox images install the tooling Agentrove needs to run coding
 - Claude Code
 - Codex CLI
 - Cursor CLI (`cursor-agent`)
+- OpenCode CLI (`opencode`)
 - `claude-agent-acp`
 - `codex-acp`
 - GitHub CLI


### PR DESCRIPTION
## Summary
- expand the README to cover currently implemented agent runtimes beyond Claude and Codex
- document missing user-facing features across chat, workspaces, GitHub, auth, and settings
- correct the included tooling list to mention OpenCode CLI support

## Testing
- not run (docs-only change)