### PR TITLE
Move PR Review Inbox shortcut off Cmd+Shift+R

### DIFF
--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -107,7 +107,7 @@ const VIEW_COMMANDS: ViewCommandItem[] = [
     id: 'prReview',
     label: 'PR Review Inbox',
     icon: Inbox,
-    shortcut: 'r',
+    shortcut: 'i',
     requiresChat: true,
   },
   { type: 'view', id: 'secrets', label: 'Secrets', icon: KeyRound, shortcut: 's' },


### PR DESCRIPTION
## Summary
- `Cmd/Ctrl+Shift+R` collided with the browser's hard-reload binding; the command-menu handler runs in capture phase with `preventDefault`, so reload was blocked whenever a chat was active.
- Rebind PR Review Inbox to `Cmd/Ctrl+Shift+I` (Inbox), which was previously unused in `SHORTCUT_MAP`.

## Test plan
- [ ] Open a chat and press `Cmd+Shift+R` — browser hard-reloads (no longer intercepted).
- [ ] Press `Cmd+Shift+I` — PR Review Inbox toggles in the mosaic.
- [ ] Confirm the displayed shortcut hint in the command menu shows `⌘⇧I`.