### PR TITLE
fix: keep image attachments visible after picking slash command

### DIFF
--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -134,7 +134,6 @@ export function InputProvider({
 
   const handleSlashCommandSelect = useCallback(
     (command: SlashCommand) => {
-      setPreviewDismissed(true);
       const newMessage = `${command.value} `;
       setMessage(newMessage);
       focusTextarea(newMessage);


### PR DESCRIPTION
## Summary
- Selecting a slash command / skill suggestion was calling `setPreviewDismissed(true)` in `handleSlashCommandSelect`, which hid the attachment preview UI even though `attachedFiles` was still populated — making uploaded images appear to disappear from the input bar.
- Removed the dismissal call. Inserting command text into the textarea shouldn't touch attachment UI; preview dismissal still happens correctly on actual submit (`handleSubmit`) and on attachment-count change.

## Test plan
- [ ] Attach an image to the chat input
- [ ] Type `/` to open the slash command/skill suggestions panel
- [ ] Select a suggestion (click or Enter)
- [ ] Verify the image thumbnail remains visible in the input bar
- [ ] Submit the message and verify the attachment preview clears as before
- [ ] `cd frontend && npm run lint && npm run typecheck`