### PR TITLE
Add backend sandbox endpoint tests

### DIFF
--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -1,3 +1,4 @@
+import json
 from uuid import UUID
 
 from sqlalchemy import select
@@ -5,6 +6,182 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.db_models.refresh_token import RefreshToken
 from app.models.db_models.user import User, UserSettings
+from app.services.sandbox_providers.base import SandboxProvider
+from app.services.sandbox_providers.types import (
+    CommandResult,
+    FileContent,
+    FileMetadata,
+    PtyDataCallbackType,
+    PtySession,
+    PtySize,
+)
+
+
+class FakeSandboxProvider(SandboxProvider):
+    def __init__(self, workspace_path: str | None = None) -> None:
+        self._workspace_root = workspace_path or "/tmp/agentrove-test-sandbox"
+        self.files = {
+            "README.md": FileContent(
+                path="README.md",
+                content="Initial readme",
+                type="file",
+                is_binary=False,
+            )
+        }
+        self.writes: list[tuple[str, str, str | bytes]] = []
+        self.commands: list[tuple[str, str, dict[str, str] | None]] = []
+
+    @property
+    def workspace_root(self) -> str:
+        return self._workspace_root
+
+    async def create_sandbox(self, workspace_path: str | None = None) -> str:
+        return "sandbox-1"
+
+    async def delete_sandbox(self, sandbox_id: str) -> None:
+        return None
+
+    async def execute_command(
+        self,
+        sandbox_id: str,
+        command: str,
+        envs: dict[str, str] | None = None,
+        timeout: int = 120,
+    ) -> CommandResult:
+        self.commands.append((sandbox_id, command, envs))
+        if "git for-each-ref" in command:
+            return CommandResult(
+                stdout=(
+                    "main\n"
+                    "__BRANCHES_LOCAL__\n"
+                    "main\n"
+                    "__BRANCHES_REMOTE__\n"
+                    "origin/HEAD\n"
+                    "origin/feature\n"
+                ),
+                stderr="",
+                exit_code=0,
+            )
+        if "git rev-parse --is-inside-work-tree" in command:
+            return CommandResult(stdout="true\n", stderr="", exit_code=0)
+        if "git diff" in command:
+            return CommandResult(
+                stdout="diff --git a/app.py b/app.py\n",
+                stderr="",
+                exit_code=0,
+            )
+        if "git checkout 'feature'" in command:
+            return CommandResult(stdout="", stderr="", exit_code=0)
+        if "git rev-parse --abbrev-ref HEAD" in command:
+            return CommandResult(stdout="feature\n", stderr="", exit_code=0)
+        if "git add -A && git commit" in command:
+            return CommandResult(stdout="committed\n", stderr="", exit_code=0)
+        if "git checkout HEAD --" in command:
+            return CommandResult(stdout="restored\n", stderr="", exit_code=0)
+        if "git checkout -b 'feature-two' 'main'" in command:
+            return CommandResult(stdout="", stderr="", exit_code=0)
+        if "git remote get-url origin" in command:
+            return CommandResult(
+                stdout="https://github.com/agentrove/app.git\n",
+                stderr="",
+                exit_code=0,
+            )
+        if "rg " in command:
+            payload = {
+                "type": "match",
+                "data": {
+                    "path": {"text": "./app.py"},
+                    "line_number": 1,
+                    "lines": {"text": "needle = True\n"},
+                    "submatches": [{"start": 0, "end": 6}],
+                },
+            }
+            return CommandResult(
+                stdout=json.dumps(payload) + "\n",
+                stderr="",
+                exit_code=0,
+            )
+        return CommandResult(stdout="", stderr="", exit_code=0)
+
+    async def write_file(
+        self,
+        sandbox_id: str,
+        path: str,
+        content: str | bytes,
+    ) -> None:
+        self.writes.append((sandbox_id, path, content))
+        self.files[path] = FileContent(
+            path=path,
+            content=str(content),
+            type="file",
+            is_binary=False,
+        )
+
+    async def read_file(
+        self,
+        sandbox_id: str,
+        path: str,
+    ) -> FileContent:
+        return self.files[path]
+
+    async def list_files(
+        self,
+        sandbox_id: str,
+        path: str = "",
+    ) -> list[FileMetadata]:
+        return [
+            FileMetadata(path="src", type="directory"),
+            *[
+                FileMetadata(path=file_path, type="file", is_binary=file.is_binary)
+                for file_path, file in self.files.items()
+            ],
+        ]
+
+    async def create_pty(
+        self,
+        sandbox_id: str,
+        rows: int,
+        cols: int,
+        tmux_session: str,
+        on_data: PtyDataCallbackType | None = None,
+    ) -> PtySession:
+        return PtySession(id="pty-1", pid=None, rows=rows, cols=cols)
+
+    async def send_pty_input(
+        self,
+        sandbox_id: str,
+        pty_id: str,
+        data: bytes,
+    ) -> None:
+        return None
+
+    async def resize_pty(
+        self,
+        sandbox_id: str,
+        pty_id: str,
+        size: PtySize,
+    ) -> None:
+        return None
+
+    async def kill_pty(self, sandbox_id: str, pty_id: str) -> None:
+        return None
+
+    async def cleanup(self) -> None:
+        return None
+
+
+class FakeProviderFactory:
+    def __init__(self, provider: FakeSandboxProvider | None = None) -> None:
+        self.provider = provider
+
+    def __call__(
+        self,
+        provider_type: str,
+        workspace_path: str | None = None,
+    ) -> FakeSandboxProvider:
+        if self.provider is not None:
+            return self.provider
+        return FakeSandboxProvider(workspace_path=workspace_path)
 
 
 async def get_user_by_email(db: AsyncSession, email: str) -> User | None:

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -1,0 +1,318 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.db_models.user import User
+from app.models.db_models.workspace import Workspace
+from app.services.sandbox_providers.base import SandboxProvider
+
+from tests.conftest import LoginClient, UserFactory
+from tests.helpers import FakeProviderFactory, FakeSandboxProvider
+
+
+pytestmark = pytest.mark.anyio
+
+
+async def create_authenticated_workspace(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    *,
+    email: str = "sandbox@example.com",
+    username: str = "sandboxuser",
+    sandbox_id: str = "sandbox-test",
+) -> tuple[dict[str, str], User, Workspace]:
+    user = await create_user(email=email, username=username)
+    tokens = await login(email=email)
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+    workspace = Workspace(
+        name="Sandbox Workspace",
+        user_id=user.id,
+        sandbox_id=sandbox_id,
+        sandbox_provider="host",
+        workspace_path=f"/tmp/agentrove-test-{username}",
+        source_type="empty",
+        source_url=None,
+    )
+    db_session.add(workspace)
+    await db_session.commit()
+    await db_session.refresh(workspace)
+    return headers, user, workspace
+
+
+@pytest.fixture
+def fake_provider(monkeypatch: pytest.MonkeyPatch) -> FakeSandboxProvider:
+    provider = FakeSandboxProvider()
+    monkeypatch.setattr(
+        SandboxProvider,
+        "create_provider",
+        FakeProviderFactory(provider=provider),
+    )
+    return provider
+
+
+async def test_file_endpoints_use_owned_sandbox_and_provider(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    metadata_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/metadata",
+        headers=headers,
+    )
+    content_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/content/README.md",
+        headers=headers,
+    )
+    update_response = await client.put(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files",
+        json={"file_path": "src/app.py", "content": "print('updated')"},
+        headers=headers,
+    )
+    updated_content_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/content/src/app.py",
+        headers=headers,
+    )
+    invalid_path_response = await client.put(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files",
+        json={"file_path": "../outside.py", "content": "blocked"},
+        headers=headers,
+    )
+
+    assert metadata_response.status_code == 200
+    assert metadata_response.json()["files"] == [
+        {"path": "src", "type": "directory", "is_binary": False},
+        {"path": "README.md", "type": "file", "is_binary": False},
+    ]
+    assert content_response.status_code == 200
+    assert content_response.json()["content"] == "Initial readme"
+    assert update_response.status_code == 200
+    assert update_response.json() == {
+        "success": True,
+        "message": "File src/app.py updated successfully",
+    }
+    assert fake_provider.writes == [
+        (workspace.sandbox_id, "src/app.py", "print('updated')")
+    ]
+    assert updated_content_response.status_code == 200
+    assert updated_content_response.json()["content"] == "print('updated')"
+    assert invalid_path_response.status_code == 400
+
+
+async def test_sandbox_access_requires_owner_and_authentication(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    owner_headers, _owner, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="sandbox-owner@example.com",
+        username="sandboxowner",
+    )
+    other_headers, _other_user, _other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="sandbox-other@example.com",
+        username="sandboxother",
+        sandbox_id="sandbox-other",
+    )
+
+    owner_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/metadata",
+        headers=owner_headers,
+    )
+    other_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/metadata",
+        headers=other_headers,
+    )
+    missing_token_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/metadata"
+    )
+
+    assert owner_response.status_code == 200
+    assert other_response.status_code == 404
+    assert other_response.json()["detail"] == "Sandbox not found"
+    assert missing_token_response.status_code == 401
+
+
+async def test_secret_endpoints_update_user_settings(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    initial_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/secrets",
+        headers=headers,
+    )
+    add_response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/secrets",
+        json={"key": "API_TOKEN", "value": "one"},
+        headers=headers,
+    )
+    update_response = await client.put(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/secrets/API_TOKEN",
+        json={"value": "two"},
+        headers=headers,
+    )
+    append_response = await client.put(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/secrets/SECOND_TOKEN",
+        json={"value": "three"},
+        headers=headers,
+    )
+    list_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/secrets",
+        headers=headers,
+    )
+    delete_response = await client.delete(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/secrets/API_TOKEN",
+        headers=headers,
+    )
+    final_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/secrets",
+        headers=headers,
+    )
+
+    assert initial_response.status_code == 200
+    assert initial_response.json() == {"secrets": []}
+    assert add_response.status_code == 200
+    assert add_response.json()["message"] == "Secret API_TOKEN added successfully"
+    assert update_response.status_code == 200
+    assert update_response.json()["message"] == "Secret API_TOKEN updated successfully"
+    assert append_response.status_code == 200
+    assert list_response.status_code == 200
+    assert list_response.json() == {
+        "secrets": [
+            {"key": "API_TOKEN", "value": "two"},
+            {"key": "SECOND_TOKEN", "value": "three"},
+        ]
+    }
+    assert delete_response.status_code == 200
+    assert delete_response.json()["message"] == "Secret API_TOKEN deleted successfully"
+    assert final_response.status_code == 200
+    assert final_response.json() == {
+        "secrets": [{"key": "SECOND_TOKEN", "value": "three"}]
+    }
+
+
+async def test_git_endpoints_propagate_cwd_and_request_fields(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    sandbox_id = workspace.sandbox_id
+
+    diff_response = await client.get(
+        f"/api/v1/sandbox/{sandbox_id}/git/diff"
+        "?mode=staged&full_context=true&cwd=packages/api",
+        headers=headers,
+    )
+    branches_response = await client.get(
+        f"/api/v1/sandbox/{sandbox_id}/git/branches?cwd=packages/api",
+        headers=headers,
+    )
+    checkout_response = await client.post(
+        f"/api/v1/sandbox/{sandbox_id}/git/checkout",
+        json={"branch": "feature", "cwd": "packages/api"},
+        headers=headers,
+    )
+    commit_response = await client.post(
+        f"/api/v1/sandbox/{sandbox_id}/git/commit",
+        json={"message": "Update API", "cwd": "packages/api"},
+        headers=headers,
+    )
+    restore_response = await client.post(
+        f"/api/v1/sandbox/{sandbox_id}/git/restore-file",
+        json={
+            "file_path": "new.py",
+            "old_path": "old.py",
+            "cwd": "packages/api",
+        },
+        headers=headers,
+    )
+    create_branch_response = await client.post(
+        f"/api/v1/sandbox/{sandbox_id}/git/create-branch",
+        json={
+            "name": "feature-two",
+            "base_branch": "main",
+            "cwd": "packages/api",
+        },
+        headers=headers,
+    )
+    remote_response = await client.get(
+        f"/api/v1/sandbox/{sandbox_id}/git/remote-url?cwd=packages/api",
+        headers=headers,
+    )
+
+    assert diff_response.status_code == 200
+    assert diff_response.json()["has_changes"] is True
+    assert branches_response.status_code == 200
+    assert branches_response.json()["branches"] == ["feature", "main"]
+    assert checkout_response.status_code == 200
+    assert commit_response.status_code == 200
+    assert restore_response.status_code == 200
+    assert create_branch_response.status_code == 200
+    assert remote_response.status_code == 200
+    commands = [command for _sandbox_id, command, _envs in fake_provider.commands]
+    assert all(command.startswith("cd 'packages/api' && ") for command in commands)
+    assert any("git diff -U99999 --cached" in command for command in commands)
+    assert any("git for-each-ref" in command for command in commands)
+    assert any("git checkout 'feature'" in command for command in commands)
+    assert any("git commit -m 'Update API'" in command for command in commands)
+    assert any("git checkout HEAD -- old.py" in command for command in commands)
+    assert any(
+        "git checkout -b 'feature-two' 'main'" in command for command in commands
+    )
+    assert any("git remote get-url origin" in command for command in commands)
+
+
+async def test_search_endpoint_propagates_filters(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    sandbox_id = workspace.sandbox_id
+
+    response = await client.get(
+        f"/api/v1/sandbox/{sandbox_id}/search"
+        "?q=needle&cwd=src&case_sensitive=true&regex=true&whole_word=true"
+        "&include=*.py&exclude=vendor/*",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["results"][0]["path"] == "src/app.py"
+    search_commands = [
+        command
+        for _sandbox_id, command, _envs in fake_provider.commands
+        if "rg " in command
+    ]
+    assert search_commands == [
+        "cd 'src' && rg --json -n --max-count=100 --max-columns=500 "
+        "-w -g '*.py' -g '!vendor/*' -- needle ."
+    ]

--- a/backend/tests/test_workspace.py
+++ b/backend/tests/test_workspace.py
@@ -6,106 +6,17 @@ import pytest
 from httpx import AsyncClient
 
 from app.services.sandbox_providers.base import SandboxProvider
-from app.services.sandbox_providers.types import (
-    CommandResult,
-    FileContent,
-    FileMetadata,
-    PtyDataCallbackType,
-    PtySession,
-    PtySize,
-)
 
 from tests.conftest import LoginClient, UserFactory
+from tests.helpers import FakeProviderFactory
 
 
 pytestmark = pytest.mark.anyio
 
 
-class FakeSandboxProvider(SandboxProvider):
-    def __init__(self, workspace_path: str | None = None) -> None:
-        self._workspace_root = workspace_path or "/tmp/agentrove-test-workspace"
-
-    @property
-    def workspace_root(self) -> str:
-        return self._workspace_root
-
-    async def create_sandbox(self, workspace_path: str | None = None) -> str:
-        return "sandbox-1"
-
-    async def delete_sandbox(self, sandbox_id: str) -> None:
-        return None
-
-    async def execute_command(
-        self,
-        sandbox_id: str,
-        command: str,
-        envs: dict[str, str] | None = None,
-        timeout: int = 120,
-    ) -> CommandResult:
-        return CommandResult(stdout="", stderr="", exit_code=0)
-
-    async def write_file(
-        self,
-        sandbox_id: str,
-        path: str,
-        content: str | bytes,
-    ) -> None:
-        return None
-
-    async def read_file(
-        self,
-        sandbox_id: str,
-        path: str,
-    ) -> FileContent:
-        return FileContent(path=path, content="", type="file", is_binary=False)
-
-    async def list_files(
-        self,
-        sandbox_id: str,
-        path: str = "",
-    ) -> list[FileMetadata]:
-        return []
-
-    async def create_pty(
-        self,
-        sandbox_id: str,
-        rows: int,
-        cols: int,
-        tmux_session: str,
-        on_data: PtyDataCallbackType | None = None,
-    ) -> PtySession:
-        return PtySession(id="pty-1", pid=None, rows=rows, cols=cols)
-
-    async def send_pty_input(
-        self,
-        sandbox_id: str,
-        pty_id: str,
-        data: bytes,
-    ) -> None:
-        return None
-
-    async def resize_pty(
-        self,
-        sandbox_id: str,
-        pty_id: str,
-        size: PtySize,
-    ) -> None:
-        return None
-
-    async def kill_pty(self, sandbox_id: str, pty_id: str) -> None:
-        return None
-
-
-def _fake_create_provider(
-    provider_type: str,
-    workspace_path: str | None = None,
-) -> FakeSandboxProvider:
-    return FakeSandboxProvider(workspace_path=workspace_path)
-
-
 @pytest.fixture
 def workspace_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(SandboxProvider, "create_provider", _fake_create_provider)
+    monkeypatch.setattr(SandboxProvider, "create_provider", FakeProviderFactory())
 
 
 async def create_authenticated_workspace(


### PR DESCRIPTION
## Summary
- Add `backend/tests/test_sandbox.py` covering files/secrets/git/search endpoints, ownership/auth checks, and cwd propagation.
- Extract `FakeSandboxProvider` and a `FakeProviderFactory` from `test_workspace.py` into `tests/helpers.py` so both suites share the same fake.

## Test plan
- [ ] `pytest backend/tests/test_sandbox.py`
- [ ] `pytest backend/tests/test_workspace.py`