### PR TITLE
Cascade refresh tokens on user delete

### DIFF
--- a/backend/app/models/db_models/refresh_token.py
+++ b/backend/app/models/db_models/refresh_token.py
@@ -29,7 +29,7 @@ class RefreshToken(Base):
     user_agent: Mapped[str | None] = mapped_column(String(512), nullable=True)
     ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
 
-    user = relationship("User", backref="refresh_tokens")
+    user = relationship("User", back_populates="refresh_tokens")
 
     __table_args__ = (Index("idx_refresh_token_user_revoked", "user_id", "revoked_at"),)
 

--- a/backend/app/models/db_models/user.py
+++ b/backend/app/models/db_models/user.py
@@ -58,6 +58,9 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         uselist=False,
         cascade="all, delete-orphan",
     )
+    refresh_tokens = relationship(
+        "RefreshToken", back_populates="user", cascade="all, delete-orphan"
+    )
 
 
 class UserSettings(Base):


### PR DESCRIPTION
## Summary
- add an explicit User.refresh_tokens relationship with delete-orphan cascade
- replace the RefreshToken user backref with back_populates

## Verification
- ruff (legacy alias) via pre-commit
- ruff format via pre-commit

## Notes
Admin user deletion can otherwise fail on refresh token rows and surface as a vague undefined error in sqladmin.