### PR TITLE
Enable persona selector for OpenCode

### DIFF
--- a/backend/app/prompts/system_prompt.py
+++ b/backend/app/prompts/system_prompt.py
@@ -34,10 +34,8 @@ def build_system_prompt_for_chat(
     selected_persona_name: str = DEFAULT_PERSONA_NAME,
 ) -> str:
     persona_content = ""
-    # Only apply the persona for agents whose CLI honors a replaced system
-    # prompt; for others (cursor, copilot, opencode) the persona would be
-    # silently dropped, so skip it here and keep the prompt suggestions
-    # instructions unchanged.
+    # Only apply the persona for agents whose adapter can replace the base
+    # prompt; others silently drop replacement instructions over ACP.
     if (
         agent_kind in PERSONAS_SUPPORTED_AGENTS
         and selected_persona_name != DEFAULT_PERSONA_NAME

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -65,11 +65,11 @@ OPENCODE_SESSION_MODES = frozenset({"build", "plan"})
 
 # Agents that can have their base system prompt replaced by a persona.
 # Claude/Codex expose a first-class mechanism (ACP _meta.systemPrompt for
-# Claude; model_instructions_file CLI flag for Codex). Cursor, Copilot, and
-# OpenCode CLIs silently ignore any system prompt we send over ACP, so
-# personas would have no effect there — we hide the selector instead.
+# Claude; model_instructions_file CLI flag for Codex). OpenCode uses a custom
+# primary agent injected through OPENCODE_CONFIG_CONTENT. Cursor and Copilot
+# ignore system prompt replacement over ACP, so personas would have no effect.
 PERSONAS_SUPPORTED_AGENTS: frozenset[AgentKind] = frozenset(
-    {AgentKind.CLAUDE, AgentKind.CODEX}
+    {AgentKind.CLAUDE, AgentKind.CODEX, AgentKind.OPENCODE}
 )
 
 
@@ -451,9 +451,43 @@ class OpencodeAgentAdapter(AgentAdapter):
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:
-        meta = build_system_prompt_meta(system_prompt, system_prompt_is_full_replace)
+        if system_prompt and system_prompt_is_full_replace:
+            # OpenCode ignores ACP _meta.systemPrompt, so inject the persona as
+            # a custom primary agent via OPENCODE_CONFIG_CONTENT and select it
+            # as the session mode.
+            mode = self.map_session_mode(permission_mode)
+            agent_name = f"agentrove-persona-{mode}"
+            permission: dict[str, Any] = (
+                {"question": "allow", "plan_enter": "allow"}
+                if mode == "build"
+                else {
+                    "question": "allow",
+                    "plan_exit": "allow",
+                    "edit": {
+                        "*": "deny",
+                        ".opencode/plans/*.md": "allow",
+                    },
+                }
+            )
+            config_content = json.dumps(
+                {
+                    "agent": {
+                        agent_name: {
+                            "description": "Agentrove persona",
+                            "mode": "primary",
+                            "prompt": system_prompt,
+                            "permission": permission,
+                        }
+                    },
+                    "default_agent": agent_name,
+                }
+            )
+            return SessionConfig(
+                env_overrides={"OPENCODE_CONFIG_CONTENT": config_content},
+                permission=PermissionConfig(session_mode=agent_name),
+            )
+
         return SessionConfig(
-            meta=meta,
             permission=PermissionConfig(
                 session_mode=self.map_session_mode(permission_mode)
             ),

--- a/frontend/src/components/chat/persona-selector/PersonaSelector.tsx
+++ b/frontend/src/components/chat/persona-selector/PersonaSelector.tsx
@@ -10,13 +10,13 @@ import { useIsSplitMode } from '@/hooks/useIsSplitMode';
 import { useChatContext } from '@/hooks/useChatContext';
 import type { AgentKind } from '@/types/chat.types';
 
-// Only Claude and Codex CLIs honor a replaced system prompt (Claude via ACP
-// _meta.systemPrompt; Codex via model_instructions_file). Cursor, Copilot, and
-// OpenCode silently ignore it, so personas are hidden for those agents and
-// the backend skips applying them as well.
+// Claude and Codex expose direct prompt-replacement hooks; OpenCode uses a
+// generated primary agent with the persona prompt. Cursor and Copilot ignore
+// prompt replacement over ACP, so personas are hidden for those agents.
 export const PERSONAS_SUPPORTED_AGENTS: ReadonlySet<AgentKind> = new Set<AgentKind>([
   'claude',
   'codex',
+  'opencode',
 ]);
 
 interface PersonaOption {

--- a/frontend/src/components/settings/tabs/PersonasSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/PersonasSettingsTab.tsx
@@ -18,7 +18,7 @@ export const PersonasSettingsTab: React.FC<PersonasSettingsTabProps> = ({
   return (
     <ListManagementTab<Persona>
       title="Personas"
-      description="Create personas with custom system prompts. Select from the persona dropdown in the input bar. Only Claude and Codex support replacing the system prompt; the persona selector is hidden for Cursor, Copilot, and OpenCode."
+      description="Create personas with custom system prompts. Select from the persona dropdown in the input bar. Claude, Codex, and OpenCode support replacing the system prompt; the persona selector is hidden for Cursor and Copilot."
       items={personas}
       emptyIcon={UserCircle}
       emptyText="No personas configured yet"


### PR DESCRIPTION
## Summary
- Add OpenCode to `PERSONAS_SUPPORTED_AGENTS` (backend + frontend) so the persona selector is no longer hidden for OpenCode chats.
- In `OpencodeAgentAdapter.build_session_config`, when a persona is in use, generate a custom primary agent and inject it via `OPENCODE_CONFIG_CONTENT`, then select it as the session mode. OpenCode ignores ACP `_meta.systemPrompt`, so this is the only path that actually applies the persona prompt.
- Mirror the supported-agent set in `PersonaSelector.tsx` and refresh related comments / settings copy.

## Test plan
- [ ] Create a persona, switch a chat to OpenCode, select the persona, send a message — verify the persona prompt is applied.
- [ ] Toggle between `build` and `plan` permission modes with a persona active — verify the corresponding permissions (edit allow vs deny) take effect.
- [ ] Switch back to no persona on OpenCode — verify session falls back to the regular `build`/`plan` primary agent.
- [ ] Confirm Cursor and Copilot still hide the persona selector.