### PR TITLE
Clean production compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,13 @@ Agentrove also syncs local Claude and Codex auth/config files into sandboxes whe
 
 - Production setup serves frontend at `/` and API under `/api/*`
 - Single-host Docker production:
-  `SECRET_KEY=$(openssl rand -hex 32) docker compose -f docker-compose-production.yml up -d --build`
+  ```bash
+  SECRET_KEY=$(openssl rand -hex 32) \
+    SERVICE_FQDN_WEB_80=https://yourdomain.com \
+    APP_URL=https://yourdomain.com \
+    ALLOWED_ORIGINS=https://yourdomain.com \
+    docker compose -f docker-compose-production.yml up -d --build
+  ```
 
 ## Tech Stack
 

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -49,8 +49,6 @@ services:
       STORAGE_PATH: /data/agentrove/storage
       DOCKER_IMAGE: ${DOCKER_IMAGE:-ghcr.io/mng-dev-ai/agentrove-sandbox:latest}
       DOCKER_NETWORK: agentrove-sandbox-net
-      DOCKER_PERMISSION_API_URL: http://api:8080
-      HOST_PERMISSION_API_URL: http://api:8080
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       PYTHONUNBUFFERED: "1"
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost,http://127.0.0.1}


### PR DESCRIPTION
## Summary
- remove unused permission API environment variables from the production compose file
- document the production compose command with the working Coolify/web route variables

## Verification
- Not run per repository instructions

## Notes
Left .env.example unchanged because those variables belong to the existing development compose setup.