### PR TITLE
Replace blocking update dialog with in-menu update flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useState, Suspense, lazy } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { Layout } from '@/components/layout/Layout';
 import { Toaster } from 'react-hot-toast';
-import toast from 'react-hot-toast';
 import { useAuthStore } from '@/store/authStore';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { useCurrentUserQuery } from '@/hooks/queries/useAuthQueries';
@@ -17,9 +16,8 @@ import { AuthRoute } from '@/components/routes/AuthRoute';
 import { setApiPort } from '@/lib/api';
 import { isTauri, invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { check } from '@tauri-apps/plugin-updater';
-import { ask } from '@tauri-apps/plugin-dialog';
 import { authStorage } from '@/utils/storage';
+import { checkDesktopUpdate } from '@/services/desktopUpdateService';
 import { DesktopDragRegion } from '@/components/layout/TitleBar';
 
 const LandingPage = lazy(() =>
@@ -40,27 +38,6 @@ const ResetPasswordPage = lazy(() =>
   import('@/pages/ResetPasswordPage').then((m) => ({ default: m.ResetPasswordPage })),
 );
 const SettingsPage = lazy(() => import('@/pages/SettingsPage'));
-
-async function checkDesktopUpdate(): Promise<void> {
-  const update = await check();
-  if (!update?.available) {
-    return;
-  }
-
-  const shouldInstall = await ask(`Agentrove ${update.version} is available. Install now?`, {
-    title: 'Update Available',
-    kind: 'info',
-  });
-  if (!shouldInstall) {
-    return;
-  }
-
-  toast.loading('Downloading desktop update...', { id: 'desktop-update' });
-  await update.downloadAndInstall();
-  toast.success(`Agentrove ${update.version} installed. Restart app to finish update.`, {
-    id: 'desktop-update',
-  });
-}
 
 function AppContent() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,17 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useNavigate } from 'react-router-dom';
-import {
-  Plus,
-  MoreHorizontal,
-  SquarePen,
-  ChevronDown,
-  Settings,
-  LogOut,
-  Sun,
-  Moon,
-  Monitor,
-} from 'lucide-react';
+import { Plus, MoreHorizontal, SquarePen, ChevronDown } from 'lucide-react';
 import toast from 'react-hot-toast';
 import type { Chat } from '@/types/chat.types';
 import type { Workspace } from '@/types/workspace.types';
@@ -36,33 +26,13 @@ import { useStreamStore } from '@/store/streamStore';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useCurrentUserQuery, useLogoutMutation } from '@/hooks/queries/useAuthQueries';
 import { useAuthStore } from '@/store/authStore';
-import { UserAvatarCircle } from '@/components/chat/message-bubble/MessageAvatars';
+import { UserProfileMenu } from './UserProfileMenu';
 import { SidebarChatItem } from './SidebarChatItem';
 import { SubThreadList } from './SubThreadList';
 import { ChatDropdown } from './ChatDropdown';
 import { DROPDOWN_WIDTH, DROPDOWN_HEIGHT, DROPDOWN_MARGIN } from '@/config/constants';
 
 const CHATS_PER_WORKSPACE = 5;
