### PR TITLE
Enable Pierre file tree icons

### DIFF
--- a/frontend/src/components/editor/file-tree/Tree.tsx
+++ b/frontend/src/components/editor/file-tree/Tree.tsx
@@ -68,7 +68,7 @@ export const Tree = memo(function Tree({
     initialExpansion: 'open',
     initialSelectedPaths: selectedFile ? [selectedFile.path] : [],
     search: true,
-    icons: 'minimal',
+    icons: 'complete',
     itemHeight: 26,
     unsafeCSS: UNSAFE_CSS,
     onSelectionChange: (selectedPaths) => {


### PR DESCRIPTION
## Summary
- switch Pierre file tree from the minimal icon set to the complete icon set
- enables semantic colored file-type icons in the editor file tree

## Verification
- not run manually; commit hook ran eslint --fix and prettier --write on the staged TSX file