### PR TITLE
Use IPv4 web healthcheck

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -79,7 +79,7 @@ services:
     expose:
       - "80"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost/"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1/"]
       interval: 10s
       timeout: 5s
       retries: 12


### PR DESCRIPTION
## Summary
- change the production web healthcheck from localhost to 127.0.0.1

## Verification
- Not run per repository instructions

## Notes
The web container runs nginx successfully, but BusyBox wget can resolve localhost to IPv6 ::1 while nginx is listening on IPv4 port 80.