### PR TITLE
Add per-message git checkpoints with restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentrove
 
-Self-hosted AI coding workspace for Claude Code, Codex, Copilot, Cursor, and OpenCode, using ACP adapters to run agents inside per-workspace sandboxes with chat, editor, terminal, and git tooling.
+Self-hosted AI coding workspace for single users and small teams running Claude Code, Codex, Copilot, Cursor, and OpenCode through ACP adapters inside per-workspace sandboxes with chat, editor, terminal, and git tooling.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentrove
 
-Self-hosted AI coding workspace for single users and small teams running Claude Code, Codex, Copilot, Cursor, and OpenCode through ACP adapters inside per-workspace sandboxes with chat, editor, terminal, and git tooling.
+Self-hosted AI coding workspace for Claude Code, Codex, Copilot, Cursor, and OpenCode, using ACP adapters to run agents inside per-workspace sandboxes with chat, editor, terminal, and git tooling.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
@@ -8,7 +8,7 @@ Self-hosted AI coding workspace for single users and small teams running Claude 
 [![FastAPI](https://img.shields.io/badge/FastAPI-009688.svg)](https://fastapi.tiangolo.com/)
 [![Discord](https://img.shields.io/badge/Discord-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/HvkJU8dcBA)
 
-> **Note:** Agentrove is under active development. Expect breaking changes between releases.
+> **Note:** Agentrove is under active development. Expect breaking changes between releases, and review release notes before upgrading.
 
 ## Screenshots
 

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -49,6 +49,7 @@ from app.models.schemas.chat import (
     MessageEvent,
     PermissionRespondResponse,
 )
+from app.models.schemas.sandbox import GitCommandResponse
 from app.models.schemas.pagination import (
     CursorPaginatedResponse,
     CursorPaginationParams,
@@ -61,6 +62,7 @@ from app.services.agent import AgentService
 from app.services.exceptions import (
     AgentException,
     ChatException,
+    SandboxException,
 )
 from app.services.queue import QueueService
 from app.services.session_registry import session_registry
@@ -143,6 +145,7 @@ async def send_message(
             "chat_id": result["chat_id"],
             "message_id": result["message_id"],
             "last_seq": result["last_seq"],
+            "checkpoint_id": result["checkpoint_id"],
         }
     except ChatException as e:
         raise HTTPException(
@@ -412,6 +415,28 @@ async def get_message_events(
     return await chat_service.message_service.get_message_events_after_seq(
         message_id, after_seq, limit=5000
     )
+
+
+@router.post(
+    "/messages/{message_id}/checkpoint/restore-all",
+    response_model=GitCommandResponse,
+)
+async def restore_message_checkpoint(
+    message_id: UUID,
+    current_user: User = Depends(get_current_user),
+    chat_service: ChatService = Depends(get_chat_service),
+) -> GitCommandResponse:
+    try:
+        return await chat_service.restore_checkpoint_all(message_id, current_user)
+    except ChatException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
+    except SandboxException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
 
 
 @router.delete("/chats/{chat_id}/stream", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/models/db_models/chat.py
+++ b/backend/app/models/db_models/chat.py
@@ -17,6 +17,7 @@ from sqlalchemy import JSON
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base_class import Base
+from app.db.migration_helpers import uuid_server_default
 from app.db.types import GUID, enum_values
 
 from .enums import AttachmentType, MessageRole, MessageStreamStatus
@@ -259,4 +260,35 @@ class MessageEvent(Base):
             "idx_message_events_chat_id_stream_id_seq", "chat_id", "stream_id", "seq"
         ),
         Index("uq_message_events_stream_seq", "stream_id", "seq", unique=True),
+    )
+
+
+class ChatCheckpoint(Base):
+    __tablename__ = "chat_checkpoints"
+
+    id: Mapped[UUID] = mapped_column(
+        GUID(),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=uuid_server_default(),
+    )
+    chat_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("chats.id", ondelete="CASCADE"), nullable=False
+    )
+    assistant_message_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("messages.id", ondelete="CASCADE"), nullable=False
+    )
+    cwd: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    base_head: Mapped[str] = mapped_column(String(64), nullable=False)
+    pre_run_diff: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=""
+    )
+
+    __table_args__ = (
+        Index(
+            "idx_chat_checkpoints_assistant_message_id",
+            "assistant_message_id",
+            unique=True,
+        ),
+        Index("idx_chat_checkpoints_chat_id_created_at", "chat_id", "created_at"),
     )

--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -55,6 +55,7 @@ class Message(MessageBase):
     model_id: str | None = None
     stream_status: MessageStreamStatus | None = None
     attachments: list[MessageAttachment] = Field(default_factory=list)
+    checkpoint_id: UUID | None = None
 
 
 class ChatBase(BaseModel):
@@ -99,6 +100,7 @@ class ChatCompletionResponse(BaseModel):
     chat_id: UUID
     message_id: UUID
     last_seq: int = 0
+    checkpoint_id: UUID | None = None
 
 
 class EnhancePromptResponse(BaseModel):

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -45,6 +45,7 @@ class ChatCompletionResult(TypedDict):
     message_id: str
     chat_id: str
     last_seq: int
+    checkpoint_id: str | None
 
 
 class YamlMetadata(TypedDict, total=False):

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -71,6 +71,28 @@ class AgentService:
         except (SQLAlchemyError, ValueError) as exc:
             logger.error("Failed to persist worktree_cwd for chat %s: %s", chat_id, exc)
 
+    async def ensure_worktree_cwd(self, chat: Chat) -> str:
+        if chat.worktree_cwd:
+            return cast(str, chat.worktree_cwd)
+
+        sandbox_id = chat.sandbox_id
+        if not sandbox_id:
+            return ""
+
+        provider = SandboxProvider.create_provider(
+            SandboxProviderType(chat.sandbox_provider),
+            workspace_path=chat.workspace_path,
+        )
+        git_service = GitService(SandboxService(provider))
+        worktree_cwd = await git_service.create_worktree(
+            sandbox_id,
+            "",
+            str(chat.id),
+        )
+        chat.worktree_cwd = worktree_cwd
+        await self._save_worktree_cwd(chat.id, worktree_cwd)
+        return worktree_cwd
+
     async def build_session_config(
         self,
         *,
@@ -102,23 +124,7 @@ class AgentService:
             )
 
         if worktree and sandbox_id:
-            if chat.worktree_cwd:
-                # Reuse the already-persisted worktree path from a prior turn.
-                cwd = chat.worktree_cwd
-            else:
-                provider = SandboxProvider.create_provider(
-                    sandbox_provider,
-                    workspace_path=workspace_path,
-                )
-                git_service = GitService(SandboxService(provider))
-                worktree_cwd = await git_service.create_worktree(
-                    sandbox_id,
-                    cwd,
-                    str(chat.id),
-                )
-                cwd = worktree_cwd
-                chat.worktree_cwd = worktree_cwd
-                await self._save_worktree_cwd(chat.id, worktree_cwd)
+            cwd = await self.ensure_worktree_cwd(chat)
 
         is_custom_persona = selected_persona_name != DEFAULT_PERSONA_NAME
 

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -8,10 +8,11 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from sqlalchemy import exists, func, select, update
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import aliased, selectinload
 
 from app.constants import MODELS, REDIS_KEY_CHAT_STREAM_LIVE
-from app.models.db_models.chat import Chat, Message
+from app.models.db_models.chat import Chat, ChatCheckpoint, Message
 from app.models.db_models.enums import MessageRole, MessageStreamStatus, StreamEventKind
 from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
@@ -25,6 +26,7 @@ from app.models.schemas.chat import (
     ChatUpdate,
 )
 from app.models.schemas.chat import Message as MessageSchema
+from app.models.schemas.sandbox import GitCommandResponse
 from app.models.schemas.pagination import (
     CursorPaginatedResponse,
     PaginatedResponse,
@@ -33,7 +35,8 @@ from app.models.schemas.pagination import (
 from app.models.types import ChatCompletionResult, MessageAttachmentDict, PermissionMode
 from app.prompts.system_prompt import DEFAULT_PERSONA_NAME, build_system_prompt_for_chat
 from app.services.db import BaseDbService, SessionFactoryType
-from app.services.exceptions import ChatException, ErrorCode
+from app.services.exceptions import ChatException, ErrorCode, SandboxException
+from app.services.git import GitService
 from app.services.message import MessageService
 from app.services.sandbox import SandboxService
 from app.services.sandbox_providers.base import SandboxProvider
@@ -622,6 +625,77 @@ class ChatService(BaseDbService[Chat]):
 
         return await self.message_service.get_chat_messages(chat_id, cursor, limit)
 
+    async def create_checkpoint_for_message(
+        self,
+        chat: Chat,
+        assistant_message_id: UUID,
+    ) -> UUID | None:
+        # Checkpoints are best-effort; a non-git workspace should not block
+        # the user's agent run.
+        sandbox_id = chat.workspace.sandbox_id
+        if not sandbox_id:
+            return None
+
+        cwd = chat.worktree_cwd
+        git_service = GitService(self.sandbox_for_workspace(chat.workspace))
+        checkpoint = await git_service.create_checkpoint(sandbox_id, cwd)
+        if checkpoint is None:
+            return None
+
+        async with self.session_factory() as db:
+            checkpoint_row = ChatCheckpoint(
+                chat_id=chat.id,
+                assistant_message_id=assistant_message_id,
+                cwd=cwd,
+                base_head=checkpoint.base_head,
+                pre_run_diff=checkpoint.pre_run_diff,
+            )
+            db.add(checkpoint_row)
+            await db.commit()
+            await db.refresh(checkpoint_row)
+            return checkpoint_row.id
+
+    async def restore_checkpoint_all(
+        self,
+        message_id: UUID,
+        user: User,
+    ) -> GitCommandResponse:
+        checkpoint, chat = await self._get_checkpoint_target(message_id, user)
+        git_service = GitService(self.sandbox_for_workspace(chat.workspace))
+        return await git_service.restore_checkpoint_all(
+            chat.workspace.sandbox_id,
+            base_head=checkpoint.base_head,
+            pre_run_diff=checkpoint.pre_run_diff,
+            cwd=checkpoint.cwd,
+        )
+
+    async def _get_checkpoint_target(
+        self,
+        message_id: UUID,
+        user: User,
+    ) -> tuple[ChatCheckpoint, Chat]:
+        async with self.session_factory() as db:
+            result = await db.execute(
+                select(ChatCheckpoint, Chat)
+                .join(Chat, Chat.id == ChatCheckpoint.chat_id)
+                .options(selectinload(Chat.workspace))
+                .where(
+                    ChatCheckpoint.assistant_message_id == message_id,
+                    Chat.user_id == user.id,
+                    Chat.deleted_at.is_(None),
+                )
+            )
+            row = result.one_or_none()
+            if row is None:
+                raise ChatException(
+                    "Checkpoint not found",
+                    error_code=ErrorCode.CHAT_NOT_FOUND,
+                    details={"message_id": str(message_id)},
+                    status_code=404,
+                )
+            checkpoint, chat = row
+            return checkpoint, chat
+
     async def _replay_stream_backlog(
         self,
         chat_id: UUID,
@@ -938,6 +1012,19 @@ class ChatService(BaseDbService[Chat]):
             stream_status=MessageStreamStatus.IN_PROGRESS,
         )
 
+        checkpoint_id = None
+        try:
+            checkpoint_id = await self.create_checkpoint_for_message(
+                chat,
+                assistant_message.id,
+            )
+        except (SandboxException, SQLAlchemyError) as exc:
+            logger.warning(
+                "Failed to create checkpoint for message %s: %s",
+                assistant_message.id,
+                exc,
+            )
+
         model = MODELS[request.model_id]
         system_prompt = build_system_prompt_for_chat(
             user_settings,
@@ -970,6 +1057,7 @@ class ChatService(BaseDbService[Chat]):
             "message_id": str(assistant_message.id),
             "chat_id": str(chat_id),
             "last_seq": chat.last_event_seq,
+            "checkpoint_id": str(checkpoint_id) if checkpoint_id else None,
         }
 
     async def _enqueue_chat_task(

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -4,7 +4,7 @@ import logging
 import math
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, cast
 from uuid import UUID, uuid4
 
 from sqlalchemy import exists, func, select, update
@@ -34,6 +34,7 @@ from app.models.schemas.pagination import (
 )
 from app.models.types import ChatCompletionResult, MessageAttachmentDict, PermissionMode
 from app.prompts.system_prompt import DEFAULT_PERSONA_NAME, build_system_prompt_for_chat
+from app.services.agent import AgentService
 from app.services.db import BaseDbService, SessionFactoryType
 from app.services.exceptions import ChatException, ErrorCode, SandboxException
 from app.services.git import GitService
@@ -625,35 +626,52 @@ class ChatService(BaseDbService[Chat]):
 
         return await self.message_service.get_chat_messages(chat_id, cursor, limit)
 
+    @staticmethod
     async def create_checkpoint_for_message(
-        self,
         chat: Chat,
         assistant_message_id: UUID,
+        session_factory: SessionFactoryType,
+        worktree: bool,
     ) -> UUID | None:
-        # Checkpoints are best-effort; a non-git workspace should not block
-        # the user's agent run.
-        sandbox_id = chat.workspace.sandbox_id
+        # Best-effort: a non-git workspace must not block the agent run.
+        sandbox_id = chat.sandbox_id
         if not sandbox_id:
             return None
 
-        cwd = chat.worktree_cwd
-        git_service = GitService(self.sandbox_for_workspace(chat.workspace))
-        checkpoint = await git_service.create_checkpoint(sandbox_id, cwd)
-        if checkpoint is None:
-            return None
-
-        async with self.session_factory() as db:
-            checkpoint_row = ChatCheckpoint(
-                chat_id=chat.id,
-                assistant_message_id=assistant_message_id,
-                cwd=cwd,
-                base_head=checkpoint.base_head,
-                pre_run_diff=checkpoint.pre_run_diff,
+        try:
+            if worktree:
+                await AgentService(session_factory=session_factory).ensure_worktree_cwd(
+                    chat
+                )
+            cwd = chat.worktree_cwd if worktree else ""
+            provider = SandboxProvider.create_provider(
+                chat.sandbox_provider, workspace_path=chat.workspace_path
             )
-            db.add(checkpoint_row)
-            await db.commit()
-            await db.refresh(checkpoint_row)
-            return checkpoint_row.id
+            checkpoint = await GitService(SandboxService(provider)).create_checkpoint(
+                sandbox_id, cwd
+            )
+            if checkpoint is None:
+                return None
+
+            async with session_factory() as db:
+                checkpoint_row = ChatCheckpoint(
+                    chat_id=chat.id,
+                    assistant_message_id=assistant_message_id,
+                    cwd=cwd,
+                    base_head=checkpoint.base_head,
+                    pre_run_diff=checkpoint.pre_run_diff,
+                )
+                db.add(checkpoint_row)
+                await db.commit()
+                await db.refresh(checkpoint_row)
+                return cast(UUID, checkpoint_row.id)
+        except (SandboxException, SQLAlchemyError, TimeoutError, ValueError) as exc:
+            logger.warning(
+                "Failed to create checkpoint for message %s: %s",
+                assistant_message_id,
+                exc,
+            )
+            return None
 
     async def restore_checkpoint_all(
         self,
@@ -689,7 +707,7 @@ class ChatService(BaseDbService[Chat]):
             if row is None:
                 raise ChatException(
                     "Checkpoint not found",
-                    error_code=ErrorCode.CHAT_NOT_FOUND,
+                    error_code=ErrorCode.MESSAGE_NOT_FOUND,
                     details={"message_id": str(message_id)},
                     status_code=404,
                 )
@@ -1012,18 +1030,12 @@ class ChatService(BaseDbService[Chat]):
             stream_status=MessageStreamStatus.IN_PROGRESS,
         )
 
-        checkpoint_id = None
-        try:
-            checkpoint_id = await self.create_checkpoint_for_message(
-                chat,
-                assistant_message.id,
-            )
-        except (SandboxException, SQLAlchemyError) as exc:
-            logger.warning(
-                "Failed to create checkpoint for message %s: %s",
-                assistant_message.id,
-                exc,
-            )
+        checkpoint_id = await self.create_checkpoint_for_message(
+            chat,
+            assistant_message.id,
+            self._session_factory,
+            request.worktree,
+        )
 
         model = MODELS[request.model_id]
         system_prompt = build_system_prompt_for_chat(

--- a/backend/app/services/git.py
+++ b/backend/app/services/git.py
@@ -1,9 +1,9 @@
-import base64
 import posixpath
 import re
 import shlex
 from string import Template
 from typing import Literal, NamedTuple
+from uuid import uuid4
 
 from app.models.schemas.sandbox import (
     GitBranchesResponse,
@@ -29,8 +29,7 @@ GITHUB_REMOTE_RE = re.compile(
 
 GIT_IS_REPO_CMD = "git rev-parse --is-inside-work-tree 2>/dev/null"
 GIT_CURRENT_BRANCH_CMD = "git rev-parse --abbrev-ref HEAD 2>/dev/null"
-# Combined: emit HEAD on line 1 and `dirty`/`clean` marker on line 2 in one
-# round-trip so a clean tree skips the full diff capture below.
+# One round-trip so a clean tree (the common case) avoids the diff capture.
 GIT_CHECKPOINT_PROBE_CMD = (
     "git rev-parse HEAD 2>/dev/null && "
     '(test -z "$(git status --porcelain 2>/dev/null)" '
@@ -86,9 +85,20 @@ GIT_DIFF_ALL_TEMPLATE = Template(
     " || { git diff$ctx --cached 2>/dev/null; git diff$ctx 2>/dev/null; }; };"
     "$untracked"
 )
+GIT_CHECKPOINT_DIFF_ALL_TEMPLATE = Template(
+    "{ git diff --binary -U99999 HEAD 2>/dev/null"
+    " || { git diff --binary -U99999 --cached 2>/dev/null; "
+    "git diff --binary -U99999 2>/dev/null; }; };"
+    "$untracked"
+)
 GIT_UNTRACKED_DIFF_TEMPLATE = Template(
     " git ls-files --others --exclude-standard -z"
     " | xargs -0 -I{} git diff$ctx --no-index -- /dev/null {} 2>/dev/null"
+)
+GIT_CHECKPOINT_UNTRACKED_DIFF_TEMPLATE = (
+    " git ls-files --others --exclude-standard -z"
+    " | xargs -0 -I{} "
+    "git diff --binary -U99999 --no-index -- /dev/null {} 2>/dev/null"
 )
 # Diff HEAD against the merge-base with the default branch. Default branch is
 # detected via the remote HEAD symref, falling back to main/master/develop/
@@ -143,15 +153,19 @@ RESTORE_FILE_TEMPLATE = Template(
 )
 
 GIT_RESTORE_CHECKPOINT_ALL_TEMPLATE = Template(
-    GIT_CD_REPO_ROOT + "git reset --hard '$base_head' >/dev/null 2>&1 && "
-    "git clean -fd >/dev/null 2>&1 && "
-    "if [ -n '$patch' ]; then "
-    "tmp=$$(mktemp); "
-    "printf '%s' '$patch' > \"$$tmp\"; "
-    '{ base64 -d "$$tmp" 2>/dev/null || base64 -D "$$tmp"; } '
-    "| git apply --whitespace=nowarn 2>&1; "
-    'status=$$?; rm -f "$$tmp"; exit $$status; '
-    "fi"
+    "tmp=''; "
+    'if [ -n "$patch_file" ]; then '
+    'tmp=$$(mktemp) && cp $patch_file "$$tmp"; '
+    "status=$$?; rm -f $patch_file; "
+    'if [ $$status -ne 0 ]; then rm -f "$$tmp"; exit $$status; fi; '
+    'fi; cd "$$(git rev-parse --show-toplevel)" && '
+    "git reset --hard '$base_head' >/dev/null 2>&1; "
+    "status=$$?; "
+    "if [ $$status -eq 0 ]; then git clean -fd >/dev/null 2>&1; status=$$?; fi; "
+    'if [ $$status -eq 0 ] && [ -n "$$tmp" ]; then '
+    'git apply --whitespace=nowarn "$$tmp" 2>&1; status=$$?; '
+    "fi; "
+    'rm -f "$$tmp"; exit $$status'
 )
 
 
@@ -379,8 +393,14 @@ class GitService:
         if marker == "clean":
             return Checkpoint(base_head=head, pre_run_diff="")
 
-        diff = await self.get_diff(sandbox_id, "all", True, cwd)
-        return Checkpoint(base_head=head, pre_run_diff=diff.diff)
+        cmd = GIT_CHECKPOINT_DIFF_ALL_TEMPLATE.substitute(
+            untracked=GIT_CHECKPOINT_UNTRACKED_DIFF_TEMPLATE
+        )
+        result = await self.sandbox_service.execute_command(
+            sandbox_id,
+            f"{cd_prefix}{cmd}",
+        )
+        return Checkpoint(base_head=head, pre_run_diff=result.stdout)
 
     async def restore_checkpoint_all(
         self,
@@ -390,11 +410,21 @@ class GitService:
         pre_run_diff: str,
         cwd: str | None = None,
     ) -> GitCommandResponse:
-        self._validate_commit_ref(base_head)
-        patch = base64.b64encode(pre_run_diff.encode()).decode()
+        if not re.fullmatch(r"[0-9a-fA-F]{40}", base_head):
+            raise ValueError("Invalid checkpoint commit")
+        patch_file = ""
+        if pre_run_diff:
+            name = f".agentrove-checkpoint-{uuid4().hex}.patch"
+            patch_path = posixpath.join(cwd, name) if cwd else name
+            await self.sandbox_service.provider.write_file(
+                sandbox_id, patch_path, pre_run_diff
+            )
+            patch_file = shlex.quote(
+                self.sandbox_service.provider.resolve_workspace_path(patch_path)
+            )
         cmd = GIT_RESTORE_CHECKPOINT_ALL_TEMPLATE.substitute(
             base_head=base_head,
-            patch=patch,
+            patch_file=patch_file,
         )
         return await self.run_command(sandbox_id, cmd, cwd)
 
@@ -524,8 +554,3 @@ class GitService:
             or "\x00" in path
         ):
             raise ValueError("Invalid file path")
-
-    @staticmethod
-    def _validate_commit_ref(ref: str) -> None:
-        if not re.fullmatch(r"[0-9a-fA-F]{40}", ref):
-            raise ValueError("Invalid checkpoint commit")

--- a/backend/app/services/git.py
+++ b/backend/app/services/git.py
@@ -1,8 +1,9 @@
+import base64
 import posixpath
 import re
 import shlex
 from string import Template
-from typing import Literal
+from typing import Literal, NamedTuple
 
 from app.models.schemas.sandbox import (
     GitBranchesResponse,
@@ -16,12 +17,25 @@ from app.services.exceptions import SandboxException
 from app.services.sandbox import SandboxService
 from app.utils.sandbox import BRANCH_NAME_RE, git_cd_prefix
 
+
+class Checkpoint(NamedTuple):
+    base_head: str
+    pre_run_diff: str
+
+
 GITHUB_REMOTE_RE = re.compile(
     r"(?:https?://github\.com/|git@github\.com:)([^/]+)/([^/]+?)(?:\.git)?$"
 )
 
 GIT_IS_REPO_CMD = "git rev-parse --is-inside-work-tree 2>/dev/null"
 GIT_CURRENT_BRANCH_CMD = "git rev-parse --abbrev-ref HEAD 2>/dev/null"
+# Combined: emit HEAD on line 1 and `dirty`/`clean` marker on line 2 in one
+# round-trip so a clean tree skips the full diff capture below.
+GIT_CHECKPOINT_PROBE_CMD = (
+    "git rev-parse HEAD 2>/dev/null && "
+    '(test -z "$(git status --porcelain 2>/dev/null)" '
+    "&& echo clean || echo dirty)"
+)
 GIT_PUSH_CMD = "git push -u origin HEAD"
 GIT_PULL_CMD = "git pull"
 GIT_REMOTE_URL_CMD = "git remote get-url origin 2>/dev/null"
@@ -125,6 +139,18 @@ RESTORE_FILE_TEMPLATE = Template(
     "else "
     "git reset -- $fp >/dev/null 2>&1; "
     "rm -f -- $fp; "
+    "fi"
+)
+
+GIT_RESTORE_CHECKPOINT_ALL_TEMPLATE = Template(
+    GIT_CD_REPO_ROOT + "git reset --hard '$base_head' >/dev/null 2>&1 && "
+    "git clean -fd >/dev/null 2>&1 && "
+    "if [ -n '$patch' ]; then "
+    "tmp=$$(mktemp); "
+    "printf '%s' '$patch' > \"$$tmp\"; "
+    '{ base64 -d "$$tmp" 2>/dev/null || base64 -D "$$tmp"; } '
+    "| git apply --whitespace=nowarn 2>&1; "
+    'status=$$?; rm -f "$$tmp"; exit $$status; '
     "fi"
 )
 
@@ -331,6 +357,47 @@ class GitService:
     ) -> GitCommandResponse:
         return await self.run_command(sandbox_id, RESTORE_ALL_CMD, cwd)
 
+    async def create_checkpoint(
+        self,
+        sandbox_id: str,
+        cwd: str | None = None,
+    ) -> Checkpoint | None:
+        # Single probe avoids a separate diff round-trip when the tree is clean
+        # — the common case for the first turn of a fresh chat.
+        cd_prefix = git_cd_prefix(cwd)
+        probe = await self.sandbox_service.execute_command(
+            sandbox_id,
+            f"{cd_prefix}{GIT_CHECKPOINT_PROBE_CMD}",
+        )
+        if probe.exit_code != 0:
+            return None
+        lines = probe.stdout.splitlines()
+        head = lines[0].strip() if lines else ""
+        marker = lines[1].strip() if len(lines) > 1 else ""
+        if not head:
+            return None
+        if marker == "clean":
+            return Checkpoint(base_head=head, pre_run_diff="")
+
+        diff = await self.get_diff(sandbox_id, "all", True, cwd)
+        return Checkpoint(base_head=head, pre_run_diff=diff.diff)
+
+    async def restore_checkpoint_all(
+        self,
+        sandbox_id: str,
+        *,
+        base_head: str,
+        pre_run_diff: str,
+        cwd: str | None = None,
+    ) -> GitCommandResponse:
+        self._validate_commit_ref(base_head)
+        patch = base64.b64encode(pre_run_diff.encode()).decode()
+        cmd = GIT_RESTORE_CHECKPOINT_ALL_TEMPLATE.substitute(
+            base_head=base_head,
+            patch=patch,
+        )
+        return await self.run_command(sandbox_id, cmd, cwd)
+
     async def create_branch(
         self,
         sandbox_id: str,
@@ -457,3 +524,8 @@ class GitService:
             or "\x00" in path
         ):
             raise ValueError("Invalid file path")
+
+    @staticmethod
+    def _validate_commit_ref(ref: str) -> None:
+        if not re.fullmatch(r"[0-9a-fA-F]{40}", ref):
+            raise ValueError("Invalid checkpoint commit")

--- a/backend/app/services/message.py
+++ b/backend/app/services/message.py
@@ -7,7 +7,13 @@ from sqlalchemy import and_, case, insert, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.db_models.chat import Chat, Message, MessageAttachment, MessageEvent
+from app.models.db_models.chat import (
+    Chat,
+    ChatCheckpoint,
+    Message,
+    MessageAttachment,
+    MessageEvent,
+)
 from app.models.db_models.enums import MessageRole, MessageStreamStatus
 from app.models.schemas.chat import Message as MessageSchema
 from app.models.schemas.pagination import CursorPaginatedResponse
@@ -265,7 +271,11 @@ class MessageService(BaseDbService[Message]):
         # created in the same tick share a timestamp.
         async with self.session_factory() as db:
             query = (
-                select(Message)
+                select(Message, ChatCheckpoint.id)
+                .outerjoin(
+                    ChatCheckpoint,
+                    ChatCheckpoint.assistant_message_id == Message.id,
+                )
                 .options(selectinload(Message.attachments))
                 .filter(Message.chat_id == chat_id, Message.deleted_at.is_(None))
                 .order_by(Message.created_at.desc(), Message.id.desc())
@@ -289,10 +299,13 @@ class MessageService(BaseDbService[Message]):
                 )
 
             result = await db.execute(query)
-            rows = list(result.scalars().all())
+            rows = list(result.all())
 
             has_more = len(rows) > limit
-            items = rows[:limit]
+            items = []
+            for message, checkpoint_id in rows[:limit]:
+                message.checkpoint_id = checkpoint_id
+                items.append(message)
 
             next_cursor = None
             if has_more and items:

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -511,6 +511,15 @@ class ChatStreamRuntime:
                 model_id=next_msg["model_id"],
                 stream_status=MessageStreamStatus.IN_PROGRESS,
             )
+            # Inline import to avoid circular dependency with chat.py.
+            from app.services.chat import ChatService
+
+            checkpoint_id = await ChatService.create_checkpoint_for_message(
+                self.chat,
+                assistant_message.id,
+                self.session_factory,
+                next_msg["worktree"],
+            )
 
             await self.emit_event(
                 "queue_processing",
@@ -518,6 +527,7 @@ class ChatStreamRuntime:
                     "queued_message_id": next_msg["id"],
                     "user_message_id": str(user_message.id),
                     "assistant_message_id": str(assistant_message.id),
+                    "checkpoint_id": str(checkpoint_id) if checkpoint_id else None,
                     "content": next_msg["content"],
                     "model_id": next_msg["model_id"],
                     "attachments": MessageService.serialize_attachments(
@@ -833,6 +843,16 @@ class ChatStreamRuntime:
                 chat = result.scalar_one_or_none()
                 if not chat:
                     raise AgentException(f"Chat {chat_id} not found for idle send-now")
+
+            # Inline import to avoid circular dependency with chat.py.
+            from app.services.chat import ChatService
+
+            await ChatService.create_checkpoint_for_message(
+                chat,
+                assistant_message.id,
+                session_factory,
+                queued_msg["worktree"],
+            )
 
             user_service = UserService(session_factory=session_factory)
             user_settings = await user_service.get_user_settings(chat.user_id, db=None)

--- a/backend/migrations/versions/05d565131567_add_chat_checkpoints.py
+++ b/backend/migrations/versions/05d565131567_add_chat_checkpoints.py
@@ -1,0 +1,69 @@
+# Revision ID: 05d565131567
+# Revises: b7fae3df7bca
+# Create Date: 2026-05-03 02:06:33.241931
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from app.db.migration_helpers import uuid_server_default, now_server_default
+from app.db.types import GUID
+
+# revision identifiers, used by Alembic.
+revision: str = "05d565131567"
+down_revision: str | None = "b7fae3df7bca"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_checkpoints",
+        sa.Column("id", GUID(), server_default=uuid_server_default(), nullable=False),
+        sa.Column("chat_id", GUID(), nullable=False),
+        sa.Column("assistant_message_id", GUID(), nullable=False),
+        sa.Column("cwd", sa.String(length=512), nullable=True),
+        sa.Column("base_head", sa.String(length=64), nullable=False),
+        sa.Column("pre_run_diff", sa.Text(), server_default="", nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=now_server_default(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=now_server_default(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["assistant_message_id"], ["messages.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["chat_id"], ["chats.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_chat_checkpoints_assistant_message_id",
+        "chat_checkpoints",
+        ["assistant_message_id"],
+        unique=True,
+    )
+    op.create_index(
+        "idx_chat_checkpoints_chat_id_created_at",
+        "chat_checkpoints",
+        ["chat_id", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_chat_checkpoints_chat_id_created_at",
+        table_name="chat_checkpoints",
+    )
+    op.drop_index(
+        "idx_chat_checkpoints_assistant_message_id",
+        table_name="chat_checkpoints",
+    )
+    op.drop_table("chat_checkpoints")

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.endpoints import chat as chat_endpoint
 from app.constants import MODELS, REDIS_KEY_CHAT_CONTEXT_USAGE
 from app.core.deps import get_agent_service, get_chat_service, get_queue_service
-from app.models.db_models.chat import Chat, Message, MessageEvent
+from app.models.db_models.chat import Chat, ChatCheckpoint, Message, MessageEvent
 from app.models.db_models.enums import MessageRole, MessageStreamStatus
 from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
@@ -25,6 +25,7 @@ from tests.conftest import LoginClient, UserFactory
 from tests.helpers import (
     EndpointCache,
     FakeProviderFactory,
+    FakeSandboxProvider,
     create_authenticated_workspace,
 )
 
@@ -79,7 +80,7 @@ class ChatCompletionServiceOverride:
 
     async def initiate_chat_completion(
         self, request: ChatRequest, user: User
-    ) -> dict[str, UUID | int]:
+    ) -> dict[str, UUID | int | None]:
         self.requests.append(request)
         self.users.append(user)
         if self.fail:
@@ -88,6 +89,7 @@ class ChatCompletionServiceOverride:
             "chat_id": request.chat_id,
             "message_id": UUID("00000000-0000-0000-0000-000000000123"),
             "last_seq": 4,
+            "checkpoint_id": None,
         }
 
 
@@ -181,6 +183,27 @@ async def create_message_event_row(
     return event
 
 
+async def create_checkpoint_row(
+    db_session: AsyncSession,
+    chat: Chat,
+    assistant_message: Message,
+    *,
+    cwd: str | None = None,
+    pre_run_diff: str = "",
+) -> ChatCheckpoint:
+    checkpoint = ChatCheckpoint(
+        chat_id=chat.id,
+        assistant_message_id=assistant_message.id,
+        cwd=cwd,
+        base_head="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        pre_run_diff=pre_run_diff,
+    )
+    db_session.add(checkpoint)
+    await db_session.commit()
+    await db_session.refresh(checkpoint)
+    return checkpoint
+
+
 async def test_create_list_and_get_chat(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -257,6 +280,7 @@ async def test_send_message_endpoint_passes_form_fields_to_chat_service(
         "chat_id": str(chat.id),
         "message_id": "00000000-0000-0000-0000-000000000123",
         "last_seq": 4,
+        "checkpoint_id": None,
     }
     request = chat_service.requests[0]
     assert request.prompt == "Ship this"
@@ -550,6 +574,127 @@ async def test_chat_messages_returns_only_owned_chat_messages(
     assert body["items"][0]["id"] == str(message.id)
     assert body["items"][0]["content_text"] == "Visible message"
     assert other_response.status_code == 403
+
+
+async def test_chat_messages_include_assistant_checkpoint_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+    assistant_message = await create_message_row(
+        db_session,
+        chat,
+        content="Changed files",
+        role=MessageRole.ASSISTANT,
+    )
+    checkpoint = await create_checkpoint_row(db_session, chat, assistant_message)
+
+    response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 1
+    assert body["items"][0]["id"] == str(assistant_message.id)
+    assert body["items"][0]["checkpoint_id"] == str(checkpoint.id)
+
+
+async def test_restore_message_checkpoint_resets_workspace(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = FakeSandboxProvider()
+    monkeypatch.setattr(
+        SandboxProvider,
+        "create_provider",
+        FakeProviderFactory(provider=provider),
+    )
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+    assistant_message = await create_message_row(
+        db_session,
+        chat,
+        content="Changed files",
+        role=MessageRole.ASSISTANT,
+    )
+    await create_checkpoint_row(
+        db_session,
+        chat,
+        assistant_message,
+        cwd="packages/api",
+        pre_run_diff="diff --git a/app.py b/app.py\n",
+    )
+
+    response = await client.post(
+        f"/api/v1/chat/messages/{assistant_message.id}/checkpoint/restore-all",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"success": True, "output": "", "error": None}
+    assert len(provider.writes) == 1
+    sandbox_id, patch_path, patch_content = provider.writes[0]
+    assert sandbox_id == workspace.sandbox_id
+    assert patch_path.startswith("packages/api/.agentrove-checkpoint-")
+    assert patch_path.endswith(".patch")
+    assert patch_content == "diff --git a/app.py b/app.py\n"
+    commands = [command for _sandbox_id, command, _envs in provider.commands]
+    assert commands[-1].startswith("cd 'packages/api' && ")
+    assert "git reset --hard 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'" in commands[-1]
+    assert "git apply --whitespace=nowarn" in commands[-1]
+
+
+async def test_restore_message_checkpoint_rejects_other_users(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = FakeSandboxProvider()
+    monkeypatch.setattr(
+        SandboxProvider,
+        "create_provider",
+        FakeProviderFactory(provider=provider),
+    )
+    _headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+    assistant_message = await create_message_row(
+        db_session,
+        chat,
+        content="Changed files",
+        role=MessageRole.ASSISTANT,
+    )
+    await create_checkpoint_row(db_session, chat, assistant_message)
+    other_headers, _other_user, _other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="checkpoint-other@example.com",
+        username="checkpointother",
+    )
+
+    response = await client.post(
+        f"/api/v1/chat/messages/{assistant_message.id}/checkpoint/restore-all",
+        headers=other_headers,
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Checkpoint not found"
+    assert provider.commands == []
 
 
 async def test_chat_status_reports_active_stream_only_when_runtime_is_active(

--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -342,6 +342,7 @@ export const Chat = memo(function Chat() {
               isStreaming={messageIsStreaming}
               createdAt={msg.created_at}
               modelId={msg.model_id}
+              checkpointId={msg.checkpoint_id}
               isLastBotMessage={isLastBotMessage && !messageIsStreaming}
             />
           ) : (

--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -112,6 +112,8 @@ export const AssistantMessage = memo(function AssistantMessage({
   // message, so tool renderers can handle per-agent rawInput shape variations
   // (e.g. Copilot's apply_patch vs. Codex's structured changes).
   const agentKind = modelId ? getAgentKindForModelId(modelId) : undefined;
+  const hasContentText = contentText.trim().length > 0;
+  const showFooter = (hasContentText || checkpointId != null) && !isStreaming;
 
   return (
     <div className="group px-4 py-1.5 sm:px-6 sm:py-2">
@@ -129,33 +131,22 @@ export const AssistantMessage = memo(function AssistantMessage({
             />
           </div>
 
-          {contentText.trim() && !isStreaming && (
+          {showFooter && (
             <div className="mt-2 flex items-center justify-between">
               <div className="flex items-center gap-0.5">
-                <MessageActions messageId={id} contentText={contentText} />
+                {hasContentText && <MessageActions messageId={id} contentText={contentText} />}
                 {checkpointId && (
-                  <>
-                    <Tooltip content="Restore to before this run" position="bottom">
-                      <Button
-                        onClick={() => setRestoreOpen(true)}
-                        variant="unstyled"
-                        disabled={isRestoring}
-                        className="rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-quaternary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
-                      >
-                        <Undo2 className="h-3.5 w-3.5" />
-                      </Button>
-                    </Tooltip>
-                    {restoreOpen && (
-                      <ConfirmDialog
-                        isOpen
-                        onClose={() => setRestoreOpen(false)}
-                        onConfirm={() => restore()}
-                        title="Restore to before this run?"
-                        message="The workspace will be reset to the checkpoint captured before this assistant run. Changes made by the run will be discarded."
-                        confirmLabel="Restore"
-                      />
-                    )}
-                  </>
+                  <Tooltip content="Restore to before this run" position="bottom">
+                    <Button
+                      onClick={() => setRestoreOpen(true)}
+                      variant="unstyled"
+                      disabled={isRestoring}
+                      aria-label="Restore to before this run"
+                      className="rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-quaternary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+                    >
+                      <Undo2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </Tooltip>
                 )}
               </div>
 
@@ -172,6 +163,16 @@ export const AssistantMessage = memo(function AssistantMessage({
           )}
         </div>
       </div>
+      {restoreOpen && (
+        <ConfirmDialog
+          isOpen
+          onClose={() => setRestoreOpen(false)}
+          onConfirm={() => restore()}
+          title="Restore to before this run?"
+          message="The workspace will be reset to the checkpoint captured before this assistant run. Changes made by the run will be discarded."
+          confirmLabel="Restore"
+        />
+      )}
     </div>
   );
 });

--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -1,4 +1,5 @@
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useState } from 'react';
+import { Undo2 } from 'lucide-react';
 import { UserMessageContent, AssistantMessageContent } from './MessageContent';
 import { MessageActions } from './MessageActions';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
@@ -8,9 +9,12 @@ import {
   type MessageAttachment,
 } from '@/types/chat.types';
 import { Tooltip } from '@/components/ui/Tooltip';
+import { Button } from '@/components/ui/primitives/Button';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { formatRelativeTime, formatFullTimestamp } from '@/utils/date';
 import { useChatContext } from '@/hooks/useChatContext';
 import { useChatInputMessageContext } from '@/hooks/useChatInputMessageContext';
+import { useCheckpointRestore } from '@/hooks/useCheckpointRestore';
 
 interface SharedContentProps {
   contentRender: {
@@ -66,6 +70,7 @@ export const UserMessage = memo(function UserMessage({
 export interface AssistantMessageProps extends SharedContentProps {
   contentText: string;
   id: string;
+  checkpointId: string | null;
   createdAt?: string;
   modelId?: string;
   isLastBotMessage?: boolean;
@@ -73,6 +78,7 @@ export interface AssistantMessageProps extends SharedContentProps {
 
 export const AssistantMessage = memo(function AssistantMessage({
   id,
+  checkpointId,
   contentText,
   contentRender,
   attachments,
@@ -81,10 +87,12 @@ export const AssistantMessage = memo(function AssistantMessage({
   modelId,
   isLastBotMessage,
 }: AssistantMessageProps) {
-  const { chatId } = useChatContext();
+  const { chatId, sandboxId } = useChatContext();
   const { setInputMessage } = useChatInputMessageContext();
   const onSuggestionSelect = isLastBotMessage ? setInputMessage : undefined;
   const modelMap = useModelMap();
+  const [restoreOpen, setRestoreOpen] = useState(false);
+  const { restore, isRestoring } = useCheckpointRestore(id, sandboxId);
 
   const relativeTime = createdAt ? formatRelativeTime(createdAt) : '';
   const fullTimestamp = createdAt ? formatFullTimestamp(createdAt) : '';
@@ -123,7 +131,33 @@ export const AssistantMessage = memo(function AssistantMessage({
 
           {contentText.trim() && !isStreaming && (
             <div className="mt-2 flex items-center justify-between">
-              <MessageActions messageId={id} contentText={contentText} />
+              <div className="flex items-center gap-0.5">
+                <MessageActions messageId={id} contentText={contentText} />
+                {checkpointId && (
+                  <>
+                    <Tooltip content="Restore to before this run" position="bottom">
+                      <Button
+                        onClick={() => setRestoreOpen(true)}
+                        variant="unstyled"
+                        disabled={isRestoring}
+                        className="rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-quaternary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+                      >
+                        <Undo2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </Tooltip>
+                    {restoreOpen && (
+                      <ConfirmDialog
+                        isOpen
+                        onClose={() => setRestoreOpen(false)}
+                        onConfirm={() => restore()}
+                        title="Restore to before this run?"
+                        message="The workspace will be reset to the checkpoint captured before this assistant run. Changes made by the run will be discarded."
+                        confirmLabel="Restore"
+                      />
+                    )}
+                  </>
+                )}
+              </div>
 
               <div className="flex items-center gap-1.5 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
                 {modelName && <span>{modelName}</span>}

--- a/frontend/src/hooks/queries/useSandboxQueries.ts
+++ b/frontend/src/hooks/queries/useSandboxQueries.ts
@@ -236,7 +236,7 @@ export const useSearchInFilesQuery = (
 // paths (e.g. `.worktrees/<id>/src/App.tsx`), so targeting a specific
 // `fileContent` key would miss worktree entries. Invalidate the whole
 // file-content space under this sandbox instead.
-const invalidateAfterGitRestore = (queryClient: QueryClient, sandboxId: string) =>
+export const invalidateAfterGitRestore = (queryClient: QueryClient, sandboxId: string) =>
   Promise.all([
     queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitDiffAll(sandboxId) }),
     queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.filesMetadata(sandboxId) }),

--- a/frontend/src/hooks/useCheckpointRestore.ts
+++ b/frontend/src/hooks/useCheckpointRestore.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { chatService } from '@/services/chatService';
+import { invalidateAfterGitRestore } from '@/hooks/queries/useSandboxQueries';
+
+export function useCheckpointRestore(messageId: string, sandboxId?: string) {
+  const queryClient = useQueryClient();
+
+  const restoreMutation = useMutation({
+    mutationFn: () => chatService.restoreMessageCheckpoint(messageId),
+    onSuccess: async (result) => {
+      if (!result.success) {
+        toast.error(result.error || 'Failed to restore checkpoint');
+        return;
+      }
+      toast.success('Workspace restored to before this run');
+      if (sandboxId) {
+        await invalidateAfterGitRestore(queryClient, sandboxId);
+      }
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : 'Failed to restore checkpoint');
+    },
+  });
+
+  return {
+    restore: restoreMutation.mutate,
+    isRestoring: restoreMutation.isPending,
+  };
+}

--- a/frontend/src/hooks/useMessageActions.ts
+++ b/frontend/src/hooks/useMessageActions.ts
@@ -31,7 +31,10 @@ interface UseMessageActionsParams {
   setWasAborted: (aborted: boolean) => void;
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
   addMessageToCache: (message: Message, userMessage?: Message) => void;
-  startStream: (request: ChatRequest, signal?: AbortSignal) => Promise<string>;
+  startStream: (
+    request: ChatRequest,
+    signal?: AbortSignal,
+  ) => Promise<{ messageId: string; checkpointId: string | null }>;
   storeBlobUrl: (file: File, url: string) => void;
   setPendingUserMessageId: (id: string | null) => void;
   isLoading: boolean;
@@ -123,7 +126,7 @@ export function useMessageActions({
           selected_persona_name: validPersona,
         };
 
-        const messageId = await startStream(request, startController.signal);
+        const { messageId, checkpointId } = await startStream(request, startController.signal);
         pendingStartControllerRef.current = null;
 
         setCurrentMessageId(messageId);
@@ -142,6 +145,7 @@ export function useMessageActions({
           attachments: [],
           created_at: new Date().toISOString(),
           model_id: selectedModelId ?? undefined,
+          checkpoint_id: checkpointId,
         };
 
         // Replace a trailing empty placeholder if present, otherwise append.
@@ -232,6 +236,7 @@ export function useMessageActions({
         model_id: selectedModelId,
         created_at: new Date().toISOString(),
         attachments: createAttachmentsFromFiles(inputFiles, storeBlobUrl) ?? [],
+        checkpoint_id: null,
       };
 
       setMessages((prev) => [...prev, newMessage]);

--- a/frontend/src/hooks/useMessageInitialization.ts
+++ b/frontend/src/hooks/useMessageInitialization.ts
@@ -68,6 +68,7 @@ export function useMessageInitialization({
         attachments: processedAttachments,
         created_at: msg.created_at,
         model_id: msg.model_id,
+        checkpoint_id: msg.checkpoint_id,
       };
     });
 

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -193,7 +193,10 @@ interface UseStreamCallbacksResult {
   ) => void;
   onError: (error: Error, messageId?: string, streamId?: string) => void;
   onQueueProcess: (data: QueueProcessingData) => void;
-  startStream: (request: StreamOptions['request'], signal?: AbortSignal) => Promise<string>;
+  startStream: (
+    request: StreamOptions['request'],
+    signal?: AbortSignal,
+  ) => Promise<{ messageId: string; checkpointId: string | null }>;
   replayStream: (messageId: string, afterSeq?: number) => Promise<string>;
   stopStream: (messageId: string) => Promise<void>;
   updateMessageInCache: ReturnType<typeof useMessageCache>['updateMessageInCache'];
@@ -745,7 +748,7 @@ export function useStreamCallbacks({
         model_id: data.modelId,
         attachments: [],
         is_bot: true,
-        checkpoint_id: null,
+        checkpoint_id: data.checkpointId,
       };
 
       // Cache updates must run even for off-screen chats so returning

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -729,6 +729,7 @@ export function useStreamCallbacks({
         created_at: new Date().toISOString(),
         attachments: data.attachments || [],
         is_bot: false,
+        checkpoint_id: null,
       };
 
       const assistantMessage: Message = {
@@ -744,6 +745,7 @@ export function useStreamCallbacks({
         model_id: data.modelId,
         attachments: [],
         is_bot: true,
+        checkpoint_id: null,
       };
 
       // Cache updates must run even for off-screen chats so returning
@@ -793,7 +795,10 @@ export function useStreamCallbacks({
   }, [chatId, onEnvelope, onComplete, onError, onQueueProcess]);
 
   const startStream = useCallback(
-    async (request: StreamOptions['request'], signal?: AbortSignal): Promise<string> => {
+    async (
+      request: StreamOptions['request'],
+      signal?: AbortSignal,
+    ): Promise<{ messageId: string; checkpointId: string | null }> => {
       const currentOptions = optionsRef.current;
       if (!currentOptions) {
         throw new Error('Stream options not available');

--- a/frontend/src/hooks/useStreamReconnect.ts
+++ b/frontend/src/hooks/useStreamReconnect.ts
@@ -131,6 +131,7 @@ export function useStreamReconnect({
             created_at: new Date().toISOString(),
             model_id: selectedModelIdRef.current || '',
             is_bot: true,
+            checkpoint_id: null,
           };
           addMessageToCache(placeholderMessage);
           setMessages((prev) => [...prev, placeholderMessage]);

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -10,6 +10,7 @@ import type {
   CreateChatRequest,
   ContextUsage,
 } from '@/types/chat.types';
+import type { GitCommitResult } from '@/types/sandbox.types';
 import type { CursorPaginationParams, PaginatedChats, PaginatedMessages } from '@/types/api.types';
 
 async function createCompletion(
@@ -50,6 +51,7 @@ async function createCompletion(
         chat_id: string;
         message_id: string;
         last_seq?: number;
+        checkpoint_id: string | null;
       }>('/chat/chat', formData, signal);
 
       const payload = ensureResponse(taskResponse, 'Failed to start chat completion');
@@ -58,6 +60,7 @@ async function createCompletion(
       return {
         source: eventSource,
         messageId: payload.message_id,
+        checkpointId: payload.checkpoint_id,
       };
     },
     { signal },
@@ -280,6 +283,17 @@ async function enhancePrompt(prompt: string, modelId: string): Promise<string> {
   });
 }
 
+async function restoreMessageCheckpoint(messageId: string): Promise<GitCommitResult> {
+  validateId(messageId, 'Message ID');
+
+  return serviceCall(async () => {
+    const response = await apiClient.post<GitCommitResult>(
+      `/chat/messages/${messageId}/checkpoint/restore-all`,
+    );
+    return ensureResponse(response, 'Failed to restore checkpoint');
+  });
+}
+
 export const chatService = {
   createCompletion,
   checkChatStatus,
@@ -295,6 +309,7 @@ export const chatService = {
   deleteAllChats,
   getContextUsage,
   enhancePrompt,
+  restoreMessageCheckpoint,
   pinChat,
   unpinChat,
   getSubThreads,

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -118,6 +118,7 @@ class StreamService {
       queued_message_id?: string;
       user_message_id?: string;
       assistant_message_id?: string;
+      checkpoint_id?: string | null;
       content?: string;
       model_id: string;
       attachments?: Array<{
@@ -146,6 +147,7 @@ class StreamService {
         queuedMessageId: payload.queued_message_id,
         userMessageId: payload.user_message_id,
         assistantMessageId: payload.assistant_message_id,
+        checkpointId: payload.checkpoint_id ?? null,
         content: payload.content,
         modelId: payload.model_id,
         attachments: payload.attachments,

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -1,7 +1,12 @@
 import { useStreamStore } from '@/store/streamStore';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
 import type { ChatRequest } from '@/types/chat.types';
-import type { ActiveStream, QueueProcessingData, StreamEnvelope } from '@/types/stream.types';
+import type {
+  ActiveStream,
+  ApiStreamResponse,
+  QueueProcessingData,
+  StreamEnvelope,
+} from '@/types/stream.types';
 import { StreamProcessingError } from '@/types/stream.types';
 import { chatService } from '@/services/chatService';
 import { logger } from '@/utils/logger';
@@ -242,11 +247,13 @@ class StreamService {
     };
   }
 
-  async startStream(options: StreamOptions): Promise<string> {
+  async startStream(
+    options: StreamOptions,
+  ): Promise<Pick<ApiStreamResponse, 'messageId' | 'checkpointId'>> {
     const streamId = crypto.randomUUID();
 
     try {
-      const { source, messageId } = await chatService.createCompletion(
+      const { source, messageId, checkpointId } = await chatService.createCompletion(
         options.request,
         options.signal,
       );
@@ -270,7 +277,7 @@ class StreamService {
       this.store.addStream(activeStream);
       this.attachStreamHandlers(streamId, messageId);
 
-      return messageId;
+      return { messageId, checkpointId };
     } catch (error) {
       this.store.removeStream(streamId);
       throw error;

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -25,6 +25,7 @@ export interface Message {
   model_id: string | null;
   attachments: MessageAttachment[];
   created_at: string;
+  checkpoint_id: string | null;
 }
 
 export type AssistantStreamEvent =

--- a/frontend/src/types/stream.types.ts
+++ b/frontend/src/types/stream.types.ts
@@ -30,6 +30,7 @@ export interface QueueProcessingData {
   queuedMessageId: string;
   userMessageId: string;
   assistantMessageId: string;
+  checkpointId: string | null;
   content: string;
   modelId: string;
   attachments?: MessageAttachment[];

--- a/frontend/src/types/stream.types.ts
+++ b/frontend/src/types/stream.types.ts
@@ -38,6 +38,7 @@ export interface QueueProcessingData {
 export interface ApiStreamResponse {
   source: EventSource;
   messageId: string;
+  checkpointId: string | null;
 }
 
 export interface ActiveStream {

--- a/frontend/src/utils/message.ts
+++ b/frontend/src/utils/message.ts
@@ -35,6 +35,7 @@ export function createInitialMessage(
         : [],
     created_at: new Date().toISOString(),
     model_id: modelId,
+    checkpoint_id: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- Capture HEAD + pre-run diff before each assistant run and persist as a `chat_checkpoints` row keyed by the assistant message
- Expose `POST /chat/messages/{id}/checkpoint/restore-all` to reset the workspace back to that snapshot (hard reset + clean + reapply pre-run diff)
- Surface a Restore button on assistant messages with a confirm dialog; checkpoint capture is best-effort and skipped on non-git workspaces

## Test plan
- [ ] Send a chat message in a git workspace and confirm the assistant message shows a Restore button
- [ ] Click Restore and verify the working tree returns to the pre-run state (HEAD reset, untracked files cleaned, prior uncommitted edits reapplied)
- [ ] Send a chat message in a non-git workspace and verify the run completes without errors and no Restore button appears
- [ ] Reload the chat and confirm `checkpoint_id` is hydrated for past assistant messages