### PR TITLE
Add Cmd+R reload shortcut in desktop app

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -233,6 +233,23 @@ export default function App() {
     });
   });
 
+  // Cmd+R / Ctrl+R reloads the webview — Tauri release builds disable this by default
+  useMountEffect(() => {
+    if (!isTauri()) return;
+
+    function handler(e: KeyboardEvent) {
+      const accel = e.metaKey || e.ctrlKey;
+      if (!accel || e.altKey) return;
+      const key = e.key.toLowerCase();
+      if (key !== 'r') return;
+      e.preventDefault();
+      window.location.reload();
+    }
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  });
+
   // Open external links in the system browser — Tauri doesn't handle target="_blank" natively
   useMountEffect(() => {
     if (!isTauri()) return;


### PR DESCRIPTION
## Summary
- Bind Cmd/Ctrl+R in Tauri builds to `window.location.reload()` so users can refresh the desktop app (release builds disable this by default).

## Test plan
- [ ] Build/run the desktop app and confirm Cmd+R reloads the webview
- [ ] Confirm Cmd+R has no effect in the web build (listener gated on `isTauri()`)