### PR TITLE
Surface truncated labels via title attrs and autofocus command menu search

### DIFF
--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -155,6 +155,7 @@ export const ModelSelector = memo(function ModelSelector({
                   ? 'text-text-primary dark:text-text-dark-primary'
                   : 'text-text-secondary dark:text-text-dark-secondary',
               )}
+              title={model.name}
             >
               {model.name}
             </span>

--- a/frontend/src/components/editor/file-search/SearchPanel.tsx
+++ b/frontend/src/components/editor/file-search/SearchPanel.tsx
@@ -3,6 +3,7 @@ import { CaseSensitive, Loader2, Regex, Search, WholeWord, X } from 'lucide-reac
 import type { LucideIcon } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { Input } from '@/components/ui/primitives/Input';
+import { useMountEffect } from '@/hooks/useMountEffect';
 import { useSearchInFilesQuery } from '@/hooks/queries/useSandboxQueries';
 import type { SearchParams } from '@/types/sandbox.types';
 import { cn } from '@/utils/cn';
@@ -39,6 +40,10 @@ export const SearchPanel = memo(function SearchPanel({
   const [activeLine, setActiveLine] = useState<{ path: string; line: number } | null>(null);
   const localInputRef = useRef<HTMLInputElement>(null);
   const activeInputRef = inputRef ?? localInputRef;
+
+  useMountEffect(() => {
+    inputRef?.current?.focus();
+  });
 
   const handleOpen = useCallback(
     (path: string, lineNumber: number) => {

--- a/frontend/src/components/ui/primitives/Dropdown.tsx
+++ b/frontend/src/components/ui/primitives/Dropdown.tsx
@@ -187,7 +187,10 @@ function DropdownInner<T>({
                 )}
               />
             )}
-            <span className={cn(labelClasses, 'text-inherit dark:text-inherit')}>
+            <span
+              className={cn(labelClasses, 'text-inherit dark:text-inherit')}
+              title={triggerLabel}
+            >
               {triggerLabel}
             </span>
           </>
@@ -201,7 +204,9 @@ function DropdownInner<T>({
                 )}
               />
             )}
-            <span className={labelClasses}>{triggerLabel}</span>
+            <span className={labelClasses} title={triggerLabel}>
+              {triggerLabel}
+            </span>
             {!disabled && (
               <ChevronDown className={`${chevronClasses} ${isOpen ? 'rotate-180' : ''}`} />
             )}


### PR DESCRIPTION
## Summary
- Add native `title` tooltip to `Dropdown` trigger label and `ModelSelector` row so truncated names remain discoverable on hover
- Autofocus `SearchPanel`'s input when the parent provides an `inputRef` (covers the `CommandMenu` search mode)

## Test plan
- [ ] Open model selector with a long model name — hover shows full name
- [ ] Open a narrow dropdown with a long label — hover shows full label
- [ ] Press Cmd+Shift+F in the command menu — search input is focused on mount