### PR TITLE
Make workspace-relative paths the app-level contract

### DIFF
--- a/backend/app/api/endpoints/sandbox.py
+++ b/backend/app/api/endpoints/sandbox.py
@@ -43,7 +43,7 @@ from app.services.git import GitService
 from app.services.sandbox import SandboxService
 from app.services.search import SearchService
 from app.services.user import UserService
-from app.utils.sandbox import normalize_sandbox_file_path
+from app.utils.sandbox import normalize_relative_path
 
 
 router = APIRouter()
@@ -70,10 +70,14 @@ async def get_file_content(
     sandbox_service: SandboxService = Depends(get_sandbox_service),
 ) -> FileContentResponse:
     try:
-        file_data = await sandbox_service.get_file_content(
-            sandbox_id, normalize_sandbox_file_path(file_path)
-        )
+        normalized_path = normalize_relative_path(file_path)
+        file_data = await sandbox_service.get_file_content(sandbox_id, normalized_path)
         return FileContentResponse(**file_data)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
     except SandboxException as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -88,14 +92,14 @@ async def update_file_in_sandbox(
     sandbox_service: SandboxService = Depends(get_sandbox_service),
 ) -> UpdateFileResponse:
     try:
-        normalized_path = normalize_sandbox_file_path(request.file_path)
+        normalized_path = normalize_relative_path(request.file_path)
         await sandbox_service.provider.write_file(
             sandbox_id, normalized_path, request.content
         )
         return UpdateFileResponse(
             success=True, message=f"File {normalized_path} updated successfully"
         )
-    except SandboxException as e:
+    except (ValueError, SandboxException) as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),

--- a/backend/app/models/schemas/sandbox.py
+++ b/backend/app/models/schemas/sandbox.py
@@ -1,16 +1,9 @@
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 
 class UpdateFileRequest(BaseModel):
-    file_path: str = Field(..., min_length=1)
+    file_path: str = Field(..., min_length=1, max_length=4096)
     content: str
-
-    @field_validator("file_path")
-    @classmethod
-    def normalize_file_path(cls, v: str) -> str:
-        if not v.startswith("/"):
-            return f"/{v.lstrip('/')}"
-        return v
 
 
 class UpdateFileResponse(BaseModel):

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -153,10 +153,6 @@ class AcpClientHandler:
                 data = event.get("data")
                 if isinstance(data, dict):
                     data.setdefault("session_id", session_id)
