### PR TITLE
Build frontend as production web image

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -66,77 +66,16 @@ services:
       retries: 12
       start_period: 30s
 
-  frontend-build:
-    image: node:20-alpine
-    restart: "no"
-    working_dir: /app
-    volumes:
-      - ./frontend:/app
-      - frontend_node_modules:/app/node_modules
-      - frontend_dist:/dist
-    environment:
-      VITE_API_BASE_URL: /api/v1
-      VITE_WS_URL: /api/v1/ws
-    command: ["sh", "-c", "npm ci --legacy-peer-deps && npm run build -- --outDir /dist --emptyOutDir"]
-
   web:
-    image: nginx:1.27-alpine
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.production
     restart: unless-stopped
     depends_on:
       api:
         condition: service_healthy
-      frontend-build:
-        condition: service_completed_successfully
     ports:
       - "${HTTP_PORT:-80}:80"
-    volumes:
-      - frontend_dist:/usr/share/nginx/html:ro
-    command:
-      - /bin/sh
-      - -c
-      - |
-        cat > /etc/nginx/conf.d/default.conf <<'EOF'
-        server {
-          listen 80;
-          server_name _;
-
-          root /usr/share/nginx/html;
-          index index.html;
-
-          client_max_body_size 10m;
-
-          location /api/ {
-            proxy_pass http://api:8080;
-            proxy_http_version 1.1;
-            proxy_set_header Host $$host;
-            proxy_set_header X-Real-IP $$remote_addr;
-            proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $$scheme;
-            proxy_set_header Upgrade $$http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_read_timeout 3600s;
-            proxy_send_timeout 3600s;
-          }
-
-          location /admin {
-            proxy_pass http://api:8080;
-            proxy_http_version 1.1;
-            proxy_set_header Host $$host;
-            proxy_set_header X-Real-IP $$remote_addr;
-            proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $$scheme;
-          }
-
-          location /health {
-            proxy_pass http://api:8080/health;
-          }
-
-          location / {
-            try_files $$uri $$uri/ /index.html;
-          }
-        }
-        EOF
-        exec nginx -g 'daemon off;'
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost/health"]
       interval: 10s
@@ -149,5 +88,3 @@ networks:
 
 volumes:
   redis_data:
-  frontend_node_modules:
-  frontend_dist:

--- a/frontend/Dockerfile.production
+++ b/frontend/Dockerfile.production
@@ -1,0 +1,20 @@
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --legacy-peer-deps
+
+COPY . .
+
+ENV VITE_API_BASE_URL=/api/v1
+ENV VITE_WS_URL=/api/v1/ws
+
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY nginx-production.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/frontend/nginx-production.conf
+++ b/frontend/nginx-production.conf
@@ -1,0 +1,39 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  client_max_body_size 10m;
+
+  location /api/ {
+    proxy_pass http://api:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+  }
+
+  location /admin {
+    proxy_pass http://api:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /health {
+    proxy_pass http://api:8080/health;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}


### PR DESCRIPTION
## Summary
- remove the one-shot frontend-build service from production compose
- add a dedicated frontend production Dockerfile that builds Vite assets and serves them with nginx
- move production nginx proxy config into a checked-in config file

## Verification
- Not run per repository instructions

## Notes
This avoids Coolify failing deployment when the temporary frontend-build service exits unsuccessfully.