### PR TITLE
Gate personas to agents whose CLI honors a replaced system prompt

### DIFF
--- a/backend/app/prompts/system_prompt.py
+++ b/backend/app/prompts/system_prompt.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+from app.services.acp.adapters import AgentKind, PERSONAS_SUPPORTED_AGENTS
+
 if TYPE_CHECKING:
     from app.models.db_models.user import UserSettings
 
@@ -28,10 +30,19 @@ DEFAULT_PERSONA_NAME = "Default"
 
 def build_system_prompt_for_chat(
     user_settings: "UserSettings",
+    agent_kind: AgentKind,
     selected_persona_name: str = DEFAULT_PERSONA_NAME,
 ) -> str:
     persona_content = ""
-    if selected_persona_name != DEFAULT_PERSONA_NAME and user_settings.personas:
+    # Only apply the persona for agents whose CLI honors a replaced system
+    # prompt; for others (cursor, copilot, opencode) the persona would be
+    # silently dropped, so skip it here and keep the prompt suggestions
+    # instructions unchanged.
+    if (
+        agent_kind in PERSONAS_SUPPORTED_AGENTS
+        and selected_persona_name != DEFAULT_PERSONA_NAME
+        and user_settings.personas
+    ):
         persona = next(
             (
                 p

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -63,6 +63,15 @@ CURSOR_SESSION_MODES = frozenset({"agent", "plan", "ask"})
 # restricts edits to `.opencode/plans/*.md`, `build` has full tool access.
 OPENCODE_SESSION_MODES = frozenset({"build", "plan"})
 
+# Agents that can have their base system prompt replaced by a persona.
+# Claude/Codex expose a first-class mechanism (ACP _meta.systemPrompt for
+# Claude; model_instructions_file CLI flag for Codex). Cursor, Copilot, and
+# OpenCode CLIs silently ignore any system prompt we send over ACP, so
+# personas would have no effect there — we hide the selector instead.
+PERSONAS_SUPPORTED_AGENTS: frozenset[AgentKind] = frozenset(
+    {AgentKind.CLAUDE, AgentKind.CODEX}
+)
+
 
 def coerce_thinking_mode(mode: str | None, valid_modes: frozenset[str]) -> str:
     # Normalises the UI's named thinking tier to one the agent actually accepts,

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -807,8 +807,10 @@ class ChatService(BaseDbService[Chat]):
             stream_status=MessageStreamStatus.IN_PROGRESS,
         )
 
+        model = MODELS[request.model_id]
         system_prompt = build_system_prompt_for_chat(
             user_settings,
+            agent_kind=model.agent_kind,
             selected_persona_name=request.selected_persona_name,
         )
         try:
@@ -825,7 +827,7 @@ class ChatService(BaseDbService[Chat]):
                 worktree=request.worktree,
                 plan_mode=request.plan_mode,
                 attachments=attachments,
-                context_window=MODELS[request.model_id].context_window,
+                context_window=model.context_window,
                 selected_persona_name=request.selected_persona_name,
             )
         except Exception as e:

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -757,11 +757,13 @@ class ChatStreamRuntime:
         # Queue items come from QueueService.add_message, so all behavioral
         # fields must already exist here.
         selected_persona_name = queued_msg["selected_persona_name"]
+        model = MODELS[queued_msg["model_id"]]
         system_prompt = build_system_prompt_for_chat(
             user_settings,
+            agent_kind=model.agent_kind,
             selected_persona_name=selected_persona_name,
         )
