### PR TITLE
Add gpt-5.5 to Codex models

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For git-backed workspaces, chats can opt into worktree isolation. Agentrove crea
 Current model families exposed by the backend:
 
 - **Claude**: `sonnet[1m]`, `opus[1m]`, `haiku`
-- **Codex**: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`
+- **Codex**: `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`
 - **Copilot**: Claude and GPT model variants exposed through Copilot ACP
 - **Cursor**: Cursor composer, GPT, Claude, Gemini, Grok, and other Cursor ACP model variants
 - **OpenCode**: OpenCode-hosted and provider-backed ACP model variants

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -131,6 +131,7 @@ MODELS: dict[str, ModelInfo] = {
     "sonnet[1m]": ModelInfo("Sonnet", AgentKind.CLAUDE, 1_000_000),
     "opus[1m]": ModelInfo("Opus", AgentKind.CLAUDE, 1_000_000),
     "haiku": ModelInfo("Haiku", AgentKind.CLAUDE, 200_000),
+    "gpt-5.5": ModelInfo("GPT 5.5", AgentKind.CODEX, 1_000_000),
     "gpt-5.4": ModelInfo("GPT 5.4", AgentKind.CODEX, 1_000_000),
     "gpt-5.4-mini": ModelInfo("GPT 5.4 Mini", AgentKind.CODEX, 400_000),
     "gpt-5.3-codex": ModelInfo("GPT 5.3 Codex", AgentKind.CODEX, 400_000),

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -95,6 +95,7 @@ export interface Model {
 }
 
 const CODEX_MODEL_IDS = new Set([
+  'gpt-5.5',
   'gpt-5.4',
   'gpt-5.4-mini',
   'gpt-5.3-codex',


### PR DESCRIPTION
## Summary
- add `gpt-5.5` to the backend Codex model list
- classify `gpt-5.5` as a Codex model in the frontend
- update the README Codex model list

## Verification
- not run manually
- local commit hooks ran automatically during `git commit`