### PR TITLE
Add backend chat queue endpoint tests

### DIFF
--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,13 +1,20 @@
+from collections.abc import AsyncIterator
 from uuid import UUID
 
 import pytest
+from fastapi import FastAPI
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.deps import get_queue_service
 from app.models.db_models.chat import Chat, Message
 from app.models.db_models.enums import MessageRole, MessageStreamStatus
 from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
+from app.services.db import SessionFactoryType
+from app.services.queue import QueueService
+from app.services.streaming.runtime import ChatStreamRuntime
+from app.utils.cache import MemoryStore
 
 from tests.conftest import LoginClient, UserFactory
 
@@ -15,6 +22,25 @@ from tests.conftest import LoginClient, UserFactory
 TEST_MODEL_ID = "opencode:google-vertex-anthropic/claude-sonnet-4-5@20250929"
 
 pytestmark = pytest.mark.anyio
+
+
+class QueueServiceOverride:
+    def __init__(self) -> None:
+        self.store = MemoryStore()
+
+    async def __call__(self) -> AsyncIterator[QueueService]:
+        yield QueueService(self.store)
+
+
+class SendNowCapture:
+    def __init__(self) -> None:
+        self.chat_ids: list[str] = []
+
+    async def process_send_now_idle(
+        self, chat_id: str, _session_factory: SessionFactoryType
+    ) -> bool:
+        self.chat_ids.append(chat_id)
+        return True
 
 
 async def create_authenticated_workspace(
@@ -294,6 +320,182 @@ async def test_chat_messages_returns_only_owned_chat_messages(
     assert body["items"][0]["id"] == str(message.id)
     assert body["items"][0]["content_text"] == "Visible message"
     assert other_response.status_code == 403
+
+
+async def test_queue_message_lifecycle(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_override = QueueServiceOverride()
+    send_now_capture = SendNowCapture()
+
+    app.dependency_overrides[get_queue_service] = queue_override
+    monkeypatch.setattr(
+        ChatStreamRuntime,
+        "process_send_now_idle",
+        staticmethod(send_now_capture.process_send_now_idle),
+    )
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    create_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={
+            "content": "First queued prompt",
+            "model_id": TEST_MODEL_ID,
+            "permission_mode": "bypassPermissions",
+            "thinking_mode": "high",
+            "worktree": "true",
+            "plan_mode": "true",
+            "selected_persona_name": "Default",
+        },
+        headers=headers,
+    )
+
+    assert create_response.status_code == 201
+    queued_id = create_response.json()["id"]
+
+    list_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/queue", headers=headers
+    )
+    assert list_response.status_code == 200
+    queued = list_response.json()
+    assert len(queued) == 1
+    assert queued[0]["id"] == queued_id
+    assert queued[0]["content"] == "First queued prompt"
+    assert queued[0]["model_id"] == TEST_MODEL_ID
+    assert queued[0]["permission_mode"] == "bypassPermissions"
+    assert queued[0]["thinking_mode"] == "high"
+    assert queued[0]["worktree"] is True
+    assert queued[0]["plan_mode"] is True
+    assert queued[0]["selected_persona_name"] == "Default"
+    assert queued[0]["attachments"] is None
+
+    update_response = await client.patch(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued_id}",
+        json={"content": "Edited queued prompt"},
+        headers=headers,
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["content"] == "Edited queued prompt"
+
+    missing_id = UUID("00000000-0000-0000-0000-000000000001")
+    missing_update_response = await client.patch(
+        f"/api/v1/chat/chats/{chat.id}/queue/{missing_id}",
+        json={"content": "Missing prompt"},
+        headers=headers,
+    )
+    missing_delete_response = await client.delete(
+        f"/api/v1/chat/chats/{chat.id}/queue/{missing_id}", headers=headers
+    )
+    missing_send_now_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{missing_id}/send-now", headers=headers
+    )
+    send_now_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued_id}/send-now", headers=headers
+    )
+
+    assert missing_update_response.status_code == 404
+    assert missing_delete_response.status_code == 404
+    assert missing_send_now_response.status_code == 404
+    assert send_now_response.status_code == 204
+    assert send_now_capture.chat_ids == [str(chat.id)]
+
+    delete_response = await client.delete(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued_id}", headers=headers
+    )
+    final_list_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/queue", headers=headers
+    )
+    assert delete_response.status_code == 204
+    assert final_list_response.status_code == 200
+    assert final_list_response.json() == []
+
+    second_create_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Second queued prompt", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    clear_response = await client.delete(
+        f"/api/v1/chat/chats/{chat.id}/queue", headers=headers
+    )
+    cleared_list_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/queue", headers=headers
+    )
+
+    assert second_create_response.status_code == 201
+    assert clear_response.status_code == 204
+    assert cleared_list_response.status_code == 200
+    assert cleared_list_response.json() == []
+
+
+async def test_queue_access_is_limited_to_chat_owner(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    app.dependency_overrides[get_queue_service] = QueueServiceOverride()
+    owner_headers, owner, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="queue-owner@example.com",
+        username="queueowner",
+    )
+    chat = await create_chat_row(db_session, owner, workspace)
+    other_headers, _other_user, _other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="queue-other@example.com",
+        username="queueother",
+    )
+
+    create_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Owner queued prompt", "model_id": TEST_MODEL_ID},
+        headers=owner_headers,
+    )
+    assert create_response.status_code == 201
+    queued_id = create_response.json()["id"]
+
+    other_list_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/queue", headers=other_headers
+    )
+    other_update_response = await client.patch(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued_id}",
+        json={"content": "Stolen prompt"},
+        headers=other_headers,
+    )
+    other_delete_response = await client.delete(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued_id}", headers=other_headers
+    )
+    other_send_now_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued_id}/send-now",
+        headers=other_headers,
+    )
+    other_clear_response = await client.delete(
+        f"/api/v1/chat/chats/{chat.id}/queue", headers=other_headers
+    )
+    owner_list_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/queue", headers=owner_headers
+    )
+
+    assert other_list_response.status_code == 404
+    assert other_update_response.status_code == 404
+    assert other_delete_response.status_code == 404
+    assert other_send_now_response.status_code == 404
+    assert other_clear_response.status_code == 404
+    assert owner_list_response.status_code == 200
+    assert owner_list_response.json()[0]["content"] == "Owner queued prompt"
 
 
 async def test_search_chats_returns_matches_and_rejects_blank_query(


### PR DESCRIPTION
## Summary
- Add lifecycle test for the chat queue endpoints: create, list, update, send-now, delete, and clear, including 404s for missing IDs.
- Add ownership test verifying non-owners cannot list/update/delete/send-now/clear another user's chat queue.
- Stub `QueueService` with an in-memory store and capture `ChatStreamRuntime.process_send_now_idle` invocations so tests stay within the API boundary.

## Test plan
- [ ] `pytest backend/tests/test_chat.py -k queue`