### PR TITLE
Replace bundled Node bin symlinks with bash launchers

### DIFF
--- a/desktop/run_build.mjs
+++ b/desktop/run_build.mjs
@@ -116,6 +116,32 @@ function fetchNode() {
   writeStamp('node', NODE_STAMP);
 }
 
+// Tauri's resource bundler dereferences symlinks when copying the sidecar
+// into the .app, turning `bin/npx` (a symlink to ../lib/node_modules/npm/bin/npx-cli.js)
+// into a verbatim copy of that script. Its `require('../lib/cli.js')` then
+// resolves relative to bin/ instead of lib/node_modules/npm/bin/ and crashes.
+// Replace each symlink with a bash launcher that invokes the real script
+// through the bundled node — survives any copy/bundle step.
+function replaceNodeShims() {
+  const shims = [
+    { name: 'npm', target: 'lib/node_modules/npm/bin/npm-cli.js' },
+    { name: 'npx', target: 'lib/node_modules/npm/bin/npx-cli.js' },
+    { name: 'corepack', target: 'lib/node_modules/corepack/dist/corepack.js' },
+  ];
+  for (const { name, target } of shims) {
+    const shimPath = join(nodeDir, 'bin', name);
+    if (!existsSync(join(nodeDir, target))) continue;
+    rmSync(shimPath, { force: true });
+    writeFileSync(
+      shimPath,
+      '#!/bin/bash\n' +
+        'SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"\n' +
+        `exec "$SCRIPT_DIR/node" "$SCRIPT_DIR/../${target}" "$@"\n`,
+    );
+    chmodSync(shimPath, 0o755);
+  }
+}
+
 function fetchRipgrep() {
   const innerDir = `ripgrep-${RIPGREP_VERSION}-${ARCH_TRIPLE}`;
   const url = `https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/${innerDir}.tar.gz`;
@@ -246,6 +272,7 @@ function run() {
   const nodeChanged = !upToDate('node', NODE_STAMP, nodeBin, npmBin);
   if (nodeChanged) fetchNode();
   else console.log('Node already installed, skipping download.');
+  replaceNodeShims();
 
   if (!nodeChanged && upToDate('acp', ACP_STAMP, claudeAcpBin, codexAcpBin)) {
     console.log('ACP adapters already installed, skipping install.');


### PR DESCRIPTION
## Summary
- The bundled Node tarball ships `node/bin/{npx,npm,corepack}` as symlinks into `node/lib/node_modules/...`. Tauri's resource bundler dereferences those symlinks when copying the sidecar into the `.app`, replacing them with verbatim copies of the target `.js` files.
- Once that happens, `npx-cli.js`'s `require('../lib/cli.js')` resolves relative to `bin/` instead of `lib/node_modules/npm/bin/`, so any `npx`/`npm`/`corepack` invocation in the shipped app crashes with `MODULE_NOT_FOUND`.
- Replace the symlinks at build time with bash launchers that invoke the real script through the bundled `node` — same pattern already used for the ACP adapter launchers (`writeAcpLauncher`). Survives any copy/bundle step.

## Test plan
- [ ] `node desktop/run_build.mjs` rewrites `frontend/backend-sidecar/node/bin/{npx,npm,corepack}` as bash launchers (no longer symlinks).
- [ ] `frontend/backend-sidecar/node/bin/npx --version` prints the npm version cleanly.
- [ ] After a full Tauri bundle, `Agentrove.app/Contents/Resources/_up_/backend-sidecar/node/bin/npx --version` works (previously crashed with `Cannot find module '../lib/cli.js'`).
- [ ] Pre-commit hook (`npx lint-staged`) succeeds when the bundled `npx` is first on `PATH`.