### PR TITLE
Relaunch app after desktop updater install()

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@tauri-apps/plugin-dialog": "^2.4.0",
         "@tauri-apps/plugin-notification": "^2.3.1",
         "@tauri-apps/plugin-opener": "^2.5.3",
+        "@tauri-apps/plugin-process": "^2.3.0",
         "@tauri-apps/plugin-store": "^2.4.0",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "clsx": "^2.1.1",
@@ -1411,6 +1412,15 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
       "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@tauri-apps/plugin-dialog": "^2.4.0",
     "@tauri-apps/plugin-notification": "^2.3.1",
     "@tauri-apps/plugin-opener": "^2.5.3",
+    "@tauri-apps/plugin-process": "^2.3.0",
     "@tauri-apps/plugin-store": "^2.4.0",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "clsx": "^2.1.1",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-store",
  "tauri-plugin-updater",
 ]
@@ -4020,6 +4021,16 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -10,6 +10,7 @@ tauri-build = { version = "2.5.5", features = [] }
 [dependencies]
 tauri = { version = "2.10.2", features = ["devtools"] }
 tauri-plugin-updater = "2.10.0"
+tauri-plugin-process = "2.3.0"
 tauri-plugin-notification = "2.3.0"
 tauri-plugin-dialog = "2.4.0"
 serde = { version = "1", features = ["derive"] }

--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -13,6 +13,8 @@
     "core:window:allow-start-dragging",
     "store:default",
     "updater:default",
+    "process:default",
+    "process:allow-restart",
     "notification:default",
     "dialog:default",
     "opener:default"

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -189,6 +189,7 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())

--- a/frontend/src/services/desktopUpdateService.ts
+++ b/frontend/src/services/desktopUpdateService.ts
@@ -1,4 +1,5 @@
 import { check, type Update } from '@tauri-apps/plugin-updater';
+import { relaunch } from '@tauri-apps/plugin-process';
 import { useDesktopUpdateStore } from '@/store/updateStore';
 
 // Silently check for an update and stage it in the store. Does NOT download —
@@ -32,9 +33,10 @@ async function downloadAndInstall(update: Update): Promise<void> {
       }
     });
     useDesktopUpdateStore.getState().setInstalling();
-    // install() exits the current process on Windows and restarts the app
-    // on macOS — no separate relaunch() call needed.
     await update.install();
+    // On Windows install() exits the current process; on macOS/Linux it
+    // replaces the bundle in place and requires an explicit relaunch.
+    await relaunch();
   } catch (error) {
     useDesktopUpdateStore
       .getState()


### PR DESCRIPTION
## Summary
- On macOS, `@tauri-apps/plugin-updater`'s `install()` replaces the `.app` bundle but does **not** restart the app — the user menu stayed on "Installing…" forever.
- Wire up `tauri-plugin-process` (Cargo + npm + capabilities) and call `relaunch()` after `install()` so the app restarts on macOS/Linux. On Windows `install()` still exits the current process as before.

## Test plan
- [ ] Build desktop app (`npm run desktop:build`) and confirm it completes without the Rollup resolve error.
- [ ] On macOS, trigger an update from the user menu and verify the app restarts into the new version instead of hanging on "Installing…".
- [ ] Verify the updater error path still surfaces in the menu when `install()` fails.