### PR TITLE
Enable command menu and split view on landing page

### DIFF
--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -17,7 +17,6 @@ export interface CodeViewProps {
   onFileSelect: (file: FileStructure | null) => void;
   theme: string;
   sandboxId?: string;
-  chatId?: string;
   cwd?: string;
   onDownload?: () => void;
   isDownloading?: boolean;
@@ -32,7 +31,6 @@ export const CodeView = memo(function CodeView({
   onFileSelect,
   theme,
   sandboxId,
-  chatId,
   cwd,
   onDownload,
   isDownloading,
@@ -178,7 +176,6 @@ export const CodeView = memo(function CodeView({
             selectedFile={selectedFile}
             fileStructure={files}
             sandboxId={sandboxId}
-            chatId={chatId}
             onToggleFileTree={() => setShowMobileTree(true)}
             targetLine={targetLine}
           />
@@ -225,7 +222,6 @@ export const CodeView = memo(function CodeView({
               selectedFile={selectedFile}
               fileStructure={files}
               sandboxId={sandboxId}
-              chatId={chatId}
               onToggleFileTree={handleToggleFileTree}
               isFileTreeCollapsed={isFileTreeCollapsed}
               targetLine={targetLine}

--- a/frontend/src/components/editor/editor-core/Editor.tsx
+++ b/frontend/src/components/editor/editor-core/Editor.tsx
@@ -2,7 +2,6 @@ import { memo, useState, useCallback } from 'react';
 import { logger } from '@/utils/logger';
 import { CodeView } from '../code-view/CodeView';
 import type { FileStructure } from '@/types/file-system.types';
-import type { Chat } from '@/types/chat.types';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { sandboxService } from '@/services/sandboxService';
 
@@ -10,7 +9,8 @@ export interface EditorProps {
   files: FileStructure[];
   selectedFile: FileStructure | null;
   onFileSelect: (file: FileStructure | null) => void;
-  currentChat?: Chat | null;
+  sandboxId?: string;
+  worktreeCwd?: string;
   isSandboxSyncing?: boolean;
   onRefresh?: () => void;
   isRefreshing?: boolean;
@@ -20,7 +20,8 @@ export const Editor = memo(function Editor({
   files,
   onFileSelect,
   selectedFile,
-  currentChat,
+  sandboxId,
+  worktreeCwd,
   isSandboxSyncing = false,
   onRefresh,
   isRefreshing = false,
@@ -30,18 +31,18 @@ export const Editor = memo(function Editor({
 
   const handleDownload = useCallback(async () => {
     try {
-      if (!currentChat?.sandbox_id) {
+      if (!sandboxId) {
         return false;
       }
 
       setIsDownloading(true);
 
-      const zipBlob = await sandboxService.downloadZip(currentChat.sandbox_id);
+      const zipBlob = await sandboxService.downloadZip(sandboxId);
 
       const url = URL.createObjectURL(zipBlob);
       const link = document.createElement('a');
       link.href = url;
-      const fileName = `sandbox_${currentChat.sandbox_id}_${crypto.randomUUID()}.zip`;
+      const fileName = `sandbox_${sandboxId}_${crypto.randomUUID()}.zip`;
       link.download = fileName;
 
       document.body.appendChild(link);
@@ -56,7 +57,7 @@ export const Editor = memo(function Editor({
     } finally {
       setIsDownloading(false);
     }
-  }, [currentChat?.sandbox_id]);
+  }, [sandboxId]);
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden bg-surface-secondary dark:bg-surface-dark-secondary">
@@ -65,9 +66,8 @@ export const Editor = memo(function Editor({
         selectedFile={selectedFile}
         onFileSelect={onFileSelect}
         theme={theme}
-        sandboxId={currentChat?.sandbox_id}
-        chatId={currentChat?.id}
-        cwd={currentChat?.worktree_cwd ?? undefined}
+        sandboxId={sandboxId}
+        cwd={worktreeCwd}
         onDownload={handleDownload}
         isDownloading={isDownloading}
         isSandboxSyncing={isSandboxSyncing}

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -16,7 +16,6 @@ export interface ViewProps {
   selectedFile: FileStructure | null;
   fileStructure?: FileStructure[];
   sandboxId?: string;
-  chatId?: string;
   onToggleFileTree?: () => void;
   isFileTreeCollapsed?: boolean;
   targetLine?: { path: string; line: number; nonce: number } | null;
@@ -26,7 +25,6 @@ export const View = memo(function View({
   selectedFile,
   fileStructure = [],
   sandboxId,
-  chatId,
   onToggleFileTree,
   isFileTreeCollapsed,
   targetLine,
@@ -49,7 +47,7 @@ export const View = memo(function View({
     isLoading: isLoadingContent,
     error: fileContentError,
   } = useFileContentQuery(sandboxId, selectedFile?.path, {
-    enabled: !!sandboxId && !!chatId && !!selectedFile?.path,
+    enabled: !!sandboxId && !!selectedFile?.path,
     retry: 1,
   });
 
@@ -120,7 +118,7 @@ export const View = memo(function View({
   }, []);
 
   const handleUpdateFile = useCallback(async () => {
-    if (!selectedFile || !sandboxId || !chatId || !hasUnsavedChanges) return;
+    if (!selectedFile || !sandboxId || !hasUnsavedChanges) return;
 
     updateFileMutation.mutate(
       {
@@ -139,7 +137,7 @@ export const View = memo(function View({
         },
       },
     );
-  }, [selectedFile, sandboxId, chatId, currentContent, hasUnsavedChanges, updateFileMutation]);
+  }, [selectedFile, sandboxId, currentContent, hasUnsavedChanges, updateFileMutation]);
 
   const handleEditorMount = useCallback(
     (editor: monaco.editor.IStandaloneCodeEditor, monaco: typeof import('monaco-editor')) => {

--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -68,6 +68,7 @@ interface ViewCommandItem {
   icon: React.ComponentType<{ className?: string }>;
   shortcut: string;
   hideOnMobile?: boolean;
+  requiresChat?: boolean;
 }
 
 interface ActionCommandItem {
@@ -77,6 +78,7 @@ interface ActionCommandItem {
   icon: React.ComponentType<{ className?: string }>;
   shortcut: string;
   hideOnMobile?: boolean;
+  requiresChat?: boolean;
 }
 
 type CommandItem = ViewCommandItem | ActionCommandItem;
@@ -84,21 +86,50 @@ type CommandItem = ViewCommandItem | ActionCommandItem;
 const VIEW_COMMANDS: ViewCommandItem[] = [
   { type: 'view', id: 'agent', label: 'Agent', icon: MessagesSquare, shortcut: 'a' },
   { type: 'view', id: 'editor', label: 'Editor', icon: Code, shortcut: 'e' },
-  { type: 'view', id: 'terminal', label: 'Terminal', icon: SquareTerminal, shortcut: 't' },
-  { type: 'view', id: 'diff', label: 'Diff', icon: GitCompareArrows, shortcut: 'd' },
-  { type: 'view', id: 'prReview', label: 'PR Review Inbox', icon: Inbox, shortcut: 'r' },
+  {
+    type: 'view',
+    id: 'terminal',
+    label: 'Terminal',
+    icon: SquareTerminal,
+    shortcut: 't',
+    requiresChat: true,
+  },
+  {
+    type: 'view',
+    id: 'diff',
+    label: 'Diff',
+    icon: GitCompareArrows,
+    shortcut: 'd',
+    requiresChat: true,
+  },
+  {
+    type: 'view',
+    id: 'prReview',
+    label: 'PR Review Inbox',
+    icon: Inbox,
+    shortcut: 'r',
+    requiresChat: true,
+  },
   { type: 'view', id: 'secrets', label: 'Secrets', icon: KeyRound, shortcut: 's' },
 ];
 
 const ACTION_COMMANDS: ActionCommandItem[] = [
   { type: 'action', id: 'new-thread', label: 'New thread', icon: MessageSquarePlus, shortcut: 'w' },
-  { type: 'action', id: 'new-sub-thread', label: 'New sub-thread', icon: GitBranch, shortcut: 'n' },
+  {
+    type: 'action',
+    id: 'new-sub-thread',
+    label: 'New sub-thread',
+    icon: GitBranch,
+    shortcut: 'n',
+    requiresChat: true,
+  },
   {
     type: 'action',
     id: 'create-commit',
     label: 'Create commit',
     icon: GitCommitHorizontal,
     shortcut: 'c',
+    requiresChat: true,
   },
   {
     type: 'action',
@@ -106,15 +137,31 @@ const ACTION_COMMANDS: ActionCommandItem[] = [
     label: 'Create pull request',
     icon: GitPullRequest,
     shortcut: 'l',
+    requiresChat: true,
   },
-  { type: 'action', id: 'create-branch', label: 'Create branch', icon: GitBranch, shortcut: 'h' },
-  { type: 'action', id: 'switch-branch', label: 'Switch branch', icon: GitBranch, shortcut: 'b' },
+  {
+    type: 'action',
+    id: 'create-branch',
+    label: 'Create branch',
+    icon: GitBranch,
+    shortcut: 'h',
+    requiresChat: true,
+  },
+  {
+    type: 'action',
+    id: 'switch-branch',
+    label: 'Switch branch',
+    icon: GitBranch,
+    shortcut: 'b',
+    requiresChat: true,
+  },
   {
     type: 'action',
     id: 'push-remote',
     label: 'Push to remote',
     icon: ArrowUpFromLine,
     shortcut: 'u',
+    requiresChat: true,
   },
   {
     type: 'action',
@@ -122,6 +169,7 @@ const ACTION_COMMANDS: ActionCommandItem[] = [
     label: 'Pull from remote',
     icon: ArrowDownFromLine,
     shortcut: 'j',
+    requiresChat: true,
   },
 ];
 
@@ -350,7 +398,7 @@ export function CommandMenu() {
   const activeLeafSet = useMemo(() => new Set(activeLeaves), [activeLeaves]);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { fileStructure, sandboxId } = useChatContext();
+  const { fileStructure, sandboxId, chatId } = useChatContext();
   const worktreeCwd = useChatStore((s) => s.currentChat?.worktree_cwd) ?? undefined;
 
   // Fetch branches whenever the menu is open so we can both render the branches mode and
@@ -377,10 +425,11 @@ export function CommandMenu() {
     () =>
       ALL_COMMANDS.filter((cmd) => {
         if (isMobile && cmd.hideOnMobile) return false;
+        if (cmd.requiresChat && !chatId) return false;
         if (cmd.id === 'switch-branch' && !canSwitchBranch) return false;
         return true;
       }),
-    [isMobile, canSwitchBranch],
+    [isMobile, canSwitchBranch, chatId],
   );
 
   const filteredCommands = useMemo(

--- a/frontend/src/components/ui/SplitViewContainer.tsx
+++ b/frontend/src/components/ui/SplitViewContainer.tsx
@@ -1,18 +1,12 @@
 import { memo, lazy, Suspense, ReactNode } from 'react';
 import { useUIStore } from '@/store/uiStore';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { Spinner } from '@/components/ui/primitives/Spinner';
 import { isMosaicSplitNode } from '@/utils/mosaicHelpers';
+import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback';
 import type { ViewType } from '@/types/ui.types';
 
 const MosaicSplitView = lazy(() =>
   import('@/components/ui/MosaicSplitView').then((m) => ({ default: m.MosaicSplitView })),
-);
-
-const mosaicFallback = (
-  <div className="flex h-full w-full items-center justify-center bg-surface-secondary dark:bg-surface-dark-secondary">
-    <Spinner size="md" className="text-text-quaternary dark:text-text-dark-quaternary" />
-  </div>
 );
 
 interface SplitViewContainerProps {
@@ -34,7 +28,7 @@ export const SplitViewContainer = memo(function SplitViewContainer({
   }
 
   return (
-    <Suspense fallback={mosaicFallback}>
+    <Suspense fallback={viewLoadingFallback}>
       <MosaicSplitView mosaicLayout={mosaicLayout} renderView={renderView} />
     </Suspense>
   );

--- a/frontend/src/components/ui/shared/ViewLoadingFallback.tsx
+++ b/frontend/src/components/ui/shared/ViewLoadingFallback.tsx
@@ -1,0 +1,7 @@
+import { Spinner } from '@/components/ui/primitives/Spinner';
+
+export const viewLoadingFallback = (
+  <div className="flex h-full w-full items-center justify-center bg-surface-secondary dark:bg-surface-dark-secondary">
+    <Spinner size="md" className="text-text-quaternary dark:text-text-dark-quaternary" />
+  </div>
+);

--- a/frontend/src/hooks/useCommandMenu.ts
+++ b/frontend/src/hooks/useCommandMenu.ts
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useUIStore } from '@/store/uiStore';
+import { useChatStore } from '@/store/chatStore';
 import { useQueryClient } from '@tanstack/react-query';
 import { SHORTCUT_MAP, executeCommand } from '@/components/ui/CommandMenu';
 import { MOBILE_BREAKPOINT } from '@/config/constants';
@@ -34,6 +35,7 @@ export function useCommandMenu() {
       if (!cmd) return;
 
       if (cmd.hideOnMobile && window.innerWidth < MOBILE_BREAKPOINT) return;
+      if (cmd.requiresChat && !useChatStore.getState().currentChat) return;
 
       e.preventDefault();
       executeCommand(cmd, queryClient, navigate, true);

--- a/frontend/src/hooks/usePendingFileOpen.ts
+++ b/frontend/src/hooks/usePendingFileOpen.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { useUIStore } from '@/store/uiStore';
+import { findFileByToolPath } from '@/utils/file';
+import type { FileStructure } from '@/types/file-system.types';
+
+export function usePendingFileOpen(
+  fileStructure: FileStructure[],
+  setSelectedFile: (file: FileStructure | null) => void,
+) {
+  const pendingFilePath = useUIStore((s) => s.pendingFilePath);
+
+  useEffect(() => {
+    if (!pendingFilePath || fileStructure.length === 0) return;
+    const file = findFileByToolPath(fileStructure, pendingFilePath);
+    setSelectedFile(file ?? { path: pendingFilePath, type: 'file', content: '' });
+    useUIStore.setState({ pendingFilePath: null });
+  }, [pendingFilePath, setSelectedFile, fileStructure]);
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -8,11 +8,12 @@ import { SplitViewContainer } from '@/components/ui/SplitViewContainer';
 import { CommandMenu } from '@/components/ui/CommandMenu';
 import { useCommandMenu } from '@/hooks/useCommandMenu';
 import { useActiveViews } from '@/hooks/useActiveViews';
-import { Spinner } from '@/components/ui/primitives/Spinner';
+import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback';
 import type { ViewType } from '@/types/ui.types';
 import { Chat as ChatComponent } from '@/components/chat/chat-window/Chat';
 import { ChatSessionOrchestrator } from '@/components/chat/chat-window/ChatSessionOrchestrator';
 import { useEditorState } from '@/hooks/useEditorState';
+import { usePendingFileOpen } from '@/hooks/usePendingFileOpen';
 import { useChatData } from '@/hooks/useChatData';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
 import {
@@ -20,7 +21,6 @@ import {
   useWorkspaceResourcesQuery,
 } from '@/hooks/queries/useWorkspaceQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
-import { findFileByToolPath } from '@/utils/file';
 import { ChatProvider } from '@/contexts/ChatContext';
 import { CreateSubThreadDialog } from '@/components/chat/sub-threads/CreateSubThreadDialog';
 
@@ -51,12 +51,6 @@ const CreateCommitDialog = lazy(() =>
 );
 const CreatePRDialog = lazy(() =>
   import('@/components/chat/github/CreatePRDialog').then((m) => ({ default: m.CreatePRDialog })),
-);
-
-const viewLoadingFallback = (
-  <div className="flex h-full w-full items-center justify-center bg-surface-secondary dark:bg-surface-dark-secondary">
-    <Spinner size="md" className="text-text-quaternary dark:text-text-dark-quaternary" />
-  </div>
 );
 
 export function ChatPage() {
@@ -134,15 +128,7 @@ export function ChatPage() {
     });
   }
 
-  const pendingFilePath = useUIStore((s) => s.pendingFilePath);
-
-  useEffect(() => {
-    if (!pendingFilePath || fileStructure.length === 0) return;
-
-    const file = findFileByToolPath(fileStructure, pendingFilePath);
-    setSelectedFile(file ?? { path: pendingFilePath, type: 'file', content: '' });
-    useUIStore.setState({ pendingFilePath: null });
-  }, [pendingFilePath, setSelectedFile, fileStructure]);
+  usePendingFileOpen(fileStructure, setSelectedFile);
 
   const handleChatSelect = useCallback(
     (selectedChatId: string) => {
@@ -193,7 +179,8 @@ export function ChatPage() {
                 files={fileStructure}
                 selectedFile={selectedFile}
                 onFileSelect={handleFileSelect}
-                currentChat={currentChat}
+                sandboxId={currentChat?.sandbox_id}
+                worktreeCwd={worktreeCwd}
                 isSandboxSyncing={isFileMetadataLoading}
                 onRefresh={handleRefresh}
                 isRefreshing={isRefreshing}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,4 +1,13 @@
-import { useState, useRef, useMemo, useCallback, useEffect } from 'react';
+import {
+  useState,
+  useRef,
+  useMemo,
+  useCallback,
+  useEffect,
+  ReactNode,
+  lazy,
+  Suspense,
+} from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useNavigate, useLocation } from 'react-router-dom';
 import toast from 'react-hot-toast';
@@ -23,6 +32,20 @@ import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
 import { ChatProvider } from '@/contexts/ChatContext';
 import { Button } from '@/components/ui/primitives/Button';
 import { buildFileStructureFromSandboxFiles } from '@/utils/file';
+import { SplitViewContainer } from '@/components/ui/SplitViewContainer';
+import { CommandMenu } from '@/components/ui/CommandMenu';
+import { useCommandMenu } from '@/hooks/useCommandMenu';
+import { useEditorState } from '@/hooks/useEditorState';
+import { usePendingFileOpen } from '@/hooks/usePendingFileOpen';
+import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback';
+import type { ViewType } from '@/types/ui.types';
+
+const Editor = lazy(() =>
+  import('@/components/editor/editor-core/Editor').then((m) => ({ default: m.Editor })),
+);
+const SecretsView = lazy(() =>
+  import('@/components/sandbox/secrets/SecretsView').then((m) => ({ default: m.SecretsView })),
+);
 
 const EXAMPLE_PROMPTS = [
   'Build a REST API with authentication',
@@ -33,6 +56,7 @@ const EXAMPLE_PROMPTS = [
 export function LandingPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  useCommandMenu();
   const attachedFiles = useChatStore((state) => state.attachedFiles);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { selectedModelId, selectModel } = useModelSelection({
@@ -91,14 +115,28 @@ export function LandingPage() {
     ? workspaces.find((ws) => ws.id === selectedWorkspaceId)?.sandbox_id
     : undefined;
 
-  const { data: filesMetadata = [] } = useFilesMetadataQuery(selectedSandboxId, {
-    enabled: isAuthenticated && !!selectedSandboxId,
-  });
+  const { data: filesMetadata = [], refetch: refetchFilesMetadata } = useFilesMetadataQuery(
+    selectedSandboxId,
+    {
+      enabled: isAuthenticated && !!selectedSandboxId,
+    },
+  );
 
   const fileStructure = useMemo(
     () => buildFileStructureFromSandboxFiles(filesMetadata, []),
     [filesMetadata],
   );
+
+  const { selectedFile, setSelectedFile, isRefreshing, handleRefresh, handleFileSelect } =
+    useEditorState(refetchFilesMetadata);
+
+  const prevSandboxIdRef = useRef(selectedSandboxId);
+  if (prevSandboxIdRef.current !== selectedSandboxId) {
+    prevSandboxIdRef.current = selectedSandboxId;
+    setSelectedFile(null);
+  }
+
+  usePendingFileOpen(fileStructure, setSelectedFile);
 
   const { data: settings } = useSettingsQuery({
     enabled: isAuthenticated,
@@ -106,7 +144,9 @@ export function LandingPage() {
 
   useMountEffect(() => {
     useChatStore.getState().setCurrentChat(null);
-    useUIStore.getState().exitSplitMode();
+    // Reset to the agent (workspace selector) leaf — a stale split layout from a prior chat
+    // would otherwise persist into the landing screen.
+    useUIStore.getState().setCurrentView('agent');
   });
 
   const handleFileAttach = useCallback((files: File[]) => {
@@ -180,57 +220,107 @@ export function LandingPage() {
 
   useLayoutSidebar(sidebarContent);
 
+  const renderView = useCallback(
+    (view: ViewType): ReactNode => {
+      switch (view) {
+        case 'agent':
+          return (
+            <div className="flex h-full w-full items-center justify-center px-4 pb-10">
+              <div className="w-full max-w-2xl">
+                <div className="relative z-30 mb-2 flex items-center gap-1 px-4 sm:px-6">
+                  <WorkspaceSelector
+                    selectedWorkspaceId={selectedWorkspaceId}
+                    onWorkspaceChange={setSelectedWorkspaceId}
+                    enabled={isAuthenticated}
+                  />
+                  <WorktreeToggle disabled={isLoading} />
+                </div>
+
+                <ChatInput
+                  message={message}
+                  setMessage={setMessage}
+                  onSubmit={handleNewChat}
+                  onAttach={handleFileAttach}
+                  attachedFiles={attachedFiles}
+                  isLoading={isLoading}
+                  showLoadingSpinner={true}
+                  selectedModelId={selectedModelId}
+                  onModelChange={selectModel}
+                  showTip={false}
+                  placeholder="Message Agentrove... (@ to mention, / for commands)"
+                />
+
+                <div className="mt-4 flex flex-wrap justify-center gap-2 px-4 sm:px-6">
+                  {EXAMPLE_PROMPTS.map((prompt) => (
+                    <Button
+                      key={prompt}
+                      type="button"
+                      variant="unstyled"
+                      onClick={() => setMessage(prompt)}
+                      className="rounded-lg border border-border/50 px-3 py-2 text-2xs text-text-tertiary transition-colors duration-200 hover:border-border-hover hover:bg-surface-hover hover:text-text-primary dark:border-border-dark/50 dark:text-text-dark-tertiary dark:hover:border-border-dark-hover dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+                    >
+                      {prompt}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          );
+        case 'editor':
+          return (
+            <Suspense fallback={viewLoadingFallback}>
+              <Editor
+                files={fileStructure}
+                selectedFile={selectedFile}
+                onFileSelect={handleFileSelect}
+                sandboxId={selectedSandboxId}
+                isSandboxSyncing={false}
+                onRefresh={handleRefresh}
+                isRefreshing={isRefreshing}
+              />
+            </Suspense>
+          );
+        case 'secrets':
+          return (
+            <Suspense fallback={viewLoadingFallback}>
+              <SecretsView sandboxId={selectedSandboxId} />
+            </Suspense>
+          );
+        default:
+          return null;
+      }
+    },
+    [
+      attachedFiles,
+      handleFileAttach,
+      handleNewChat,
+      isAuthenticated,
+      isLoading,
+      message,
+      selectModel,
+      selectedModelId,
+      selectedWorkspaceId,
+      fileStructure,
+      selectedFile,
+      handleFileSelect,
+      selectedSandboxId,
+      handleRefresh,
+      isRefreshing,
+    ],
+  );
+
   return (
-    <div className="flex h-full flex-col">
-      <div className="relative flex flex-1">
-        <div className="flex flex-1 items-center justify-center px-4 pb-10">
-          <div className="w-full max-w-2xl">
-            <div className="relative z-30 mb-2 flex items-center gap-1 px-4 sm:px-6">
-              <WorkspaceSelector
-                selectedWorkspaceId={selectedWorkspaceId}
-                onWorkspaceChange={setSelectedWorkspaceId}
-                enabled={isAuthenticated}
-              />
-              <WorktreeToggle disabled={isLoading} />
-            </div>
-
-            <ChatProvider
-              fileStructure={fileStructure}
-              customSkills={workspaceResources?.skills}
-              builtinSlashCommands={workspaceResources?.builtin_slash_commands}
-              personas={settings?.personas}
-            >
-              <ChatInput
-                message={message}
-                setMessage={setMessage}
-                onSubmit={handleNewChat}
-                onAttach={handleFileAttach}
-                attachedFiles={attachedFiles}
-                isLoading={isLoading}
-                showLoadingSpinner={true}
-                selectedModelId={selectedModelId}
-                onModelChange={selectModel}
-                showTip={false}
-                placeholder="Message Agentrove... (@ to mention, / for commands)"
-              />
-            </ChatProvider>
-
-            <div className="mt-4 flex flex-wrap justify-center gap-2 px-4 sm:px-6">
-              {EXAMPLE_PROMPTS.map((prompt) => (
-                <Button
-                  key={prompt}
-                  type="button"
-                  variant="unstyled"
-                  onClick={() => setMessage(prompt)}
-                  className="rounded-lg border border-border/50 px-3 py-2 text-2xs text-text-tertiary transition-colors duration-200 hover:border-border-hover hover:bg-surface-hover hover:text-text-primary dark:border-border-dark/50 dark:text-text-dark-tertiary dark:hover:border-border-dark-hover dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
-                >
-                  {prompt}
-                </Button>
-              ))}
-            </div>
-          </div>
-        </div>
+    <ChatProvider
+      sandboxId={selectedSandboxId}
+      fileStructure={fileStructure}
+      customSkills={workspaceResources?.skills}
+      builtinSlashCommands={workspaceResources?.builtin_slash_commands}
+      personas={settings?.personas}
+    >
+      <div className="flex h-full flex-1 overflow-hidden bg-surface text-text-primary dark:bg-surface-dark dark:text-text-dark-primary">
+        <SplitViewContainer renderView={renderView} />
       </div>
-    </div>
+      <CommandMenu />
+    </ChatProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Mount `CommandMenu` + `SplitViewContainer` on `LandingPage` so users can run file search, open the editor, and use navigation/global commands against the selected workspace before creating a chat.
- Add a `requiresChat` flag on command items and filter chat-scoped commands (terminal, diff, PR review, git ops, sub-thread, commit, PR, branch ops) out of the menu and shortcut path when no chat is active.
- Decouple `Editor` from the `Chat` shape — accept `sandboxId` / `worktreeCwd` directly. Drop the vestigial `chatId` guards from the editor's file-content load and save paths so editing works against a workspace sandbox.
- Reset `selectedFile` when the selected workspace changes, mirroring the chat-reset pattern in `ChatPage`.
- Extract `usePendingFileOpen` hook and the shared `viewLoadingFallback` used by both pages (also picked up by `SplitViewContainer`).

## Test plan
- [ ] On `/`, `Cmd/Ctrl+Shift+P` opens the command menu.
- [ ] With a workspace selected, "Search in files" / "Go to file" return results and open the editor pane.
- [ ] Splitting Editor / Secrets from the menu shows the workspace's files alongside the chat input.
- [ ] Saving a file from the landing editor persists to the workspace sandbox.
- [ ] Switching workspaces clears the previously open file in the editor.
- [ ] Chat-scoped commands (Terminal, Diff, PR Review Inbox, sub-thread, commit, PR, branch ops, push/pull) are absent from the menu on landing, and their shortcuts are no-ops there.
- [ ] On a chat page, the same commands still work as before; editor save/load and file content load behave unchanged.
- [ ] `Cmd/Ctrl+Shift+P` also still works inside `ChatPage` and isn't intercepted in Monaco / xterm.