### PR TITLE
Bump ACP npm packages to latest

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.87 @agentclientprotocol/claude-agent-acp@0.24.2 @zed-industries/codex-acp@0.11.1 @openai/codex
+RUN npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.31.0 @zed-industries/codex-acp@0.12.0 @openai/codex@0.124.0
 
 # Cursor CLI (installs `cursor-agent` to /root/.local/bin) — used for the Cursor
 # ACP server (`cursor-agent acp`). The install script downloads the binary for

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -58,7 +58,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.87 @agentclientprotocol/claude-agent-acp@0.24.2 @zed-industries/codex-acp@0.11.1 @openai/codex
+    npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.31.0 @zed-industries/codex-acp@0.12.0 @openai/codex@0.124.0
 
 # Cursor CLI (installs `cursor-agent` to ~/.local/bin, which is already on PATH).
 RUN curl -fsS https://cursor.com/install | bash


### PR DESCRIPTION
## Summary
- Bump `@anthropic-ai/claude-code`: `2.1.87` → `2.1.119`
- Bump `@agentclientprotocol/claude-agent-acp`: `0.24.2` → `0.31.0`
- Bump `@zed-industries/codex-acp`: `0.11.1` → `0.12.0`
- Pin `@openai/codex` at `0.124.0` (was unpinned)

## Test plan
- [ ] `docker build -f backend/Dockerfile .` succeeds
- [ ] `docker build -f sandbox/docker/Dockerfile sandbox/docker` succeeds