### PR TITLE
Move user menu into Settings sidebar

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -80,11 +80,12 @@ export function Header({ isAuthPage = false }: HeaderProps) {
   const navigate = useNavigate();
   const isChatPage = useMatch('/chat/:chatId');
   const isLandingPage = useMatch('/');
+  const isSettingsPage = useMatch('/settings');
   const theme = useUIStore((state) => state.theme);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
-  // Sidebar pages (landing, chat) use TitleBar + Sidebar for all controls
-  const isSidebarPage = isChatPage || isLandingPage;
+  // Pages with their own nav + UserProfileMenu — no Header needed
+  const isSidebarPage = isChatPage || isLandingPage || isSettingsPage;
 
   const logoutMutation = useLogoutMutation({
     onSuccess: () => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -24,6 +24,9 @@ import toast from 'react-hot-toast';
 import { GeneralSettingsTab } from '@/components/settings/tabs/GeneralSettingsTab';
 import { SkillsSettingsTab } from '@/components/settings/tabs/SkillsSettingsTab';
 import { SettingsProvider } from '@/contexts/SettingsContext';
+import { UserProfileMenu } from '@/components/layout/UserProfileMenu';
+import { useCurrentUserQuery, useLogoutMutation } from '@/hooks/queries/useAuthQueries';
+import { useAuthStore } from '@/store/authStore';
 import { getGeneralSecretFields } from '@/utils/settings';
 import { PersonasSection } from '@/components/settings/sections/PersonasSection';
 import { EnvVarsSection } from '@/components/settings/sections/EnvVarsSection';
@@ -72,6 +75,15 @@ const tabLoadingFallback = (
 
 const SettingsPage: React.FC = () => {
   const navigate = useNavigate();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const { data: currentUser } = useCurrentUserQuery({ enabled: isAuthenticated });
+  const userDisplayName = currentUser?.username || currentUser?.email || '';
+  const logoutMutation = useLogoutMutation({
+    onSuccess: () => {
+      useAuthStore.getState().setAuthenticated(false);
+      navigate('/login');
+    },
+  });
   const [activeTab, setActiveTab] = useState<TabKey>('general');
   const [isDeleteAllDialogOpen, setIsDeleteAllDialogOpen] = useState(false);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
@@ -265,7 +277,7 @@ const SettingsPage: React.FC = () => {
     <div className="flex h-full overflow-hidden bg-surface dark:bg-surface-dark">
       {/* Vertical settings navigation — desktop */}
       <nav
-        className="hidden w-56 shrink-0 flex-col border-r border-border bg-surface-secondary dark:border-border-dark dark:bg-surface-dark-secondary md:flex"
+        className="hidden w-72 shrink-0 flex-col border-r border-border bg-surface-secondary dark:border-border-dark dark:bg-surface-dark-secondary md:flex"
         aria-label="Settings sections"
       >
         <div className="border-b border-border px-5 py-4 dark:border-border-dark">
@@ -314,6 +326,14 @@ const SettingsPage: React.FC = () => {
               </Button>
             );
           })}
+        </div>
+
+        <div className="flex-shrink-0 border-t border-border/50 px-4 py-2.5 dark:border-border-dark/50">
+          <UserProfileMenu
+            displayName={userDisplayName}
+            onOpenSettings={() => navigate('/settings')}
+            onSignOut={() => logoutMutation.mutate()}
+          />
         </div>
       </nav>
 


### PR DESCRIPTION
## Summary
- Add `UserProfileMenu` to the bottom of the Settings desktop sidebar, mirroring the main `Sidebar` layout.
- Hide the global `Header` on `/settings` so theme and sign-out aren't duplicated.
- Widen the Settings sidebar (`w-56` → `w-72`) so the profile dropdown fits within its bounds.

## Test plan
- [ ] Open `/settings` and confirm the top-right theme/sign-out icons are gone.
- [ ] Click the profile avatar at the sidebar bottom and verify Theme, Settings, and Sign out actions all work.
- [ ] Confirm the dropdown stays within the sidebar width in light and dark mode.
- [ ] On mobile, confirm the settings page still renders correctly (no regression in the mobile top bar nav).