### PR TITLE
Move git hooks to repo root

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+
+cd frontend
+npx lint-staged
+cd ..
+
+# Backend CI runs Ruff on the whole backend tree. Running the shared pre-commit
+# hooks on staged backend paths catches the same failures before PR creation.
+backend_files=$(git diff --cached --name-only --diff-filter=ACMR | grep '^backend/' || true)
+if [ -n "$backend_files" ]; then
+  pre-commit run --files $backend_files
+fi

--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ docker compose down
 docker compose logs -f
 ```
 
+### Developer hooks
+
+The repo uses a root `.githooks/pre-commit` hook for frontend staged-file checks and backend `ruff` linting. Point Git at the repo hook directory once per clone:
+
+```bash
+./scripts/install-hooks.sh
+pip install pre-commit
+pre-commit run --all-files
+```
+
 ### Default web ports
 
 - Frontend: `3000`

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,1 +1,0 @@
-cd frontend && npx lint-staged

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,7 +55,6 @@
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.11",
         "globals": "^15.9.0",
-        "husky": "^9.1.7",
         "lint-staged": "^15.2.10",
         "postcss": "^8.5.6",
         "prettier": "^3.4.2",
@@ -3819,22 +3818,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "desktop:dev": "tauri dev",
-    "desktop:build": "tauri build",
-    "prepare": "cd .. && husky frontend/.husky"
+    "desktop:build": "tauri build"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
@@ -65,7 +64,6 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
-    "husky": "^9.1.7",
     "lint-staged": "^15.2.10",
     "postcss": "^8.5.6",
     "prettier": "^3.4.2",

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -e
+
+repo_root=$(git rev-parse --show-toplevel)
+git -C "$repo_root" config core.hooksPath .githooks
+echo "Configured core.hooksPath=.githooks"


### PR DESCRIPTION
## Summary
- move the shared pre-commit hook to a repo-owned `.githooks` directory
- add a small install script that sets `core.hooksPath` for the clone
- remove the frontend Husky-owned hook wiring and document the new setup

## Testing
- ran `pre-commit run --all-files`
- ran `./scripts/install-hooks.sh`
- ran `./.githooks/pre-commit`