### PR TITLE
fix: reject unsupported image types at attachment time

### DIFF
--- a/frontend/src/utils/file.ts
+++ b/frontend/src/utils/file.ts
@@ -126,7 +126,17 @@ export function filterChatAttachmentFiles(
   files: File[],
   { toastOnError = true }: { toastOnError?: boolean } = {},
 ): File[] {
-  const supportedFiles = files.filter(isSupportedUploadedFile);
+  const supportedFiles: File[] = [];
+  const unsupportedFiles: File[] = [];
+
+  for (const file of files) {
+    if (isSupportedUploadedFile(file)) {
+      supportedFiles.push(file);
+    } else {
+      unsupportedFiles.push(file);
+    }
+  }
+
   const validFiles: File[] = [];
   const oversizedFiles: File[] = [];
 
@@ -135,6 +145,14 @@ export function filterChatAttachmentFiles(
       oversizedFiles.push(file);
     } else {
       validFiles.push(file);
+    }
+  }
+
+  if (toastOnError && unsupportedFiles.length > 0) {
+    if (unsupportedFiles.length === 1) {
+      toast.error(`File "${unsupportedFiles[0].name}" is not a supported file type`);
+    } else {
+      toast.error(`${unsupportedFiles.length} files are not a supported file type`);
     }
   }
 

--- a/frontend/src/utils/fileTypes.ts
+++ b/frontend/src/utils/fileTypes.ts
@@ -33,7 +33,9 @@ const FILE_TYPE_EXTENSIONS: Record<string, string[]> = {
   pdf: ['.pdf'],
 };
 
-export const isUploadedImageFile = (file: File): boolean => checkMimeType(file, 'image/*');
+// Must match backend ALLOWED_IMAGE_TYPES (image/jpeg, image/png, image/gif, image/webp)
+export const isUploadedImageFile = (file: File): boolean =>
+  checkMimeType(file, ['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
 
 export const isUploadedPdfFile = (file: File): boolean =>
   checkMimeType(file, 'application/pdf', '.pdf');


### PR DESCRIPTION
## Summary
- Narrow frontend image type validation to match backend `ALLOWED_IMAGE_TYPES` (jpeg, png, gif, webp)
- Add toast notification for files with unsupported types (previously silently dropped)
- Invalid types like `.bmp`, `.svg` are now caught at attachment time, preventing chat creation and navigation before the error surfaces

## Test plan
- [ ] Upload an image with unsupported extension (e.g., `.bmp`) — toast shows, file not attached, chat not created
- [ ] Upload valid image (`.png`, `.jpg`, `.webp`) — attaches and sends normally
- [ ] Upload PDF and XLSX — still accepted as before