### PR TITLE
Always keep a workspace selected on the landing page

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -78,6 +78,7 @@ export function LandingPage() {
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!workspaces.length) return;
     if (
       initialWorkspaceId &&
       initialWorkspaceId !== consumedWorkspaceRef.current &&
@@ -85,18 +86,11 @@ export function LandingPage() {
     ) {
       consumedWorkspaceRef.current = initialWorkspaceId;
       setSelectedWorkspaceId(initialWorkspaceId);
+      return;
     }
-  }, [initialWorkspaceId, workspaces]);
-
-  useEffect(() => {
-    if (
-      selectedWorkspaceId &&
-      workspaces.length &&
-      !workspaces.some((ws) => ws.id === selectedWorkspaceId)
-    ) {
-      setSelectedWorkspaceId(null);
-    }
-  }, [workspaces, selectedWorkspaceId]);
+    if (selectedWorkspaceId && workspaces.some((ws) => ws.id === selectedWorkspaceId)) return;
+    setSelectedWorkspaceId(workspaces[0].id);
+  }, [initialWorkspaceId, workspaces, selectedWorkspaceId]);
 
   if (initialMessage && !consumedInitialMessageRef.current) {
     consumedInitialMessageRef.current = true;


### PR DESCRIPTION
## Summary
- Merge the two landing-page selection effects so route-provided `workspaceId` (sidebar "new thread", PR review handoff) is consumed before any fallback runs.
- Fall back to the first available workspace whenever the current selection is empty or stale (e.g. after deletion), so a workspace is always selected when one exists.

## Test plan
- [ ] Open landing page with no prior selection — first workspace is auto-selected.
- [ ] From sidebar, "New thread" under a non-first workspace — that workspace is selected on landing.
- [ ] Delete the currently selected workspace — selection moves to another workspace instead of going empty.
- [ ] Fresh account with zero workspaces — no auto-selection, "Please select a workspace" toast still guards chat creation.