### PR TITLE
Declare Coolify web route

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -74,6 +74,8 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    environment:
+      - SERVICE_FQDN_WEB_80
     expose:
       - "80"
     healthcheck:


### PR DESCRIPTION
## Summary
- declare SERVICE_FQDN_WEB_80 on the production web service so Coolify creates a port-80 route from the compose file

## Verification
- Not run per repository instructions

## Notes
Set SERVICE_FQDN_WEB_80=https://claudex.pro in Coolify after this is merged, then redeploy.