### PR TITLE
Refactor service layer and terminal WebSocket encapsulation

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -242,9 +242,7 @@ async def get_chat_context_usage(
         logger.warning("Failed to get context usage from cache: %s", e)
 
     tokens_used = chat.context_token_usage
-    context_window = (
-        await chat_service.get_model_context_window(chat_id, current_user.id) or 0
-    )
+    context_window = await chat_service.get_model_context_window(chat_id) or 0
     percentage = 0.0
     if context_window > 0:
         percentage = min((tokens_used / context_window) * 100, 100.0)

--- a/backend/app/api/endpoints/websocket.py
+++ b/backend/app/api/endpoints/websocket.py
@@ -4,25 +4,24 @@ import json
 import logging
 
 from fastapi import APIRouter, WebSocket
-from sqlalchemy import select
 from starlette.websockets import WebSocketDisconnect
 
 from app.constants import (
     DEFAULT_PTY_COLS,
     DEFAULT_PTY_ROWS,
+    DEFAULT_TERMINAL_ID,
     WS_CLOSE_AUTH_FAILED,
-    WS_CLOSE_SANDBOX_NOT_FOUND,
     WS_MSG_CLOSE,
     WS_MSG_DETACH,
     WS_MSG_INIT,
     WS_MSG_PING,
     WS_MSG_RESIZE,
 )
-from app.db.session import SessionLocal
-from app.models.db_models.workspace import Workspace
-from app.services.sandbox_providers import SandboxProviderType
+from app.core.security import (
+    resolve_websocket_sandbox_access,
+    wait_for_websocket_auth,
+)
 from app.services.terminal import terminal_session_registry
-from app.core.security import wait_for_websocket_auth
 from app.utils.parsing import parse_pty_dimension
 
 router = APIRouter()
@@ -34,6 +33,11 @@ async def terminal_websocket(
     websocket: WebSocket,
     sandbox_id: str,
 ) -> None:
+    # Client protocol: after accept, the first frame must be an auth message
+    # (handled by wait_for_websocket_auth). Subsequent frames are either raw
+    # bytes (forwarded to the PTY stdin) or JSON control messages
+    # (init / resize / close / detach). A 30s receive-timeout drives a
+    # server→client ping so idle connections keep NAT/LB state alive.
     await websocket.accept()
 
     user, _ = await wait_for_websocket_auth(websocket)
@@ -41,30 +45,12 @@ async def terminal_websocket(
         await websocket.close(code=WS_CLOSE_AUTH_FAILED, reason="Authentication failed")
         return
 
-    async with SessionLocal() as db:
-        query = select(Workspace.sandbox_provider, Workspace.workspace_path).where(
-            Workspace.sandbox_id == sandbox_id,
-            Workspace.user_id == user.id,
-            Workspace.deleted_at.is_(None),
-        )
-        result = await db.execute(query)
-        row = result.one_or_none()
-        if not row:
-            await websocket.close(
-                code=WS_CLOSE_SANDBOX_NOT_FOUND, reason="Sandbox not found"
-            )
-            return
-        sandbox_provider_type = row.sandbox_provider
-        workspace_path = row.workspace_path
-
-    try:
-        provider_type = SandboxProviderType(sandbox_provider_type)
-    except ValueError:
-        await websocket.close(
-            code=WS_CLOSE_SANDBOX_NOT_FOUND, reason="Invalid sandbox provider"
-        )
+    access = await resolve_websocket_sandbox_access(websocket, sandbox_id, user)
+    if access is None:
         return
-    terminal_id = websocket.query_params.get("terminalId") or "terminal-1"
+    provider_type, workspace_path = access
+
+    terminal_id = websocket.query_params.get("terminalId") or DEFAULT_TERMINAL_ID
     session = await terminal_session_registry.get_or_create(
         user_id=str(user.id),
         sandbox_id=sandbox_id,

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -121,6 +121,7 @@ WS_CLOSE_SANDBOX_NOT_FOUND: Final[int] = 4004
 TERMINAL_TYPE: Final[str] = "xterm-256color"
 DEFAULT_PTY_ROWS: Final[int] = 24
 DEFAULT_PTY_COLS: Final[int] = 80
+DEFAULT_TERMINAL_ID: Final[str] = "terminal-1"
 DOCKER_STATUS_RUNNING: Final[str] = "running"
 
 SANDBOX_BASHRC_PATH: Final[str] = "/home/user/.bashrc"

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -16,9 +16,10 @@ from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..constants import WS_MSG_AUTH
+from ..constants import WS_CLOSE_SANDBOX_NOT_FOUND, WS_MSG_AUTH
 from ..db.session import SessionLocal, get_db
 from ..models.db_models.user import User
+from ..models.db_models.workspace import Workspace
 from ..services.exceptions import UserException
 from ..services.sandbox_providers import SandboxProviderType
 from ..services.user import UserService
@@ -177,3 +178,39 @@ async def wait_for_websocket_auth(
         return NO_WS_AUTH
 
     return await authenticate_websocket_user(token)
+
+
+async def resolve_websocket_sandbox_access(
+    websocket: WebSocket,
+    sandbox_id: str,
+    user: User,
+) -> tuple[SandboxProviderType, str] | None:
+    # Verifies the sandbox belongs to the authenticated user and resolves its
+    # provider type + workspace path. Closes the WS with a SANDBOX_NOT_FOUND
+    # code on failure and returns None so the caller can short-circuit. Lives
+    # here rather than as a FastAPI Depends because the WebSocket handshake
+    # requires accept→auth→access ordering that Depends can't enforce.
+    async with SessionLocal() as db:
+        query = select(Workspace.sandbox_provider, Workspace.workspace_path).where(
+            Workspace.sandbox_id == sandbox_id,
+            Workspace.user_id == user.id,
+            Workspace.deleted_at.is_(None),
+        )
+        result = await db.execute(query)
+        row = result.one_or_none()
+
+    if not row:
+        await websocket.close(
+            code=WS_CLOSE_SANDBOX_NOT_FOUND, reason="Sandbox not found"
+        )
+        return None
+
+    try:
+        provider_type = SandboxProviderType(row.sandbox_provider)
+    except ValueError:
+        await websocket.close(
+            code=WS_CLOSE_SANDBOX_NOT_FOUND, reason="Invalid sandbox provider"
+        )
+        return None
+
+    return provider_type, row.workspace_path

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -34,7 +34,7 @@ class PersonaDict(TypedDict):
     content: str
 
 
-class MessageAttachmentDict(TypedDict, total=False):
+class MessageAttachmentDict(TypedDict):
     file_url: str
     file_path: str | None
     file_type: str

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -10,8 +10,7 @@ from uuid import UUID, uuid4
 from sqlalchemy import exists, func, select, update
 from sqlalchemy.orm import aliased, selectinload
 
-from app.constants import REDIS_KEY_CHAT_STREAM_LIVE
-from app.core.config import get_settings
+from app.constants import MODELS, REDIS_KEY_CHAT_STREAM_LIVE
 from app.models.db_models.chat import Chat, Message
 from app.models.db_models.enums import MessageRole, MessageStreamStatus, StreamEventKind
 from app.models.db_models.user import User
@@ -26,38 +25,21 @@ from app.models.schemas.pagination import (
 )
 from app.models.types import ChatCompletionResult, MessageAttachmentDict, PermissionMode
 from app.prompts.system_prompt import DEFAULT_PERSONA_NAME, build_system_prompt_for_chat
-from app.services.session_registry import session_registry
 from app.services.db import BaseDbService, SessionFactoryType
 from app.services.exceptions import ChatException, ErrorCode
 from app.services.message import MessageService
-from app.constants import MODELS
 from app.services.sandbox import SandboxService
 from app.services.sandbox_providers.base import SandboxProvider
+from app.services.session_registry import session_registry
 from app.services.storage import StorageService
 from app.services.streaming.runtime import ChatStreamRuntime
 from app.services.streaming.types import ChatStreamRequest, StreamEnvelope
 from app.services.user import UserService
 from app.utils.cache import CachePubSub, cache_connection, cache_pubsub
 
-settings = get_settings()
 logger = logging.getLogger(__name__)
 
-TERMINAL_STREAM_EVENT_TYPES = {"cancelled", "complete", "error"}
-
-
-def _extract_queue_processing_message_id(raw_data: Any) -> UUID | None:
-    if not isinstance(raw_data, str):
-        return None
-    if StreamEventKind.QUEUE_PROCESSING.value not in raw_data:
-        return None
-    try:
-        env = json.loads(raw_data)
-        if env.get("kind") != StreamEventKind.QUEUE_PROCESSING.value:
-            return None
-        new_mid = (env.get("payload") or {}).get("assistant_message_id")
-        return UUID(new_mid) if new_mid else None
-    except (json.JSONDecodeError, ValueError):
-        return None
+TERMINAL_STREAM_EVENT_TYPES = frozenset({"cancelled", "complete", "error"})
 
 
 class ChatService(BaseDbService[Chat]):
@@ -78,6 +60,21 @@ class ChatService(BaseDbService[Chat]):
             workspace.sandbox_provider, workspace_path=workspace.workspace_path
         )
         return SandboxService(provider)
+
+    @staticmethod
+    def _extract_queue_processing_message_id(raw_data: Any) -> UUID | None:
+        if not isinstance(raw_data, str):
+            return None
+        if StreamEventKind.QUEUE_PROCESSING.value not in raw_data:
+            return None
+        try:
+            env = json.loads(raw_data)
+            if env.get("kind") != StreamEventKind.QUEUE_PROCESSING.value:
+                return None
+            new_mid = (env.get("payload") or {}).get("assistant_message_id")
+            return UUID(new_mid) if new_mid else None
+        except (json.JSONDecodeError, ValueError):
+            return None
 
     async def get_user_chats(
         self,
@@ -108,7 +105,7 @@ class ChatService(BaseDbService[Chat]):
 
             count_query = select(func.count(Chat.id)).filter(*base_filters)
             count_result = await db.execute(count_query)
-            total = count_result.scalar()
+            total = count_result.scalar() or 0
 
             offset = (pagination.page - 1) * pagination.per_page
 
@@ -147,7 +144,7 @@ class ChatService(BaseDbService[Chat]):
                 page=pagination.page,
                 per_page=pagination.per_page,
                 total=total,
-                pages=math.ceil(total / pagination.per_page) if total > 0 else 0,
+                pages=math.ceil(total / pagination.per_page),
             )
 
     async def create_chat(self, user: User, chat_data: ChatCreate) -> Chat:
@@ -325,9 +322,7 @@ class ChatService(BaseDbService[Chat]):
 
             return chat
 
-    async def get_model_context_window(
-        self, chat_id: UUID, user_id: UUID
-    ) -> int | None:
+    async def get_model_context_window(self, chat_id: UUID) -> int | None:
         last_msg = await self.message_service.get_latest_assistant_message(chat_id)
         if not last_msg or not last_msg.model_id:
             return None
@@ -545,9 +540,6 @@ class ChatService(BaseDbService[Chat]):
 
     @staticmethod
     def _build_stream_sse_event(
-        # Canonical builder for the SSE envelope shape sent to the frontend.
-        # The live-Redis path in _stream_live_redis_events constructs the same
-        # {id, event, data} shape directly from pre-serialized envelope JSON.
         *,
         chat_id: UUID,
         message_id: UUID,
@@ -556,6 +548,9 @@ class ChatService(BaseDbService[Chat]):
         kind: str,
         payload: dict[str, Any],
     ) -> dict[str, Any]:
+        # Canonical builder for the SSE envelope shape sent to the frontend.
+        # The live-Redis path in _stream_live_redis_events constructs the same
+        # {id, event, data} shape directly from pre-serialized envelope JSON.
         return {
             "id": str(seq),
             "event": StreamEventKind.STREAM.value,
@@ -589,7 +584,7 @@ class ChatService(BaseDbService[Chat]):
                 chat_id=chat_id,
                 message_id=uuid4(),
                 stream_id=stream_id or uuid4(),
-                seq=max(int(fallback_seq), 0) + 1,
+                seq=fallback_seq + 1,
                 kind="error",
                 payload=payload,
             )
@@ -606,12 +601,14 @@ class ChatService(BaseDbService[Chat]):
                 audit_payload={"payload": payload},
             )
         except Exception as exc:
+            # Broad catch so the client always receives an error event, even if
+            # DB persistence fails; fall back to a synthesized seq.
             logger.warning(
                 "Failed to persist stream error event for chat %s: %s",
                 chat_id,
                 exc,
             )
-            error_seq = max(int(fallback_seq), 0) + 1
+            error_seq = fallback_seq + 1
 
         return self._build_stream_sse_event(
             chat_id=chat_id,
@@ -714,7 +711,9 @@ class ChatService(BaseDbService[Chat]):
                     async for item in self._replay_stream_backlog(chat_id, after_seq):
                         yield item
                         last_seq = int(item["id"])
-                        new_mid = _extract_queue_processing_message_id(item.get("data"))
+                        new_mid = self._extract_queue_processing_message_id(
+                            item.get("data")
+                        )
                         if new_mid:
                             active_message_id = new_mid
                             active_stream_id = None
@@ -729,7 +728,7 @@ class ChatService(BaseDbService[Chat]):
                         if event_seq > last_seq:
                             last_seq = event_seq
 
-                        new_mid = _extract_queue_processing_message_id(
+                        new_mid = self._extract_queue_processing_message_id(
                             event.get("data")
                         )
                         if new_mid:
@@ -737,6 +736,8 @@ class ChatService(BaseDbService[Chat]):
                             active_stream_id = None
 
         except Exception as exc:
+            # Final SSE safety net — any failure must surface as an error
+            # event rather than a silently hung connection.
             logger.error(
                 "Error in event stream for chat %s: %s", chat_id, exc, exc_info=True
             )
@@ -791,12 +792,9 @@ class ChatService(BaseDbService[Chat]):
                 )
             )
 
-        session_id = chat.session_id
-        user_prompt = MessageService.extract_user_text_content(request.prompt)
-
         await self.message_service.create_message(
             chat_id,
-            user_prompt,
+            request.prompt,
             MessageRole.USER,
             attachments=attachments,
         )
@@ -813,26 +811,21 @@ class ChatService(BaseDbService[Chat]):
             user_settings,
             selected_persona_name=request.selected_persona_name,
         )
-        custom_instructions = (
-            user_settings.custom_instructions if user_settings else None
-        )
-
-        context_window = MODELS[request.model_id].context_window
         try:
             await self._enqueue_chat_task(
-                prompt=user_prompt,
+                prompt=request.prompt,
                 system_prompt=system_prompt,
-                custom_instructions=custom_instructions,
+                custom_instructions=user_settings.custom_instructions,
                 chat=chat,
                 permission_mode=request.permission_mode,
                 model_id=request.model_id,
-                session_id=session_id,
+                session_id=chat.session_id,
                 assistant_message_id=str(assistant_message.id),
                 thinking_mode=request.thinking_mode,
                 worktree=request.worktree,
                 plan_mode=request.plan_mode,
                 attachments=attachments,
-                context_window=context_window,
+                context_window=MODELS[request.model_id].context_window,
                 selected_persona_name=request.selected_persona_name,
             )
         except Exception as e:
@@ -847,9 +840,6 @@ class ChatService(BaseDbService[Chat]):
         }
 
     async def _enqueue_chat_task(
-        # Package the chat state into a ChatStreamRequest and kick off the
-        # background streaming task. Separate method so tests can override it
-        # to run synchronously without the background task machinery.
         self,
         *,
         prompt: str,
@@ -861,12 +851,15 @@ class ChatService(BaseDbService[Chat]):
         session_id: str | None,
         assistant_message_id: str,
         thinking_mode: str | None,
+        attachments: list[MessageAttachmentDict] | None,
         worktree: bool = False,
         plan_mode: bool = False,
-        attachments: list[MessageAttachmentDict] | None,
         context_window: int | None = None,
         selected_persona_name: str = DEFAULT_PERSONA_NAME,
     ) -> None:
+        # Package the chat state into a ChatStreamRequest and kick off the
+        # background streaming task. Separate method so tests can override it
+        # to run synchronously without the background task machinery.
         stream_attachments = (
             [dict(item) for item in attachments] if attachments else None
         )

--- a/backend/app/services/message.py
+++ b/backend/app/services/message.py
@@ -1,20 +1,19 @@
 import logging
-import json
 from datetime import datetime, timezone
 from typing import Any, cast
 from uuid import UUID, uuid4
 
-from sqlalchemy import case, select, update, or_, and_, insert
-from sqlalchemy.orm import selectinload
+from sqlalchemy import and_, case, insert, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models.db_models.chat import Chat, Message, MessageAttachment, MessageEvent
 from app.models.db_models.enums import MessageRole, MessageStreamStatus
-from app.models.schemas.pagination import CursorPaginatedResponse
 from app.models.schemas.chat import Message as MessageSchema
+from app.models.schemas.pagination import CursorPaginatedResponse
 from app.models.types import MessageAttachmentDict
 from app.services.db import BaseDbService, SessionFactoryType
-from app.services.exceptions import MessageException, ErrorCode
+from app.services.exceptions import ErrorCode, MessageException
 from app.utils.attachment_urls import AttachmentURL
 from app.utils.cursor import Cursor, InvalidCursorError
 