-
-const THEME_ICON_MAP = { dark: Sun, light: Moon, system: Monitor } as const;
-const THEME_NEXT_LABEL = { dark: 'light', light: 'system', system: 'dark' } as const;
-
-function ThemeToggle() {
-  const theme = useUIStore((state) => state.theme);
-  const Icon = THEME_ICON_MAP[theme as keyof typeof THEME_ICON_MAP] ?? Monitor;
-  const nextLabel = THEME_NEXT_LABEL[theme as keyof typeof THEME_NEXT_LABEL] ?? 'dark';
-  return (
-    <Button
-      onClick={() => useUIStore.getState().toggleTheme()}
-      variant="unstyled"
-      className="rounded-full p-1.5 text-text-quaternary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-      aria-label="Toggle theme"
-      title={`Switch to ${nextLabel} mode`}
-    >
-      <Icon className="h-3.5 w-3.5" />
-    </Button>
-  );
-}
 
 async function mutateWithToast<T>(
   mutateFn: () => Promise<T>,
@@ -711,36 +681,11 @@ export function Sidebar({
 
         {/* User profile — fixed at sidebar bottom; always rendered so settings/logout are accessible even if the user query is loading or failed */}
         <div className="flex-shrink-0 border-t border-border/50 px-4 py-2.5 dark:border-border-dark/50">
-          <div className="flex items-center gap-2.5">
-            <UserAvatarCircle displayName={userDisplayName} size="large" />
-            {userDisplayName && (
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-xs font-medium text-text-primary dark:text-text-dark-primary">
-                  {userDisplayName}
-                </p>
-              </div>
-            )}
-            {!userDisplayName && <div className="flex-1" />}
-            <ThemeToggle />
-            <Button
-              onClick={() => navigate('/settings')}
-              variant="unstyled"
-              className="rounded-full p-1.5 text-text-quaternary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-              aria-label="Settings"
-              title="Settings"
-            >
-              <Settings className="h-3.5 w-3.5" />
-            </Button>
-            <Button
-              onClick={() => logoutMutation.mutate()}
-              variant="unstyled"
-              className="rounded-full p-1.5 text-text-quaternary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-              aria-label="Sign out"
-              title="Sign out"
-            >
-              <LogOut className="h-3.5 w-3.5" />
-            </Button>
-          </div>
+          <UserProfileMenu
+            displayName={userDisplayName}
+            onOpenSettings={() => navigate('/settings')}
+            onSignOut={() => logoutMutation.mutate()}
+          />
         </div>
       </aside>
 

--- a/frontend/src/components/layout/UserProfileMenu.tsx
+++ b/frontend/src/components/layout/UserProfileMenu.tsx
@@ -1,0 +1,225 @@
+import { Download, Loader2, AlertCircle, Settings, LogOut, Sun, Moon, Monitor } from 'lucide-react';
+import { UserAvatarCircle } from '@/components/chat/message-bubble/MessageAvatars';
+import { Button } from '@/components/ui/primitives/Button';
+import { useDesktopUpdateStore } from '@/store/updateStore';
+import { useUIStore } from '@/store/uiStore';
+import { useDropdown } from '@/hooks/useDropdown';
+import { formatBytes } from '@/utils/format';
+import { checkDesktopUpdate } from '@/services/desktopUpdateService';
+import { cn } from '@/utils/cn';
+
+const THEME_ICON_MAP = { dark: Moon, light: Sun, system: Monitor } as const;
+const THEME_LABEL_MAP = { dark: 'Dark', light: 'Light', system: 'System' } as const;
+
+const MENU_ITEM_CLASS =
+  'flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left ' +
+  'text-text-secondary hover:bg-surface-hover hover:text-text-primary ' +
+  'dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary ' +
+  'transition-colors duration-200';
+
+interface UserProfileMenuProps {
+  displayName: string | undefined;
+  onOpenSettings: () => void;
+  onSignOut: () => void;
+}
+
+export function UserProfileMenu({ displayName, onOpenSettings, onSignOut }: UserProfileMenuProps) {
+  const updateStatus = useDesktopUpdateStore((s) => s.status);
+  const updateVersion = useDesktopUpdateStore((s) => s.version);
+  const downloadedBytes = useDesktopUpdateStore((s) => s.downloadedBytes);
+  const totalBytes = useDesktopUpdateStore((s) => s.totalBytes);
+  const releaseNotes = useDesktopUpdateStore((s) => s.releaseNotes);
+  const errorMessage = useDesktopUpdateStore((s) => s.errorMessage);
+
+  const theme = useUIStore((s) => s.theme);
+  const ThemeIcon = THEME_ICON_MAP[theme];
+
+  const { isOpen, dropdownRef, setIsOpen } = useDropdown();
+
+  const hasUpdate = updateStatus !== 'idle';
+  const progress = totalBytes && totalBytes > 0 ? Math.min(1, downloadedBytes / totalBytes) : null;
+
+  function handleInstall() {
+    const trigger = useDesktopUpdateStore.getState().triggerInstall;
+    if (!trigger) return;
+    void trigger();
+  }
+
+  function handleRetry() {
+    checkDesktopUpdate().catch((error) => {
+      console.error('Desktop updater retry failed:', error);
+    });
+  }
+
+  return (
+    <div ref={dropdownRef} className="relative flex items-center gap-2.5">
+      <Button
+        variant="unstyled"
+        onClick={() => setIsOpen((v) => !v)}
+        className="flex min-w-0 flex-1 items-center gap-2.5 rounded-md text-left"
+        aria-label="Open user menu"
+      >
+        <span className="relative flex-shrink-0">
+          <UserAvatarCircle displayName={displayName} size="large" />
+          {hasUpdate && (
+            <span
+              className={cn(
+                'absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full',
+                'bg-text-primary dark:bg-text-dark-primary',
+                'ring-2 ring-surface-secondary dark:ring-surface-dark-secondary',
+              )}
+            />
+          )}
+        </span>
+        {displayName && (
+          <span className="min-w-0 flex-1 truncate text-xs font-medium text-text-primary dark:text-text-dark-primary">
+            {displayName}
+          </span>
+        )}
+      </Button>
+
+      {isOpen && (
+        <div
+          className={cn(
+            'absolute bottom-full left-0 z-50 mb-2 w-64 animate-fade-in',
+            'rounded-xl border border-border/50 bg-surface-secondary shadow-medium',
+            'dark:border-border-dark/50 dark:bg-surface-dark-secondary',
+          )}
+        >
+          {hasUpdate && (
+            <div className="border-b border-border/50 p-2 dark:border-border-dark/50">
+              {updateStatus === 'downloading' && (
+                <div
+                  className={cn(
+                    'flex items-start gap-2.5 rounded-md px-2 py-1.5',
+                    'text-text-secondary dark:text-text-dark-secondary',
+                  )}
+                >
+                  <Loader2 className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 animate-spin" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-xs font-medium text-text-primary dark:text-text-dark-primary">
+                      Downloading update
+                      {progress != null ? ` · ${Math.round(progress * 100)}%` : ''}
+                    </div>
+                    <div className="mt-0.5 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                      {totalBytes != null
+                        ? `${formatBytes(downloadedBytes)} of ${formatBytes(totalBytes)}`
+                        : formatBytes(downloadedBytes)}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {updateStatus === 'available' && (
+                <Button
+                  variant="unstyled"
+                  onClick={() => {
+                    setIsOpen(false);
+                    handleInstall();
+                  }}
+                  className={cn(
+                    'flex w-full items-start gap-2.5 rounded-md px-2 py-1.5 text-left',
+                    'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+                    'transition-colors duration-200',
+                  )}
+                >
+                  <Download className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-text-primary dark:text-text-dark-primary" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-xs font-medium text-text-primary dark:text-text-dark-primary">
+                      Update to {updateVersion}
+                    </div>
+                    <div className="mt-0.5 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                      Download and restart
+                    </div>
+                    {releaseNotes && (
+                      <div className="mt-1.5 line-clamp-3 whitespace-pre-wrap text-2xs leading-relaxed text-text-tertiary dark:text-text-dark-tertiary">
+                        {releaseNotes.trim()}
+                      </div>
+                    )}
+                  </div>
+                </Button>
+              )}
+
+              {updateStatus === 'installing' && (
+                <div
+                  className={cn(
+                    'flex items-center gap-2.5 rounded-md px-2 py-1.5',
+                    'text-text-secondary dark:text-text-dark-secondary',
+                  )}
+                >
+                  <Loader2 className="h-3.5 w-3.5 flex-shrink-0 animate-spin" />
+                  <div className="text-xs font-medium text-text-primary dark:text-text-dark-primary">
+                    Installing…
+                  </div>
+                </div>
+              )}
+
+              {updateStatus === 'error' && (
+                <Button
+                  variant="unstyled"
+                  onClick={() => {
+                    setIsOpen(false);
+                    handleRetry();
+                  }}
+                  className={cn(
+                    'flex w-full items-start gap-2.5 rounded-md px-2 py-1.5 text-left',
+                    'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+                    'transition-colors duration-200',
+                  )}
+                >
+                  <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-error-600 dark:text-error-400" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-xs font-medium text-text-primary dark:text-text-dark-primary">
+                      Update failed — retry
+                    </div>
+                    {errorMessage && (
+                      <div className="mt-0.5 truncate text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                        {errorMessage}
+                      </div>
+                    )}
+                  </div>
+                </Button>
+              )}
+            </div>
+          )}
+
+          <div className="p-1.5">
+            <Button
+              variant="unstyled"
+              onClick={() => useUIStore.getState().toggleTheme()}
+              className={MENU_ITEM_CLASS}
+            >
+              <ThemeIcon className="h-3.5 w-3.5 flex-shrink-0" />
+              <span className="flex-1 text-xs">Theme</span>
+              <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                {THEME_LABEL_MAP[theme]}
+              </span>
+            </Button>
+            <Button
+              variant="unstyled"
+              onClick={() => {
+                setIsOpen(false);
+                onOpenSettings();
+              }}
+              className={MENU_ITEM_CLASS}
+            >
+              <Settings className="h-3.5 w-3.5 flex-shrink-0" />
+              <span className="text-xs">Settings</span>
+            </Button>
+            <Button
+              variant="unstyled"
+              onClick={() => {
+                setIsOpen(false);
+                onSignOut();
+              }}
+              className={MENU_ITEM_CLASS}
+            >
+              <LogOut className="h-3.5 w-3.5 flex-shrink-0" />
+              <span className="text-xs">Sign out</span>
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
@@ -3,12 +3,7 @@ import { Zap, Edit2 } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { Button } from '@/components/ui/primitives/Button';
 import { SkillEditDialog } from '@/components/settings/dialogs/SkillEditDialog';
-
-const formatBytes = (bytes: number): string => {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-};
+import { formatBytes } from '@/utils/format';
 
 interface SkillsSettingsTabProps {
   skills: CustomSkill[] | undefined;

--- a/frontend/src/services/desktopUpdateService.ts
+++ b/frontend/src/services/desktopUpdateService.ts
@@ -1,0 +1,43 @@
+import { check, type Update } from '@tauri-apps/plugin-updater';
+import { useDesktopUpdateStore } from '@/store/updateStore';
+
+// Silently check for an update and stage it in the store. Does NOT download —
+// download+install runs only when the user clicks the menu item, so we don't
+// waste bandwidth re-downloading on every app launch.
+export async function checkDesktopUpdate(): Promise<void> {
+  const update = await check();
+  if (!update) return;
+
+  useDesktopUpdateStore.getState().setAvailable(
+    {
+      version: update.version,
+      currentVersion: update.currentVersion,
+      body: update.body ?? null,
+      date: update.date ?? null,
+    },
+    () => downloadAndInstall(update),
+  );
+}
+
+async function downloadAndInstall(update: Update): Promise<void> {
+  const store = useDesktopUpdateStore.getState();
+  store.setDownloading();
+  try {
+    await update.download((event) => {
+      const s = useDesktopUpdateStore.getState();
+      if (event.event === 'Started') {
+        s.setDownloadStarted(event.data.contentLength ?? null);
+      } else if (event.event === 'Progress') {
+        s.addDownloadChunk(event.data.chunkLength);
+      }
+    });
+    useDesktopUpdateStore.getState().setInstalling();
+    // install() exits the current process on Windows and restarts the app
+    // on macOS — no separate relaunch() call needed.
+    await update.install();
+  } catch (error) {
+    useDesktopUpdateStore
+      .getState()
+      .setError(error instanceof Error ? error.message : 'Update failed');
+  }
+}

--- a/frontend/src/store/updateStore.ts
+++ b/frontend/src/store/updateStore.ts
@@ -1,0 +1,69 @@
+import { create } from 'zustand';
+
+export type DesktopUpdateStatus = 'idle' | 'available' | 'downloading' | 'installing' | 'error';
+
+interface DesktopUpdateState {
+  status: DesktopUpdateStatus;
+  version: string | null;
+  currentVersion: string | null;
+  releaseNotes: string | null;
+  releaseDate: string | null;
+  downloadedBytes: number;
+  // null when the server didn't send Content-Length
+  totalBytes: number | null;
+  errorMessage: string | null;
+  // Downloads and installs the staged update. Set when check() finds an update.
+  triggerInstall: (() => Promise<void>) | null;
+}
+
+interface DesktopUpdateActions {
+  setAvailable: (
+    info: {
+      version: string;
+      currentVersion: string;
+      body: string | null;
+      date: string | null;
+    },
+    triggerInstall: () => Promise<void>,
+  ) => void;
+  setDownloading: () => void;
+  setDownloadStarted: (totalBytes: number | null) => void;
+  addDownloadChunk: (chunkLength: number) => void;
+  setInstalling: () => void;
+  setError: (message: string) => void;
+}
+
+const initialState: DesktopUpdateState = {
+  status: 'idle',
+  version: null,
+  currentVersion: null,
+  releaseNotes: null,
+  releaseDate: null,
+  downloadedBytes: 0,
+  totalBytes: null,
+  errorMessage: null,
+  triggerInstall: null,
+};
+
+export const useDesktopUpdateStore = create<DesktopUpdateState & DesktopUpdateActions>((set) => ({
+  ...initialState,
+  setAvailable: ({ version, currentVersion, body, date }, triggerInstall) =>
+    set({
+      status: 'available',
+      version,
+      currentVersion,
+      releaseNotes: body,
+      releaseDate: date,
+      downloadedBytes: 0,
+      totalBytes: null,
+      errorMessage: null,
+      triggerInstall,
+    }),
+  setDownloading: () =>
+    set({ status: 'downloading', downloadedBytes: 0, totalBytes: null, errorMessage: null }),
+  setDownloadStarted: (totalBytes) => set({ totalBytes }),
+  addDownloadChunk: (chunkLength) =>
+    set((state) => ({ downloadedBytes: state.downloadedBytes + chunkLength })),
+  setInstalling: () => set({ status: 'installing' }),
+  setError: (message) => set({ status: 'error', errorMessage: message }),
+}));

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -11,6 +11,12 @@ export const formatValue = (value: unknown): string => {
 
 export const extractFilename = (path: string): string => path.split('/').pop() ?? path;
 
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 export function formatNumberCompact(num: number): string {
   if (num < 1000) return num.toString();
   if (num < 1000000) return Math.round(num / 1000) + 'K';


### PR DESCRIPTION
## Summary
- Silent on-launch update check; download only runs when the user clicks the menu row (no more re-downloading on every launch)
- Avatar shows a dot badge when an update is available, downloading, installing, or failed
- New `UserProfileMenu` dropdown consolidates update status, theme, settings, and sign out into one place
- Share `formatBytes` in `utils/format.ts`; remove the duplicate in `SkillsSettingsTab`

## Test plan
- [ ] Launch app with update available — avatar shows dot, menu row says "Update to vX.Y.Z"
- [ ] Click update row — progress shows in menu, then "Installing…", then app restarts
- [ ] Launch app without update — no dot, menu has only Theme/Settings/Sign out
- [ ] Theme row cycles dark → light → system without closing menu
- [ ] Settings and Sign out behave as before
- [ ] Update failure surfaces an error row with retry