### PR TITLE
Update agent Docker tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ The backend and sandbox images install the tooling Agentrove needs to run coding
 
 - Claude Code
 - Codex CLI
+- Copilot CLI (`copilot`)
 - Cursor CLI (`cursor-agent`)
 - OpenCode CLI (`opencode`)
 - `claude-agent-acp`

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.31.0 @zed-industries/codex-acp@0.12.0 @openai/codex@0.124.0
+RUN npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.31.0 @zed-industries/codex-acp@0.12.0 @openai/codex@0.125.0 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to /root/.local/bin) — used for the Cursor
 # ACP server (`cursor-agent acp`). The install script downloads the binary for

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -58,7 +58,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.31.0 @zed-industries/codex-acp@0.12.0 @openai/codex@0.124.0
+    npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.31.0 @zed-industries/codex-acp@0.12.0 @openai/codex@0.125.0 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to ~/.local/bin, which is already on PATH).
 RUN curl -fsS https://cursor.com/install | bash


### PR DESCRIPTION
## Summary
- bump Codex CLI to 0.125.0 in backend and sandbox images
- install GitHub Copilot CLI in backend and sandbox images
- document Copilot CLI in included tooling

## Verification
- Not run per repo instructions