### PR TITLE
Add backend chat, websocket, and workspace endpoint tests

### DIFF
--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -8,18 +8,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.endpoints import chat as chat_endpoint
 from app.constants import MODELS, REDIS_KEY_CHAT_CONTEXT_USAGE
-from app.core.deps import get_queue_service
+from app.core.deps import get_agent_service, get_chat_service, get_queue_service
 from app.models.db_models.chat import Chat, Message, MessageEvent
 from app.models.db_models.enums import MessageRole, MessageStreamStatus
 from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
+from app.models.schemas.chat import ChatRequest
 from app.services.db import SessionFactoryType
+from app.services.exceptions import AgentException, ChatException
 from app.services.queue import QueueService
+from app.services.sandbox_providers.base import SandboxProvider
 from app.services.streaming.runtime import ChatStreamRuntime
 from app.utils.cache import MemoryStore
 
 from tests.conftest import LoginClient, UserFactory
-from tests.helpers import EndpointCache, create_authenticated_workspace
+from tests.helpers import (
+    EndpointCache,
+    FakeProviderFactory,
+    create_authenticated_workspace,
+)
 
 
 TEST_MODEL_ID = "opencode:google-vertex-anthropic/claude-sonnet-4-5@20250929"
@@ -59,6 +66,44 @@ class PermissionResolver:
     ) -> bool:
         self.calls.append((chat_id, request_id, option_id))
         return request_id == "request-1"
+
+
+class ChatCompletionServiceOverride:
+    def __init__(self) -> None:
+        self.requests: list[ChatRequest] = []
+        self.users: list[User] = []
+        self.fail = False
+
+    async def __call__(self) -> AsyncIterator["ChatCompletionServiceOverride"]:
+        yield self
+
+    async def initiate_chat_completion(
+        self, request: ChatRequest, user: User
+    ) -> dict[str, UUID | int]:
+        self.requests.append(request)
+        self.users.append(user)
+        if self.fail:
+            raise ChatException("Cannot start chat")
+        return {
+            "chat_id": request.chat_id,
+            "message_id": UUID("00000000-0000-0000-0000-000000000123"),
+            "last_seq": 4,
+        }
+
+
+class AgentServiceOverride:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, User]] = []
+        self.fail = False
+
+    def __call__(self) -> "AgentServiceOverride":
+        return self
+
+    async def enhance_prompt(self, prompt: str, model_id: str, user: User) -> str:
+        self.calls.append((prompt, model_id, user))
+        if self.fail:
+            raise AgentException("Enhance failed", status_code=503)
+        return "Enhanced: " + prompt
 
 
 @pytest.fixture
