### PR TITLE
Add backend settings and workspace endpoint tests

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -93,4 +93,4 @@ jobs:
       - name: Run backend tests
         run: |
           cd backend
-          pytest tests/test_auth.py
+          pytest tests

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,10 +1,10 @@
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass, field
-from typing import Any
 
 import httpx
 import pytest
 import pytest_asyncio
+from fastapi import FastAPI
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import tests.bootstrap
@@ -18,6 +18,104 @@ from app.models.db_models.user import User, UserSettings
 from app.services.email import email_service
 
 TEST_DIR = tests.bootstrap.TEST_DIR
+
+
+@dataclass
+class EmailCapture:
+    disposable: bool = False
+    verification: list[dict[str, str | None]] = field(default_factory=list)
+    password_reset: list[dict[str, str | None]] = field(default_factory=list)
+
+    async def is_disposable_email(self, _email: str) -> bool:
+        return self.disposable
+
+    async def send_verification_email(
+        self,
+        email: str, verification_token: str, user_name: str | None = None
+    ) -> bool:
+        self.verification.append(
+            {"email": email, "token": verification_token, "user_name": user_name}
+        )
+        return True
+
+    async def send_password_reset_email(
+        self,
+        email: str, reset_token: str, user_name: str | None = None
+    ) -> bool:
+        self.password_reset.append(
+            {"email": email, "token": reset_token, "user_name": user_name}
+        )
+        return True
+
+
+class SettingsOverride:
+    def __init__(self) -> None:
+        self.settings = get_settings()
+        self.original = {
+            "REGISTRATION_DISABLED": self.settings.REGISTRATION_DISABLED,
+            "REQUIRE_EMAIL_VERIFICATION": self.settings.REQUIRE_EMAIL_VERIFICATION,
+            "BLOCK_DISPOSABLE_EMAILS": self.settings.BLOCK_DISPOSABLE_EMAILS,
+        }
+
+    def __call__(self, **values: bool) -> None:
+        for key, value in values.items():
+            setattr(self.settings, key, value)
+
+    def restore(self) -> None:
+        for key, value in self.original.items():
+            setattr(self.settings, key, value)
+
+
+class UserFactory:
+    def __init__(self, db_session: AsyncSession) -> None:
+        self.db_session = db_session
+
+    async def __call__(
+        self,
+        *,
+        email: str = "user@example.com",
+        username: str = "testuser",
+        password: str = "password123",
+        is_active: bool = True,
+        is_verified: bool = True,
+    ) -> User:
+        user = User(
+            email=email,
+            username=username,
+            hashed_password=get_password_hash(password),
+            is_active=is_active,
+            is_verified=is_verified,
+            is_superuser=False,
+        )
+        self.db_session.add(user)
+        await self.db_session.flush()
+        self.db_session.add(
+            UserSettings(
+                user_id=user.id,
+                github_personal_access_token=None,
+            )
+        )
+        await self.db_session.commit()
+        await self.db_session.refresh(user)
+        return user
+
+
+class LoginClient:
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self.client = client
+
+    async def __call__(
+        self,
+        *,
+        email: str = "user@example.com",
+        password: str = "password123",
+    ) -> dict[str, str]:
+        response = await self.client.post(
+            "/api/v1/auth/jwt/login",
+            data={"username": email, "password": password},
+        )
+        assert response.status_code == 200
+        return response.json()
 
 
 @pytest.fixture(scope="session")
@@ -36,7 +134,7 @@ async def database() -> AsyncIterator[None]:
 
 
 @pytest.fixture
-def app() -> Any:
+def app() -> Iterator[FastAPI]:
     auth_endpoint.limiter.enabled = False
     TEST_DIR.joinpath("storage").mkdir(exist_ok=True)
     application = create_application()
@@ -45,7 +143,7 @@ def app() -> Any:
 
 
 @pytest_asyncio.fixture