@@ -24,38 +23,6 @@ logger = logging.getLogger(__name__)
 class MessageService(BaseDbService[Message]):
     def __init__(self, session_factory: SessionFactoryType | None = None) -> None:
         super().__init__(session_factory)
-
-    @staticmethod
-    def extract_user_text_content(content: str) -> str:
-        # User messages can arrive as plain text or as a JSON array of typed
-        # content blocks (e.g. [{type: "user_text", text: "..."}, ...]) when
-        # the frontend sends multi-part input. Extract just the text portions
-        # for storage in content_text, which is used for title generation and search.
-        stripped = content.strip()
-        if not stripped:
-            return ""
-        if not stripped.startswith("["):
-            return content
-
-        try:
-            parsed = json.loads(content)
-        except json.JSONDecodeError:
-            return content
-
-        if not isinstance(parsed, list):
-            return content
-
-        parts: list[str] = []
-        for item in parsed:
-            if not isinstance(item, dict):
-                continue
-            if str(item.get("type") or "").lower() != "user_text":
-                continue
-            text = item.get("text")
-            if isinstance(text, str):
-                parts.append(text)
-
-        return "".join(parts) if parts else content
 
     @staticmethod
     def serialize_attachments(
@@ -87,16 +54,17 @@ class MessageService(BaseDbService[Message]):
         session_id: str | None = None,
         stream_status: MessageStreamStatus | None = None,
     ) -> Message:
