### PR TITLE
Fetch all branches when cloning workspaces in web mode

### DIFF
--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -363,6 +363,10 @@ class WorkspaceService(BaseDbService[Workspace]):
             "clone",
             "--depth",
             "1",
+            # `--depth` implies `--single-branch`, which leaves only the default
+            # branch's remote-tracking ref — the branch selector then has nothing
+            # to list beyond `main`. Keep all branches visible at depth 1.
+            "--no-single-branch",
             git_url,
             str(workspace_dir),
             stdout=asyncio.subprocess.PIPE,


### PR DESCRIPTION
## Summary
- `git clone --depth 1` implies `--single-branch`, leaving only the default branch's remote-tracking ref. The branch selector in web mode had nothing to list beyond `main`.
- Pass `--no-single-branch` so all branches stay visible at depth 1.

## Test plan
- [ ] Create a new workspace from a repo with multiple branches in web mode
- [ ] Open the branch selector and verify all branches appear
- [ ] Confirm desktop mode behavior is unchanged