-async def client(app: Any) -> AsyncIterator[httpx.AsyncClient]:
+async def client(app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=app, client=("testclient", 50000))
     async with httpx.AsyncClient(
         transport=transport, base_url="http://testserver"
@@ -59,114 +157,33 @@ async def db_session() -> AsyncIterator[AsyncSession]:
         yield session
 
 
-@dataclass
-class EmailCapture:
-    disposable: bool = False
-    verification: list[dict[str, Any]] = field(default_factory=list)
-    password_reset: list[dict[str, Any]] = field(default_factory=list)
-
-
 @pytest.fixture
 def email_capture(monkeypatch: pytest.MonkeyPatch) -> EmailCapture:
     capture = EmailCapture()
-
-    async def is_disposable_email(_email: str) -> bool:
-        return capture.disposable
-
-    async def send_verification_email(
-        email: str, verification_token: str, user_name: str | None = None
-    ) -> bool:
-        capture.verification.append(
-            {"email": email, "token": verification_token, "user_name": user_name}
-        )
-        return True
-
-    async def send_password_reset_email(
-        email: str, reset_token: str, user_name: str | None = None
-    ) -> bool:
-        capture.password_reset.append(
-            {"email": email, "token": reset_token, "user_name": user_name}
-        )
-        return True
-
-    monkeypatch.setattr(email_service, "is_disposable_email", is_disposable_email)
     monkeypatch.setattr(
-        email_service, "send_verification_email", send_verification_email
+        email_service, "is_disposable_email", capture.is_disposable_email
     )
     monkeypatch.setattr(
-        email_service, "send_password_reset_email", send_password_reset_email
+        email_service, "send_verification_email", capture.send_verification_email
+    )
+    monkeypatch.setattr(
+        email_service, "send_password_reset_email", capture.send_password_reset_email
     )
     return capture
 
 
 @pytest.fixture
-def settings_override() -> Iterator[Callable[..., None]]:
-    settings = get_settings()
-    original = {
-        "REGISTRATION_DISABLED": settings.REGISTRATION_DISABLED,
-        "REQUIRE_EMAIL_VERIFICATION": settings.REQUIRE_EMAIL_VERIFICATION,
-        "BLOCK_DISPOSABLE_EMAILS": settings.BLOCK_DISPOSABLE_EMAILS,
-    }
-
-    def apply(**values: bool) -> None:
-        for key, value in values.items():
-            setattr(settings, key, value)
-
-    yield apply
-
-    for key, value in original.items():
-        setattr(settings, key, value)
+def settings_override() -> Iterator[SettingsOverride]:
+    override = SettingsOverride()
+    yield override
+    override.restore()
 
 
 @pytest_asyncio.fixture
-async def create_user(
-    db_session: AsyncSession,
-) -> Callable[..., Awaitable[User]]:
-    async def create(
-        *,
-        email: str = "user@example.com",
-        username: str = "testuser",
-        password: str = "password123",
-        is_active: bool = True,
-        is_verified: bool = True,
-    ) -> User:
-        user = User(
-            email=email,
-            username=username,
-            hashed_password=get_password_hash(password),
-            is_active=is_active,
-            is_verified=is_verified,
-            is_superuser=False,
-        )
-        db_session.add(user)
-        await db_session.flush()
-        db_session.add(
-            UserSettings(
-                user_id=user.id,
-                github_personal_access_token=None,
-            )
-        )
-        await db_session.commit()
-        await db_session.refresh(user)
-        return user
-
-    return create
+async def create_user(db_session: AsyncSession) -> UserFactory:
+    return UserFactory(db_session)
 
 
 @pytest_asyncio.fixture
-async def login(
-    client: httpx.AsyncClient,
-) -> Callable[..., Awaitable[dict[str, str]]]:
-    async def authenticate(
-        *,
-        email: str = "user@example.com",
-        password: str = "password123",
-    ) -> dict[str, str]:
-        response = await client.post(
-            "/api/v1/auth/jwt/login",
-            data={"username": email, "password": password},
-        )
-        assert response.status_code == 200
-        return response.json()
-
-    return authenticate
+async def login(client: httpx.AsyncClient) -> LoginClient:
+    return LoginClient(client)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -30,8 +30,7 @@ class EmailCapture:
         return self.disposable
 
     async def send_verification_email(
-        self,
-        email: str, verification_token: str, user_name: str | None = None
+        self, email: str, verification_token: str, user_name: str | None = None
     ) -> bool:
         self.verification.append(
             {"email": email, "token": verification_token, "user_name": user_name}
@@ -39,8 +38,7 @@ class EmailCapture:
         return True
 
     async def send_password_reset_email(
-        self,
-        email: str, reset_token: str, user_name: str | None = None
+        self, email: str, reset_token: str, user_name: str | None = None
     ) -> bool:
         self.password_reset.append(
             {"email": email, "token": reset_token, "user_name": user_name}

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -1,4 +1,4 @@
-from typing import Any
+from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,14 +12,14 @@ async def get_user_by_email(db: AsyncSession, email: str) -> User | None:
     return result.scalar_one_or_none()
 
 
-async def get_user_settings(db: AsyncSession, user_id: Any) -> UserSettings | None:
+async def get_user_settings(db: AsyncSession, user_id: UUID) -> UserSettings | None:
     result = await db.execute(
         select(UserSettings).where(UserSettings.user_id == user_id)
     )
     return result.scalar_one_or_none()
 
 
-async def count_refresh_tokens(db: AsyncSession, user_id: Any) -> int:
+async def count_refresh_tokens(db: AsyncSession, user_id: UUID) -> int:
     result = await db.execute(
         select(RefreshToken).where(RefreshToken.user_id == user_id)
     )

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,11 +1,10 @@
-from typing import Any
-
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.db_models.user import User
 
+from tests.conftest import EmailCapture, LoginClient, SettingsOverride, UserFactory
 from tests.helpers import count_refresh_tokens, get_user_by_email, get_user_settings
 
 
@@ -15,7 +14,7 @@ pytestmark = pytest.mark.anyio
 async def test_register_creates_user_and_settings(
     client: AsyncClient,
     db_session: AsyncSession,
-    email_capture: Any,
+    email_capture: EmailCapture,
 ) -> None:
     response = await client.post(
         "/api/v1/auth/register",
@@ -39,8 +38,8 @@ async def test_register_creates_user_and_settings(
 
 async def test_register_rejects_duplicate_email(
     client: AsyncClient,
-    create_user: Any,
-    email_capture: Any,
+    create_user: UserFactory,
+    email_capture: EmailCapture,
 ) -> None:
     await create_user(email="taken@example.com", username="existing")
 
@@ -59,8 +58,8 @@ async def test_register_rejects_duplicate_email(
 
 async def test_register_rejects_duplicate_username(
     client: AsyncClient,
-    create_user: Any,
-    email_capture: Any,
+    create_user: UserFactory,
+    email_capture: EmailCapture,
 ) -> None:
     await create_user(email="first@example.com", username="takenname")
 
@@ -79,7 +78,7 @@ async def test_register_rejects_duplicate_username(
 
 async def test_register_rejects_invalid_username(
     client: AsyncClient,
-    email_capture: Any,
+    email_capture: EmailCapture,
 ) -> None:
     response = await client.post(
         "/api/v1/auth/register",
@@ -95,8 +94,8 @@ async def test_register_rejects_invalid_username(
 
 async def test_register_rejects_disabled_registration(
     client: AsyncClient,
-    settings_override: Any,
-    email_capture: Any,
+    settings_override: SettingsOverride,
+    email_capture: EmailCapture,
 ) -> None:
     settings_override(REGISTRATION_DISABLED=True)
 
@@ -115,8 +114,8 @@ async def test_register_rejects_disabled_registration(
 
 async def test_register_rejects_disposable_email(
     client: AsyncClient,
-    settings_override: Any,
-    email_capture: Any,
+    settings_override: SettingsOverride,
+    email_capture: EmailCapture,
 ) -> None:
     settings_override(BLOCK_DISPOSABLE_EMAILS=True)
     email_capture.disposable = True
@@ -138,7 +137,7 @@ async def test_register_rejects_disposable_email(
 
 async def test_login_returns_access_and_refresh_tokens(
     client: AsyncClient,
-    create_user: Any,
+    create_user: UserFactory,
     db_session: AsyncSession,
 ) -> None:
     user = await create_user(email="login@example.com", username="loginuser")
@@ -159,7 +158,7 @@ async def test_login_returns_access_and_refresh_tokens(
 
 async def test_login_rejects_wrong_password(
     client: AsyncClient,
-    create_user: Any,
+    create_user: UserFactory,
 ) -> None:
     await create_user(email="login@example.com", username="loginuser")
 
@@ -174,7 +173,7 @@ async def test_login_rejects_wrong_password(
 
 async def test_login_rejects_inactive_user(
     client: AsyncClient,
-    create_user: Any,
+    create_user: UserFactory,
 ) -> None:
     await create_user(
         email="inactive@example.com",
@@ -193,8 +192,8 @@ async def test_login_rejects_inactive_user(
 
 async def test_login_rejects_unverified_user_when_verification_required(
     client: AsyncClient,
-    create_user: Any,
-    settings_override: Any,
+    create_user: UserFactory,
+    settings_override: SettingsOverride,
 ) -> None:
     settings_override(REQUIRE_EMAIL_VERIFICATION=True)
     await create_user(
@@ -214,8 +213,8 @@ async def test_login_rejects_unverified_user_when_verification_required(
 
 async def test_me_returns_current_user(
     client: AsyncClient,
-    create_user: Any,
-    login: Any,
+    create_user: UserFactory,
+    login: LoginClient,
 ) -> None:
     await create_user(email="me@example.com", username="meuser")
     tokens = await login(email="me@example.com")
@@ -240,8 +239,8 @@ async def test_me_rejects_missing_token(client: AsyncClient) -> None:
 
 async def test_refresh_rotates_refresh_token(
     client: AsyncClient,
-    create_user: Any,
-    login: Any,
+    create_user: UserFactory,
+    login: LoginClient,
 ) -> None:
     await create_user(email="refresh@example.com", username="refreshuser")
     tokens = await login(email="refresh@example.com")
@@ -261,8 +260,8 @@ async def test_refresh_rotates_refresh_token(
 
 async def test_refresh_rejects_rotated_token(
     client: AsyncClient,
-    create_user: Any,
-    login: Any,
+    create_user: UserFactory,
+    login: LoginClient,
 ) -> None:
     await create_user(email="refresh@example.com", username="refreshuser")
     tokens = await login(email="refresh@example.com")
@@ -292,8 +291,8 @@ async def test_refresh_rejects_invalid_token(client: AsyncClient) -> None:
 
 async def test_logout_revokes_refresh_token(
     client: AsyncClient,
-    create_user: Any,
-    login: Any,
+    create_user: UserFactory,
+    login: LoginClient,
 ) -> None:
     await create_user(email="logout@example.com", username="logoutuser")
     tokens = await login(email="logout@example.com")
@@ -313,8 +312,8 @@ async def test_logout_revokes_refresh_token(
 
 async def test_forgot_password_sends_reset_email(
     client: AsyncClient,
-    create_user: Any,
-    email_capture: Any,
+    create_user: UserFactory,
+    email_capture: EmailCapture,
 ) -> None:
     await create_user(email="reset@example.com", username="resetuser")
 
@@ -331,8 +330,8 @@ async def test_forgot_password_sends_reset_email(
 
 async def test_reset_password_accepts_valid_token(
     client: AsyncClient,
-    create_user: Any,
-    email_capture: Any,
+    create_user: UserFactory,
+    email_capture: EmailCapture,
 ) -> None:
     await create_user(email="reset@example.com", username="resetuser")
     await client.post(
@@ -365,8 +364,8 @@ async def test_reset_password_rejects_invalid_token(client: AsyncClient) -> None
 
 async def test_request_verify_token_sends_verification_email(
     client: AsyncClient,
-    create_user: Any,
-    email_capture: Any,
+    create_user: UserFactory,
+    email_capture: EmailCapture,
 ) -> None:
     await create_user(
         email="verify@example.com",
@@ -387,9 +386,9 @@ async def test_request_verify_token_sends_verification_email(
 
 async def test_verify_accepts_valid_token(
     client: AsyncClient,
-    create_user: Any,
+    create_user: UserFactory,
     db_session: AsyncSession,
-    email_capture: Any,
+    email_capture: EmailCapture,
 ) -> None:
     user: User = await create_user(
         email="verify@example.com",

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,124 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+from httpx import AsyncClient
+
+from app.api.endpoints import settings as settings_endpoint
+from app.utils.cache import CacheStore, MemoryStore
+
+from tests.conftest import LoginClient, UserFactory
+
+
+pytestmark = pytest.mark.anyio
+
+
+class SettingsCache:
+    def __init__(self) -> None:
+        self.store = MemoryStore()
+
+    @asynccontextmanager
+    async def connect(self) -> AsyncIterator[CacheStore]:
+        yield self.store
+
+
+@pytest.fixture
+def settings_cache(monkeypatch: pytest.MonkeyPatch) -> SettingsCache:
+    cache = SettingsCache()
+    monkeypatch.setattr(settings_endpoint, "cache_connection", cache.connect)
+    return cache
+
+
+async def test_get_settings_returns_current_user_settings(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    settings_cache: SettingsCache,
+) -> None:
+    user = await create_user(email="settings@example.com", username="settingsuser")
+    tokens = await login(email="settings@example.com")
+
+    response = await client.get(
+        "/api/v1/settings/",
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["user_id"] == str(user.id)
+    assert body["github_personal_access_token"] is None
+    assert body["custom_instructions"] is None
+    assert body["custom_env_vars"] is None
+    assert body["personas"] is None
+    assert body["notifications_enabled"] is True
+
+
+async def test_patch_settings_updates_persistence_and_invalidates_cache(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    settings_cache: SettingsCache,
+) -> None:
+    await create_user(email="update-settings@example.com", username="updatesettings")
+    tokens = await login(email="update-settings@example.com")
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+    payload = {
+        "github_personal_access_token": "ghp_testtoken",
+        "custom_instructions": "Prefer concise answers.",
+        "custom_env_vars": [{"key": "API_MODE", "value": "test"}],
+        "personas": [{"name": "Reviewer", "content": "Review carefully."}],
+        "notifications_enabled": False,
+    }
+
+    cached_response = await client.get("/api/v1/settings/", headers=headers)
+    assert cached_response.status_code == 200
+
+    response = await client.patch(
+        "/api/v1/settings/",
+        json=payload,
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["github_personal_access_token"] == "ghp_testtoken"
+    assert body["custom_instructions"] == "Prefer concise answers."
+    assert body["custom_env_vars"] == [{"key": "API_MODE", "value": "test"}]
+    assert body["personas"] == [{"name": "Reviewer", "content": "Review carefully."}]
+    assert body["notifications_enabled"] is False
+
+    get_response = await client.get("/api/v1/settings/", headers=headers)
+    assert get_response.status_code == 200
+    assert get_response.json()["custom_instructions"] == "Prefer concise answers."
+
+
+async def test_patch_settings_normalizes_string_json_lists(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    settings_cache: SettingsCache,
+) -> None:
+    await create_user(email="normalize-settings@example.com", username="normalize")
+    tokens = await login(email="normalize-settings@example.com")
+
+    response = await client.patch(
+        "/api/v1/settings/",
+        json={"custom_env_vars": "[]", "personas": "[]"},
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["custom_env_vars"] == []
+    assert body["personas"] == []
+
+
+async def test_settings_rejects_missing_token(client: AsyncClient) -> None:
+    get_response = await client.get("/api/v1/settings/")
+    patch_response = await client.patch(
+        "/api/v1/settings/",
+        json={"custom_instructions": "No auth"},
+    )
+
+    assert get_response.status_code == 401
+    assert patch_response.status_code == 401

--- a/backend/tests/test_workspace.py
+++ b/backend/tests/test_workspace.py
@@ -1,0 +1,289 @@
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from app.services.sandbox_providers.base import SandboxProvider
+from app.services.sandbox_providers.types import (
+    CommandResult,
+    FileContent,
+    FileMetadata,
+    PtyDataCallbackType,
+    PtySession,
+    PtySize,
+)
+
+from tests.conftest import LoginClient, UserFactory
+
+
+pytestmark = pytest.mark.anyio
+
+
+class FakeSandboxProvider(SandboxProvider):
+    def __init__(self, workspace_path: str | None = None) -> None:
+        self._workspace_root = workspace_path or "/tmp/agentrove-test-workspace"
+
+    @property
+    def workspace_root(self) -> str:
+        return self._workspace_root
+
+    async def create_sandbox(self, workspace_path: str | None = None) -> str:
+        return "sandbox-1"
+
+    async def delete_sandbox(self, sandbox_id: str) -> None:
+        return None
+
+    async def execute_command(
+        self,
+        sandbox_id: str,
+        command: str,
+        envs: dict[str, str] | None = None,
+        timeout: int = 120,
+    ) -> CommandResult:
+        return CommandResult(stdout="", stderr="", exit_code=0)
+
+    async def write_file(
+        self,
+        sandbox_id: str,
+        path: str,
+        content: str | bytes,
+    ) -> None:
+        return None
+
+    async def read_file(
+        self,
+        sandbox_id: str,
+        path: str,
+    ) -> FileContent:
+        return FileContent(path=path, content="", type="file", is_binary=False)
+
+    async def list_files(
+        self,
+        sandbox_id: str,
+        path: str = "",
+    ) -> list[FileMetadata]:
+        return []
+
+    async def create_pty(
+        self,
+        sandbox_id: str,
+        rows: int,
+        cols: int,
+        tmux_session: str,
+        on_data: PtyDataCallbackType | None = None,
+    ) -> PtySession:
+        return PtySession(id="pty-1", pid=None, rows=rows, cols=cols)
+
+    async def send_pty_input(
+        self,
+        sandbox_id: str,
+        pty_id: str,
+        data: bytes,
+    ) -> None:
+        return None
+
+    async def resize_pty(
+        self,
+        sandbox_id: str,
+        pty_id: str,
+        size: PtySize,
+    ) -> None:
+        return None
+
+    async def kill_pty(self, sandbox_id: str, pty_id: str) -> None:
+        return None
+
+
+def _fake_create_provider(
+    provider_type: str,
+    workspace_path: str | None = None,
+) -> FakeSandboxProvider:
+    return FakeSandboxProvider(workspace_path=workspace_path)
+
+
+@pytest.fixture
+def workspace_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(SandboxProvider, "create_provider", _fake_create_provider)
+
+
+async def create_authenticated_workspace(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    *,
+    email: str = "workspace@example.com",
+    username: str = "workspaceuser",
+    name: str = "Test Workspace",
+) -> tuple[dict[str, str], dict[str, Any]]:
+    await create_user(email=email, username=username)
+    tokens = await login(email=email)
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    response = await client.post(
+        "/api/v1/workspaces",
+        json={"name": name, "source_type": "empty", "sandbox_provider": "host"},
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    return headers, response.json()
+
+
+async def test_create_workspace_persists_empty_workspace(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+) -> None:
+    user = await create_user(email="create-workspace@example.com", username="createws")
+    tokens = await login(email="create-workspace@example.com")
+
+    response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "New Workspace",
+            "source_type": "empty",
+            "sandbox_provider": "host",
+        },
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["name"] == "New Workspace"
+    assert body["user_id"] == str(user.id)
+    assert body["sandbox_id"] == "sandbox-1"
+    assert body["sandbox_provider"] == "host"
+    assert body["source_type"] == "empty"
+    assert body["source_url"] is None
+    assert Path(body["workspace_path"]).is_dir()
+
+
+async def test_list_get_and_update_workspace(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+) -> None:
+    headers, workspace = await create_authenticated_workspace(
+        client, create_user, login, name="Original Name"
+    )
+    workspace_id = workspace["id"]
+
+    list_response = await client.get("/api/v1/workspaces", headers=headers)
+    get_response = await client.get(
+        f"/api/v1/workspaces/{workspace_id}", headers=headers
+    )
+    update_response = await client.patch(
+        f"/api/v1/workspaces/{workspace_id}",
+        json={"name": "Renamed Workspace"},
+        headers=headers,
+    )
+
+    assert list_response.status_code == 200
+    listed = list_response.json()
+    assert listed["total"] == 1
+    assert listed["items"][0]["id"] == workspace_id
+    assert listed["items"][0]["chat_count"] == 0
+    assert listed["items"][0]["last_chat_at"] is None
+    assert get_response.status_code == 200
+    assert get_response.json()["id"] == workspace_id
+    assert update_response.status_code == 200
+    assert update_response.json()["name"] == "Renamed Workspace"
+
+
+async def test_workspace_access_is_limited_to_owner(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+) -> None:
+    owner_headers, workspace = await create_authenticated_workspace(
+        client,
+        create_user,
+        login,
+        email="owner@example.com",
+        username="owneruser",
+    )
+    await create_user(email="other@example.com", username="otheruser")
+    other_tokens = await login(email="other@example.com")
+    other_headers = {"Authorization": f"Bearer {other_tokens['access_token']}"}
+    workspace_id = workspace["id"]
+
+    other_list = await client.get("/api/v1/workspaces", headers=other_headers)
+    other_get = await client.get(
+        f"/api/v1/workspaces/{workspace_id}", headers=other_headers
+    )
+    owner_get = await client.get(
+        f"/api/v1/workspaces/{workspace_id}", headers=owner_headers
+    )
+
+    assert other_list.status_code == 200
+    assert other_list.json()["items"] == []
+    assert other_get.status_code == 404
+    assert owner_get.status_code == 200
+
+
+async def test_delete_workspace_soft_deletes_it(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+) -> None:
+    headers, workspace = await create_authenticated_workspace(
+        client, create_user, login
+    )
+    workspace_id = workspace["id"]
+
+    response = await client.delete(
+        f"/api/v1/workspaces/{workspace_id}", headers=headers
+    )
+    list_response = await client.get("/api/v1/workspaces", headers=headers)
+    get_response = await client.get(
+        f"/api/v1/workspaces/{workspace_id}", headers=headers
+    )
+
+    assert response.status_code == 204
+    assert list_response.status_code == 200
+    assert list_response.json()["items"] == []
+    assert get_response.status_code == 404
+
+
+async def test_create_workspace_rejects_invalid_git_payload(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+) -> None:
+    await create_user(email="git-workspace@example.com", username="gitworkspace")
+    tokens = await login(email="git-workspace@example.com")
+
+    response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "Git Workspace",
+            "source_type": "git",
+            "sandbox_provider": "host",
+        },
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "git_url is required for git workspace"
+
+
+async def test_workspaces_reject_missing_token(client: AsyncClient) -> None:
+    workspace_id = UUID("00000000-0000-0000-0000-000000000001")
+
+    list_response = await client.get("/api/v1/workspaces")
+    create_response = await client.post(
+        "/api/v1/workspaces",
+        json={"name": "No Auth", "source_type": "empty", "sandbox_provider": "host"},
+    )
+    get_response = await client.get(f"/api/v1/workspaces/{workspace_id}")
+
+    assert list_response.status_code == 401
+    assert create_response.status_code == 401
+    assert get_response.status_code == 401


### PR DESCRIPTION
## Summary
- Refactor fixture closures in `conftest.py` into typed helper classes (`EmailCapture`, `SettingsOverride`, `UserFactory`, `LoginClient`) so tests get strong types instead of `Any`
- Add endpoint tests for `/api/v1/settings/` (GET, PATCH, normalization, auth) and `/api/v1/workspaces` (create, list/get/update, owner access, soft delete, validation, auth)
- CI backend test job now runs the full `tests` directory instead of only `test_auth.py`

## Test plan
- [ ] `pytest backend/tests` passes locally
- [ ] CI `Backend Tests` job is green