+        # Assistant messages start empty and get populated by the streaming
+        # pipeline via update_message_snapshot; user messages go in whole.
         async with self.session_factory() as db:
-            is_assistant = role == MessageRole.ASSISTANT
-            content_text = ""
-            content_render: dict[str, Any] = {"events": []}
-            if not is_assistant:
-                content_text = self.extract_user_text_content(content)
-                if content_text:
-                    content_render = {
-                        "events": [{"type": "user_text", "text": content_text}],
-                    }
+            if role == MessageRole.ASSISTANT:
+                content_text = ""
+                content_render: dict[str, Any] = {"events": []}
+            else:
+                content_text = content
+                content_render = {
+                    "events": [{"type": "user_text", "text": content}],
+                }
 
             message_kwargs: dict[str, Any] = {
                 "chat_id": chat_id,
@@ -156,6 +124,8 @@ class MessageService(BaseDbService[Message]):
         stream_status: MessageStreamStatus | None = None,
         total_cost_usd: float | None = None,
     ) -> Message | None:
+        # Periodic snapshot write so reconnecting clients can hydrate without
+        # replaying every event. Returns None if the row was soft-deleted mid-stream.
         async with self.session_factory() as db:
             now = datetime.now(timezone.utc)
             values: dict[str, Any] = {
@@ -197,6 +167,8 @@ class MessageService(BaseDbService[Message]):
         render_payload: dict[str, Any],
         audit_payload: dict[str, Any] | None,
     ) -> int:
