### PR TITLE
Remove 1500-char limit and frame from custom instructions

### DIFF
--- a/backend/app/models/schemas/settings.py
+++ b/backend/app/models/schemas/settings.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class CustomEnvVar(BaseModel):
@@ -18,7 +18,7 @@ class Persona(BaseModel):
 class UserSettingsBase(BaseModel):
     github_personal_access_token: str | None = None
     sandbox_provider: Literal["docker", "host"] = "docker"
-    custom_instructions: str | None = Field(default=None, max_length=1500)
+    custom_instructions: str | None = None
     custom_env_vars: list[CustomEnvVar] | None = None
     personas: list[Persona] | None = None
     notifications_enabled: bool = True

--- a/frontend/src/components/settings/tabs/InstructionsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/InstructionsSettingsTab.tsx
@@ -1,6 +1,5 @@
 import { Label } from '@/components/ui/primitives/Label';
 import { Textarea } from '@/components/ui/primitives/Textarea';
-import { cn } from '@/utils/cn';
 
 interface InstructionsSettingsTabProps {
   instructions: string;
@@ -20,20 +19,14 @@ export const InstructionsSettingsTab: React.FC<InstructionsSettingsTabProps> = (
         These instructions will be added to every conversation with the AI.
       </p>
     </div>
-    <div className={cn('rounded-xl border border-border p-5 dark:border-border-dark')}>
-      <div className="mb-2 flex items-center justify-between">
-        <Label className="text-xs text-text-secondary dark:text-text-dark-secondary">
-          Instructions for the AI assistant
-        </Label>
-        <span className="text-2xs tabular-nums text-text-quaternary dark:text-text-dark-quaternary">
-          {instructions.length}/1500
-        </span>
-      </div>
+    <div>
+      <Label className="mb-2 block text-xs text-text-secondary dark:text-text-dark-secondary">
+        Instructions for the AI assistant
+      </Label>
       <Textarea
         value={instructions}
         onChange={(e) => onInstructionsChange(e.target.value)}
         placeholder="Enter custom instructions for how the AI should behave, respond, or approach tasks..."
-        maxLength={1500}
         rows={8}
         className="min-h-32"
       />


### PR DESCRIPTION
## Summary
- Drop `max_length=1500` on `custom_instructions` in the backend schema
- Remove `maxLength`, char counter, and bordered container from the Instructions settings tab

## Test plan
- [ ] Open Settings → Instructions and verify no outline frame around the textarea
- [ ] Paste >1500 chars and confirm input is accepted
- [ ] Save and reload; confirm the full content persists via the backend