### PR TITLE
Use model_instructions_file for Codex persona mode

### DIFF
--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -132,6 +132,7 @@ class AgentAdapter(ABC):
         reasoning_effort: str | None,
         permission_mode: str | None,
         launch_approval_policy: str | None,
+        instructions_file_path: str | None = None,
     ) -> LaunchConfig:
         raise NotImplementedError
 
@@ -172,6 +173,7 @@ class ClaudeAgentAdapter(AgentAdapter):
         reasoning_effort: str | None,
         permission_mode: str | None,
         launch_approval_policy: str | None,
+        instructions_file_path: str | None = None,
     ) -> LaunchConfig:
         # Claude doesn't use CLI args — all config is via env vars and session meta.
         return LaunchConfig(binary="claude-agent-acp")
@@ -222,6 +224,7 @@ class CodexAgentAdapter(AgentAdapter):
         reasoning_effort: str | None,
         permission_mode: str | None,
         launch_approval_policy: str | None,
+        instructions_file_path: str | None = None,
     ) -> LaunchConfig:
         # Codex uses CLI -c flags for all customization (instructions,
         # reasoning effort, sandbox permissions, approval policy).
@@ -229,15 +232,23 @@ class CodexAgentAdapter(AgentAdapter):
         # Required for Codex to expose ACP session modes (auto/read-only/full-access).
         args.extend(["-c", "features.collaboration_modes=true"])
         if system_prompt:
-            # Codex has separate base vs developer instruction channels.
-            # Personas replace the base instructions entirely, while normal
-            # app-level additions should append as developer instructions.
-            instruction_key = (
-                "base_instructions"
-                if system_prompt_is_full_replace
-                else "developer_instructions"
-            )
-            args.extend(["-c", instruction_key + "=" + json.dumps(system_prompt)])
+            if system_prompt_is_full_replace and instructions_file_path:
+                # Codex ignores base_instructions for replacing the full system
+                # prompt, so the caller writes the prompt to a file we point
+                # Codex at via model_instructions_file, and we disable the
+                # default personality so the file is the sole instruction set.
+                args.extend(["-c", "features.personality=false"])
+                args.extend(["-c", 'personality="none"'])
+                args.extend(
+                    [
+                        "-c",
+                        f"model_instructions_file={json.dumps(instructions_file_path)}",
+                    ]
+                )
+            else:
+                args.extend(
+                    ["-c", "developer_instructions=" + json.dumps(system_prompt)]
+                )
         if reasoning_effort:
             args.extend(["-c", f'model_reasoning_effort="{reasoning_effort}"'])
         if launch_approval_policy == "never":
@@ -304,6 +315,7 @@ class CopilotCliAdapter(AgentAdapter):
         reasoning_effort: str | None,
         permission_mode: str | None,
         launch_approval_policy: str | None,
+        instructions_file_path: str | None = None,
     ) -> LaunchConfig:
         return LaunchConfig(binary="copilot", cli_args=["--acp", "--stdio"])
 
@@ -363,6 +375,7 @@ class CursorAgentAdapter(AgentAdapter):
         reasoning_effort: str | None,
         permission_mode: str | None,
         launch_approval_policy: str | None,
+        instructions_file_path: str | None = None,
     ) -> LaunchConfig:
         return LaunchConfig(binary="cursor-agent", cli_args=["acp"])
 
@@ -416,6 +429,7 @@ class OpencodeAgentAdapter(AgentAdapter):
         reasoning_effort: str | None,
         permission_mode: str | None,
         launch_approval_policy: str | None,
+        instructions_file_path: str | None = None,
     ) -> LaunchConfig:
         return LaunchConfig(binary="opencode", cli_args=["acp"])
 

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -84,6 +84,9 @@ class AcpSessionConfig:
     system_prompt_is_full_replace: bool = False
     reasoning_effort: str | None = None
     session_meta: dict[str, Any] = field(default_factory=dict)
+    # Codex-only: absolute path to a model_instructions_file written before spawn
+    # when doing a full system prompt replacement (persona mode).
+    codex_instructions_file_path: str | None = None
 
 
 class AcpSession:
@@ -286,6 +289,26 @@ class AcpSession:
             workspace_path=config.workspace_path,
         )
         spawn_config = replace(config, cwd=provider.resolve_workspace_path(config.cwd))
+
+        # Codex ignores base_instructions for full system prompt replacement,
+        # so we write the prompt to a sandbox file and point Codex at it via
+        # model_instructions_file (emitted by the Codex adapter).
+        if (
+            config.system_prompt_is_full_replace
+            and config.system_prompt
+            and config.agent_kind == AgentKind.CODEX
+        ):
+            instructions_rel_path = ".codex/instructions.md"
+            await provider.write_file(
+                config.sandbox_id, instructions_rel_path, config.system_prompt
+            )
+            spawn_config = replace(
+                spawn_config,
+                codex_instructions_file_path=provider.resolve_workspace_path(
+                    instructions_rel_path
+                ),
+            )
+
         process = await cls._spawn_process(spawn_config)
 
         if process.stdin is None or process.stdout is None:
@@ -432,6 +455,7 @@ class AcpSession:
             reasoning_effort=config.reasoning_effort,
             permission_mode=config.permission_mode,
             launch_approval_policy=config.launch_approval_policy,
+            instructions_file_path=config.codex_instructions_file_path,
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Codex ignores `base_instructions` for full system prompt replacement, which broke persona mode.
- Write the persona prompt to `.codex/instructions.md` in the sandbox before spawning.
- Pass the file path via `-c model_instructions_file=...` in the Codex adapter.
- Disable the default personality (`features.personality=false`, `personality="none"`) so the instructions file is the sole instruction set.
- Non-full-replace mode continues to use `developer_instructions` as before.

## Test plan
- [ ] Start a new chat with a Codex model and a custom persona — verify the persona instructions are respected.
- [ ] Start a Codex chat without a persona — verify default behavior is unchanged.