@@ -177,6 +222,122 @@ async def test_create_list_and_get_chat(
     assert detail_response.json()["id"] == created["id"]
 
 
+async def test_send_message_endpoint_passes_form_fields_to_chat_service(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    chat_service = ChatCompletionServiceOverride()
+    app.dependency_overrides[get_chat_service] = chat_service
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    response = await client.post(
+        "/api/v1/chat/chat",
+        data={
+            "prompt": "Ship this",
+            "chat_id": str(chat.id),
+            "model_id": TEST_MODEL_ID,
+            "permission_mode": "default",
+            "thinking_mode": "high",
+            "worktree": "true",
+            "plan_mode": "true",
+            "selected_persona_name": "Builder",
+        },
+        files={"attached_files": ("note.txt", b"hello", "text/plain")},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "chat_id": str(chat.id),
+        "message_id": "00000000-0000-0000-0000-000000000123",
+        "last_seq": 4,
+    }
+    request = chat_service.requests[0]
+    assert request.prompt == "Ship this"
+    assert request.chat_id == chat.id
+    assert request.model_id == TEST_MODEL_ID
+    assert request.permission_mode == "default"
+    assert request.thinking_mode == "high"
+    assert request.worktree is True
+    assert request.plan_mode is True
+    assert request.selected_persona_name == "Builder"
+    assert request.attached_files is not None
+    assert request.attached_files[0].filename == "note.txt"
+    assert [stored_user.id for stored_user in chat_service.users] == [user.id]
+
+
+async def test_send_message_endpoint_translates_chat_errors(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    chat_service = ChatCompletionServiceOverride()
+    chat_service.fail = True
+    app.dependency_overrides[get_chat_service] = chat_service
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    response = await client.post(
+        "/api/v1/chat/chat",
+        data={
+            "prompt": "Fail this",
+            "chat_id": str(chat.id),
+            "model_id": TEST_MODEL_ID,
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Cannot start chat"
+
+
+async def test_enhance_prompt_endpoint_uses_agent_service(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    agent_service = AgentServiceOverride()
+    app.dependency_overrides[get_agent_service] = agent_service
+    headers, user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        "/api/v1/chat/enhance-prompt",
+        data={"prompt": "make it concise", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"enhanced_prompt": "Enhanced: make it concise"}
+    assert [
+        (prompt, model_id, stored_user.id)
+        for prompt, model_id, stored_user in agent_service.calls
+    ] == [("make it concise", TEST_MODEL_ID, user.id)]
+
+    agent_service.fail = True
+    failure_response = await client.post(
+        "/api/v1/chat/enhance-prompt",
+        data={"prompt": "make it fail", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+
+    assert failure_response.status_code == 503
+    assert failure_response.json()["detail"] == "Enhance failed"
+
+
 async def test_chat_access_is_limited_to_owner(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -265,6 +426,47 @@ async def test_delete_chat_excludes_it_from_list_and_detail(
     assert list_response.status_code == 200
     assert [item["id"] for item in list_response.json()["items"]] == [str(remaining.id)]
     assert detail_response.status_code == 404
+
+
+async def test_delete_all_chats_only_deletes_current_user_chats(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(SandboxProvider, "create_provider", FakeProviderFactory())
+    owner_headers, owner, owner_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="delete-all-owner@example.com",
+        username="deleteallowner",
+    )
+    owner_chat = await create_chat_row(db_session, owner, owner_workspace)
+    await create_message_row(db_session, owner_chat, content="Remove me")
+    other_headers, other_user, other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="delete-all-other@example.com",
+        username="deleteallother",
+    )
+    other_chat = await create_chat_row(db_session, other_user, other_workspace)
+
+    response = await client.delete("/api/v1/chat/chats/all", headers=owner_headers)
+    owner_list = await client.get("/api/v1/chat/chats", headers=owner_headers)
+    owner_detail = await client.get(
+        f"/api/v1/chat/chats/{owner_chat.id}", headers=owner_headers
+    )
+    other_list = await client.get("/api/v1/chat/chats", headers=other_headers)
+
+    assert response.status_code == 204
+    assert owner_list.status_code == 200
+    assert owner_list.json()["items"] == []
+    assert owner_detail.status_code == 404
+    assert other_list.status_code == 200
+    assert [item["id"] for item in other_list.json()["items"]] == [str(other_chat.id)]
 
 
 async def test_sub_threads_are_listed_and_nested_sub_threads_are_rejected(

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -291,6 +291,35 @@ async def test_git_endpoints_propagate_cwd_and_request_fields(
     assert any("git remote get-url origin" in command for command in commands)
 
 
+async def test_git_remote_url_returns_owned_sandbox_remote(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/remote-url",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "remote_url": "https://github.com/agentrove/app.git",
+        "owner": "agentrove",
+        "repo": "app",
+    }
+    assert fake_provider.commands[-1] == (
+        workspace.sandbox_id,
+        "git remote get-url origin 2>/dev/null",
+        {},
+    )
+
+
 async def test_search_endpoint_propagates_filters(
     client: AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -1,0 +1,227 @@
+import json
+from typing import Any, cast
+
+import pytest
+from fastapi import WebSocket
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.endpoints import websocket as websocket_endpoint
+from app.constants import (
+    DEFAULT_TERMINAL_ID,
+    WS_CLOSE_AUTH_FAILED,
+    WS_CLOSE_SANDBOX_NOT_FOUND,
+    WS_MSG_AUTH,
+    WS_MSG_DETACH,
+    WS_MSG_INIT,
+    WS_MSG_RESIZE,
+)
+from app.services.sandbox_providers import SandboxProviderType
+
+from tests.conftest import LoginClient, UserFactory
+from tests.helpers import create_authenticated_workspace
+
+
+pytestmark = pytest.mark.anyio
+
+
+class FakeWebSocket:
+    def __init__(
+        self, frames: list[dict[str, Any]], query_params: dict[str, str] | None = None
+    ) -> None:
+        self.frames = frames
+        self.query_params = query_params or {}
+        self.accepted = False
+        self.sent_text: list[str] = []
+        self.close_code: int | None = None
+        self.close_reason: str | None = None
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive(self) -> dict[str, Any]:
+        return self.frames.pop(0)
+
+    async def send_text(self, payload: str) -> None:
+        self.sent_text.append(payload)
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.close_code = code
+        self.close_reason = reason
+
+
+class FakeTerminalSession:
+    def __init__(self) -> None:
+        self.pty_id = "pty-1"
+        self.sandbox_id = "sandbox-websocket"
+        self.active_websocket: WebSocket | None = None
+        self.ensure_started_calls: list[tuple[int, int]] = []
+        self.resize_calls: list[tuple[int, int]] = []
+        self.inputs: list[bytes] = []
+        self.attach_count = 0
+        self.detach_count = 0
+        self.terminate_count = 0
+
+    async def ensure_started(self, rows: int, cols: int) -> bool:
+        self.ensure_started_calls.append((rows, cols))
+        return False
+
+    async def attach(self, websocket: WebSocket) -> None:
+        self.active_websocket = websocket
+        self.attach_count += 1
+
+    def enqueue_input(self, data: bytes) -> None:
+        self.inputs.append(data)
+
+    async def resize(self, rows: int, cols: int) -> None:
+        self.resize_calls.append((rows, cols))
+
+    async def terminate(self) -> None:
+        self.terminate_count += 1
+
+    async def detach(self) -> None:
+        self.active_websocket = None
+        self.detach_count += 1
+
+
+class FakeTerminalRegistry:
+    def __init__(self, session: FakeTerminalSession) -> None:
+        self.session = session
+        self.calls: list[dict[str, Any]] = []
+
+    async def get_or_create(
+        self,
+        *,
+        user_id: str,
+        sandbox_id: str,
+        terminal_id: str,
+        provider_type: SandboxProviderType,
+        workspace_path: str | None,
+    ) -> FakeTerminalSession:
+        self.calls.append(
+            {
+                "user_id": user_id,
+                "sandbox_id": sandbox_id,
+                "terminal_id": terminal_id,
+                "provider_type": provider_type,
+                "workspace_path": workspace_path,
+            }
+        )
+        self.session.sandbox_id = sandbox_id
+        return self.session
+
+
+async def run_terminal_websocket(websocket: FakeWebSocket, sandbox_id: str) -> None:
+    await websocket_endpoint.terminal_websocket(cast(WebSocket, websocket), sandbox_id)
+
+
+async def test_terminal_websocket_rejects_invalid_auth() -> None:
+    websocket = FakeWebSocket(
+        [{"text": json.dumps({"type": WS_MSG_AUTH, "token": "invalid"})}]
+    )
+
+    await run_terminal_websocket(websocket, "sandbox-1")
+
+    assert websocket.accepted is True
+    assert websocket.close_code == WS_CLOSE_AUTH_FAILED
+    assert websocket.close_reason == "Authentication failed"
+
+
+async def test_terminal_websocket_rejects_unowned_sandbox(
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    await create_user(email="ws-denied@example.com", username="wsdenied")
+    tokens = await login(email="ws-denied@example.com")
+    websocket = FakeWebSocket(
+        [{"text": json.dumps({"type": WS_MSG_AUTH, "token": tokens["access_token"]})}]
+    )
+
+    await run_terminal_websocket(websocket, "missing-sandbox")
+
+    assert websocket.close_code == WS_CLOSE_SANDBOX_NOT_FOUND
+    assert websocket.close_reason == "Sandbox not found"
+
+
+async def test_terminal_websocket_handles_control_frames(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="ws-owner@example.com",
+        username="wsowner",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    session = FakeTerminalSession()
+    registry = FakeTerminalRegistry(session)
+    monkeypatch.setattr(websocket_endpoint, "terminal_session_registry", registry)
+    websocket = FakeWebSocket(
+        [
+            {"text": json.dumps({"type": WS_MSG_AUTH, "token": token})},
+            {"text": "{not-json"},
+            {"text": json.dumps({"type": WS_MSG_INIT, "rows": 40, "cols": 120})},
+            {"bytes": b"ls\n"},
+            {"text": json.dumps({"type": WS_MSG_RESIZE, "rows": 50, "cols": 140})},
+            {"text": json.dumps({"type": WS_MSG_DETACH})},
+        ],
+        query_params={"terminalId": "term-a"},
+    )
+
+    await run_terminal_websocket(websocket, workspace.sandbox_id)
+
+    assert registry.calls == [
+        {
+            "user_id": str(user.id),
+            "sandbox_id": workspace.sandbox_id,
+            "terminal_id": "term-a",
+            "provider_type": SandboxProviderType.HOST,
+            "workspace_path": workspace.workspace_path,
+        }
+    ]
+    init_response = json.loads(websocket.sent_text[0])
+    assert init_response == {
+        "type": WS_MSG_INIT,
+        "id": "pty-1",
+        "rows": 40,
+        "cols": 120,
+    }
+    assert session.ensure_started_calls == [(40, 120)]
+    assert session.resize_calls == [(50, 140)]
+    assert session.inputs == [b"ls\n"]
+    assert session.attach_count == 1
+    assert session.detach_count == 1
+    assert session.terminate_count == 0
+    assert websocket.close_code == 1000
+
+
+async def test_terminal_websocket_uses_default_terminal_id(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="ws-default@example.com",
+        username="wsdefault",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    session = FakeTerminalSession()
+    registry = FakeTerminalRegistry(session)
+    monkeypatch.setattr(websocket_endpoint, "terminal_session_registry", registry)
+    websocket = FakeWebSocket(
+        [
+            {"text": json.dumps({"type": WS_MSG_AUTH, "token": token})},
+            {"text": json.dumps({"type": WS_MSG_DETACH})},
+        ]
+    )
+
+    await run_terminal_websocket(websocket, workspace.sandbox_id)
+
+    assert registry.calls[0]["terminal_id"] == DEFAULT_TERMINAL_ID

--- a/backend/tests/test_workspace.py
+++ b/backend/tests/test_workspace.py
@@ -105,6 +105,38 @@ async def test_list_get_and_update_workspace(
     assert update_response.json()["name"] == "Renamed Workspace"
 
 
+async def test_workspace_resources_returns_owner_resources(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+) -> None:
+    owner_headers, workspace = await create_authenticated_workspace(
+        client,
+        create_user,
+        login,
+        email="resources-owner@example.com",
+        username="resourcesowner",
+    )
+    await create_user(email="resources-other@example.com", username="resourcesother")
+    other_tokens = await login(email="resources-other@example.com")
+    other_headers = {"Authorization": f"Bearer {other_tokens['access_token']}"}
+    workspace_id = workspace["id"]
+
+    owner_response = await client.get(
+        f"/api/v1/workspaces/{workspace_id}/resources", headers=owner_headers
+    )
+    other_response = await client.get(
+        f"/api/v1/workspaces/{workspace_id}/resources", headers=other_headers
+    )
+
+    assert owner_response.status_code == 200
+    body = owner_response.json()
+    assert isinstance(body["skills"], list)
+    assert set(body["builtin_slash_commands"]) >= {"claude", "codex"}
+    assert other_response.status_code == 404
+
+
 async def test_workspace_access_is_limited_to_owner(
     client: AsyncClient,
     create_user: UserFactory,


### PR DESCRIPTION
## Summary
- Add chat send-message and enhance-prompt endpoint tests with fake `ChatService`/`AgentService` overrides covering happy paths and error translation
- Add `/chats/all` deletion scoping test ensuring other users' chats are preserved
- Add new `test_websocket.py` covering terminal websocket auth failure, unowned-sandbox rejection, control-frame handling, and default terminal id fallback
- Add sandbox `git/remote-url` test and workspace `/resources` access-control test

## Test plan
- [ ] `pytest backend/tests/test_chat.py backend/tests/test_sandbox.py backend/tests/test_workspace.py backend/tests/test_websocket.py`