### PR TITLE
Add chat search across all workspaces

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -10,6 +10,7 @@ from fastapi import (
     File,
     Form,
     HTTPException,
+    Query,
     Request,
     UploadFile,
     status,
@@ -38,6 +39,7 @@ from app.models.schemas.chat import (
     Chat as ChatSchema,
     ChatCompletionResponse,
     ChatCreate,
+    ChatSearchResponse,
     ChatStatusResponse,
     ChatUpdate,
     ChatRequest,
@@ -175,6 +177,34 @@ async def get_chats(
     return await chat_service.get_user_chats(
         current_user, pagination, workspace_id=workspace_id, pinned=pinned
     )
+
+
+@router.get("/chats/search", response_model=ChatSearchResponse)
+async def search_chats(
+    q: str = Query(..., min_length=2, max_length=200),
+    limit: int = Query(50, ge=1, le=200),
+    per_chat_limit: int = Query(5, ge=1, le=50),
+    current_user: User = Depends(get_current_user),
+    chat_service: ChatService = Depends(get_chat_service),
+) -> ChatSearchResponse:
+    # Strip and re-validate so whitespace-only queries (e.g. "  ") don't bypass
+    # min_length and reach the DB as an empty %LIKE% that matches everything.
+    stripped = q.strip()
+    if len(stripped) < 2:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Query must contain at least 2 non-whitespace characters",
+        )
+    try:
+        return await chat_service.search_messages(
+            current_user, stripped, limit=limit, per_chat_limit=per_chat_limit
+        )
+    except SQLAlchemyError as e:
+        logger.error("Database error searching chats: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error while searching chats",
+        ) from e
 
 
 @router.get("/chats/{chat_id}/sub-threads", response_model=list[ChatSchema])

--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -128,3 +128,28 @@ class MessageEvent(BaseModel):
 
 class PermissionRespondResponse(BaseModel):
     success: bool
+
+
+class ChatSearchMatch(BaseModel):
+    message_id: UUID
+    role: MessageRole
+    # Pre-split snippet so the frontend doesn't need to slice by char offsets —
+    # Python codepoint indices and JS UTF-16 units disagree on non-BMP chars.
+    snippet_before: str
+    snippet_match: str
+    snippet_after: str
+    created_at: datetime
+
+
+class ChatSearchResult(BaseModel):
+    chat_id: UUID
+    chat_title: str
+    workspace_id: UUID
+    workspace_name: str
+    matches: list[ChatSearchMatch]
+    match_count: int
+
+
+class ChatSearchResponse(BaseModel):
+    results: list[ChatSearchResult]
+    truncated: bool

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -16,7 +16,14 @@ from app.models.db_models.enums import MessageRole, MessageStreamStatus, StreamE
 from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
 from app.models.schemas.chat import Chat as ChatSchema
-from app.models.schemas.chat import ChatCreate, ChatRequest, ChatUpdate
+from app.models.schemas.chat import (
+    ChatCreate,
+    ChatRequest,
+    ChatSearchMatch,
+    ChatSearchResponse,
+    ChatSearchResult,
+    ChatUpdate,
+)
 from app.models.schemas.chat import Message as MessageSchema
 from app.models.schemas.pagination import (
     CursorPaginatedResponse,
@@ -40,6 +47,14 @@ from app.utils.cache import CachePubSub, cache_connection, cache_pubsub
 logger = logging.getLogger(__name__)
 
 TERMINAL_STREAM_EVENT_TYPES = frozenset({"cancelled", "complete", "error"})
+
+# Snippet windowing for chat message search results — keep some context before
+# the match so the user sees what surrounds it without ballooning the payload.
+SEARCH_SNIPPET_CONTEXT_BEFORE = 30
+SEARCH_SNIPPET_MAX_LENGTH = 160
+# Safety cap on rows fetched for a single search — prevents a common query
+# (e.g. "the") on heavy chat history from loading tens of thousands of rows.
+SEARCH_MAX_ROWS = 5000
 
 
 class ChatService(BaseDbService[Chat]):
@@ -146,6 +161,122 @@ class ChatService(BaseDbService[Chat]):
                 total=total,
                 pages=math.ceil(total / pagination.per_page),
             )
+
+    async def search_messages(
+        self,
+        user: User,
+        query: str,
+        *,
+        limit: int = 50,
+        per_chat_limit: int = 5,
+    ) -> ChatSearchResponse:
+        # Searches plain-text message bodies (content_text) across all of the
+        # user's non-deleted chats and workspaces. Order: most recent matching
+        # message first; then in Python we group per-chat, capping matches per
+        # chat and total chats. The frontend further groups results by workspace
+        # for display. Caller is expected to pass a non-empty trimmed query.
+        # +1 lookahead lets us flag truncation when more chats exist than the cap
+        chat_cap = limit + 1
+
+        async with self.session_factory() as db:
+            stmt = (
+                select(
+                    Message.id,
+                    Message.chat_id,
+                    Message.role,
+                    Message.content_text,
+                    Message.created_at,
+                    Chat.title,
+                    Chat.workspace_id,
+                    Workspace.name.label("workspace_name"),
+                )
+                .join(Chat, Chat.id == Message.chat_id)
+                .join(Workspace, Workspace.id == Chat.workspace_id)
+                .where(
+                    Chat.user_id == user.id,
+                    Chat.deleted_at.is_(None),
+                    Message.deleted_at.is_(None),
+                    Message.content_text.icontains(query, autoescape=True),
+                )
+                .order_by(Message.created_at.desc())
+                .limit(SEARCH_MAX_ROWS)
+            )
+            result = await db.execute(stmt)
+            rows = result.all()
+
+        # Group by chat in insertion order (which is desc by created_at).
+        grouped: dict[UUID, ChatSearchResult] = {}
+        # Hitting the SQL cap means there may be older matches we never saw —
+        # report truncation even if the per-chat / chat-cap loop never trips.
+        truncated = len(rows) == SEARCH_MAX_ROWS
+        query_lower = query.lower()
+
+        for row in rows:
+            chat_id = row.chat_id
+            existing = grouped.get(chat_id)
+            if existing is None:
+                if len(grouped) >= chat_cap:
+                    truncated = True
+                    break
+                existing = ChatSearchResult(
+                    chat_id=chat_id,
+                    chat_title=row.title,
+                    workspace_id=row.workspace_id,
+                    workspace_name=row.workspace_name,
+                    matches=[],
+                    match_count=0,
+                )
+                grouped[chat_id] = existing
+
+            existing.match_count += 1
+            if len(existing.matches) >= per_chat_limit:
+                truncated = True
+                continue
+
+            before, match_text, after = self._build_snippet(
+                row.content_text, query_lower
+            )
+            existing.matches.append(
+                ChatSearchMatch(
+                    message_id=row.id,
+                    role=row.role,
+                    snippet_before=before,
+                    snippet_match=match_text,
+                    snippet_after=after,
+                    created_at=row.created_at,
+                )
+            )
+
+        # The loop only sets truncated when a NEW chat would push us past the
+        # lookahead cap; if we land at exactly limit+1 and the rows end there,
+        # we still drop a chat in the slice below — flag it.
+        if len(grouped) > limit:
+            truncated = True
+        return ChatSearchResponse(
+            results=list(grouped.values())[:limit], truncated=truncated
+        )
+
+    @staticmethod
+    def _build_snippet(content: str, query_lower: str) -> tuple[str, str, str]:
+        # Slide a window around the first match so long messages don't bloat
+        # the payload. Returns (before, match, after) — pre-split so consumers
+        # don't need to reason about codepoint vs UTF-16 indices.
+        idx = content.lower().find(query_lower)
+        if idx < 0:
+            # Shouldn't happen since the SQL filter matched, but fall back to head.
+            return content[:SEARCH_SNIPPET_MAX_LENGTH], "", ""
+
+        start = max(0, idx - SEARCH_SNIPPET_CONTEXT_BEFORE)
+        end = start + SEARCH_SNIPPET_MAX_LENGTH
+        match_end_in_content = idx + len(query_lower)
+        prefix = "…" if start > 0 else ""
+        suffix = "…" if end < len(content) else ""
+        before = prefix + content[start:idx]
+        # Slice the matched text out of the original content (preserves the
+        # caller's case) instead of echoing query_lower.
+        match_text = content[idx:match_end_in_content]
+        after = content[match_end_in_content:end] + suffix
+        return before, match_text, after
 
     async def create_chat(self, user: User, chat_data: ChatCreate) -> Chat:
         async with self.session_factory() as db:

--- a/frontend/src/components/chat/chat-search/ChatSearchPanel.tsx
+++ b/frontend/src/components/chat/chat-search/ChatSearchPanel.tsx
@@ -1,0 +1,189 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Loader2, Search, X } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { Input } from '@/components/ui/primitives/Input';
+import { useMountEffect } from '@/hooks/useMountEffect';
+import { useSearchChatsQuery } from '@/hooks/queries/useChatQueries';
+import type { ChatSearchResult } from '@/types/chat.types';
+import { cn } from '@/utils/cn';
+import { ChatSearchResultGroup } from './ChatSearchResultGroup';
+
+export interface ChatSearchPanelProps {
+  onOpenChat: (chatId: string) => void;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+}
+
+interface WorkspaceGroup {
+  workspaceId: string;
+  workspaceName: string;
+  results: ChatSearchResult[];
+}
+
+function groupByWorkspace(results: ChatSearchResult[]): WorkspaceGroup[] {
+  const groups = new Map<string, WorkspaceGroup>();
+  for (const result of results) {
+    let group = groups.get(result.workspace_id);
+    if (!group) {
+      group = {
+        workspaceId: result.workspace_id,
+        workspaceName: result.workspace_name,
+        results: [],
+      };
+      groups.set(result.workspace_id, group);
+    }
+    group.results.push(result);
+  }
+  return Array.from(groups.values());
+}
+
+export const ChatSearchPanel = memo(function ChatSearchPanel({
+  onOpenChat,
+  inputRef,
+}: ChatSearchPanelProps) {
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const localInputRef = useRef<HTMLInputElement>(null);
+  const activeInputRef = inputRef ?? localInputRef;
+
+  useMountEffect(() => {
+    activeInputRef.current?.focus();
+  });
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(query), 250);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  const { data, isFetching, error } = useSearchChatsQuery(debouncedQuery);
+
+  const handleClear = useCallback(() => {
+    setQuery('');
+    setDebouncedQuery('');
+    activeInputRef.current?.focus();
+  }, [activeInputRef]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Escape' && query) {
+        e.preventDefault();
+        handleClear();
+      }
+    },
+    [query, handleClear],
+  );
+
+  const { grouped, totalMatches } = useMemo(() => {
+    const results = data?.results ?? [];
+    return {
+      grouped: groupByWorkspace(results),
+      totalMatches: results.reduce((acc, r) => acc + r.match_count, 0),
+    };
+  }, [data]);
+
+  const hasQuery = debouncedQuery.trim().length >= 2;
+  const hasResults = !!data && data.results.length > 0;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-none flex-col gap-2 border-b border-border/50 px-3 py-2 dark:border-border-dark/50">
+        <div
+          role="search"
+          className="relative flex items-center rounded-md border border-border/50 bg-surface dark:border-border-dark/50 dark:bg-surface-dark"
+        >
+          <Search className="pointer-events-none absolute left-2 h-3 w-3 text-text-quaternary dark:text-text-dark-quaternary" />
+          <Input
+            ref={activeInputRef}
+            variant="unstyled"
+            type="text"
+            role="searchbox"
+            aria-label="Search in chats"
+            placeholder="Search chats"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className={cn(
+              'h-7 w-full border-none bg-transparent py-1 pl-7 pr-2 text-xs',
+              'text-text-primary dark:text-text-dark-primary',
+              'placeholder:text-text-quaternary dark:placeholder:text-text-dark-quaternary',
+              'focus:outline-none',
+            )}
+          />
+          {query && (
+            <Button
+              onClick={handleClear}
+              variant="unstyled"
+              title="Clear search"
+              aria-label="Clear search"
+              className="mr-1 flex h-5 w-5 items-center justify-center rounded text-text-quaternary transition-colors hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-2 pb-6 pt-1">
+        {!hasQuery && (
+          <p className="px-2 py-6 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
+            Type at least 2 characters to search.
+          </p>
+        )}
+
+        {hasQuery && isFetching && !data && (
+          <div className="flex items-center justify-center gap-2 py-6 text-xs text-text-quaternary dark:text-text-dark-quaternary">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Searching...
+          </div>
+        )}
+
+        {hasQuery && error && (
+          <p className="px-2 py-4 text-xs text-error-500 dark:text-error-400">
+            {error instanceof Error ? error.message : 'Search failed'}
+          </p>
+        )}
+
+        {hasQuery && data && !hasResults && !isFetching && (
+          <p className="px-2 py-6 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
+            No results for &ldquo;{debouncedQuery}&rdquo;
+          </p>
+        )}
+
+        {hasQuery && hasResults && (
+          <>
+            <p className="flex items-center gap-2 px-2 pb-2 pt-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+              {isFetching && <Loader2 className="h-3 w-3 animate-spin" />}
+              <span>
+                {totalMatches} {totalMatches === 1 ? 'result' : 'results'} in {data.results.length}{' '}
+                {data.results.length === 1 ? 'chat' : 'chats'} · {grouped.length}{' '}
+                {grouped.length === 1 ? 'workspace' : 'workspaces'}
+                {data.truncated && ' (truncated)'}
+              </span>
+            </p>
+            <div
+              aria-busy={isFetching}
+              className={cn(
+                'flex flex-col gap-0.5 transition-opacity duration-150',
+                isFetching && 'pointer-events-none opacity-50',
+              )}
+            >
+              {grouped.map((group) => (
+                <div key={group.workspaceId} className="mt-2 first:mt-0">
+                  <p className="px-1.5 pb-1 pt-1 text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
+                    {group.workspaceName}
+                  </p>
+                  {group.results.map((result) => (
+                    <ChatSearchResultGroup
+                      key={result.chat_id}
+                      result={result}
+                      onOpen={onOpenChat}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/chat/chat-search/ChatSearchResultGroup.tsx
+++ b/frontend/src/components/chat/chat-search/ChatSearchResultGroup.tsx
@@ -1,0 +1,60 @@
+import { memo, useState } from 'react';
+import { ChevronRight, MessageSquare } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import type { ChatSearchResult } from '@/types/chat.types';
+import { cn } from '@/utils/cn';
+import { ChatSearchResultLine } from './ChatSearchResultLine';
+
+export interface ChatSearchResultGroupProps {
+  result: ChatSearchResult;
+  onOpen: (chatId: string) => void;
+}
+
+export const ChatSearchResultGroup = memo(function ChatSearchResultGroup({
+  result,
+  onOpen,
+}: ChatSearchResultGroupProps) {
+  const [expanded, setExpanded] = useState(true);
+  const hasMore = result.match_count > result.matches.length;
+
+  return (
+    <div className="flex flex-col">
+      <Button
+        variant="unstyled"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex items-center gap-1.5 rounded px-1.5 py-1 text-left hover:bg-surface-hover dark:hover:bg-surface-dark-hover"
+      >
+        <ChevronRight
+          className={cn(
+            'h-3 w-3 shrink-0 text-text-quaternary transition-transform duration-150 dark:text-text-dark-quaternary',
+            expanded && 'rotate-90',
+          )}
+        />
+        <MessageSquare className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+        <span className="min-w-0 flex-1 truncate text-xs font-medium text-text-primary dark:text-text-dark-primary">
+          {result.chat_title}
+        </span>
+        <span className="ml-auto rounded-full bg-surface-active px-1.5 text-2xs tabular-nums text-text-secondary dark:bg-surface-dark-hover dark:text-text-dark-secondary">
+          {result.match_count}
+        </span>
+      </Button>
+
+      {expanded && (
+        <div className="flex flex-col pl-2">
+          {result.matches.map((match) => (
+            <ChatSearchResultLine
+              key={match.message_id}
+              match={match}
+              onClick={() => onOpen(result.chat_id)}
+            />
+          ))}
+          {hasMore && (
+            <span className="px-1.5 py-0.5 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+              +{result.match_count - result.matches.length} more
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/frontend/src/components/chat/chat-search/ChatSearchResultLine.tsx
+++ b/frontend/src/components/chat/chat-search/ChatSearchResultLine.tsx
@@ -1,0 +1,34 @@
+import { memo } from 'react';
+import { Button } from '@/components/ui/primitives/Button';
+import type { ChatSearchMatch } from '@/types/chat.types';
+
+export interface ChatSearchResultLineProps {
+  match: ChatSearchMatch;
+  onClick: () => void;
+}
+
+export const ChatSearchResultLine = memo(function ChatSearchResultLine({
+  match,
+  onClick,
+}: ChatSearchResultLineProps) {
+  const { snippet_before, snippet_match, snippet_after, role } = match;
+
+  return (
+    <Button
+      variant="unstyled"
+      onClick={onClick}
+      className="flex w-full items-start gap-1.5 rounded px-1.5 py-0.5 text-left text-2xs leading-5 text-text-secondary hover:bg-surface-hover dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover"
+    >
+      <span className="min-w-[1.75rem] shrink-0 text-right uppercase tabular-nums text-text-quaternary dark:text-text-dark-quaternary">
+        {role === 'user' ? 'you' : 'ai'}
+      </span>
+      <span className="min-w-0 flex-1 truncate">
+        {snippet_before}
+        <mark className="rounded-sm bg-surface-active px-0.5 text-text-primary dark:bg-surface-dark-hover dark:text-text-dark-primary">
+          {snippet_match}
+        </mark>
+        {snippet_after}
+      </span>
+    </Button>
+  );
+});

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -309,7 +309,6 @@ export function Sidebar({
   // Tracks which parent chats have their sub-threads expanded — collapsed by default to keep the sidebar compact
   const [expandedSubThreads, toggleSubThreadExpand, setExpandedSubThreads] = useToggleSet<string>();
 
-  const searchInputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const workspaceDropdownRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -347,18 +346,6 @@ export function Sidebar({
       return next;
     });
   }, [selectedChatParentId, setExpandedSubThreads]);
-
-  useMountEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-        e.preventDefault();
-        searchInputRef.current?.focus();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  });
 
   useMountEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -24,6 +24,7 @@ import {
   Sun,
   FileSearch,
   File,
+  MessageSquare,
 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useNavigate, type NavigateFunction } from 'react-router-dom';
@@ -41,6 +42,7 @@ import { getLeaves } from '@/utils/mosaicHelpers';
 import { traverseFileStructure, getFileName } from '@/utils/file';
 import { HighlightMatch } from '@/components/ui/shared/HighlightMatch';
 import { SearchPanel } from '@/components/editor/file-search/SearchPanel';
+import { ChatSearchPanel } from '@/components/chat/chat-search/ChatSearchPanel';
 import { cn } from '@/utils/cn';
 import type { ViewType, MosaicDirection } from '@/types/ui.types';
 import type { FileStructure } from '@/types/file-system.types';
@@ -136,7 +138,7 @@ const SETTING_COMMANDS: ActionCommandItem[] = [
     id: 'theme-dark',
     label: 'Theme: Dark',
     icon: Moon,
-    shortcut: 'k',
+    shortcut: 'm',
   },
   {
     type: 'action',
@@ -161,6 +163,13 @@ const SETTING_COMMANDS: ActionCommandItem[] = [
   },
   {
     type: 'action',
+    id: 'search-in-chats',
+    label: 'Search in chats',
+    icon: MessageSquare,
+    shortcut: 'k',
+  },
+  {
+    type: 'action',
     id: 'go-to-file',
     label: 'Go to file',
     icon: FileSearch,
@@ -177,11 +186,12 @@ export const SHORTCUT_MAP = new Map<string, CommandItem>(
   ]),
 );
 
-type MenuMode = 'commands' | 'files' | 'branches' | 'search';
+type MenuMode = 'commands' | 'files' | 'branches' | 'search' | 'chat-search';
 
 // Commands that switch the menu into a sub-mode instead of dispatching an action.
 const COMMAND_TO_MODE: Partial<Record<string, MenuMode>> = {
   'search-in-files': 'search',
+  'search-in-chats': 'chat-search',
   'go-to-file': 'files',
   'switch-branch': 'branches',
 };
@@ -291,6 +301,9 @@ export function executeCommand(
   } else if (cmd.id === 'search-in-files') {
     pendingMenuMode = 'search';
     ui.setCommandMenuOpen(true);
+  } else if (cmd.id === 'search-in-chats') {
+    pendingMenuMode = 'chat-search';
+    ui.setCommandMenuOpen(true);
   } else if (cmd.id === 'go-to-file') {
     pendingMenuMode = 'files';
     ui.setCommandMenuOpen(true);
@@ -320,6 +333,7 @@ export function CommandMenu() {
   const [mode, setMode] = useState<MenuMode>('commands');
   const inputRef = useRef<HTMLInputElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const chatSearchInputRef = useRef<HTMLInputElement>(null);
   const previousFocusRef = useRef<Element | null>(null);
   const activeItemRef = useRef<HTMLDivElement>(null);
   const stateRef = useRef({ activeIndex: 0, mode: 'commands' as MenuMode });
@@ -403,6 +417,8 @@ export function CommandMenu() {
     if (next === 'search') {
       // SearchPanel owns its own input; focus it after React flushes the mode change.
       requestAnimationFrame(() => searchInputRef.current?.focus());
+    } else if (next === 'chat-search') {
+      requestAnimationFrame(() => chatSearchInputRef.current?.focus());
     } else {
       requestAnimationFrame(() => inputRef.current?.focus());
     }
@@ -446,6 +462,14 @@ export function CommandMenu() {
       close();
     },
     [close],
+  );
+
+  const handleOpenChatResult = useCallback(
+    (chatId: string) => {
+      navigate(`/chat/${chatId}`);
+      close();
+    },
+    [close, navigate],
   );
 
   const handleSelectBranch = useCallback(
@@ -504,9 +528,9 @@ export function CommandMenu() {
       const { activeIndex: idx, mode: m } = stateRef.current;
       const len = listLengthRef.current;
 
-      if (m === 'search') {
-        // SearchPanel handles its own typing + click-to-open; don't hijack
-        // Enter/arrows here. Only wire Escape to step back to commands.
+      if (m === 'search' || m === 'chat-search') {
+        // The embedded panel handles its own typing + click-to-open; don't
+        // hijack Enter/arrows here. Only wire Escape to step back to commands.
         if (e.key === 'Escape') {
           e.preventDefault();
           e.stopImmediatePropagation();
@@ -576,7 +600,7 @@ export function CommandMenu() {
           'mt-20 h-fit w-full',
           // Widen for search mode so code snippets don't wrap; keep the compact
           // dialog for every other mode.
-          mode === 'search' ? 'max-w-2xl' : 'max-w-md',
+          mode === 'search' || mode === 'chat-search' ? 'max-w-2xl' : 'max-w-md',
           'rounded-xl border border-border/50 shadow-strong dark:border-border-dark/50',
           'bg-surface/95 backdrop-blur-xl dark:bg-surface-dark/95',
           'animate-fade-in',
@@ -606,6 +630,25 @@ export function CommandMenu() {
                 onOpenResult={handleOpenSearchResult}
                 inputRef={searchInputRef}
               />
+            </div>
+          </>
+        ) : mode === 'chat-search' ? (
+          <>
+            <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2 dark:border-border-dark/50">
+              <Button
+                variant="unstyled"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => switchMode('commands')}
+                className="shrink-0 rounded-md bg-surface-hover px-1.5 py-0.5 text-2xs font-medium text-text-secondary dark:bg-surface-dark-hover dark:text-text-dark-secondary"
+              >
+                Search in chats
+              </Button>
+              <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                Esc to go back
+              </span>
+            </div>
+            <div className="h-[28rem]">
+              <ChatSearchPanel onOpenChat={handleOpenChatResult} inputRef={chatSearchInputRef} />
             </div>
           </>
         ) : (

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -2,6 +2,8 @@ import type { DiffMode } from '@/types/sandbox.types';
 
 export const queryKeys = {
   chats: 'chats',
+  chatsSearch: (query: string) => ['chats', 'search', query] as const,
+  chatsSearchAll: ['chats', 'search'] as const,
   chat: (chatId?: string) => ['chat', chatId] as const,
   messages: (chatId?: string) => ['messages', chatId] as const,
   contextUsage: (chatId?: string) => ['chat', chatId, 'context-usage'] as const,

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -1,4 +1,10 @@
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import type {
   UseMutationOptions,
   UseQueryOptions,
@@ -7,7 +13,7 @@ import type {
 } from '@tanstack/react-query';
 import { chatService } from '@/services/chatService';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
-import type { Chat, ContextUsage, CreateChatRequest } from '@/types/chat.types';
+import type { Chat, ChatSearchResponse, ContextUsage, CreateChatRequest } from '@/types/chat.types';
 import type { PaginatedChats } from '@/types/api.types';
 import { createMutation } from './createMutation';
 import { queryKeys } from './queryKeys';
@@ -58,6 +64,21 @@ export const useInfiniteChatsQuery = (options?: {
     initialPageParam: 1,
     enabled: options?.enabled ?? true,
     gcTime: 1000 * 60 * 1,
+  });
+};
+
+export const useSearchChatsQuery = (
+  query: string,
+  options?: Partial<UseQueryOptions<ChatSearchResponse>>,
+) => {
+  const trimmed = query.trim();
+  return useQuery({
+    queryKey: queryKeys.chatsSearch(trimmed),
+    queryFn: () => chatService.searchChats(trimmed),
+    enabled: trimmed.length >= 2,
+    placeholderData: keepPreviousData,
+    staleTime: 15_000,
+    ...options,
   });
 };
 
@@ -164,6 +185,9 @@ export const useUpdateChatMutation = createMutation<
     );
 
     queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
+    // Search results embed the chat title, so a rename leaves a stale title
+    // visible until the search query is refetched.
+    queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
 
     if (updatedChat.parent_chat_id) {
       queryClient.invalidateQueries({
@@ -234,6 +258,7 @@ export const useDeleteChatMutation = createMutation<void, Error, string>(
     queryClient.removeQueries({ queryKey: queryKeys.subThreads(chatId) });
     queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
     queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
+    queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
     useMessageQueueStore.getState().cleanupChat(chatId);
   },
 );
@@ -241,6 +266,7 @@ export const useDeleteChatMutation = createMutation<void, Error, string>(
 export const useDeleteAllChatsMutation = createMutation<void, Error, void>(
   () => chatService.deleteAllChats(),
   (queryClient) => {
+    // removeQueries on the prefix ['chats'] also clears chatsSearch entries.
     queryClient.removeQueries({ queryKey: [queryKeys.chats] });
     queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
   },

--- a/frontend/src/hooks/queries/useWorkspaceQueries.ts
+++ b/frontend/src/hooks/queries/useWorkspaceQueries.ts
@@ -50,6 +50,9 @@ export const useUpdateWorkspaceMutation = createMutation<
   ({ workspaceId, data }) => workspaceService.updateWorkspace(workspaceId, data),
   (queryClient) => {
     queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
+    // Search results embed workspace_name, so a rename leaves a stale label
+    // visible until the search query naturally refetches.
+    queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
   },
 );
 

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -583,6 +583,11 @@ export function useStreamCallbacks({
         }
       }
 
+      // Invalidate the chat-search cache regardless of whether the completed
+      // stream belongs to the on-screen chat — otherwise off-screen completions
+      // (background turns) leave search results stale for up to staleTime.
+      queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
+
       if (!isCurrentChat) return;
 
       setPendingUserMessageId(null);

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -3,7 +3,13 @@ import { ensureResponse, serviceCall, buildQueryString } from '@/services/base/B
 import { authService } from '@/services/authService';
 import { validateRequired, validateId } from '@/utils/validation';
 import { chatStorage } from '@/utils/storage';
-import type { ChatRequest, Chat, CreateChatRequest, ContextUsage } from '@/types/chat.types';
+import type {
+  ChatRequest,
+  Chat,
+  ChatSearchResponse,
+  CreateChatRequest,
+  ContextUsage,
+} from '@/types/chat.types';
 import type { CursorPaginationParams, PaginatedChats, PaginatedMessages } from '@/types/api.types';
 
 async function createCompletion(
@@ -121,6 +127,14 @@ async function listChats(params?: {
 
     const response = await apiClient.get<PaginatedChats>(endpoint);
     return ensureResponse(response, 'Failed to fetch chats');
+  });
+}
+
+async function searchChats(query: string): Promise<ChatSearchResponse> {
+  return serviceCall(async () => {
+    const queryString = buildQueryString({ q: query });
+    const response = await apiClient.get<ChatSearchResponse>(`/chat/chats/search${queryString}`);
+    return ensureResponse(response, 'Failed to search chats');
   });
 }
 
@@ -273,6 +287,7 @@ export const chatService = {
   stopStream,
   getMessages,
   listChats,
+  searchChats,
   getChat,
   createChat,
   updateChat,

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -78,6 +78,29 @@ export interface ChatRequest {
   selected_persona_name: string;
 }
 
+export interface ChatSearchMatch {
+  message_id: string;
+  role: 'user' | 'assistant';
+  snippet_before: string;
+  snippet_match: string;
+  snippet_after: string;
+  created_at: string;
+}
+
+export interface ChatSearchResult {
+  chat_id: string;
+  chat_title: string;
+  workspace_id: string;
+  workspace_name: string;
+  matches: ChatSearchMatch[];
+  match_count: number;
+}
+
+export interface ChatSearchResponse {
+  results: ChatSearchResult[];
+  truncated: boolean;
+}
+
 export interface CreateChatRequest {
   title: string;
   model_id: string;


### PR DESCRIPTION
## Summary
- New `GET /chat/chats/search` endpoint that scans `Message.content_text` (case-insensitive, wildcard-escaped) across the user's chats and returns pre-split snippet fragments grouped per chat with workspace metadata.
- Frontend `ChatSearchPanel` mounted as a new `chat-search` mode of the existing command menu (⌘⇧K). Results are grouped by workspace, snippets highlight the match, the panel auto-focuses, and Esc steps back to the commands list.
- Cache invalidation wired into chat rename/delete, workspace rename, and stream completion (including off-screen completions) so search results stay fresh.
- Removed the standalone sidebar search UI in favor of the command-menu mode; "Theme: Dark" shortcut moved from `m` to free up `k` for chat search.

## Test plan
- [ ] Press ⌘⇧K — command menu opens directly in chat search mode.
- [ ] Press ⌘⇧P → "Search in chats" — same panel opens.
- [ ] Type a phrase that exists in multiple chats across multiple workspaces; verify results group by workspace, match counts are right, and the snippet highlights the matched text (including for emoji-containing messages).
- [ ] Type `%` or `_` literally — verify they match as literal characters, not as SQL wildcards.
- [ ] Type only whitespace — request rejected with 422; UI shows the empty hint.
- [ ] Click a result — chat opens at `/chat/:id` and the panel closes.
- [ ] Rename a chat / delete a chat / rename a workspace — open search again, verify the cache reflects the change.
- [ ] Stream a new message in a different chat (off-screen) — search results refetch and include the new content.
- [ ] Search for a term with > 50 matching chats — `truncated` shows in the summary.