### PR TITLE
Drop hover background on mosaic tile close button

### DIFF
--- a/frontend/src/components/ui/MosaicSplitView.tsx
+++ b/frontend/src/components/ui/MosaicSplitView.tsx
@@ -54,7 +54,6 @@ export function MosaicSplitView({ mosaicLayout, renderView }: MosaicSplitViewPro
                       'h-5 w-5 rounded-md',
                       'text-text-tertiary dark:text-text-dark-tertiary',
                       'hover:text-text-primary dark:hover:text-text-dark-primary',
-                      'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
                       'transition-colors duration-200',
                     )}
                     title="Close tile"


### PR DESCRIPTION
## Summary
- The close (X) button on mosaic tile toolbars was swapping its surface on hover in addition to the icon color. The background swap read louder than the color change and added noise for a control that is already subtle. Keeping only the text-color transition matches the quieter hover behavior used elsewhere in the toolbar.

## Test plan
- [ ] Open a split mosaic layout (so tile close buttons are visible)
- [ ] Hover the X on each tile — only icon color changes, no background fill
- [ ] Confirm light and dark modes both look correct