+        # Allocate a gapless chat-scoped seq atomically via UPDATE...RETURNING;
+        # clients use it as the SSE id for catch-up on reconnect.
         async with self.session_factory() as db:
             seq_result = await db.execute(
                 update(Chat)
@@ -241,6 +213,9 @@ class MessageService(BaseDbService[Message]):
         stream_id: UUID,
         events: list[tuple[str, dict[str, Any], dict[str, Any] | None]],
     ) -> int:
+        # Bulk variant: one UPDATE bumps Chat.last_event_seq by N and the
+        # contiguous range is assigned to the inserts — cuts write amplification
+        # during chunky agent output bursts.
         if not events:
             return 0
 
@@ -286,6 +261,8 @@ class MessageService(BaseDbService[Message]):
     async def get_chat_messages(
         self, chat_id: UUID, cursor: str | None = None, limit: int = 20
     ) -> CursorPaginatedResponse[MessageSchema]:
+        # (created_at, id) tiebreak matters — user + empty-assistant pairs
+        # created in the same tick share a timestamp.
         async with self.session_factory() as db:
             query = (
                 select(Message)
@@ -380,6 +357,8 @@ class MessageService(BaseDbService[Message]):
     async def get_attachment(
         self, attachment_id: UUID, db: AsyncSession
     ) -> MessageAttachment | None:
+        # Takes an explicit session so AttachmentService can share the
+        # request-scoped one. Eager-loads message.chat for the ownership check.
         result = await db.execute(
             select(MessageAttachment)
             .options(selectinload(MessageAttachment.message).selectinload(Message.chat))

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -12,28 +12,29 @@ from uuid import UUID, uuid4
 
 from sqlalchemy import func, select, update
 
+from app.constants import BUILTIN_SLASH_COMMANDS
 from app.core.config import get_settings
 from app.models.db_models.chat import Chat, Message
 from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
-from app.models.schemas.workspace import WorkspaceCreate, WorkspaceUpdate
+from app.models.schemas.pagination import PaginatedResponse, PaginationParams
 from app.models.schemas.workspace import (
     BuiltinSlashCommand,
     CustomSkill,
     Workspace as WorkspaceSchema,
+    WorkspaceCreate,
     WorkspaceResources,
+    WorkspaceUpdate,
 )
-from app.models.schemas.pagination import PaginatedResponse, PaginationParams
+from app.services.acp.adapters import AgentKind
 from app.services.db import BaseDbService, SessionFactoryType
 from app.services.exceptions import ErrorCode, WorkspaceException
 from app.services.sandbox import SandboxService
 from app.services.sandbox_providers.base import SandboxProvider
 from app.services.sandbox_providers.types import SandboxProviderType
-from app.services.acp.adapters import AgentKind
-from app.constants import BUILTIN_SLASH_COMMANDS
+from app.services.session_registry import session_registry
 from app.services.skill import SkillService
 from app.services.user import UserService
-from app.services.session_registry import session_registry
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
@@ -54,6 +55,8 @@ class WorkspaceService(BaseDbService[Workspace]):
         self._base_dir.mkdir(parents=True, exist_ok=True)
 
     async def create_workspace(self, user: User, data: WorkspaceCreate) -> Workspace:
+        # Sandbox is provisioned before the DB insert so a persistence failure
+        # can trigger teardown via the except block — never leave an orphan.
         user_settings = await self.user_service.get_user_settings(user.id)
         user_workspace_dir = (self._base_dir / str(user.id)).resolve()
         user_workspace_dir.mkdir(parents=True, exist_ok=True)
@@ -138,6 +141,8 @@ class WorkspaceService(BaseDbService[Workspace]):
                 await db.refresh(workspace)
                 return workspace
         except Exception:
+            # Broad catch so any persistence failure still triggers sandbox
+            # teardown — otherwise we leak the container provisioned above.
             logger.error(
                 "Failed to persist workspace, cleaning up sandbox %s", sandbox_id
             )
@@ -147,6 +152,8 @@ class WorkspaceService(BaseDbService[Workspace]):
     async def get_user_workspaces(
         self, user: User, pagination: PaginationParams | None = None
     ) -> PaginatedResponse[WorkspaceSchema]:
+        # Annotates each workspace with chat_count and last_chat_at so the UI
+        # can sort by recency in a single round trip.
         async with self._session_factory() as db:
             chat_count_col = func.count(Chat.id).label("chat_count")
             last_chat_at_col = func.max(Chat.updated_at).label("last_chat_at")
@@ -171,7 +178,7 @@ class WorkspaceService(BaseDbService[Workspace]):
                 count_query = select(func.count(Workspace.id)).filter(
                     Workspace.user_id == user.id, Workspace.deleted_at.is_(None)
                 )
-                total = (await db.execute(count_query)).scalar()
+                total = (await db.execute(count_query)).scalar() or 0
                 offset = (pagination.page - 1) * pagination.per_page
                 query = query.offset(offset).limit(pagination.per_page)
             else:
@@ -208,7 +215,7 @@ class WorkspaceService(BaseDbService[Workspace]):
                 page=page,
                 per_page=per_page,
                 total=total,
-                pages=math.ceil(total / per_page) if total > 0 else 0,
+                pages=math.ceil(total / per_page),
             )
 
     async def get_workspace(self, workspace_id: UUID, user: User) -> Workspace:
@@ -233,6 +240,8 @@ class WorkspaceService(BaseDbService[Workspace]):
     async def update_workspace(
         self, workspace_id: UUID, user: User, data: WorkspaceUpdate
     ) -> Workspace:
+        # db.merge re-attaches the detached instance from get_workspace so
+        # ORM-tracked mutations flush as an UPDATE.
         workspace = await self.get_workspace(workspace_id, user)
         async with self._session_factory() as db:
             managed: Workspace = await db.merge(workspace)
@@ -245,6 +254,8 @@ class WorkspaceService(BaseDbService[Workspace]):
     def _build_workspace_resources(
         skill_service: SkillService,
     ) -> WorkspaceResources:
+        # Synchronous so the caller can offload to a thread — SkillService
+        # does blocking filesystem reads.
         return WorkspaceResources(
             skills=[CustomSkill(**skill) for skill in skill_service.list_all()],
             builtin_slash_commands={
@@ -259,6 +270,7 @@ class WorkspaceService(BaseDbService[Workspace]):
     async def get_workspace_resources(
         self, workspace_id: UUID, user: User
     ) -> WorkspaceResources:
+        # Thread-offloaded: SkillService walks the filesystem synchronously.
         workspace = await self.get_workspace(workspace_id, user)
         workspace_path = Path(workspace.workspace_path)
         skill_service = SkillService(workspace_path=workspace_path)
@@ -266,6 +278,8 @@ class WorkspaceService(BaseDbService[Workspace]):
         return await asyncio.to_thread(self._build_workspace_resources, skill_service)
 
     async def delete_workspace(self, workspace_id: UUID, user: User) -> None:
+        # DB commit lands before the session/sandbox teardown tasks so the DB
+        # stays consistent even if those fire-and-forget cleanups fail.
         workspace = await self.get_workspace(workspace_id, user)
         async with self._session_factory() as db:
             workspace = await db.merge(workspace)
@@ -318,6 +332,8 @@ class WorkspaceService(BaseDbService[Workspace]):
         git_url: str,
         github_token: str | None = None,
     ) -> str:
+        # Tokens go through a temporary GIT_ASKPASS script rather than the URL
+        # or CLI args to keep them out of process listings and git's own logs.
         repo_name = self._extract_repo_name(git_url)
         workspace_dir = user_workspace_dir / f"{repo_name}-{uuid4().hex[:8]}"
 
@@ -393,6 +409,8 @@ class WorkspaceService(BaseDbService[Workspace]):
 
     @staticmethod
     def _normalize_git_url(git_url: str) -> str:
+        # SSH passes through unmodified — auth is at the transport layer, not
+        # the URL. HTTPS must not embed credentials (supplied via GIT_ASKPASS).
         candidate = git_url.strip()
         if not candidate:
             raise WorkspaceException(

--- a/frontend/src/components/sandbox/terminal/TerminalTab.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab.tsx
@@ -23,6 +23,10 @@ type SessionState = 'idle' | 'connecting' | 'ready' | 'error';
 
 const encoder = new TextEncoder();
 
+// Mirrors backend WS_CLOSE_* codes in app/constants.py
+const WS_CLOSE_AUTH_FAILED = 4001;
+const WS_CLOSE_SANDBOX_NOT_FOUND = 4004;
+
 export const TerminalTab: FC<TerminalTabProps> = ({
   isVisible,
   sandboxId,
@@ -32,6 +36,7 @@ export const TerminalTab: FC<TerminalTabProps> = ({
 }) => {
   const theme = useResolvedTheme();
   const [sessionState, setSessionState] = useState<SessionState>('idle');
+  const [closeReason, setCloseReason] = useState<string | null>(null);
 
   const lastSentSizeRef = useRef<TerminalSize | null>(null);
   const hasSentInitRef = useRef(false);
@@ -100,6 +105,7 @@ export const TerminalTab: FC<TerminalTabProps> = ({
     const wsUrl = `${WS_BASE_URL}/${sandboxId}/terminal${terminalParam}`;
 
     setSessionState('connecting');
+    setCloseReason(null);
 
     const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
@@ -130,8 +136,8 @@ export const TerminalTab: FC<TerminalTabProps> = ({
       }
       try {
         const message = JSON.parse(event.data) as Record<string, unknown>;
+        // Server ping is a NAT/LB keepalive — no pong is expected.
         if (message.type === 'ping') {
-          ws.send(JSON.stringify({ type: 'pong' }));
           return;
         }
         if (message.type === 'stdout' && typeof message.data === 'string') {
@@ -146,10 +152,6 @@ export const TerminalTab: FC<TerminalTabProps> = ({
             lastSentSizeRef.current = { rows, cols };
           }
           setSessionState('ready');
-          return;
-        }
-        if (message.type === 'error') {
-          setSessionState('error');
         }
       } catch (error) {
         logger.error('Terminal write failed', 'TerminalTab', error);
@@ -160,8 +162,16 @@ export const TerminalTab: FC<TerminalTabProps> = ({
       setSessionState('error');
     };
 
-    const handleClose = () => {
+    const handleClose = (event: CloseEvent) => {
       resetWsRefs();
+      // The server closes with WS_CLOSE_AUTH_FAILED / WS_CLOSE_SANDBOX_NOT_FOUND
+      // and a human-readable reason. Surface both so the overlay can tell the
+      // user why the connection dropped instead of showing a generic message.
+      if (event.code === WS_CLOSE_AUTH_FAILED || event.code === WS_CLOSE_SANDBOX_NOT_FOUND) {
+        setCloseReason(event.reason || null);
+        setSessionState('error');
+        return;
+      }
       setSessionState((prev) => (prev === 'error' ? prev : 'idle'));
     };
 
@@ -226,7 +236,7 @@ export const TerminalTab: FC<TerminalTabProps> = ({
     : sessionState === 'connecting'
       ? 'Connecting to sandbox terminal...'
       : sessionState === 'error'
-        ? 'Terminal connection interrupted'
+        ? (closeReason ?? 'Terminal connection interrupted')
         : null;
 
   return (


### PR DESCRIPTION
## Summary
- Services (chat/message/workspace): CLAUDE.md-aligned cleanup — dead code removal, import ordering, validation tightening, and trimmed method comments focused on non-obvious "why" only.
- `MessageService.extract_user_text_content` deleted: the JSON-array input shape it handled is never produced by the frontend (schema is `str`).
- `MessageAttachmentDict` → `total=True`: all fields are always set by `storage.save_file`.
- WebSocket terminal endpoint no longer imports `SessionLocal` — ownership/provider lookup extracted to `core.security.resolve_websocket_sandbox_access`.
- `TerminalTab.tsx`: drops dead `pong`/`error` handlers, inspects `event.code` + `event.reason` to surface the server's close reason (auth failed / sandbox not found) instead of the generic overlay.

## Test plan
- [ ] Start a chat, send a message, confirm render + title generation still work
- [ ] Create a workspace via git URL (with and without token) — clone + cleanup still work
- [ ] Delete a workspace — chats/messages cascade-soft-delete, sandbox tears down
- [ ] Open a terminal tab against an active sandbox — attach, resize, detach still work
- [ ] Close the active sandbox while terminal is open — overlay shows the server's reason
- [ ] Reconnect the SSE stream mid-response — replay + live pub/sub still work