### PR TITLE
Switch Claude thinking budget to ACP effort and add Opus xhigh tier

### DIFF
--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -30,15 +30,6 @@ NATIVE_FILE_TYPES: dict[AgentKind, frozenset[str]] = {
 }
 
 
-# Claude uses MAX_THINKING_TOKENS env var (not a CLI arg) to cap the
-# extended-thinking budget. These map the UI's named tiers to token counts.
-THINKING_MODE_TOKENS: dict[str, int] = {
-    "low": 4000,
-    "medium": 10000,
-    "high": 15000,
-    "max": 32000,
-}
-
 # Maps UI permission modes to codex-acp launch-time approval_policy values.
 # "untrusted" = deny all writes, "on-request" = prompt for risky actions,
 # "never" = never prompt (auto-approve everything).
@@ -61,6 +52,7 @@ COPILOT_SESSION_MODE_IDS: dict[str, str] = {
 }
 
 CLAUDE_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "max"})
+CLAUDE_OPUS_VALID_THINKING_MODES = CLAUDE_VALID_THINKING_MODES | {"xhigh"}
 CODEX_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
 COPILOT_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
 
@@ -149,6 +141,7 @@ class AgentAdapter(ABC):
         *,
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
+        model_id: str,
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:
@@ -188,24 +181,27 @@ class ClaudeAgentAdapter(AgentAdapter):
         *,
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
+        model_id: str,
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:
         meta = build_system_prompt_meta(system_prompt, system_prompt_is_full_replace)
 
