### PR TITLE
Fix production web healthcheck

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -79,7 +79,7 @@ services:
     expose:
       - "80"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/"]
       interval: 10s
       timeout: 5s
       retries: 12


### PR DESCRIPTION
## Summary
- change the production web container healthcheck to check nginx's root route instead of proxying /health to the API

## Verification
- Not run per repository instructions

## Notes
The web container was running but unhealthy in Coolify, causing Traefik to return no available server.