### PR TITLE
Add backend models endpoint and sandbox zip download tests

### DIFF
--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,78 @@
+import pytest
+from httpx import AsyncClient
+
+from app.constants import MODELS
+from app.services.acp.adapters import AgentKind
+
+from tests.conftest import LoginClient, UserFactory
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+async def auth_headers(
+    create_user: UserFactory,
+    login: LoginClient,
+) -> dict[str, str]:
+    await create_user(email="models-user@example.com", username="modelsuser")
+    tokens = await login(email="models-user@example.com")
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+async def test_list_models_returns_registered_models(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    response = await client.get("/api/v1/models/", headers=auth_headers)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == len(MODELS)
+    model_ids = {item["model_id"] for item in body}
+    assert model_ids == set(MODELS)
+    assert {
+        "model_id": "haiku",
+        "name": MODELS["haiku"].display_name,
+        "agent_kind": MODELS["haiku"].agent_kind.value,
+        "context_window": MODELS["haiku"].context_window,
+    } in body
+
+
+async def test_list_models_filters_by_agent_kind(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    response = await client.get(
+        f"/api/v1/models/?agent_kind={AgentKind.CODEX.value}",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body
+    assert {item["agent_kind"] for item in body} == {AgentKind.CODEX.value}
+    assert {item["model_id"] for item in body} == {
+        model_id
+        for model_id, info in MODELS.items()
+        if info.agent_kind == AgentKind.CODEX
+    }
+
+
+async def test_list_models_rejects_invalid_agent_kind(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+) -> None:
+    response = await client.get(
+        "/api/v1/models/?agent_kind=invalid",
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid agent_kind: invalid"
+
+
+async def test_models_reject_missing_token(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/models/")
+
+    assert response.status_code == 401

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -1,3 +1,6 @@
+import io
+import zipfile
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -118,6 +121,34 @@ async def test_sandbox_access_requires_owner_and_authentication(
     assert other_response.status_code == 404
     assert other_response.json()["detail"] == "Sandbox not found"
     assert missing_token_response.status_code == 401
+
+
+async def test_download_zip_returns_owned_sandbox_files(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    await fake_provider.write_file(workspace.sandbox_id, "src/app.py", "print('zip')")
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/download-zip",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/zip"
+    assert response.headers["content-disposition"] == (
+        f'attachment; filename="sandbox_{workspace.sandbox_id}.zip"'
+    )
+    with zipfile.ZipFile(io.BytesIO(response.content)) as archive:
+        assert archive.namelist() == ["README.md", "src/app.py"]
+        assert archive.read("README.md") == b"Initial readme"
+        assert archive.read("src/app.py") == b"print('zip')"
 
 
 async def test_secret_endpoints_update_user_settings(


### PR DESCRIPTION
## Summary
- Add `tests/test_models.py` covering the models listing endpoint: full registry response, `agent_kind` filter, invalid-kind rejection, and missing-token auth.
- Add a `test_download_zip_returns_owned_sandbox_files` case in `tests/test_sandbox.py` exercising the sandbox download-zip endpoint against the fake provider.

## Test plan
- [ ] `pytest backend/tests/test_models.py`
- [ ] `pytest backend/tests/test_sandbox.py::test_download_zip_returns_owned_sandbox_files`