-        context_window = MODELS[queued_msg["model_id"]].context_window
+        context_window = model.context_window
         resolved_session_id = session_id_override or chat.session_id
         return ChatStreamRequest(
             prompt=queued_msg["content"],

--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -4,7 +4,10 @@ import {
   THINKING_MODES_BY_AGENT,
   ThinkingModeSelector,
 } from '@/components/chat/thinking-mode-selector/ThinkingModeSelector';
-import { PersonaSelector } from '@/components/chat/persona-selector/PersonaSelector';
+import {
+  PersonaSelector,
+  PERSONAS_SUPPORTED_AGENTS,
+} from '@/components/chat/persona-selector/PersonaSelector';
 import { BranchSelector } from '@/components/chat/branch-selector/BranchSelector';
 import { useInputState, useInputActions } from '@/hooks/useInputContext';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
@@ -26,7 +29,8 @@ export function InputControls() {
   const worktreeCwd = useChatStore((s) => s.currentChat?.worktree_cwd) ?? undefined;
   const { data: branchesData } = useGitBranchesQuery(sandboxId, !!sandboxId, worktreeCwd);
 
-  const showPersona = personas.length > 0;
+  const showPersona =
+    personas.length > 0 && (!agentKind || PERSONAS_SUPPORTED_AGENTS.has(agentKind));
   const showBranch = !!sandboxId && !!branchesData?.is_git_repo && branchesData.branches.length > 0;
   const showThinking = agentKind ? THINKING_MODES_BY_AGENT[agentKind].length > 0 : true;
 

--- a/frontend/src/components/chat/persona-selector/PersonaSelector.tsx
+++ b/frontend/src/components/chat/persona-selector/PersonaSelector.tsx
@@ -8,6 +8,16 @@ import {
 } from '@/store/chatSettingsStore';
 import { useIsSplitMode } from '@/hooks/useIsSplitMode';
 import { useChatContext } from '@/hooks/useChatContext';
+import type { AgentKind } from '@/types/chat.types';
+
+// Only Claude and Codex CLIs honor a replaced system prompt (Claude via ACP
+// _meta.systemPrompt; Codex via model_instructions_file). Cursor, Copilot, and
+// OpenCode silently ignore it, so personas are hidden for those agents and
+// the backend skips applying them as well.
+export const PERSONAS_SUPPORTED_AGENTS: ReadonlySet<AgentKind> = new Set<AgentKind>([
+  'claude',
+  'codex',
+]);
 
 interface PersonaOption {
   value: string;

--- a/frontend/src/components/settings/tabs/PersonasSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/PersonasSettingsTab.tsx
@@ -18,7 +18,7 @@ export const PersonasSettingsTab: React.FC<PersonasSettingsTabProps> = ({
   return (
     <ListManagementTab<Persona>
       title="Personas"
-      description="Create personas with custom system prompts. Select from the persona dropdown in the input bar."
+      description="Create personas with custom system prompts. Select from the persona dropdown in the input bar. Only Claude and Codex support replacing the system prompt; the persona selector is hidden for Cursor, Copilot, and OpenCode."
       items={personas}
       emptyIcon={UserCircle}
       emptyText="No personas configured yet"


### PR DESCRIPTION
## Summary
- Cursor, Copilot, and OpenCode CLIs silently ignore the system prompt passed over ACP, so selecting a persona had no effect on those agents.
- Added `PERSONAS_SUPPORTED_AGENTS = {claude, codex}` on both backend and frontend. Claude replaces the system prompt via ACP `_meta.systemPrompt`; Codex uses `model_instructions_file` (landed in #541).
- Backend: `build_system_prompt_for_chat` now takes `agent_kind` and skips the persona when the agent isn't supported; callers in `chat.py` and `streaming/runtime.py` derive it from `MODELS[model_id].agent_kind`.
- Frontend: `PersonaSelector` is hidden in the input bar for unsupported agents, and the Personas settings tab description notes the limitation.
- OpenCode technically supports prompt replacement via a custom-agent markdown file + `--agent` flag, but that's a separate integration — hidden here along with cursor/copilot.

## Test plan
- [ ] Select a Claude model, pick a persona, send a message — persona applies as before.
- [ ] Select a Codex model, pick a persona, send a message — persona applies via `model_instructions_file`.
- [ ] Switch to a Cursor / Copilot / OpenCode model — persona selector disappears from the input bar.
- [ ] Open Settings → Personas — description mentions Claude/Codex only.
- [ ] Queue a message on a Claude chat, then switch the queued chat's agent to Cursor — backend drops the persona when the queue item is drained.