### PR TITLE
Expand per-file diffs inline in changed files panel

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -49,7 +49,11 @@ from app.models.schemas.chat import (
     MessageEvent,
     PermissionRespondResponse,
 )
-from app.models.schemas.sandbox import ChangedFilesResponse, GitCommandResponse
+from app.models.schemas.sandbox import (
+    ChangedFilesResponse,
+    FileDiffResponse,
+    GitCommandResponse,
+)
 from app.models.schemas.pagination import (
     CursorPaginatedResponse,
     CursorPaginationParams,
@@ -450,6 +454,29 @@ async def get_message_changes(
 ) -> ChangedFilesResponse:
     try:
         return await chat_service.get_changed_files(message_id, current_user)
+    except ChatException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
+    except SandboxException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+
+@router.get(
+    "/messages/{message_id}/changes/diff",
+    response_model=FileDiffResponse,
+)
+async def get_message_file_diff(
+    message_id: UUID,
+    path: str = Query(..., min_length=1, max_length=4096),
+    current_user: User = Depends(get_current_user),
+    chat_service: ChatService = Depends(get_chat_service),
+) -> FileDiffResponse:
+    try:
+        return await chat_service.get_file_diff(message_id, path, current_user)
     except ChatException as e:
         raise HTTPException(status_code=e.status_code, detail=str(e)) from e
     except SandboxException as e:

--- a/backend/app/models/schemas/sandbox.py
+++ b/backend/app/models/schemas/sandbox.py
@@ -114,6 +114,11 @@ class ChangedFilesResponse(BaseModel):
     cwd: str = ""
 
 
+class FileDiffResponse(BaseModel):
+    path: str
+    diff: str
+
+
 class SearchMatch(BaseModel):
     line_number: int
     line_text: str

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -26,7 +26,11 @@ from app.models.schemas.chat import (
     ChatUpdate,
 )
 from app.models.schemas.chat import Message as MessageSchema
-from app.models.schemas.sandbox import ChangedFilesResponse, GitCommandResponse
+from app.models.schemas.sandbox import (
+    ChangedFilesResponse,
+    FileDiffResponse,
+    GitCommandResponse,
+)
 from app.models.schemas.pagination import (
     CursorPaginatedResponse,
     PaginatedResponse,
@@ -701,6 +705,22 @@ class ChatService(BaseDbService[Chat]):
             cwd=checkpoint.cwd,
         )
         return ChangedFilesResponse(files=files, cwd=checkpoint.cwd or "")
+
+    async def get_file_diff(
+        self,
+        message_id: UUID,
+        path: str,
+        user: User,
+    ) -> FileDiffResponse:
+        checkpoint, chat = await self._get_checkpoint_target(message_id, user)
+        git_service = GitService(self.sandbox_for_workspace(chat.workspace))
+        return await git_service.get_file_diff(
+            chat.workspace.sandbox_id,
+            base_head=checkpoint.base_head,
+            path=path,
+            pre_run_diff=checkpoint.pre_run_diff,
+            cwd=checkpoint.cwd,
+        )
 
     async def _get_checkpoint_target(
         self,

--- a/backend/app/services/git.py
+++ b/backend/app/services/git.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from app.models.schemas.sandbox import (
     ChangedFile,
+    FileDiffResponse,
     GitBranchesResponse,
     GitCheckoutResponse,
     GitCommandResponse,
@@ -84,7 +85,10 @@ GIT_WORKTREE_ADD_TEMPLATE = Template(
 # untracked files into the comparison, so pre-existing untracked files stay
 # silent and assistant-created files surface as additions.
 # `--no-renames` collapses renames to add+delete so the parser stays simple.
-GIT_CHANGED_FILES_TEMPLATE = Template(
+# Builds `base_tree` (HEAD-or-`$base` with optional `$patch_file` applied) and
+# `cur_tree` (current working tree staged via temp index) so callers can diff
+# them with `git diff "$base_tree" "$cur_tree"`. Closes with `}` in the caller.
+GIT_BUILD_TREES_PREFIX = (
     "{ base_tree='$base'; "
     'if [ -n "$patch_file" ]; then '
     "tmp_b=$$(mktemp); "
@@ -101,9 +105,24 @@ GIT_CHANGED_FILES_TEMPLATE = Template(
     'GIT_INDEX_FILE="$$tmp_c" git add -A 2>/dev/null; '
     'cur_tree=$$(GIT_INDEX_FILE="$$tmp_c" git write-tree 2>/dev/null); '
     'rm -f "$$tmp_c"; '
-    'git diff --numstat --no-renames "$$base_tree" "$$cur_tree" 2>/dev/null; '
+)
+
+GIT_CHANGED_FILES_TEMPLATE = Template(
+    GIT_BUILD_TREES_PREFIX + "git diff --numstat --no-renames "
+    '"$$base_tree" "$$cur_tree" -- . '
+    "':(exclude).agentrove-changed-*.patch' "
+    "':(exclude,glob)**/.agentrove-changed-*.patch' 2>/dev/null; "
     "printf '__STATUS__\\n'; "
-    'git diff --name-status --no-renames "$$base_tree" "$$cur_tree" 2>/dev/null; '
+    "git diff --name-status --no-renames "
+    '"$$base_tree" "$$cur_tree" -- . '
+    "':(exclude).agentrove-changed-*.patch' "
+    "':(exclude,glob)**/.agentrove-changed-*.patch' 2>/dev/null; "
+    "}"
+)
+
+GIT_FILE_DIFF_TEMPLATE = Template(
+    GIT_BUILD_TREES_PREFIX + "git diff --no-renames "
+    '"$$base_tree" "$$cur_tree" -- $path 2>/dev/null; '
     "}"
 )
 
@@ -444,16 +463,9 @@ class GitService:
     ) -> GitCommandResponse:
         if not re.fullmatch(r"[0-9a-fA-F]{40}", base_head):
             raise ValueError("Invalid checkpoint commit")
-        patch_file = ""
-        if pre_run_diff:
-            name = f".agentrove-checkpoint-{uuid4().hex}.patch"
-            patch_path = posixpath.join(cwd, name) if cwd else name
-            await self.sandbox_service.provider.write_file(
-                sandbox_id, patch_path, pre_run_diff
-            )
-            patch_file = shlex.quote(
-                self.sandbox_service.provider.resolve_workspace_path(patch_path)
-            )
+        patch_file = await self._write_patch_file(
+            sandbox_id, pre_run_diff, cwd, ".agentrove-checkpoint-"
+        )
         cmd = GIT_RESTORE_CHECKPOINT_ALL_TEMPLATE.substitute(
             base_head=base_head,
             patch_file=patch_file,
@@ -469,16 +481,9 @@ class GitService:
     ) -> list[ChangedFile]:
         if not re.fullmatch(r"[0-9a-fA-F]{40}", base_head):
             raise ValueError("Invalid checkpoint commit")
-        patch_file = ""
-        if pre_run_diff:
-            name = f".agentrove-changed-{uuid4().hex}.patch"
-            patch_path = posixpath.join(cwd, name) if cwd else name
-            await self.sandbox_service.provider.write_file(
-                sandbox_id, patch_path, pre_run_diff
-            )
-            patch_file = shlex.quote(
-                self.sandbox_service.provider.resolve_workspace_path(patch_path)
-            )
+        patch_file = await self._write_patch_file(
+            sandbox_id, pre_run_diff, cwd, ".agentrove-changed-"
+        )
         cd_prefix = git_cd_prefix(cwd)
         cmd = GIT_CHANGED_FILES_TEMPLATE.substitute(
             base=base_head, patch_file=patch_file
@@ -489,6 +494,51 @@ class GitService:
         if result.exit_code != 0:
             return []
         return self._parse_changed_files(result.stdout)
+
+    async def get_file_diff(
+        self,
+        sandbox_id: str,
+        base_head: str,
+        path: str,
+        pre_run_diff: str = "",
+        cwd: str | None = None,
+    ) -> FileDiffResponse:
+        if not re.fullmatch(r"[0-9a-fA-F]{40}", base_head):
+            raise ValueError("Invalid checkpoint commit")
+        self._validate_relative_path(path)
+        patch_file = await self._write_patch_file(
+            sandbox_id, pre_run_diff, cwd, ".agentrove-changed-"
+        )
+        cd_prefix = git_cd_prefix(cwd)
+        cmd = GIT_FILE_DIFF_TEMPLATE.substitute(
+            base=base_head,
+            patch_file=patch_file,
+            path=shlex.quote(path),
+        )
+        result = await self.sandbox_service.execute_command(
+            sandbox_id, f"{cd_prefix}{cmd}"
+        )
+        return FileDiffResponse(
+            path=path, diff=result.stdout if result.exit_code == 0 else ""
+        )
+
+    async def _write_patch_file(
+        self,
+        sandbox_id: str,
+        pre_run_diff: str,
+        cwd: str | None,
+        name_prefix: str,
+    ) -> str:
+        if not pre_run_diff:
+            return ""
+        name = f"{name_prefix}{uuid4().hex}.patch"
+        patch_path = posixpath.join(cwd, name) if cwd else name
+        await self.sandbox_service.provider.write_file(
+            sandbox_id, patch_path, pre_run_diff
+        )
+        return shlex.quote(
+            self.sandbox_service.provider.resolve_workspace_path(patch_path)
+        )
 
     @staticmethod
     def _parse_changed_files(output: str) -> list[ChangedFile]:

--- a/frontend/src/components/chat/message-bubble/ChangedFilesPanel.tsx
+++ b/frontend/src/components/chat/message-bubble/ChangedFilesPanel.tsx
@@ -1,7 +1,15 @@
-import { memo, useState } from 'react';
-import { ChevronDown, Files } from 'lucide-react';
+import { Fragment, memo, useState } from 'react';
+import {
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  Files,
+  GitCompareArrows,
+  Loader2,
+} from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
-import { useMessageChangesQuery } from '@/hooks/queries/useChatQueries';
+import { DiffView } from '@/components/chat/tools/common/DiffView';
+import { useMessageChangesQuery, useMessageFileDiffQuery } from '@/hooks/queries/useChatQueries';
 import { useUIStore } from '@/store/uiStore';
 import type { ChangedFile, ChangedFileStatus } from '@/types/sandbox.types';
 
@@ -22,7 +30,7 @@ const STATUS_COLOR: Record<ChangedFileStatus, string> = {
 };
 
 const ChangedFilesPanelInner: React.FC<ChangedFilesPanelProps> = ({ messageId }) => {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(false);
   const { data } = useMessageChangesQuery(messageId);
 
   const files = data?.files ?? [];
@@ -66,13 +74,8 @@ const ChangedFilesPanelInner: React.FC<ChangedFilesPanelProps> = ({ messageId })
 
       {expanded && (
         <div className="border-t border-border/50 dark:border-border-dark/50">
-          {files.map((file, index) => (
-            <ChangedFileRow
-              key={file.path}
-              file={file}
-              cwd={cwd}
-              isLast={index === files.length - 1}
-            />
+          {files.map((file) => (
+            <ChangedFileRow key={file.path} messageId={messageId} file={file} cwd={cwd} />
           ))}
         </div>
       )}
@@ -80,44 +83,105 @@ const ChangedFilesPanelInner: React.FC<ChangedFilesPanelProps> = ({ messageId })
   );
 };
 
-const ChangedFileRow: React.FC<{ file: ChangedFile; cwd: string; isLast: boolean }> = ({
-  file,
-  cwd,
-  isLast,
-}) => {
+const ChangedFileRow: React.FC<{
+  messageId: string;
+  file: ChangedFile;
+  cwd: string;
+}> = ({ messageId, file, cwd }) => {
+  const [open, setOpen] = useState(false);
   const isDeleted = file.status === 'D';
   const editorPath = cwd ? `${cwd}/${file.path}` : file.path;
-  const borderClass = isLast ? '' : 'border-b border-border/50 dark:border-border-dark/50';
-  const interactiveClass = isDeleted
-    ? 'cursor-default'
-    : 'transition-colors duration-150 hover:bg-surface-hover dark:hover:bg-surface-dark-hover';
+
   return (
-    <Button
-      type="button"
-      variant="unstyled"
-      disabled={isDeleted}
-      onClick={isDeleted ? undefined : () => useUIStore.getState().openFileInEditor(editorPath)}
-      className={`flex w-full items-center gap-2.5 px-3 py-2 text-left ${interactiveClass} ${borderClass}`}
-    >
-      <span
-        className={`w-3.5 flex-shrink-0 text-center font-mono text-2xs ${STATUS_COLOR[file.status]}`}
-        title={STATUS_LABEL[file.status]}
-      >
-        {file.status}
-      </span>
-      <span
-        className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary dark:text-text-dark-secondary"
-        title={file.path}
-      >
-        {file.path}
-      </span>
-      <span className="min-w-[28px] flex-shrink-0 text-right font-mono text-2xs tabular-nums text-success-600 dark:text-success-400">
-        +{file.additions}
-      </span>
-      <span className="min-w-[24px] flex-shrink-0 text-right font-mono text-2xs tabular-nums text-error-600 dark:text-error-400">
-        −{file.deletions}
-      </span>
-    </Button>
+    <Fragment>
+      <div className="flex w-full items-center gap-2 border-b border-border/50 px-3 py-2 transition-colors duration-150 last:border-b-0 hover:bg-surface-hover dark:border-border-dark/50 dark:hover:bg-surface-dark-hover">
+        <Button
+          type="button"
+          variant="unstyled"
+          onClick={() => setOpen((prev) => !prev)}
+          aria-expanded={open}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+        >
+          {open ? (
+            <ChevronDown className="h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+          ) : (
+            <ChevronRight className="h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+          )}
+          <span
+            className={`w-3.5 flex-shrink-0 text-center font-mono text-2xs ${STATUS_COLOR[file.status]}`}
+            title={STATUS_LABEL[file.status]}
+          >
+            {file.status}
+          </span>
+          <span
+            className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary dark:text-text-dark-secondary"
+            title={file.path}
+          >
+            {file.path}
+          </span>
+          <span className="flex-shrink-0 font-mono text-2xs tabular-nums text-success-600 dark:text-success-400">
+            +{file.additions}
+          </span>
+          <span className="flex-shrink-0 font-mono text-2xs tabular-nums text-error-600 dark:text-error-400">
+            −{file.deletions}
+          </span>
+        </Button>
+        <div className="flex flex-shrink-0 items-center gap-2">
+          <Button
+            type="button"
+            variant="unstyled"
+            onClick={() => useUIStore.getState().openInDiffView(file.path)}
+            aria-label="Open in diff view"
+            title="Open in diff view"
+            className="text-text-quaternary transition-colors duration-150 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+          >
+            <GitCompareArrows className="h-3 w-3" />
+          </Button>
+          {!isDeleted && (
+            <Button
+              type="button"
+              variant="unstyled"
+              onClick={() => useUIStore.getState().openFileInEditor(editorPath)}
+              aria-label="Open in editor"
+              title="Open in editor"
+              className="text-text-quaternary transition-colors duration-150 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </Button>
+          )}
+        </div>
+      </div>
+      {open && <FileDiffSection messageId={messageId} path={file.path} />}
+    </Fragment>
+  );
+};
+
+const FileDiffSection: React.FC<{
+  messageId: string;
+  path: string;
+}> = ({ messageId, path }) => {
+  const { data, isLoading, isError } = useMessageFileDiffQuery(messageId, path);
+
+  return (
+    <div className="bg-surface-primary dark:bg-surface-dark-primary border-b border-border/50 px-3 py-2 last:border-b-0 dark:border-border-dark/50">
+      {isLoading && (
+        <div className="flex items-center gap-2 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          Loading diff…
+        </div>
+      )}
+      {isError && (
+        <div className="text-2xs text-error-600 dark:text-error-400">Failed to load diff</div>
+      )}
+      {data &&
+        (data.diff.trim().length > 0 ? (
+          <DiffView diff={data.diff} />
+        ) : (
+          <div className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+            No textual diff available
+          </div>
+        ))}
+    </div>
   );
 };
 

--- a/frontend/src/components/sandbox/git/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView.tsx
@@ -24,6 +24,7 @@ import {
   useGitRestoreFileMutation,
 } from '@/hooks/queries/useSandboxQueries';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
+import { useUIStore } from '@/store/uiStore';
 import { parsePatchFiles, parseDiffFromFile } from '@pierre/diffs';
 import type { FileDiffMetadata, FileContents } from '@pierre/diffs';
 import { FileDiff, Virtualizer, WorkerPoolContextProvider } from '@pierre/diffs/react';
@@ -342,6 +343,30 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
     [theme, diffStyle],
   );
 
+  // External request (from ChangedFilesPanel "open in diff view") to focus a
+  // specific file. Best-effort match against parsedFiles — exact, then suffix
+  // either way to absorb cwd/repo-root prefix differences.
+  const pendingDiffFile = useUIStore((s) => s.pendingDiffFile);
+  useEffect(() => {
+    if (!pendingDiffFile || parsedFiles.length === 0) return;
+    const match =
+      parsedFiles.find((f) => f.name === pendingDiffFile) ??
+      parsedFiles.find((f) => f.name.endsWith(pendingDiffFile) || pendingDiffFile.endsWith(f.name));
+    if (match) {
+      setExpandedFiles((prev) => {
+        if (prev.has(match.name)) return prev;
+        const next = new Set(prev);
+        next.add(match.name);
+        return next;
+      });
+      requestAnimationFrame(() => {
+        const el = document.querySelector(`[data-diff-file-path="${CSS.escape(match.name)}"]`);
+        el?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      });
+    }
+    useUIStore.getState().consumeDiffFileJump();
+  }, [pendingDiffFile, parsedFiles, setExpandedFiles]);
+
   const allExpanded = parsedFiles.length > 0 && parsedFiles.every((f) => expandedFiles.has(f.name));
 
   const toggleAll = useCallback(() => {
@@ -509,7 +534,7 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
                 const isExpanded = expandedFiles.has(file.name);
                 const isRenamed = isRenameFileType(file.type);
                 return (
-                  <div key={file.name}>
+                  <div key={file.name} data-diff-file-path={file.name}>
                     <div className="group flex w-full items-center transition-colors duration-200 hover:bg-surface-hover dark:hover:bg-surface-dark-hover">
                       <Button
                         variant="unstyled"

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -8,6 +8,8 @@ export const queryKeys = {
   messages: (chatId?: string) => ['messages', chatId] as const,
   contextUsage: (chatId?: string) => ['chat', chatId, 'context-usage'] as const,
   messageChanges: (messageId?: string) => ['message', messageId, 'changes'] as const,
+  messageFileDiff: (messageId?: string, path?: string) =>
+    ['message', messageId, 'changes', 'diff', path] as const,
   subThreads: (chatId?: string) => ['chat', chatId, 'sub-threads'] as const,
   auth: {
     user: 'auth-user',

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -14,7 +14,7 @@ import type {
 import { chatService } from '@/services/chatService';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
 import type { Chat, ChatSearchResponse, ContextUsage, CreateChatRequest } from '@/types/chat.types';
-import type { ChangedFilesData } from '@/types/sandbox.types';
+import type { ChangedFilesData, FileDiffData } from '@/types/sandbox.types';
 import type { PaginatedChats } from '@/types/api.types';
 import { createMutation } from './createMutation';
 import { queryKeys } from './queryKeys';
@@ -133,6 +133,21 @@ export const useMessageChangesQuery = (
     queryFn: () => chatService.getMessageChanges(messageId!),
     enabled: !!messageId,
     staleTime: Infinity,
+    ...options,
+  });
+};
+
+export const useMessageFileDiffQuery = (
+  messageId: string | undefined,
+  path: string | undefined,
+  options?: Partial<UseQueryOptions<FileDiffData>>,
+) => {
+  return useQuery({
+    queryKey: queryKeys.messageFileDiff(messageId, path),
+    queryFn: () => chatService.getMessageFileDiff(messageId!, path!),
+    enabled: !!messageId && !!path,
+    staleTime: Infinity,
+    gcTime: 1000 * 60 * 5,
     ...options,
   });
 };

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -10,7 +10,7 @@ import type {
   CreateChatRequest,
   ContextUsage,
 } from '@/types/chat.types';
-import type { ChangedFilesData, GitCommitResult } from '@/types/sandbox.types';
+import type { ChangedFilesData, FileDiffData, GitCommitResult } from '@/types/sandbox.types';
 import type { CursorPaginationParams, PaginatedChats, PaginatedMessages } from '@/types/api.types';
 
 async function createCompletion(
@@ -292,6 +292,19 @@ async function getMessageChanges(messageId: string): Promise<ChangedFilesData> {
   });
 }
 
+async function getMessageFileDiff(messageId: string, path: string): Promise<FileDiffData> {
+  validateId(messageId, 'Message ID');
+  validateRequired(path, 'Path');
+
+  return serviceCall(async () => {
+    const queryString = buildQueryString({ path });
+    const response = await apiClient.get<FileDiffData>(
+      `/chat/messages/${messageId}/changes/diff${queryString}`,
+    );
+    return ensureResponse(response, 'Failed to load file diff');
+  });
+}
+
 async function restoreMessageCheckpoint(messageId: string): Promise<GitCommitResult> {
   validateId(messageId, 'Message ID');
 
@@ -319,6 +332,7 @@ export const chatService = {
   getContextUsage,
   enhancePrompt,
   getMessageChanges,
+  getMessageFileDiff,
   restoreMessageCheckpoint,
   pinChat,
   unpinChat,

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -32,6 +32,9 @@ type UIStoreState = ThemeState &
     pendingFileJump: { path: string; line: number; nonce: number } | null;
     openFileInEditor: (path: string, line?: number) => void;
     consumeFileJump: () => void;
+    pendingDiffFile: string | null;
+    openInDiffView: (path: string) => void;
+    consumeDiffFileJump: () => void;
     pendingChatMessage: string | null;
     setPendingChatMessage: (message: string | null) => void;
   };
@@ -40,6 +43,32 @@ const getInitialSidebarState = (): boolean => {
   if (typeof window === 'undefined') return false;
   return window.innerWidth >= MOBILE_BREAKPOINT;
 };
+
+// Mobile switches the sole view; desktop appends a tile to the mosaic
+// unless the view is already present.
+function ensureViewVisible(
+  set: (partial: Partial<UIStoreState>) => void,
+  get: () => UIStoreState,
+  view: ViewType,
+): void {
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < MOBILE_BREAKPOINT;
+  if (isMobile) {
+    set({ currentView: view, mosaicLayout: view });
+    return;
+  }
+  const state = get();
+  const layout = state.mosaicLayout;
+  if (layout && isMosaicSplitNode(layout)) {
+    if (!getLeaves(layout).includes(view)) {
+      set({ mosaicLayout: { direction: 'row', first: layout, second: view } });
+    }
+    return;
+  }
+  const currentView = (layout ?? state.currentView) as ViewType;
+  if (currentView !== view) {
+    set({ mosaicLayout: { direction: 'row', first: currentView, second: view } });
+  }
+}
 
 export const useUIStore = create<UIStoreState>()(
   persist(
@@ -72,40 +101,19 @@ export const useUIStore = create<UIStoreState>()(
       pendingFilePath: null,
       pendingFileJump: null,
       consumeFileJump: () => set({ pendingFileJump: null }),
-      // Sets the pending file path and ensures the editor pane is visible.
-      // On mobile, switches to the editor view. On desktop, adds an editor
-      // tile to the mosaic layout if one isn't already present.
-      // When `line` is provided, also queues a jump the editor view consumes.
+      pendingDiffFile: null,
+      consumeDiffFileJump: () => set({ pendingDiffFile: null }),
       openFileInEditor: (path, line) => {
         set({
           pendingFilePath: path,
           pendingFileJump:
             line != null ? { path, line, nonce: (get().pendingFileJump?.nonce ?? 0) + 1 } : null,
         });
-        const isMobile = typeof window !== 'undefined' && window.innerWidth < MOBILE_BREAKPOINT;
-        if (isMobile) {
-          set({ currentView: 'editor', mosaicLayout: 'editor' });
-        } else {
-          const state = get();
-          const layout = state.mosaicLayout;
-          if (layout && isMosaicSplitNode(layout)) {
-            const leaves = getLeaves(layout);
-            if (!leaves.includes('editor')) {
-              set({ mosaicLayout: { direction: 'row', first: layout, second: 'editor' } });
-            }
-          } else {
-            const currentView = (layout ?? state.currentView) as ViewType;
-            if (currentView !== 'editor') {
-              set({
-                mosaicLayout: {
-                  direction: 'row',
-                  first: currentView,
-                  second: 'editor',
-                },
-              });
-            }
-          }
-        }
+        ensureViewVisible(set, get, 'editor');
+      },
+      openInDiffView: (path) => {
+        set({ pendingDiffFile: path });
+        ensureViewVisible(set, get, 'diff');
       },
 
       currentView: 'agent',

--- a/frontend/src/types/sandbox.types.ts
+++ b/frontend/src/types/sandbox.types.ts
@@ -84,6 +84,11 @@ export interface ChangedFilesData {
   cwd: string;
 }
 
+export interface FileDiffData {
+  path: string;
+  diff: string;
+}
+
 export interface GitRemoteUrlData {
   owner: string;
   repo: string;


### PR DESCRIPTION
## Summary
- Adds a per-file expand toggle in the changed-files panel that fetches and renders the diff inline using the existing tool DiffView
- Adds an "open in diff view" affordance that focuses the corresponding file in the full DiffView pane, opening the pane on mobile or appending it to the desktop mosaic
- Backend exposes `GET /chat/messages/{id}/changes/diff?path=...` returning a per-path diff against the message's checkpoint base (with the pre-run patch applied)
- Refactors `GitService` to share patch-file write and tree-build logic between changed-files and per-file-diff queries; excludes the temporary `.agentrove-changed-*.patch` from results

## Test plan
- [ ] Expand a changed file row in a chat message and confirm the diff renders
- [ ] Click the diff-view shortcut and confirm the DiffView pane opens (mobile + desktop mosaic) and scrolls to the file
- [ ] Restore a checkpoint and re-open the panel; verify deleted files show no editor link but still expand to a diff