### PR TITLE
Remove agent auth env defaults

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -49,7 +49,8 @@ ENV HOME=/home/appuser
 ENV PYTHONUNBUFFERED=1
 ENV TERM=xterm-256color
 
-RUN mkdir -p /app/storage/claude-data /app/storage/codex-data /app/storage/images /app/storage/pdfs /app/storage/xlsx
+RUN mkdir -p /data/agentrove/storage/images /data/agentrove/storage/pdfs /data/agentrove/storage/xlsx && \
+    chown -R appuser:appuser /data/agentrove/storage
 
 EXPOSE 8080
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -46,10 +46,6 @@ RUN chown -R appuser:appuser /app && \
     chmod +x /app/entrypoint.sh
 
 ENV HOME=/home/appuser
-ENV CLAUDE_CONFIG_DIR=/app/storage/claude-data
-ENV CLAUDE_HOME=/app/storage/claude-data
-ENV CODEX_HOME=/app/storage/codex-data
-ENV CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 ENV PYTHONUNBUFFERED=1
 ENV TERM=xterm-256color
 

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -61,7 +61,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = sqlite+aiosqlite:////app/storage/agentrove.db
+sqlalchemy.url = sqlite+aiosqlite:////data/agentrove/storage/agentrove.db
 
 
 [post_write_hooks]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -10,7 +10,8 @@ from pydantic import ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings
 from pythonjsonlogger import jsonlogger
 
-DEFAULT_DATABASE_URL = "sqlite+aiosqlite:////app/storage/agentrove.db"
+DEFAULT_STORAGE_PATH = "/data/agentrove/storage"
+DEFAULT_DATABASE_URL = f"sqlite+aiosqlite:///{DEFAULT_STORAGE_PATH}/agentrove.db"
 
 
 def _desktop_data_dir() -> Path:
@@ -43,7 +44,7 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
     REFRESH_TOKEN_EXPIRE_DAYS: int = 30
 
-    STORAGE_PATH: str = "/app/storage"
+    STORAGE_PATH: str = DEFAULT_STORAGE_PATH
 
     ALLOWED_ORIGINS: str | list[str] = [
         "http://localhost:3000",
@@ -90,7 +91,7 @@ class Settings(BaseSettings):
         default_db = f"sqlite+aiosqlite:///{(data_dir / 'agentrove.db').as_posix()}"
         if self.DATABASE_URL == DEFAULT_DATABASE_URL:
             self.DATABASE_URL = default_db
-        if self.STORAGE_PATH == "/app/storage":
+        if self.STORAGE_PATH == DEFAULT_STORAGE_PATH:
             self.STORAGE_PATH = str(data_dir / "storage")
             Path(self.STORAGE_PATH).mkdir(parents=True, exist_ok=True)
         origins = (
@@ -175,7 +176,7 @@ class Settings(BaseSettings):
     ) -> str | None:
         if v:
             return v
-        storage_path = info.data.get("STORAGE_PATH", "/app/storage")
+        storage_path = info.data.get("STORAGE_PATH", DEFAULT_STORAGE_PATH)
         return f"{storage_path.rstrip('/')}/host-sandboxes"
 
     def get_host_sandbox_base_dir(self) -> str:

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -510,12 +510,10 @@ class AcpSession:
             # host sandbox directory so helpers like GIT_ASKPASS resolve.
             for key, val in config.env.items():
                 env[key] = val.replace(SANDBOX_HOME_DIR, host_home)
-            # Web mode: override HOME and CODEX_HOME so the agent uses the
-            # sandbox dir. Desktop mode keeps the real host locations so the
-            # user's existing Codex auth continues to resolve.
+            # Web mode: override HOME so the agent uses the sandbox dir.
+            # Desktop mode keeps the real host location so existing auth resolves.
             if not settings.DESKTOP_MODE:
                 env["HOME"] = host_home
-                env["CODEX_HOME"] = f"{host_home}/.codex"
         else:
             env.update(config.env)
         env.setdefault("TERM", TERMINAL_TYPE)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - "${BACKEND_PORT}:8080"
     volumes:
       - ./backend:/app
-      - ./storage:/app/storage
+      - ./storage:/data/agentrove/storage
       - /app/__pycache__
       - /var/run/docker.sock:/var/run/docker.sock
     env_file: .env

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -6,7 +6,6 @@ ENV PATH="/home/user/.local/bin:/home/user/.nvm/versions/node/v20.18.0/bin:$PATH
 ENV NVM_DIR="/home/user/.nvm"
 ENV NODE_VERSION=20.18.0
 ENV TERM=xterm-256color
-ENV CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 
 RUN apt-get update && apt-get install -y \
     curl \


### PR DESCRIPTION
## Summary
- remove Claude and Codex auth/config env defaults from the backend image
- stop overriding CODEX_HOME for host-provider ACP sessions
- remove Claude nonessential traffic disable env from the sandbox image

## Verification
- Not run, per project instruction.