### PR TITLE
Align host terminal home with agent home

### DIFF
--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -513,6 +513,7 @@ class AcpSession:
             # Web mode: override HOME so the agent uses the sandbox dir.
             # Desktop mode keeps the real host location so existing auth resolves.
             if not settings.DESKTOP_MODE:
+                Path(host_home).mkdir(parents=True, exist_ok=True)
                 env["HOME"] = host_home
         else:
             env.update(config.env)

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -17,6 +17,7 @@ from app.constants import (
     SANDBOX_DEFAULT_COMMAND_TIMEOUT,
     TERMINAL_TYPE,
 )
+from app.core.config import get_settings
 from app.services.exceptions import SandboxException
 from app.services.sandbox_providers.base import GIT_LS_FILES_CMD, SandboxProvider
 from app.services.sandbox_providers.types import (
@@ -30,6 +31,7 @@ from app.services.sandbox_providers.types import (
 from app.utils.sandbox import normalize_relative_path
 
 logger = logging.getLogger(__name__)
+settings = get_settings()
 
 
 class LocalHostProvider(SandboxProvider):
@@ -213,6 +215,10 @@ class LocalHostProvider(SandboxProvider):
         )
 
         env = os.environ.copy()
+        if sandbox_id and not settings.DESKTOP_MODE:
+            host_home = Path(settings.get_host_sandbox_base_dir()) / sandbox_id
+            host_home.mkdir(parents=True, exist_ok=True)
+            env["HOME"] = str(host_home)
         env["TERM"] = TERMINAL_TYPE
         shell = env.get("SHELL", "/bin/bash")
         cmd = (


### PR DESCRIPTION
## Summary
- use the per-sandbox host HOME for host-mode terminal sessions
- ensure the per-sandbox HOME exists before launching host-mode ACP agents
- keeps Codex login from the workspace terminal visible to Codex chat in host mode

## Verification
- ruff and ruff format passed via commit hook
- Tests not run, per project instruction.