### PR TITLE
Make Cmd+Shift+F a global rg-powered content search

### DIFF
--- a/frontend/src/components/editor/code-sidebar/CodeSidebar.tsx
+++ b/frontend/src/components/editor/code-sidebar/CodeSidebar.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef } from 'react';
+import { memo } from 'react';
 import { Download, Loader2, PanelLeftClose } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { RefreshButton } from '@/components/ui/shared/RefreshButton';
@@ -27,10 +27,6 @@ export interface CodeSidebarProps {
   cwd?: string;
   activeTab: SidebarTab;
   onActiveTabChange: (tab: SidebarTab) => void;
-  // Bumped counter from the parent: each bump switches to the search tab
-  // and focuses the input — used for Cmd+Shift+F without letting the sidebar
-  // own the global shortcut.
-  focusSignal: number;
 }
 
 export const CodeSidebar = memo(function CodeSidebar({
@@ -51,23 +47,7 @@ export const CodeSidebar = memo(function CodeSidebar({
   cwd,
   activeTab,
   onActiveTabChange,
-  focusSignal,
 }: CodeSidebarProps) {
-  const searchInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    // Skip the initial mount bump — only react when the parent increments.
-    if (focusSignal === 0) return;
-    // Parent bumped focusSignal (Cmd+Shift+F). Switch to search and focus the
-    // input; selecting existing text lets the user type over it immediately.
-    onActiveTabChange('search');
-    const id = requestAnimationFrame(() => {
-      searchInputRef.current?.focus();
-      searchInputRef.current?.select();
-    });
-    return () => cancelAnimationFrame(id);
-  }, [focusSignal, onActiveTabChange]);
-
   return (
     <div className="flex h-full flex-col bg-surface-secondary dark:bg-surface-dark-secondary">
       <div className="flex flex-none items-center justify-between border-b border-border/50 px-2 py-1 dark:border-border-dark/50">
@@ -140,12 +120,7 @@ export const CodeSidebar = memo(function CodeSidebar({
           />
         </div>
         <div className={cn('h-full', activeTab !== 'search' && 'hidden')}>
-          <SearchPanel
-            sandboxId={sandboxId}
-            cwd={cwd}
-            onOpenResult={onOpenResult}
-            inputRef={searchInputRef}
-          />
+          <SearchPanel sandboxId={sandboxId} cwd={cwd} onOpenResult={onOpenResult} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -9,8 +9,7 @@ import { cn } from '@/utils/cn';
 import { findFileInStructure, getAncestorFolderPaths } from '@/utils/file';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useMountEffect } from '@/hooks/useMountEffect';
-
-const IS_MAC = navigator.platform.toUpperCase().startsWith('MAC');
+import { useUIStore } from '@/store/uiStore';
 
 export interface CodeViewProps {
   files: FileStructure[];
@@ -63,7 +62,6 @@ export const CodeView = memo(function CodeView({
   const fileTreeContainerRef = useRef<HTMLDivElement>(null);
   const [isFileTreeCollapsed, setIsFileTreeCollapsed] = useState(true);
   const [activeTab, setActiveTab] = useState<SidebarTab>('files');
-  const [focusSignal, setFocusSignal] = useState(0);
   const [targetLine, setTargetLine] = useState<{
     path: string;
     line: number;
@@ -139,26 +137,19 @@ export const CodeView = memo(function CodeView({
     [onFileSelect, isMobile],
   );
 
+  // Consume jumps dispatched from outside the editor (e.g. command menu search).
+  // ChatPage handles the file selection via pendingFilePath; we only translate the
+  // line nonce into local targetLine so View scrolls/highlights the line.
+  const pendingFileJump = useUIStore((s) => s.pendingFileJump);
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      const modifier = IS_MAC ? e.metaKey : e.ctrlKey;
-      if (!modifier || !e.shiftKey || e.key.toLowerCase() !== 'f') return;
-      const active = document.activeElement as HTMLElement | null;
-      const tag = active?.tagName;
-      const inInput = tag === 'INPUT' || tag === 'TEXTAREA' || active?.isContentEditable;
-      // Skip when typing in an unrelated field so we don't hijack the
-      // browser's own find dialog mid-edit; re-focus when already inside
-      // the sidebar input so the shortcut still works as a "jump here".
-      if (inInput && !active?.closest('[data-code-sidebar]')) return;
-      e.preventDefault();
-      if (isMobile) setShowMobileTree(true);
-      else if (fileTreePanelRef.current?.isCollapsed()) fileTreePanelRef.current.expand();
-      setActiveTab('search');
-      setFocusSignal((n) => n + 1);
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [isMobile]);
+    if (!pendingFileJump) return;
+    setTargetLine({
+      path: pendingFileJump.path,
+      line: pendingFileJump.line,
+      nonce: pendingFileJump.nonce,
+    });
+    useUIStore.getState().consumeFileJump();
+  }, [pendingFileJump]);
 
   // Shared sidebar props — mobile and desktop differ only in the file-select
   // handler and close callback, so everything else is hoisted once here.
@@ -177,7 +168,6 @@ export const CodeView = memo(function CodeView({
     cwd,
     activeTab,
     onActiveTabChange: setActiveTab,
-    focusSignal,
   };
 
   if (isMobile) {

--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -40,6 +40,7 @@ import { fuzzySearch } from '@/utils/fuzzySearch';
 import { getLeaves } from '@/utils/mosaicHelpers';
 import { traverseFileStructure, getFileName } from '@/utils/file';
 import { HighlightMatch } from '@/components/editor/file-tree/HighlightMatch';
+import { SearchPanel } from '@/components/editor/file-search/SearchPanel';
 import { cn } from '@/utils/cn';
 import type { ViewType, MosaicDirection } from '@/types/ui.types';
 import type { FileStructure } from '@/types/file-system.types';
@@ -153,10 +154,17 @@ const SETTING_COMMANDS: ActionCommandItem[] = [
   },
   {
     type: 'action',
-    id: 'search-files',
-    label: 'Search files',
-    icon: FileSearch,
+    id: 'search-in-files',
+    label: 'Search in files',
+    icon: Search,
     shortcut: 'f',
+  },
+  {
+    type: 'action',
+    id: 'go-to-file',
+    label: 'Go to file',
+    icon: FileSearch,
+    shortcut: 'o',
   },
 ];
 
@@ -169,7 +177,14 @@ export const SHORTCUT_MAP = new Map<string, CommandItem>(
   ]),
 );
 
-type MenuMode = 'commands' | 'files' | 'branches';
+type MenuMode = 'commands' | 'files' | 'branches' | 'search';
+
+// Commands that switch the menu into a sub-mode instead of dispatching an action.
+const COMMAND_TO_MODE: Partial<Record<string, MenuMode>> = {
+  'search-in-files': 'search',
+  'go-to-file': 'files',
+  'switch-branch': 'branches',
+};
 
 let pendingMenuMode: MenuMode | null = null;
 
@@ -273,7 +288,10 @@ export function executeCommand(
     ui.setSidebarOpen(!ui.sidebarOpen);
   } else if (cmd.id.startsWith('theme-')) {
     ui.setTheme(cmd.id.slice(6) as 'dark' | 'light' | 'system');
-  } else if (cmd.id === 'search-files') {
+  } else if (cmd.id === 'search-in-files') {
+    pendingMenuMode = 'search';
+    ui.setCommandMenuOpen(true);
+  } else if (cmd.id === 'go-to-file') {
     pendingMenuMode = 'files';
     ui.setCommandMenuOpen(true);
   } else if (cmd.id === 'switch-branch') {
@@ -301,6 +319,7 @@ export function CommandMenu() {
   const [activeIndex, setActiveIndex] = useState(0);
   const [mode, setMode] = useState<MenuMode>('commands');
   const inputRef = useRef<HTMLInputElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const previousFocusRef = useRef<Element | null>(null);
   const activeItemRef = useRef<HTMLDivElement>(null);
   const stateRef = useRef({ activeIndex: 0, mode: 'commands' as MenuMode });
@@ -381,14 +400,20 @@ export function CommandMenu() {
     setMode(next);
     setQuery('');
     setActiveIndex(0);
+    if (next === 'search') {
+      // SearchPanel owns its own input; focus it after React flushes the mode change.
+      requestAnimationFrame(() => searchInputRef.current?.focus());
+    } else {
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
   }, []);
 
   useEffect(() => {
     if (isOpen) {
       previousFocusRef.current = document.activeElement;
+      // switchMode also focuses the right input for the target mode.
       switchMode(pendingMenuMode ?? 'commands');
       pendingMenuMode = null;
-      requestAnimationFrame(() => inputRef.current?.focus());
     } else if (previousFocusRef.current instanceof HTMLElement) {
       previousFocusRef.current.focus();
       previousFocusRef.current = null;
@@ -410,6 +435,14 @@ export function CommandMenu() {
   const handleSelectFile = useCallback(
     (file: FlatFileItem) => {
       useUIStore.getState().openFileInEditor(file.path);
+      close();
+    },
+    [close],
+  );
+
+  const handleOpenSearchResult = useCallback(
+    (path: string, lineNumber: number) => {
+      useUIStore.getState().openFileInEditor(path, lineNumber);
       close();
     },
     [close],
@@ -471,6 +504,17 @@ export function CommandMenu() {
       const { activeIndex: idx, mode: m } = stateRef.current;
       const len = listLengthRef.current;
 
+      if (m === 'search') {
+        // SearchPanel handles its own typing + click-to-open; don't hijack
+        // Enter/arrows here. Only wire Escape to step back to commands.
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          switchMode('commands');
+        }
+        return;
+      }
+
       switch (e.key) {
         case 'Escape':
           e.preventDefault();
@@ -504,13 +548,9 @@ export function CommandMenu() {
           } else {
             const cmd = filteredCommandsRef.current[idx];
             if (cmd) {
-              if (cmd.id === 'search-files') {
-                switchMode('files');
-              } else if (cmd.id === 'switch-branch') {
-                switchMode('branches');
-              } else {
-                handleSelectItem(cmd);
-              }
+              const nextMode = COMMAND_TO_MODE[cmd.id];
+              if (nextMode) switchMode(nextMode);
+              else handleSelectItem(cmd);
             }
           }
           break;
@@ -533,7 +573,10 @@ export function CommandMenu() {
     >
       <div
         className={cn(
-          'mt-20 h-fit w-full max-w-md',
+          'mt-20 h-fit w-full',
+          // Widen for search mode so code snippets don't wrap; keep the compact
+          // dialog for every other mode.
+          mode === 'search' ? 'max-w-2xl' : 'max-w-md',
           'rounded-xl border border-border/50 shadow-strong dark:border-border-dark/50',
           'bg-surface/95 backdrop-blur-xl dark:bg-surface-dark/95',
           'animate-fade-in',
@@ -541,246 +584,271 @@ export function CommandMenu() {
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center gap-2 border-b border-border/50 px-3 dark:border-border-dark/50">
-          {(mode === 'files' || mode === 'branches') && (
-            <Button
-              variant="unstyled"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => switchMode('commands')}
-              className="shrink-0 rounded-md bg-surface-hover px-1.5 py-0.5 text-2xs font-medium text-text-secondary dark:bg-surface-dark-hover dark:text-text-dark-secondary"
-            >
-              {mode === 'files' ? 'Files' : 'Branches'}
-            </Button>
-          )}
-          <Search className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
-          <Input
-            ref={inputRef}
-            variant="unstyled"
-            value={query}
-            onChange={(e) => {
-              setQuery(e.target.value);
-              setActiveIndex(0);
-            }}
-            placeholder={
-              mode === 'files'
-                ? 'Search files...'
-                : mode === 'branches'
-                  ? 'Search branches...'
-                  : 'Search...'
-            }
-            className="h-10 w-full bg-transparent text-sm text-text-primary outline-none placeholder:text-text-quaternary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary"
-            role="combobox"
-            aria-expanded="true"
-            aria-controls={listId}
-            aria-activedescendant={
-              mode === 'files'
-                ? filteredFiles[activeIndex]
-                  ? `file-item-${activeIndex}`
-                  : undefined
-                : mode === 'branches'
-                  ? filteredBranches[activeIndex]
-                    ? `branch-item-${activeIndex}`
-                    : undefined
-                  : filteredCommands[activeIndex]
-                    ? `command-item-${filteredCommands[activeIndex].id}`
-                    : undefined
-            }
-          />
-        </div>
-
-        <div className="max-h-64 overflow-y-auto py-1" role="listbox" id={listId}>
-          {mode === 'files' ? (
-            <>
-              {filteredFiles.map((file, index) => (
-                <div
-                  key={file.path}
-                  ref={index === activeIndex ? activeItemRef : undefined}
-                  className={cn(
-                    rowClass,
-                    index === activeIndex
-                      ? 'bg-surface-active dark:bg-surface-dark-active'
-                      : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-                  )}
-                  onMouseEnter={() => setActiveIndex(index)}
+        {mode === 'search' ? (
+          <>
+            <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2 dark:border-border-dark/50">
+              <Button
+                variant="unstyled"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => switchMode('commands')}
+                className="shrink-0 rounded-md bg-surface-hover px-1.5 py-0.5 text-2xs font-medium text-text-secondary dark:bg-surface-dark-hover dark:text-text-dark-secondary"
+              >
+                Search in files
+              </Button>
+              <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                Esc to go back
+              </span>
+            </div>
+            <div className="h-[28rem]">
+              <SearchPanel
+                sandboxId={sandboxId ?? undefined}
+                cwd={worktreeCwd}
+                onOpenResult={handleOpenSearchResult}
+                inputRef={searchInputRef}
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex items-center gap-2 border-b border-border/50 px-3 dark:border-border-dark/50">
+              {(mode === 'files' || mode === 'branches') && (
+                <Button
+                  variant="unstyled"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => switchMode('commands')}
+                  className="shrink-0 rounded-md bg-surface-hover px-1.5 py-0.5 text-2xs font-medium text-text-secondary dark:bg-surface-dark-hover dark:text-text-dark-secondary"
                 >
-                  <Button
-                    variant="unstyled"
-                    id={`file-item-${index}`}
-                    role="option"
-                    aria-selected={index === activeIndex}
-                    className="flex flex-1 items-center gap-3 overflow-hidden"
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => handleSelectFile(file)}
-                  >
-                    <File className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
-                    <span className="truncate">
-                      <HighlightMatch
-                        text={file.name}
-                        searchQuery={query}
-                        className="font-medium"
-                      />
-                      <span className="ml-2 text-text-quaternary dark:text-text-dark-quaternary">
-                        {file.path}
-                      </span>
-                    </span>
-                  </Button>
-                </div>
-              ))}
-              {filteredFiles.length === 0 && (
-                <p className="px-3 py-4 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
-                  No matching files
-                </p>
+                  {mode === 'files' ? 'Files' : 'Branches'}
+                </Button>
               )}
-            </>
-          ) : mode === 'branches' ? (
-            <>
-              {filteredBranches.map((branch, index) => {
-                const isCurrent = branch === branchesData?.current_branch;
-                return (
-                  <div
-                    key={branch}
-                    ref={index === activeIndex ? activeItemRef : undefined}
-                    className={cn(
-                      rowClass,
-                      index === activeIndex
-                        ? 'bg-surface-active dark:bg-surface-dark-active'
-                        : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-                    )}
-                    onMouseEnter={() => setActiveIndex(index)}
-                  >
-                    <Button
-                      variant="unstyled"
-                      id={`branch-item-${index}`}
-                      role="option"
-                      aria-selected={index === activeIndex}
-                      className="flex flex-1 items-center gap-3 overflow-hidden"
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() => handleSelectBranch(branch)}
-                      disabled={checkoutBranch.isPending}
-                    >
-                      <GitBranch className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
-                      <HighlightMatch
-                        text={branch}
-                        searchQuery={query}
-                        className="flex-1 truncate text-left font-mono"
-                      />
-                      {isCurrent && (
-                        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-text-primary dark:bg-text-dark-primary" />
-                      )}
-                    </Button>
-                  </div>
-                );
-              })}
-              {filteredBranches.length === 0 && (
-                <p className="px-3 py-4 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
-                  {!sandboxId
-                    ? 'No sandbox connected'
-                    : !branchesData
-                      ? 'Loading branches…'
-                      : !branchesData.is_git_repo
-                        ? 'Not a git repository'
-                        : branchesData.branches.length === 0
-                          ? 'No branches in this repository'
-                          : 'No matching branches'}
-                </p>
-              )}
-            </>
-          ) : (
-            <>
-              {filteredCommands.map((cmd, index) => {
-                const Icon = cmd.icon;
-                const isActive =
-                  (cmd.type === 'view' && activeLeafSet.has(cmd.id)) || cmd.id === `theme-${theme}`;
+              <Search className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
+              <Input
+                ref={inputRef}
+                variant="unstyled"
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setActiveIndex(0);
+                }}
+                placeholder={
+                  mode === 'files'
+                    ? 'Search files...'
+                    : mode === 'branches'
+                      ? 'Search branches...'
+                      : 'Search...'
+                }
+                className="h-10 w-full bg-transparent text-sm text-text-primary outline-none placeholder:text-text-quaternary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary"
+                role="combobox"
+                aria-expanded="true"
+                aria-controls={listId}
+                aria-activedescendant={
+                  mode === 'files'
+                    ? filteredFiles[activeIndex]
+                      ? `file-item-${activeIndex}`
+                      : undefined
+                    : mode === 'branches'
+                      ? filteredBranches[activeIndex]
+                        ? `branch-item-${activeIndex}`
+                        : undefined
+                      : filteredCommands[activeIndex]
+                        ? `command-item-${filteredCommands[activeIndex].id}`
+                        : undefined
+                }
+              />
+            </div>
 
-                return (
-                  <div
-                    key={cmd.id}
-                    ref={index === activeIndex ? activeItemRef : undefined}
-                    className={cn(
-                      rowClass,
-                      index === activeIndex
-                        ? 'bg-surface-active dark:bg-surface-dark-active'
-                        : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-                    )}
-                    onMouseEnter={() => setActiveIndex(index)}
-                  >
-                    <Button
-                      variant="unstyled"
-                      id={`command-item-${cmd.id}`}
-                      role="option"
-                      aria-selected={index === activeIndex}
-                      className="flex flex-1 items-center gap-3"
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() => {
-                        if (cmd.id === 'search-files') {
-                          switchMode('files');
-                        } else if (cmd.id === 'switch-branch') {
-                          switchMode('branches');
-                        } else {
-                          handleSelectItem(cmd);
-                        }
-                      }}
-                    >
-                      <Icon className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
-                      <HighlightMatch
-                        text={cmd.label}
-                        searchQuery={query}
-                        className="flex-1 text-left"
-                      />
-                      {isActive && (
-                        <span className="h-1.5 w-1.5 rounded-full bg-text-primary dark:bg-text-dark-primary" />
+            <div className="max-h-64 overflow-y-auto py-1" role="listbox" id={listId}>
+              {mode === 'files' ? (
+                <>
+                  {filteredFiles.map((file, index) => (
+                    <div
+                      key={file.path}
+                      ref={index === activeIndex ? activeItemRef : undefined}
+                      className={cn(
+                        rowClass,
+                        index === activeIndex
+                          ? 'bg-surface-active dark:bg-surface-dark-active'
+                          : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
                       )}
-                    </Button>
-                    {!isMobile && cmd.shortcut && (
-                      <kbd className="ml-auto shrink-0 font-mono text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-                        {formatShortcut(cmd.shortcut)}
-                      </kbd>
-                    )}
-                    {cmd.type === 'view' && !isMobile && !isActive && (
-                      <div className="flex items-center gap-0.5">
+                      onMouseEnter={() => setActiveIndex(index)}
+                    >
+                      <Button
+                        variant="unstyled"
+                        id={`file-item-${index}`}
+                        role="option"
+                        aria-selected={index === activeIndex}
+                        className="flex flex-1 items-center gap-3 overflow-hidden"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={() => handleSelectFile(file)}
+                      >
+                        <File className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
+                        <span className="truncate">
+                          <HighlightMatch
+                            text={file.name}
+                            searchQuery={query}
+                            className="font-medium"
+                          />
+                          <span className="ml-2 text-text-quaternary dark:text-text-dark-quaternary">
+                            {file.path}
+                          </span>
+                        </span>
+                      </Button>
+                    </div>
+                  ))}
+                  {filteredFiles.length === 0 && (
+                    <p className="px-3 py-4 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
+                      No matching files
+                    </p>
+                  )}
+                </>
+              ) : mode === 'branches' ? (
+                <>
+                  {filteredBranches.map((branch, index) => {
+                    const isCurrent = branch === branchesData?.current_branch;
+                    return (
+                      <div
+                        key={branch}
+                        ref={index === activeIndex ? activeItemRef : undefined}
+                        className={cn(
+                          rowClass,
+                          index === activeIndex
+                            ? 'bg-surface-active dark:bg-surface-dark-active'
+                            : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+                        )}
+                        onMouseEnter={() => setActiveIndex(index)}
+                      >
                         <Button
                           variant="unstyled"
+                          id={`branch-item-${index}`}
+                          role="option"
+                          aria-selected={index === activeIndex}
+                          className="flex flex-1 items-center gap-3 overflow-hidden"
                           onMouseDown={(e) => e.preventDefault()}
-                          onClick={() => handleSplit(cmd.id, 'row')}
-                          className={splitButtonClass}
-                          title="Split right"
+                          onClick={() => handleSelectBranch(branch)}
+                          disabled={checkoutBranch.isPending}
                         >
-                          <PanelRight className="h-3 w-3" />
-                        </Button>
-                        <Button
-                          variant="unstyled"
-                          onMouseDown={(e) => e.preventDefault()}
-                          onClick={() => handleSplit(cmd.id, 'column')}
-                          className={splitButtonClass}
-                          title="Split down"
-                        >
-                          <PanelBottom className="h-3 w-3" />
+                          <GitBranch className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
+                          <HighlightMatch
+                            text={branch}
+                            searchQuery={query}
+                            className="flex-1 truncate text-left font-mono"
+                          />
+                          {isCurrent && (
+                            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-text-primary dark:bg-text-dark-primary" />
+                          )}
                         </Button>
                       </div>
-                    )}
-                  </div>
-                );
-              })}
+                    );
+                  })}
+                  {filteredBranches.length === 0 && (
+                    <p className="px-3 py-4 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
+                      {!sandboxId
+                        ? 'No sandbox connected'
+                        : !branchesData
+                          ? 'Loading branches…'
+                          : !branchesData.is_git_repo
+                            ? 'Not a git repository'
+                            : branchesData.branches.length === 0
+                              ? 'No branches in this repository'
+                              : 'No matching branches'}
+                    </p>
+                  )}
+                </>
+              ) : (
+                <>
+                  {filteredCommands.map((cmd, index) => {
+                    const Icon = cmd.icon;
+                    const isActive =
+                      (cmd.type === 'view' && activeLeafSet.has(cmd.id)) ||
+                      cmd.id === `theme-${theme}`;
 
-              {filteredCommands.length === 0 && (
-                <p className="px-3 py-4 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
-                  No matching commands
-                </p>
+                    return (
+                      <div
+                        key={cmd.id}
+                        ref={index === activeIndex ? activeItemRef : undefined}
+                        className={cn(
+                          rowClass,
+                          index === activeIndex
+                            ? 'bg-surface-active dark:bg-surface-dark-active'
+                            : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+                        )}
+                        onMouseEnter={() => setActiveIndex(index)}
+                      >
+                        <Button
+                          variant="unstyled"
+                          id={`command-item-${cmd.id}`}
+                          role="option"
+                          aria-selected={index === activeIndex}
+                          className="flex flex-1 items-center gap-3"
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={() => {
+                            const nextMode = COMMAND_TO_MODE[cmd.id];
+                            if (nextMode) switchMode(nextMode);
+                            else handleSelectItem(cmd);
+                          }}
+                        >
+                          <Icon className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
+                          <HighlightMatch
+                            text={cmd.label}
+                            searchQuery={query}
+                            className="flex-1 text-left"
+                          />
+                          {isActive && (
+                            <span className="h-1.5 w-1.5 rounded-full bg-text-primary dark:bg-text-dark-primary" />
+                          )}
+                        </Button>
+                        {!isMobile && cmd.shortcut && (
+                          <kbd className="ml-auto shrink-0 font-mono text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                            {formatShortcut(cmd.shortcut)}
+                          </kbd>
+                        )}
+                        {cmd.type === 'view' && !isMobile && !isActive && (
+                          <div className="flex items-center gap-0.5">
+                            <Button
+                              variant="unstyled"
+                              onMouseDown={(e) => e.preventDefault()}
+                              onClick={() => handleSplit(cmd.id, 'row')}
+                              className={splitButtonClass}
+                              title="Split right"
+                            >
+                              <PanelRight className="h-3 w-3" />
+                            </Button>
+                            <Button
+                              variant="unstyled"
+                              onMouseDown={(e) => e.preventDefault()}
+                              onClick={() => handleSplit(cmd.id, 'column')}
+                              className={splitButtonClass}
+                              title="Split down"
+                            >
+                              <PanelBottom className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+
+                  {filteredCommands.length === 0 && (
+                    <p className="px-3 py-4 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
+                      No matching commands
+                    </p>
+                  )}
+                </>
               )}
-            </>
-          )}
-        </div>
+            </div>
 
-        {!isMobile && (
-          <div className="flex items-center justify-between border-t border-border/50 px-3 py-2 dark:border-border-dark/50">
-            <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-              {mode === 'files'
-                ? '↵ Open file · Esc to go back'
-                : mode === 'branches'
-                  ? '↵ Switch branch · Esc to go back'
-                  : '↵ Select · Split via icons · Shortcuts work globally · Esc to close'}
-            </span>
-          </div>
+            {!isMobile && (
+              <div className="flex items-center justify-between border-t border-border/50 px-3 py-2 dark:border-border-dark/50">
+                <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                  {mode === 'files'
+                    ? '↵ Open file · Esc to go back'
+                    : mode === 'branches'
+                      ? '↵ Switch branch · Esc to go back'
+                      : '↵ Select · Split via icons · Shortcuts work globally · Esc to close'}
+                </span>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>,

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -126,6 +126,7 @@ export function ChatPage() {
     useUIStore.getState().setCurrentView('agent');
     useUIStore.setState({
       pendingFilePath: null,
+      pendingFileJump: null,
       subThreadDialogOpen: false,
       createCommitDialogOpen: false,
       createPRDialogOpen: false,

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -27,7 +27,11 @@ type UIStoreState = ThemeState &
     createCommitDialogOpen: boolean;
     setCreateCommitDialogOpen: (open: boolean) => void;
     pendingFilePath: string | null;
-    openFileInEditor: (path: string) => void;
+    // Nonce lets the consumer re-jump even when path+line repeat, so that clicking
+    // the same search result after scrolling away still reveals it.
+    pendingFileJump: { path: string; line: number; nonce: number } | null;
+    openFileInEditor: (path: string, line?: number) => void;
+    consumeFileJump: () => void;
     pendingChatMessage: string | null;
     setPendingChatMessage: (message: string | null) => void;
   };
@@ -66,11 +70,18 @@ export const useUIStore = create<UIStoreState>()(
       setPendingChatMessage: (message) => set({ pendingChatMessage: message }),
 
       pendingFilePath: null,
+      pendingFileJump: null,
+      consumeFileJump: () => set({ pendingFileJump: null }),
       // Sets the pending file path and ensures the editor pane is visible.
       // On mobile, switches to the editor view. On desktop, adds an editor
       // tile to the mosaic layout if one isn't already present.
-      openFileInEditor: (path) => {
-        set({ pendingFilePath: path });
+      // When `line` is provided, also queues a jump the editor view consumes.
+      openFileInEditor: (path, line) => {
+        set({
+          pendingFilePath: path,
+          pendingFileJump:
+            line != null ? { path, line, nonce: (get().pendingFileJump?.nonce ?? 0) + 1 } : null,
+        });
         const isMobile = typeof window !== 'undefined' && window.innerWidth < MOBILE_BREAKPOINT;
         if (isMobile) {
           set({ currentView: 'editor', mosaicLayout: 'editor' });


### PR DESCRIPTION
## Summary
- `Cmd+Shift+F` now opens the command menu in a new "Search in files" mode that embeds the existing editor `SearchPanel` (rg-powered), so users no longer have to open the editor first to search file contents.
- `Cmd+Shift+O` takes over the filename fuzzy-match entry point, matching the VS Code convention where `⌘P`/`⌘⇧O` is "Go to file" and `⌘⇧F` is "Search in files".
- Opening a result jumps the editor directly to the correct line via a new `pendingFileJump` slice on the UI store (nonce included so re-clicking the same result re-reveals after scroll).
- Removes the now-redundant `Cmd+Shift+F` listener and `focusSignal` plumbing from `CodeView` / `CodeSidebar` — the command menu owns the shortcut globally.

## Test plan
- [ ] From the chat page (no editor open), press `Cmd+Shift+F` → command menu opens in Search mode, `SearchPanel` input focused.
- [ ] Type a query (2+ chars) → results appear grouped by file with highlighted matches.
- [ ] Click a result → editor opens in a mosaic tile, selects the file, scrolls to and highlights the line.
- [ ] Click the same result again after scrolling away → editor re-reveals the line (nonce works).
- [ ] Press `Esc` in Search mode → returns to command menu; `Esc` again → closes menu.
- [ ] Press `Cmd+Shift+O` → command menu opens in filename-fuzzy (Files) mode.
- [ ] `Cmd+Shift+P` then `f` → still enters the new Search mode (command dispatch path).
- [ ] Editor sidebar Search tab still works independently (inline search).
- [ ] Switching chats clears any stale `pendingFileJump`.