-                    update_meta = getattr(update, "field_meta", None) or {}
-                    cwd = update_meta.get("cwd") or kwargs.get("cwd")
-                    if cwd:
-                        data["worktree_cwd"] = cwd
             self.event_queue.put_nowait(event)
 
     async def request_permission(
@@ -426,9 +422,8 @@ class AcpClientHandler:
         return StreamEvent(type="usage", data=self.usage)
 
     def _map_session_info(self, info: SessionInfoUpdate) -> StreamEvent | None:
-        # session_id and cwd are not on SessionInfoUpdate — they come from
-        # the outer SessionNotification and are injected by session_update().
-        # Always emit so the caller can attach the session_id.
+        # session_id comes from the outer SessionNotification and is injected
+        # by session_update(). Always emit so the caller can attach the session_id.
         return StreamEvent(type="system", data={})
 
     @staticmethod

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -5,7 +5,7 @@ import base64
 import logging
 import os
 import shlex
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +31,7 @@ from app.services.acp.adapters import (
 )
 from app.services.acp.client import AcpClientHandler
 from app.services.sandbox_providers import SandboxProviderType
+from app.services.sandbox_providers.base import SandboxProvider
 from app.services.sandbox_providers.docker_provider import (
     DOCKER_SANDBOX_CONTAINER_PREFIX,
 )
@@ -274,7 +275,14 @@ class AcpSession:
     @classmethod
     async def create(cls, config: AcpSessionConfig) -> AcpSession:
         handler = AcpClientHandler(agent_kind=config.agent_kind)
-        process = await cls._spawn_process(config)
+        # Resolve the workspace-relative cwd to a runtime-absolute path via the
+        # provider — the single edge where relative → absolute translation lives.
+        provider = SandboxProvider.create_provider(
+            SandboxProviderType(config.sandbox_provider),
+            workspace_path=config.workspace_path,
+        )
+        spawn_config = replace(config, cwd=provider.resolve_workspace_path(config.cwd))
+        process = await cls._spawn_process(spawn_config)
 
         if process.stdin is None or process.stdout is None:
             process.kill()
@@ -292,7 +300,6 @@ class AcpSession:
         try:
             await conn.initialize(protocol_version=ACP_PROTOCOL_VERSION)
 
-            session_cwd = cls._resolve_cwd(config)
             mcp_servers = cls._build_mcp_servers(config.mcp_servers)
             session_meta = config.session_meta
 
@@ -302,7 +309,7 @@ class AcpSession:
                 handler.muted = True
                 try:
                     await conn.load_session(
-                        cwd=session_cwd,
+                        cwd=spawn_config.cwd,
                         session_id=config.resume_session_id,
                         mcp_servers=mcp_servers,
                         **session_meta,
@@ -313,7 +320,7 @@ class AcpSession:
                 acp_session_id = config.resume_session_id
             else:
                 response = await conn.new_session(
-                    cwd=session_cwd,
+                    cwd=spawn_config.cwd,
                     mcp_servers=mcp_servers,
                     **session_meta,
                 )
@@ -468,8 +475,6 @@ class AcpSession:
             env.update(config.env)
         env.setdefault("TERM", TERMINAL_TYPE)
 
-        cwd = config.workspace_path or config.cwd
-
         return await asyncio.create_subprocess_exec(
             launch.binary,
             *launch.cli_args,
@@ -478,35 +483,8 @@ class AcpSession:
             stderr=asyncio.subprocess.PIPE,
             limit=STDIO_BUFFER_LIMIT,
             env=env,
-            cwd=cwd,
+            cwd=config.cwd,
         )
-
-    @staticmethod
-    def _is_virtual_prefix(cwd: str, prefix: str) -> bool:
-        # Exact match or prefix followed by "/" — avoids false positives
-        # on real Linux paths like /home/username/... when the virtual
-        # prefix is /home/user.
-        return cwd == prefix or cwd.startswith(prefix + "/")
-
-    @staticmethod
-    def _resolve_cwd(config: AcpSessionConfig) -> str:
-        # Host mode needs the real filesystem path since the virtual
-        # sandbox path (/home/user/workspace) doesn't exist on the host.
-        if config.sandbox_provider == SandboxProviderType.HOST.value:
-            host_base = f"{settings.get_host_sandbox_base_dir()}/{config.sandbox_id}"
-            # Rewrite virtual sandbox paths (and sub-paths like worktrees)
-            # to real host paths. Check workspace first — its prefix is
-            # longer so it must win over the home-dir prefix.
-            if config.workspace_path and AcpSession._is_virtual_prefix(
-                config.cwd, SANDBOX_WORKSPACE_DIR
-            ):
-                return config.cwd.replace(
-                    SANDBOX_WORKSPACE_DIR, config.workspace_path, 1
-                )
-            if AcpSession._is_virtual_prefix(config.cwd, SANDBOX_HOME_DIR):
-                return config.cwd.replace(SANDBOX_HOME_DIR, host_base, 1)
-            return config.cwd
-        return config.cwd
 
     @staticmethod
     def _build_mcp_servers(

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -8,11 +8,7 @@ from uuid import UUID
 from sqlalchemy import update
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.constants import (
-    SANDBOX_GIT_ASKPASS_PATH,
-    SANDBOX_HOME_DIR,
-    SANDBOX_WORKSPACE_DIR,
-)
+from app.constants import SANDBOX_GIT_ASKPASS_PATH
 from app.core.config import get_settings
 from app.db.session import SessionLocal
 from app.models.db_models.chat import Chat
@@ -93,9 +89,9 @@ class AgentService:
         sandbox_provider = chat.sandbox_provider
         sandbox_id: str = chat.sandbox_id or ""
         workspace_path = chat.workspace_path
-        cwd = SANDBOX_HOME_DIR
-        if workspace_path:
-            cwd = SANDBOX_WORKSPACE_DIR
+        # "" is the canonical workspace-relative root cwd; providers resolve
+        # it to a runtime-absolute cwd at the edge.
+        cwd = ""
 
         agent_kind = MODELS[model_id].agent_kind
         stored_agent_kind = getattr(chat, "session_agent_kind", None)
@@ -316,12 +312,14 @@ class AgentService:
             sandbox_id = chat.sandbox_id
             sandbox_provider = chat.sandbox_provider
             workspace_path = chat.workspace_path
-            cwd = SANDBOX_WORKSPACE_DIR if workspace_path else SANDBOX_HOME_DIR
         else:
+            # No chat/sandbox (title/commit-message/etc. one-shot calls) — use
+            # $HOME as the workspace root so the session-create edge still
+            # resolves cwd uniformly via the provider.
             sandbox_id = ""
             sandbox_provider = SandboxProviderType.HOST.value
-            workspace_path = None
-            cwd = os.environ.get("HOME", "/tmp")
+            workspace_path = os.environ.get("HOME", "/tmp")
+        cwd = ""
 
         config = AcpSessionConfig(
             sandbox_id=sandbox_id,
@@ -383,7 +381,7 @@ class AgentService:
         model_id: str,
         session_id: str | None,
         thinking_mode: str | None = None,
-        cwd: str = SANDBOX_HOME_DIR,
+        cwd: str = "",
         sandbox_provider: str = SandboxProviderType.DOCKER.value,
         sandbox_id: str = "",
         workspace_path: str | None = None,

--- a/backend/app/services/git.py
+++ b/backend/app/services/git.py
@@ -1,3 +1,4 @@
+import posixpath
 import re
 import shlex
 from string import Template
@@ -407,14 +408,16 @@ class GitService:
     ) -> str:
         # The caller only opts into this path when it explicitly requested
         # worktree isolation, so setup failures must surface instead of
-        # silently reusing the shared workspace.
+        # silently reusing the shared workspace. Returned cwd stays
+        # workspace-relative so it slots straight into chat.worktree_cwd.
         short_id = chat_id[:8]
-        worktree_dir = f"{base_cwd}/.worktrees/{short_id}"
+        rel_base_worktrees = posixpath.join(base_cwd, ".worktrees")
+        rel_worktree = posixpath.join(rel_base_worktrees, short_id)
         branch_name = f"worktree-{short_id}"
         cd_prefix = git_cd_prefix(base_cwd)
         cmd = cd_prefix + GIT_WORKTREE_ADD_TEMPLATE.substitute(
-            worktree_dir=worktree_dir,
-            base_worktrees_dir=f"{base_cwd}/.worktrees",
+            worktree_dir=rel_worktree,
+            base_worktrees_dir=rel_base_worktrees,
             branch_name=branch_name,
         )
         # Local git operation — no user secrets needed, so bypass
@@ -424,7 +427,7 @@ class GitService:
             cmd,
         )
         if result.exit_code == 0:
-            return worktree_dir
+            return rel_worktree
         error_output = (result.stdout or result.stderr).strip()
         if not error_output:
             error_output = "Worktree mode requires a git workspace"

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -1,9 +1,10 @@
 import base64
 import logging
+import posixpath
 from pathlib import Path
 from typing import Any
 
-from app.constants import SANDBOX_BINARY_EXTENSIONS, SANDBOX_HOME_DIR
+from app.constants import SANDBOX_BINARY_EXTENSIONS
 from app.core.config import get_settings
 from app.services.sandbox_providers.types import (
     CommandResult,
@@ -14,6 +15,7 @@ from app.services.sandbox_providers.types import (
     PtySize,
     SandboxProviderType,
 )
+from app.utils.sandbox import normalize_relative_path
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -32,6 +34,13 @@ class SandboxProvider:
         # workspace-relative paths (e.g. mapping search results back to
         # file-tree entries).
         raise NotImplementedError
+
+    def resolve_workspace_path(self, rel_path: str | None) -> str:
+        # Workspace-relative path → runtime-absolute path. Used for agent cwd,
+        # file reads/writes, and list-files targets — any path the app hands
+        # to runtime that needs grounding in the provider's workspace root.
+        rel = normalize_relative_path(rel_path)
+        return posixpath.join(self.workspace_root, rel) if rel else self.workspace_root
 
     @staticmethod
     def create_provider(
@@ -100,8 +109,9 @@ class SandboxProvider:
     async def list_files(
         self,
         sandbox_id: str,
-        path: str = SANDBOX_HOME_DIR,
+        path: str = "",
     ) -> list[FileMetadata]:
+        # `path` is workspace-relative. Empty string means the workspace root.
         raise NotImplementedError
 
     async def create_pty(

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -1,12 +1,11 @@
 import asyncio
 import io
 import logging
-import posixpath
 import shlex
 import tarfile
 import uuid
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any
 
 import aiodocker
@@ -15,8 +14,6 @@ from app.constants import (
     DOCKER_STATUS_RUNNING,
     SANDBOX_BINARY_EXTENSIONS,
     SANDBOX_DEFAULT_COMMAND_TIMEOUT,
-    SANDBOX_HOME_DIR,
-    SANDBOX_WORKSPACE_DIR,
     TERMINAL_TYPE,
 )
 from app.services.exceptions import SandboxException
@@ -57,23 +54,6 @@ class LocalDockerProvider(SandboxProvider):
     @property
     def workspace_root(self) -> str:
         return f"{self.config.user_home}/workspace"
-
-    @staticmethod
-    def _normalize_path(file_path: str, base: str = SANDBOX_WORKSPACE_DIR) -> str:
-        # Convert a relative or absolute path into an absolute container path —
-        # Docker's tar APIs (get_archive/put_archive) require absolute paths.
-        # Base defaults to the workspace dir because that's where list_files
-        # roots, so relative paths from the file tree (e.g. ".worktrees/.../foo")
-        # must resolve under /home/user/workspace, not /home/user.
-        path = PurePosixPath(file_path)
-        if path.is_absolute():
-            path_str = str(path)
-            # Preserve any absolute path already under /home/user/ (covers both
-            # workspace paths and sibling home-dir paths like /home/user/.bashrc).
-            if path_str.startswith(SANDBOX_HOME_DIR):
-                return posixpath.normpath(path_str)
-            return posixpath.normpath(f"{base}{path}")
-        return posixpath.normpath(f"{base}/{path}")
 
     async def _get_docker(self) -> aiodocker.Docker:
         # Lazily create the aiodocker client on first use.
@@ -229,13 +209,9 @@ class LocalDockerProvider(SandboxProvider):
     async def list_files(
         self,
         sandbox_id: str,
-        path: str = SANDBOX_HOME_DIR,
+        path: str = "",
     ) -> list[FileMetadata]:
-        # Default to the workspace directory so the file tree shows project
-        # files, not shell dotfiles in ~/.
-        target_path = (
-            f"{self.config.user_home}/workspace" if path == SANDBOX_HOME_DIR else path
-        )
+        target_path = self.resolve_workspace_path(path)
 
         # Try git ls-files — handles .gitignore natively.
         git_result = await self.execute_command(
@@ -312,10 +288,13 @@ class LocalDockerProvider(SandboxProvider):
         container = await self._get_container(sandbox_id)
         env_list = [f"{k}={v}" for k, v in (envs or {}).items()]
 
+        # Exec from the workspace root so relative cwd prefixes (e.g.
+        # `cd '.worktrees/abc' && ...`) resolve against the project files,
+        # not the user's home dir.
         exec_obj = await container.exec(
             cmd=["bash", "-c", command],
             environment=env_list,
-            workdir=self.config.user_home,
+            workdir=self.workspace_root,
         )
 
         try:
@@ -337,7 +316,7 @@ class LocalDockerProvider(SandboxProvider):
         # Docker's put_archive API requires a tar stream — we create a single-file
         # tar in memory with uid/gid 1000 (the sandbox "user" account).
         container = await self._get_container(sandbox_id)
-        normalized_path = self._normalize_path(path)
+        normalized_path = self.resolve_workspace_path(path)
 
         content_bytes = content.encode("utf-8") if isinstance(content, str) else content
 
@@ -369,7 +348,7 @@ class LocalDockerProvider(SandboxProvider):
     ) -> FileContent:
         # Docker's get_archive returns a tar — extract the first member's content.
         container = await self._get_container(sandbox_id)
-        normalized_path = self._normalize_path(path)
+        normalized_path = self.resolve_workspace_path(path)
 
         tar_obj = await container.get_archive(normalized_path)
 

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -15,7 +15,6 @@ from typing import Any
 from app.constants import (
     SANDBOX_BINARY_EXTENSIONS,
     SANDBOX_DEFAULT_COMMAND_TIMEOUT,
-    SANDBOX_HOME_DIR,
     TERMINAL_TYPE,
 )
 from app.services.exceptions import SandboxException
@@ -28,6 +27,7 @@ from app.services.sandbox_providers.types import (
     PtySession,
     PtySize,
 )
+from app.utils.sandbox import normalize_relative_path
 
 logger = logging.getLogger(__name__)
 
@@ -172,14 +172,12 @@ class LocalHostProvider(SandboxProvider):
     async def list_files(
         self,
         sandbox_id: str,
-        path: str = SANDBOX_HOME_DIR,
+        path: str = "",
     ) -> list[FileMetadata]:
         # Use git ls-files for repos — handles .gitignore, global excludes,
         # and .git/info/exclude natively. Falls back to os.walk for non-git dirs.
-        if path == SANDBOX_HOME_DIR:
-            target_dir = self._workspace
-        else:
-            target_dir = self._resolve_path(path)
+        rel = normalize_relative_path(path)
+        target_dir = self._workspace if not rel else self._resolve_path(rel)
 
         result = await self.execute_command(
             sandbox_id,

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import shlex
-from pathlib import PurePosixPath
 
 from app.models.schemas.sandbox import (
     SearchFileResult,
@@ -10,7 +9,7 @@ from app.models.schemas.sandbox import (
 )
 from app.services.exceptions import SandboxException
 from app.services.sandbox import SandboxService
-from app.utils.sandbox import git_cd_prefix
+from app.utils.sandbox import normalize_relative_path
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +52,8 @@ class SearchService:
         # filtering so users don't get matches from node_modules, dist, etc.
         # Result paths are normalized to workspace-root-relative form so they
         # line up with the frontend file tree.
-        cd_prefix = git_cd_prefix(cwd)
+        rel_cwd = normalize_relative_path(cwd)
+        cd_prefix = f"cd '{rel_cwd}' && " if rel_cwd else ""
 
         flags = ["--json", "-n", f"--max-count={max_file_matches}", "--max-columns=500"]
         if not regex:
@@ -82,31 +82,10 @@ class SearchService:
                 err_text = err_text[:MAX_ERROR_LENGTH] + "…"
             raise SandboxException(f"Search failed: {err_text}")
 
-        path_prefix = self._compute_path_prefix(cwd)
+        path_prefix = f"{rel_cwd}/" if rel_cwd else ""
         return self._parse_rg_json(
             result.stdout, max_total_matches, max_file_matches, path_prefix
         )
-
-    def _compute_path_prefix(self, cwd: str | None) -> str:
-        # Translate cwd into a path relative to the file-tree root so rg's
-        # cwd-relative result paths match the workspace-root-relative paths
-        # used by the frontend file tree. Without this, worktree chats see
-        # rg return "src/App.tsx" while the tree holds ".worktrees/abc/src/App.tsx"
-        # and result clicks no-op.
-        if not cwd:
-            return ""
-        workspace = self.sandbox_service.provider.workspace_root
-        try:
-            rel = PurePosixPath(cwd).relative_to(workspace)
-        except ValueError:
-            # cwd lives outside the workspace root — we can't map its paths
-            # back to the file tree, so return them as-is. Result clicks
-            # will miss, but that's no worse than no prefix at all.
-            return ""
-        rel_str = str(rel)
-        if rel_str == ".":
-            return ""
-        return rel_str + "/"
 
     @staticmethod
     def _parse_rg_json(

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -131,6 +131,15 @@ class ChatStreamRuntime:
                     last_seq=start_seq,
                     active_stream_id=self.stream_id,
                 )
+            # Emit worktree_cwd up front so the frontend can patch the chat
+            # cache mid-turn; without this, branch/diff/editor actions during
+            # the turn would target the workspace root until end-of-stream
+            # invalidation refetches the chat.
+            if self.chat.worktree_cwd:
+                await self.emit_event(
+                    "system",
+                    {"data": {"worktree_cwd": self.chat.worktree_cwd}},
+                )
             await self._consume_stream(ai_service, stream_result, stream)
             await self._emit_prompt_suggestions()
 
@@ -442,27 +451,22 @@ class ChatStreamRuntime:
         if not new_session_id:
             return
         prev_session_id = self.session_container.get("session_id")
-        new_worktree_cwd = payload.get("worktree_cwd", self.chat.worktree_cwd)
-        if (
-            new_session_id == prev_session_id
-            and new_worktree_cwd == self.chat.worktree_cwd
-        ):
+        if new_session_id == prev_session_id:
             return
         self.session_container["session_id"] = new_session_id
         agent_kind = MODELS[self.model_id].agent_kind
         self.chat.session_id = new_session_id
         self.chat.session_agent_kind = agent_kind.value
-        self.chat.worktree_cwd = new_worktree_cwd
         try:
             async with self.session_factory() as db:
                 chat_uuid = UUID(self.chat_id)
-                values: dict[str, Any] = {
-                    "session_id": new_session_id,
-                    "session_agent_kind": agent_kind.value,
-                    "worktree_cwd": new_worktree_cwd,
-                }
                 await db.execute(
-                    update(Chat).where(Chat.id == chat_uuid).values(**values)
+                    update(Chat)
+                    .where(Chat.id == chat_uuid)
+                    .values(
+                        session_id=new_session_id,
+                        session_agent_kind=agent_kind.value,
+                    )
                 )
                 await db.commit()
         except (SQLAlchemyError, ValueError) as exc:

--- a/backend/app/utils/sandbox.py
+++ b/backend/app/utils/sandbox.py
@@ -1,26 +1,31 @@
 import re
 
-from app.constants import SANDBOX_HOME_DIR, SANDBOX_WORKSPACE_DIR
-
-# Try workspace dir first (Docker mounts), fall back to home dir (host sandboxes)
-GIT_CD_PREFIX = f"cd {SANDBOX_WORKSPACE_DIR} 2>/dev/null || cd {SANDBOX_HOME_DIR}; "
-# Guard against shell injection in branch names and cwd paths passed to exec
+# Guard against shell injection in branch names and workspace-relative cwd
+# paths passed to exec.
 BRANCH_NAME_RE = re.compile(r"^[\w./-]+$")
-CWD_PATH_RE = re.compile(r"^/[a-zA-Z0-9/_.\- ]+$")
 
 
-def normalize_sandbox_file_path(file_path: str) -> str:
-    # FastAPI captures the path param with a leading slash; strip it to make
-    # it relative to the sandbox home dir — but keep absolute paths that
-    # already point inside SANDBOX_HOME_DIR (e.g. /home/user/workspace/...).
-    if file_path.startswith("/") and not file_path.startswith(SANDBOX_HOME_DIR):
-        return file_path.lstrip("/")
-    return file_path
+def normalize_relative_path(path: str | None) -> str:
+    # Empty / None / "." / "./" all mean the workspace root. Rejecting absolute
+    # paths, `..` escapes, and quote/control characters protects the
+    # single-quoted `cd` prefix built in git_cd_prefix from breaking out while
+    # still allowing normal repo filenames like @scoped packages or names with
+    # punctuation.
+    if path is None:
+        return ""
+    if path.startswith("/"):
+        raise ValueError(f"Path must be workspace-relative, got absolute: {path}")
+    path = path.removeprefix("./")
+    if path in ("", "."):
+        return ""
+    if any(c in path for c in "\x00\n\r'") or ".." in path.split("/"):
+        raise ValueError(f"Invalid relative path: {path}")
+    return path
 
 
 def git_cd_prefix(cwd: str | None = None) -> str:
-    if not cwd:
-        return GIT_CD_PREFIX
-    if not CWD_PATH_RE.match(cwd):
-        raise ValueError("Invalid cwd path")
-    return f"cd '{cwd}' && "
+    # Providers exec from the workspace root, so an empty/root cwd needs no cd.
+    rel = normalize_relative_path(cwd)
+    if not rel:
+        return ""
+    return f"cd '{rel}' && "


### PR DESCRIPTION
## Summary
- App code now speaks in workspace-relative paths end-to-end (file APIs, git cwd, search cwd, persisted `chat.worktree_cwd`, ACP session config). Providers and ACP session spawn resolve to runtime-absolute paths at the edge via `SandboxProvider.resolve_workspace_path()` — the single translation site.
- Docker provider execs from the workspace root instead of `$HOME`, so a relative cwd prefix like `cd '.worktrees/abc' && ...` now resolves against project files rather than silently missing the workspace.
- `normalize_relative_path()` rejects absolute paths, `..` escapes, and quote/control characters at every boundary; the old bidirectional slash coercion in `UpdateFileRequest` / `normalize_sandbox_file_path` is gone, as are `SANDBOX_HOME_DIR` / `SANDBOX_WORKSPACE_DIR` app-level defaults and the dead `AcpSession._resolve_cwd` / `_is_virtual_prefix` helpers.
- `ChatStreamRuntime` emits `worktree_cwd` up front so the frontend patches the chat cache mid-turn — branch/diff/editor actions no longer target the workspace root until end-of-stream invalidation. ACP `field_meta.cwd` → `worktree_cwd` round-trip removed since it would echo back the resolved absolute path and corrupt persisted state.

## Test plan
- [ ] File APIs: read/write a path with no leading slash (`src/App.tsx`) — succeeds.
- [ ] File APIs: read/write with leading slash (`/src/App.tsx`) or `..` — returns 400.
- [ ] File tree: `list_files` with no `path` shows workspace files, not `~` dotfiles, on both Docker and Host providers.
- [ ] Global search: cwd-less and workspace-root (`""`) searches work; results paths match the file tree.
- [ ] Worktree chat: create a worktree chat, confirm `chat.worktree_cwd` persists as `.worktrees/<id>`; branch, diff, editor actions mid-turn target the worktree.
- [ ] Search inside a worktree chat: clicking a result opens the right file (paths match the tree).
- [ ] ACP one-shot (title/commit-message): still works with no workspace (host `$HOME` fallback).
- [ ] Existing chats with old virtual `chat.worktree_cwd` values error on next use (no migration shim by design) — users clear affected chats.