### PR TITLE
Add backend attachment endpoint tests

### DIFF
--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -1,4 +1,5 @@
 import json
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import select
@@ -6,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.db_models.refresh_token import RefreshToken
 from app.models.db_models.user import User, UserSettings
+from app.models.db_models.workspace import Workspace
 from app.services.sandbox_providers.base import SandboxProvider
 from app.services.sandbox_providers.types import (
     CommandResult,
@@ -15,6 +17,9 @@ from app.services.sandbox_providers.types import (
     PtySession,
     PtySize,
 )
+
+if TYPE_CHECKING:
+    from tests.conftest import LoginClient, UserFactory
 
 
 class FakeSandboxProvider(SandboxProvider):
@@ -182,6 +187,32 @@ class FakeProviderFactory:
         if self.provider is not None:
             return self.provider
         return FakeSandboxProvider(workspace_path=workspace_path)
+
+
+async def create_authenticated_workspace(
+    db_session: AsyncSession,
+    create_user: "UserFactory",
+    login: "LoginClient",
+    *,
+    email: str = "user@example.com",
+    username: str = "testuser",
+) -> tuple[dict[str, str], User, Workspace]:
+    user = await create_user(email=email, username=username)
+    tokens = await login(email=email)
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+    workspace = Workspace(
+        name="Test Workspace",
+        user_id=user.id,
+        sandbox_id=f"sandbox-{username}",
+        sandbox_provider="host",
+        workspace_path=f"/tmp/agentrove-test-{username}",
+        source_type="empty",
+        source_url=None,
+    )
+    db_session.add(workspace)
+    await db_session.commit()
+    await db_session.refresh(workspace)
+    return headers, user, workspace
 
 
 async def get_user_by_email(db: AsyncSession, email: str) -> User | None:

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -1,0 +1,202 @@
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import tests.bootstrap
+from app.models.db_models.chat import Chat, Message, MessageAttachment
+from app.models.db_models.enums import AttachmentType, MessageRole, MessageStreamStatus
+from app.models.db_models.user import User
+from app.models.db_models.workspace import Workspace
+
+from tests.conftest import LoginClient, UserFactory
+from tests.helpers import create_authenticated_workspace
+
+
+pytestmark = pytest.mark.anyio
+
+
+async def create_attachment_row(
+    db_session: AsyncSession,
+    user: User,
+    workspace: Workspace,
+    *,
+    file_path: str,
+    filename: str = "notes.txt",
+) -> MessageAttachment:
+    chat = Chat(
+        title="Attachment Chat",
+        user_id=user.id,
+        workspace_id=workspace.id,
+    )
+    db_session.add(chat)
+    await db_session.flush()
+
+    message = Message(
+        chat_id=chat.id,
+        content_text="See attachment",
+        content_render={"events": [{"type": "user_text", "text": "See attachment"}]},
+        role=MessageRole.USER,
+        stream_status=MessageStreamStatus.COMPLETED,
+    )
+    db_session.add(message)
+    await db_session.flush()
+
+    attachment = MessageAttachment(
+        message_id=message.id,
+        file_url="/api/v1/attachments/pending/preview",
+        file_path=file_path,
+        file_type=AttachmentType.PDF,
+        filename=filename,
+    )
+    db_session.add(attachment)
+    await db_session.commit()
+    await db_session.refresh(attachment)
+    return attachment
+
+
+def storage_path(*parts: str) -> Path:
+    return tests.bootstrap.TEST_DIR.joinpath("storage", *parts)
+
+
+async def test_attachment_preview_and_download_serve_owned_file(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    file_path = storage_path("attachments", str(user.id), "notes.txt")
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("attachment body", encoding="utf-8")
+    attachment = await create_attachment_row(
+        db_session,
+        user,
+        workspace,
+        file_path=str(file_path.relative_to(storage_path())),
+    )
+
+    preview_response = await client.get(
+        f"/api/v1/attachments/{attachment.id}/preview", headers=headers
+    )
+    download_response = await client.get(
+        f"/api/v1/attachments/{attachment.id}/download", headers=headers
+    )
+
+    assert preview_response.status_code == 200
+    assert preview_response.text == "attachment body"
+    assert preview_response.headers["cache-control"] == "private, max-age=3600"
+    assert preview_response.headers["content-disposition"].startswith("inline;")
+    assert download_response.status_code == 200
+    assert download_response.text == "attachment body"
+    assert download_response.headers["content-disposition"].startswith("attachment;")
+
+
+async def test_attachment_preview_rejects_other_user(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    owner_headers, owner, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="attachment-owner@example.com",
+        username="attachmentowner",
+    )
+    other_headers, _other_user, _other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="attachment-other@example.com",
+        username="attachmentother",
+    )
+    file_path = storage_path("attachments", str(owner.id), "private.txt")
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("private attachment", encoding="utf-8")
+    attachment = await create_attachment_row(
+        db_session,
+        owner,
+        workspace,
+        file_path=str(file_path.relative_to(storage_path())),
+        filename="private.txt",
+    )
+
+    owner_response = await client.get(
+        f"/api/v1/attachments/{attachment.id}/preview", headers=owner_headers
+    )
+    other_response = await client.get(
+        f"/api/v1/attachments/{attachment.id}/preview", headers=other_headers
+    )
+
+    assert owner_response.status_code == 200
+    assert other_response.status_code == 403
+    assert other_response.json()["detail"] == "Access denied"
+
+
+async def test_attachment_preview_returns_404_for_missing_file(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    attachment = await create_attachment_row(
+        db_session,
+        user,
+        workspace,
+        file_path=f"attachments/{user.id}/missing.txt",
+        filename="missing.txt",
+    )
+
+    response = await client.get(
+        f"/api/v1/attachments/{attachment.id}/preview", headers=headers
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "File not found"
+
+
+async def test_temp_attachment_preview_allows_only_current_user_temp_dir(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    temp_file = storage_path("temp", str(user.id), "draft.txt")
+    temp_file.parent.mkdir(parents=True, exist_ok=True)
+    temp_file.write_text("draft attachment", encoding="utf-8")
+    other_temp_file = storage_path("temp", "other-user", "draft.txt")
+    other_temp_file.parent.mkdir(parents=True, exist_ok=True)
+    other_temp_file.write_text("other draft", encoding="utf-8")
+
+    preview_response = await client.get(
+        "/api/v1/attachments/temp/preview",
+        params={"path": str(temp_file.relative_to(storage_path()))},
+        headers=headers,
+    )
+    other_response = await client.get(
+        "/api/v1/attachments/temp/preview",
+        params={"path": str(other_temp_file.relative_to(storage_path()))},
+        headers=headers,
+    )
+    traversal_response = await client.get(
+        "/api/v1/attachments/temp/preview",
+        params={"path": f"temp/{user.id}/../other-user/draft.txt"},
+        headers=headers,
+    )
+
+    assert preview_response.status_code == 200
+    assert preview_response.text == "draft attachment"
+    assert preview_response.headers["content-disposition"].startswith("inline;")
+    assert other_response.status_code == 403
+    assert traversal_response.status_code == 403

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -17,6 +17,7 @@ from app.services.streaming.runtime import ChatStreamRuntime
 from app.utils.cache import MemoryStore
 
 from tests.conftest import LoginClient, UserFactory
+from tests.helpers import create_authenticated_workspace
 
 
 TEST_MODEL_ID = "opencode:google-vertex-anthropic/claude-sonnet-4-5@20250929"
@@ -41,33 +42,6 @@ class SendNowCapture:
     ) -> bool:
         self.chat_ids.append(chat_id)
         return True
-
-
-async def create_authenticated_workspace(
-    db_session: AsyncSession,
-    create_user: UserFactory,
-    login: LoginClient,
-    *,
-    email: str = "chat@example.com",
-    username: str = "chatuser",
-    workspace_name: str = "Chat Workspace",
-) -> tuple[dict[str, str], User, Workspace]:
-    user = await create_user(email=email, username=username)
-    tokens = await login(email=email)
-    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
-    workspace = Workspace(
-        name=workspace_name,
-        user_id=user.id,
-        sandbox_id=f"sandbox-{username}",
-        sandbox_provider="host",
-        workspace_path=f"/tmp/agentrove-test-{username}",
-        source_type="empty",
-        source_url=None,
-    )
-    db_session.add(workspace)
-    await db_session.commit()
-    await db_session.refresh(workspace)
-    return headers, user, workspace
 
 
 async def create_chat_row(

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -2,42 +2,17 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.db_models.user import User
-from app.models.db_models.workspace import Workspace
 from app.services.sandbox_providers.base import SandboxProvider
 
 from tests.conftest import LoginClient, UserFactory
-from tests.helpers import FakeProviderFactory, FakeSandboxProvider
+from tests.helpers import (
+    FakeProviderFactory,
+    FakeSandboxProvider,
+    create_authenticated_workspace,
+)
 
 
 pytestmark = pytest.mark.anyio
-
-
-async def create_authenticated_workspace(
-    db_session: AsyncSession,
-    create_user: UserFactory,
-    login: LoginClient,
-    *,
-    email: str = "sandbox@example.com",
-    username: str = "sandboxuser",
-    sandbox_id: str = "sandbox-test",
-) -> tuple[dict[str, str], User, Workspace]:
-    user = await create_user(email=email, username=username)
-    tokens = await login(email=email)
-    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
-    workspace = Workspace(
-        name="Sandbox Workspace",
-        user_id=user.id,
-        sandbox_id=sandbox_id,
-        sandbox_provider="host",
-        workspace_path=f"/tmp/agentrove-test-{username}",
-        source_type="empty",
-        source_url=None,
-    )
-    db_session.add(workspace)
-    await db_session.commit()
-    await db_session.refresh(workspace)
-    return headers, user, workspace
 
 
 @pytest.fixture
@@ -125,7 +100,6 @@ async def test_sandbox_access_requires_owner_and_authentication(
         login,
         email="sandbox-other@example.com",
         username="sandboxother",
-        sandbox_id="sandbox-other",
     )
 
     owner_response = await client.get(


### PR DESCRIPTION
## Summary
- Add `tests/test_attachments.py` covering preview/download for owned files, owner-only access enforcement, 404 on missing files, and temp-dir path traversal protection
- Extract `create_authenticated_workspace` into `tests/helpers.py` and reuse from chat, sandbox, and attachment tests

## Test plan
- [ ] `pytest backend/tests/test_attachments.py`
- [ ] `pytest backend/tests/test_chat.py backend/tests/test_sandbox.py` (regression)