-        # Claude uses MAX_THINKING_TOKENS env var for thinking budget.
-        env_overrides: dict[str, str] = {}
-        max_thinking = THINKING_MODE_TOKENS.get(
-            coerce_thinking_mode(thinking_mode, CLAUDE_VALID_THINKING_MODES)
+        # Claude exposes thinking budget as the "effort" session config option,
+        # applied post-handshake via set_config_option; the UI's named tiers
+        # are passed through directly as effort level IDs. `xhigh` is currently
+        # only valid for the Opus alias we expose, so other Claude models keep
+        # the narrower tier set and coerce unsupported persisted values.
+        valid_modes = (
+            CLAUDE_OPUS_VALID_THINKING_MODES
+            if model_id == "opus[1m]"
+            else CLAUDE_VALID_THINKING_MODES
         )
-        if max_thinking:
-            env_overrides["MAX_THINKING_TOKENS"] = str(max_thinking)
+        reasoning_effort = coerce_thinking_mode(thinking_mode, valid_modes)
 
-        # Claude doesn't remap reasoning effort or permission modes —
-        # thinking is controlled via env var, permissions are session-level.
         return SessionConfig(
             meta=meta,
-            env_overrides=env_overrides,
+            reasoning_effort=reasoning_effort,
             permission=PermissionConfig(session_mode=permission_mode),
         )
 
@@ -257,6 +253,7 @@ class CodexAgentAdapter(AgentAdapter):
         *,
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
+        model_id: str,
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:
@@ -315,13 +312,13 @@ class CopilotCliAdapter(AgentAdapter):
         *,
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
+        model_id: str,
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:
         meta = build_system_prompt_meta(system_prompt, system_prompt_is_full_replace)
 
-        # Copilot ACP exposes reasoning effort directly rather than Claude's
-        # MAX_THINKING_TOKENS environment variable budget.
+        # Copilot ACP exposes reasoning effort as a CLI/ACP value directly.
         reasoning_effort = coerce_thinking_mode(
             thinking_mode, COPILOT_VALID_THINKING_MODES
         )
@@ -374,6 +371,7 @@ class CursorAgentAdapter(AgentAdapter):
         *,
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
+        model_id: str,
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:
@@ -426,6 +424,7 @@ class OpencodeAgentAdapter(AgentAdapter):
         *,
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
+        model_id: str,
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -60,6 +60,10 @@ NON_IMAGE_MIME: dict[str, str] = {
 
 EMPTY_FROZENSET: frozenset[str] = frozenset()
 
+# Claude's thinking budget is advertised as the "effort" session config
+# option; value IDs are the supported Claude UI tiers.
+CLAUDE_EFFORT_CONFIG_ID = "effort"
+
 
 @dataclass
 class AcpSessionConfig:
@@ -347,6 +351,23 @@ class AcpSession:
                 except Exception:
                     logger.warning(
                         "Failed to set initial mode: %s", config.permission_mode
+                    )
+
+            # Claude receives thinking budget via the "effort" session config
+            # option (not launch CLI args), so it must be applied after
+            # new_session/load_session. Codex bakes reasoning_effort into CLI
+            # args at launch, so it doesn't need this post-handshake step.
+            if config.agent_kind == AgentKind.CLAUDE and config.reasoning_effort:
+                try:
+                    await conn.set_config_option(
+                        config_id=CLAUDE_EFFORT_CONFIG_ID,
+                        session_id=acp_session_id,
+                        value=config.reasoning_effort,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to set initial effort: %s",
+                        config.reasoning_effort,
                     )
 
         except Exception as exc:

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -198,6 +198,10 @@ class AgentService:
                     item = get_event.result()
                     get_event = None
                     if AcpClientHandler.is_sentinel(item):
+                        # The prompt task may have failed just before finish()
+                        # queued the sentinel; surface that real ACP error
+                        # instead of letting the runtime report an empty stream.
+                        prompt_task.result()
                         break
                     yield cast(StreamEvent, item)
                 else:
@@ -406,6 +410,7 @@ class AgentService:
         session_config = adapter.build_session_config(
             system_prompt=system_prompt,
             system_prompt_is_full_replace=system_prompt_is_full_replace,
+            model_id=model_id,
             thinking_mode=thinking_mode,
             permission_mode=permission_mode,
         )

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -915,7 +915,7 @@ class ChatStreamRuntime:
         try:
             message_service = MessageService(session_factory=session_factory)
             message = await message_service.get_message(UUID(assistant_message_id))
-            if not message or message.stream_status != MessageStreamStatus.IN_PROGRESS:
+            if not message:
                 return
             stream_id = uuid4()
             payload = {"error": error_message}

--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -50,6 +50,7 @@ export function InputControls() {
           <ThinkingModeSelector
             chatId={state.chatId}
             agentKind={agentKind}
+            modelId={state.selectedModelId}
             dropdownPosition={state.dropdownPosition}
             dropdownAlign="right"
             disabled={state.isLoading}

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -220,6 +220,7 @@ export function InputProvider({
       const thinkingMode = coerceThinkingModeForAgent(
         settings.thinkingModeByChat[chatId] ?? DEFAULT_THINKING_MODE,
         agentKind,
+        selectedModelId,
       );
       const worktree = settings.worktreeByChat[chatId] ?? DEFAULT_WORKTREE;
       const planMode =

--- a/frontend/src/components/chat/sub-threads/CreateSubThreadDialog.tsx
+++ b/frontend/src/components/chat/sub-threads/CreateSubThreadDialog.tsx
@@ -12,6 +12,7 @@ import { SlashCommandsPanel } from '@/components/chat/message-input/SlashCommand
 import {
   THINKING_MODES_BY_AGENT,
   coerceThinkingModeForAgent,
+  getThinkingModesForAgent,
   type ThinkingModeOption,
 } from '@/components/chat/thinking-mode-selector/ThinkingModeSelector';
 import {
@@ -60,10 +61,14 @@ export function CreateSubThreadDialog({ parentChat, onClose }: CreateSubThreadDi
   const selectedModel = models.find((m) => m.model_id === selectedModelId);
   const agentKind = selectedModel?.agent_kind ?? 'claude';
   const permissionModes = MODES_BY_AGENT[agentKind];
-  const thinkingModes = THINKING_MODES_BY_AGENT[agentKind];
+  const thinkingModes = getThinkingModesForAgent(agentKind, selectedModelId);
   const effectivePermissionMode = coercePermissionModeForAgent(permissionMode, agentKind);
   const selectedPermissionOption = getPermissionModeOption(permissionMode, agentKind);
-  const effectiveThinkingMode = coerceThinkingModeForAgent(thinkingMode.value, agentKind);
+  const effectiveThinkingMode = coerceThinkingModeForAgent(
+    thinkingMode.value,
+    agentKind,
+    selectedModelId,
+  );
   const selectedThinkingOption =
     thinkingModes.find((mode) => mode.value === effectiveThinkingMode) ?? thinkingModes[0];
 

--- a/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
+++ b/frontend/src/components/chat/thinking-mode-selector/ThinkingModeSelector.tsx
@@ -20,6 +20,13 @@ const CLAUDE_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'high', label: 'High' },
   { value: 'max', label: 'Max' },
 ];
+const CLAUDE_OPUS_THINKING_MODES: ThinkingModeOption[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'xhigh', label: 'XHigh' },
+  { value: 'max', label: 'Max' },
+];
 
 const CODEX_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'low', label: 'Low' },
@@ -49,8 +56,24 @@ const DEFAULT_BY_AGENT: Record<AgentKind, string> = {
   opencode: 'medium',
 };
 
-export function coerceThinkingModeForAgent(thinkingMode: string, agentKind: AgentKind): string {
-  const modes = THINKING_MODES_BY_AGENT[agentKind];
+export function getThinkingModesForAgent(
+  agentKind: AgentKind,
+  modelId?: string,
+): ThinkingModeOption[] {
+  // Claude exposes `xhigh` only for the Opus alias we map to Opus 4.7.
+  if (agentKind === 'claude' && modelId === 'opus[1m]') {
+    return CLAUDE_OPUS_THINKING_MODES;
+  }
+
+  return THINKING_MODES_BY_AGENT[agentKind];
+}
+
+export function coerceThinkingModeForAgent(
+  thinkingMode: string,
+  agentKind: AgentKind,
+  modelId?: string,
+): string {
+  const modes = getThinkingModesForAgent(agentKind, modelId);
   const defaultMode = DEFAULT_BY_AGENT[agentKind];
   return modes.find((mode) => mode.value === thinkingMode)?.value ?? defaultMode;
 }
@@ -58,10 +81,11 @@ export function coerceThinkingModeForAgent(thinkingMode: string, agentKind: Agen
 function getThinkingModeOption(
   thinkingMode: string,
   agentKind: AgentKind,
+  modelId?: string,
 ): ThinkingModeOption | null {
-  const modes = THINKING_MODES_BY_AGENT[agentKind];
+  const modes = getThinkingModesForAgent(agentKind, modelId);
   if (modes.length === 0) return null;
-  const effectiveMode = coerceThinkingModeForAgent(thinkingMode, agentKind);
+  const effectiveMode = coerceThinkingModeForAgent(thinkingMode, agentKind, modelId);
   const selectedMode = modes.find((mode) => mode.value === effectiveMode);
 
   if (!selectedMode) {
@@ -74,6 +98,7 @@ function getThinkingModeOption(
 export interface ThinkingModeSelectorProps {
   chatId?: string;
   agentKind?: AgentKind;
+  modelId?: string;
   dropdownPosition?: 'top' | 'bottom';
   disabled?: boolean;
   variant?: 'default' | 'text';
@@ -83,6 +108,7 @@ export interface ThinkingModeSelectorProps {
 export const ThinkingModeSelector = memo(function ThinkingModeSelector({
   chatId,
   agentKind,
+  modelId,
   dropdownPosition = 'bottom',
   dropdownAlign,
   disabled = false,
@@ -95,8 +121,8 @@ export const ThinkingModeSelector = memo(function ThinkingModeSelector({
   );
   const isSplitMode = useIsSplitMode();
 
-  const modes = THINKING_MODES_BY_AGENT[resolvedAgentKind];
-  const selectedMode = getThinkingModeOption(thinkingMode, resolvedAgentKind);
+  const modes = getThinkingModesForAgent(resolvedAgentKind, modelId);
+  const selectedMode = getThinkingModeOption(thinkingMode, resolvedAgentKind, modelId);
 
   // Some agents (e.g. Cursor) don't expose a thinking-mode control because
   // reasoning effort is chosen at the model level. Hide the selector entirely.

--- a/frontend/src/hooks/useMessageActions.ts
+++ b/frontend/src/hooks/useMessageActions.ts
@@ -108,6 +108,7 @@ export function useMessageActions({
         const effectiveThinkingMode = coerceThinkingModeForAgent(
           thinkingMode ?? 'medium',
           agentKind,
+          selectedModelId,
         );
 
         const request: ChatRequest = {


### PR DESCRIPTION
## Summary
- Replace Claude's MAX_THINKING_TOKENS env override with the ACP `effort` session config option, applied post-handshake via `set_config_option`
- Add `xhigh` thinking tier exposed only for the Opus 4.7 alias (`opus[1m]`); thread `modelId` through the frontend thinking-mode selector, coercion, and sub-thread dialog so UI options track the selected model
- Surface real ACP prompt-task errors by re-raising on sentinel instead of letting the runtime report an empty stream
- Relax final-error persistence guard so errors can be recorded regardless of the message's current stream status

## Test plan
- [ ] Select Opus 4.7 and verify `XHigh` appears in the thinking-mode menu
- [ ] Select a non-Opus Claude model and verify only low/medium/high/max show
- [ ] Send a prompt with each Claude tier and confirm effort is applied
- [ ] Trigger an ACP prompt failure and confirm the real error surfaces