### PR TITLE
feat: view two chats side-by-side via split panes

### DIFF
--- a/docs/artifacts/frontend/components.md
+++ b/docs/artifacts/frontend/components.md
@@ -87,8 +87,8 @@ References: `InputProvider.tsx` (in `components/chat/message-input/`), `ChatSess
 
 | Context | Owns |
 |---|---|
-| `ChatProvider` (`contexts/ChatContext.tsx`) | static chat metadata: `chatId`, `sandboxId`, `fileStructure`, `customSkills`, `builtinSlashCommands`, `personas` |
-| `ChatSessionProvider` (`contexts/ChatSessionContext.tsx`) | dynamic session: messages, streaming, loading, permissions, input message, model selection |
+| `ChatProvider` (`contexts/ChatContext.tsx`) | static chat metadata: `chatId`, `sandboxId`, `worktreeCwd`, `fileStructure`, `customSkills`, `builtinSlashCommands`, `personas`. Mounted **per agent pane** — the primary tile inherits the page-level provider; the secondary tile mounts its own via `AgentPane` (`components/chat/chat-window/AgentPane.tsx`) so split-chat view can show two independent chats. |
+| `ChatSessionProvider` (`contexts/ChatSessionContext.tsx`) | dynamic session: messages, streaming, loading, permissions, input message, model selection. Also mounted **per agent pane**; `useChatSessionContext()` resolves to the nearest enclosing pane's session, so split-chat works without slot-aware consumers. |
 | `InputProvider` (`components/chat/message-input/InputProvider.tsx`) | input internals: file handling, drag-drop, suggestions, enhancement, submit |
 | `LayoutContext` (`components/layout/layoutState.tsx`) | sidebar state |
 | `FileTreeProvider` (`components/editor/file-tree/FileTreeProvider.tsx`) | file tree selection/expansion |

--- a/docs/artifacts/frontend/state.md
+++ b/docs/artifacts/frontend/state.md
@@ -56,8 +56,8 @@ See `components.md` for the full context-pattern (Definition + Context/Provider 
 
 | Context | Where | Why a context, not a store |
 |---|---|---|
-| `ChatProvider` | `contexts/ChatContext.tsx` | per-chat scope; recreated on chat switch |
-| `ChatSessionProvider` | `contexts/ChatSessionContext.tsx` | per-session; carries streaming + UI state |
+| `ChatProvider` | `contexts/ChatContext.tsx` | per-chat scope; recreated on chat switch. **Mounted per agent pane**, not per page — split-chat view can show two chats simultaneously by mounting a second `AgentPane` (which carries its own `ChatProvider` + `ChatSessionProvider`). |
+| `ChatSessionProvider` | `contexts/ChatSessionContext.tsx` | per-session; carries streaming + UI state. Per agent pane; consumers read from the nearest pane via `useChatSessionContext()`. |
 | `InputProvider` | `components/chat/message-input/InputProvider.tsx` | feature-scoped (input bar) |
 | `LayoutContext` | `components/layout/layoutState.tsx` | sidebar — could be Zustand, currently context |
 | `FileTreeProvider` | `components/editor/file-tree/FileTreeProvider.tsx` | per-tree selection/expansion |

--- a/docs/domains/chat.md
+++ b/docs/domains/chat.md
@@ -52,6 +52,7 @@ State transitions go through `ChatService` and the streaming runtime — never w
 - **Send-now is cancel + re-prompt**, not a queue prepend. The currently streaming message gets a `cancelled` terminal event before the new one starts (PR #454).
 - **Sub-thread parent invalidation** — when a sub-thread completes, the parent's `sub_thread_count` may need cache refresh. Use the prefix key for broad invalidation.
 - **Permission mode and thinking mode are chat-scoped**, not user-scoped (PR #396) — they live on the chat, not on `UserSettings`.
+- **Split chat view: route owns the primary chat, `uiStore.secondaryChatId` owns the secondary.** The chat page may render two `AgentPane` instances simultaneously (`frontend/src/components/chat/chat-window/AgentPane.tsx`). Each pane owns its own `ChatProvider` + `ChatSessionProvider`, so `useChatContext()` / `useChatSessionContext()` consumers resolve to the nearest pane unchanged. Non-agent views (editor, terminal, diff, etc.), dialogs, and the command menu remain scoped to the **primary** chat. Mosaic tile leaves are `MosaicTileId` (`agent:primary | agent:secondary | <ViewType>`), not bare `ViewType` strings — see `frontend/src/types/ui.types.ts`.
 
 ## Recent prior art
 

--- a/frontend/src/components/chat/branch-selector/BranchSelector.tsx
+++ b/frontend/src/components/chat/branch-selector/BranchSelector.tsx
@@ -4,7 +4,6 @@ import { GitBranch } from 'lucide-react';
 import { Dropdown, DropdownItemType } from '@/components/ui/primitives/Dropdown';
 import { useChatContext } from '@/hooks/useChatContext';
 import { useIsSplitMode } from '@/hooks/useIsSplitMode';
-import { useChatStore } from '@/store/chatStore';
 import { useGitBranchesQuery, useCheckoutBranchMutation } from '@/hooks/queries/useSandboxQueries';
 
 export interface BranchSelectorProps {
@@ -20,8 +19,7 @@ export const BranchSelector = memo(function BranchSelector({
   disabled = false,
   variant = 'default',
 }: BranchSelectorProps) {
-  const { sandboxId } = useChatContext();
-  const worktreeCwd = useChatStore((s) => s.currentChat?.worktree_cwd) ?? undefined;
+  const { sandboxId, worktreeCwd } = useChatContext();
   const isSplitMode = useIsSplitMode();
 
   const { data: branchesData } = useGitBranchesQuery(sandboxId, !!sandboxId, worktreeCwd);

--- a/frontend/src/components/chat/chat-window/AgentPane.tsx
+++ b/frontend/src/components/chat/chat-window/AgentPane.tsx
@@ -1,0 +1,47 @@
+import { memo } from 'react';
+import { Chat as ChatComponent } from '@/components/chat/chat-window/Chat';
+import { ChatSessionOrchestrator } from '@/components/chat/chat-window/ChatSessionOrchestrator';
+import { ChatProvider } from '@/contexts/ChatContext';
+import { useChatData } from '@/hooks/useChatData';
+import { useSandboxFiles } from '@/hooks/useSandboxFiles';
+import { useWorkspaceResourcesQuery } from '@/hooks/queries/useWorkspaceQueries';
+import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
+
+interface AgentPaneProps {
+  chatId: string;
+}
+
+// Each instance subscribes to its own messages query and SSE stream via
+// useChatStreaming inside ChatSessionOrchestrator. Streaming demuxes by
+// envelope.chatId so two panes can stream concurrently.
+export const AgentPane = memo(function AgentPane({ chatId }: AgentPaneProps) {
+  const { currentChat, fetchedMessages, hasFetchedMessages, messagesQuery } = useChatData(chatId);
+  const { fileStructure, refetchFilesMetadata } = useSandboxFiles(currentChat, chatId);
+  const { data: workspaceResources } = useWorkspaceResourcesQuery(currentChat?.workspace_id);
+  const { data: settings } = useSettingsQuery();
+
+  return (
+    <ChatProvider
+      chatId={chatId}
+      sandboxId={currentChat?.sandbox_id}
+      worktreeCwd={currentChat?.worktree_cwd ?? undefined}
+      parentChatId={currentChat?.parent_chat_id ?? undefined}
+      fileStructure={fileStructure}
+      customSkills={workspaceResources?.skills}
+      builtinSlashCommands={workspaceResources?.builtin_slash_commands}
+      personas={settings?.personas}
+    >
+      <ChatSessionOrchestrator
+        chatId={chatId}
+        currentChat={currentChat}
+        fetchedMessages={fetchedMessages}
+        hasFetchedMessages={hasFetchedMessages}
+        messagesQuery={messagesQuery}
+        refetchFilesMetadata={refetchFilesMetadata}
+        useRouteInitialPrompt={false}
+      >
+        <ChatComponent />
+      </ChatSessionOrchestrator>
+    </ChatProvider>
+  );
+});

--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -83,12 +83,16 @@ export const Chat = memo(function Chat() {
 
   useEffect(() => {
     return useUIStore.subscribe((state, prev) => {
-      if (state.pendingChatMessage && state.pendingChatMessage !== prev.pendingChatMessage) {
-        setInputMessage(state.pendingChatMessage);
+      if (
+        state.pendingChatMessage &&
+        state.pendingChatMessage !== prev.pendingChatMessage &&
+        state.pendingChatMessage.chatId === chatId
+      ) {
+        setInputMessage(state.pendingChatMessage.message);
         useUIStore.getState().setPendingChatMessage(null);
       }
     });
-  }, [setInputMessage]);
+  }, [chatId, setInputMessage]);
 
   const { activeStreams, streamIdByChatMessage } = useStreamStore(
     useShallow((s) => ({

--- a/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
+++ b/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
@@ -21,6 +21,8 @@ import { useModelSelection } from '@/hooks/queries/useModelQueries';
 import type { Chat, Message } from '@/types/chat.types';
 import type { useInfiniteMessagesQuery } from '@/hooks/queries/useChatQueries';
 
+const EMPTY_FILES: File[] = [];
+
 interface ChatSessionOrchestratorProps {
   chatId: string;
   currentChat: Chat | undefined;
@@ -28,6 +30,7 @@ interface ChatSessionOrchestratorProps {
   hasFetchedMessages: boolean;
   messagesQuery: ReturnType<typeof useInfiniteMessagesQuery>;
   refetchFilesMetadata: () => Promise<unknown>;
+  useRouteInitialPrompt?: boolean;
   children: ReactNode;
 }
 
@@ -38,14 +41,15 @@ export function ChatSessionOrchestrator({
   hasFetchedMessages,
   messagesQuery,
   refetchFilesMetadata,
+  useRouteInitialPrompt = true,
   children,
 }: ChatSessionOrchestratorProps) {
   const queryClient = useQueryClient();
 
-  const { attachedFiles, setAttachedFiles } = useChatStore(
+  const { attachedFiles, clearAttachedFilesForChat } = useChatStore(
     useShallow((state) => ({
-      attachedFiles: state.attachedFiles,
-      setAttachedFiles: state.setAttachedFiles,
+      attachedFiles: state.attachedFilesByChat[chatId] ?? EMPTY_FILES,
+      clearAttachedFilesForChat: state.clearAttachedFilesForChat,
     })),
   );
 
@@ -83,6 +87,8 @@ export function ChatSessionOrchestrator({
     setInitialPromptSent,
     initialPromptFromRoute,
   } = useInitialPrompt();
+  const effectiveInitialPrompt = useRouteInitialPrompt ? initialPrompt : null;
+  const effectiveInitialPromptFromRoute = useRouteInitialPrompt ? initialPromptFromRoute : null;
 
   const { contextUsage, updateContextUsage } = useContextUsageState(
     chatId,
@@ -122,7 +128,7 @@ export function ChatSessionOrchestrator({
     fetchedMessages,
     chatId,
     selectedModelId,
-    initialPromptFromRoute,
+    initialPromptFromRoute: effectiveInitialPromptFromRoute,
     initialPromptSent,
     wasAborted,
     attachedFiles,
@@ -137,19 +143,19 @@ export function ChatSessionOrchestrator({
     chatId,
     attachedFiles,
     setInitialPromptSent,
-    setAttachedFiles,
+    clearAttachedFilesForChat,
   });
   initialPromptActionsRef.current = {
     sendMessage,
     chatId,
     attachedFiles,
     setInitialPromptSent,
-    setAttachedFiles,
+    clearAttachedFilesForChat,
   };
 
   useEffect(() => {
     if (
-      initialPrompt &&
+      effectiveInitialPrompt &&
       messages.length === 1 &&
       !isLoading &&
       !isStreaming &&
@@ -162,15 +168,15 @@ export function ChatSessionOrchestrator({
         chatId: cid,
         attachedFiles: files,
         setInitialPromptSent: setSent,
-        setAttachedFiles: setFiles,
+        clearAttachedFilesForChat: clearFiles,
       } = initialPromptActionsRef.current;
       const userMessage = messages[0];
-      send(initialPrompt, cid, userMessage, files);
+      send(effectiveInitialPrompt, cid, userMessage, files);
       setSent(true);
-      setFiles([]);
+      clearFiles(cid);
     }
   }, [
-    initialPrompt,
+    effectiveInitialPrompt,
     messages,
     isLoading,
     isStreaming,

--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -13,7 +13,6 @@ import { useInputState, useInputActions } from '@/hooks/useInputContext';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
 import { useChatQuery } from '@/hooks/queries/useChatQueries';
 import { useChatContext } from '@/hooks/useChatContext';
-import { useChatStore } from '@/store/chatStore';
 import { useGitBranchesQuery } from '@/hooks/queries/useSandboxQueries';
 import { SelectorDot } from '@/components/ui/primitives/SelectorDot';
 
@@ -25,8 +24,7 @@ export function InputControls() {
   const { data: chat } = useChatQuery(state.chatId, { enabled: !!state.chatId });
   const lockedAgentKind = chat?.session_agent_kind ?? null;
 
-  const { sandboxId, personas } = useChatContext();
-  const worktreeCwd = useChatStore((s) => s.currentChat?.worktree_cwd) ?? undefined;
+  const { sandboxId, worktreeCwd, personas } = useChatContext();
   const { data: branchesData } = useGitBranchesQuery(sandboxId, !!sandboxId, worktreeCwd);
 
   const showPersona =

--- a/frontend/src/components/layout/ChatDropdown.tsx
+++ b/frontend/src/components/layout/ChatDropdown.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, type Ref } from 'react';
-import { Edit2, Trash2, Pin, PinOff } from 'lucide-react';
+import { Edit2, Trash2, Pin, PinOff, SplitSquareHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { cn } from '@/utils/cn';
 import type { Chat } from '@/types/chat.types';
@@ -11,6 +11,7 @@ interface ChatDropdownProps {
   onRename: (chat: Chat) => void;
   onDelete: (chatId: string) => void;
   onTogglePin: (chat: Chat) => void;
+  onOpenInSplit?: (chatId: string) => void;
   onClose?: () => void;
 }
 
@@ -21,6 +22,7 @@ export const ChatDropdown = memo(function ChatDropdown({
   onRename,
   onDelete,
   onTogglePin,
+  onOpenInSplit,
   onClose,
 }: ChatDropdownProps) {
   const isPinned = !!chat.pinned_at;
@@ -81,6 +83,22 @@ export const ChatDropdown = memo(function ChatDropdown({
               Pin
             </>
           )}
+        </Button>
+      )}
+      {onOpenInSplit && (
+        <Button
+          onClick={() => onOpenInSplit(chat.id)}
+          role="menuitem"
+          variant="unstyled"
+          className={cn(
+            'w-full px-3 py-2 text-left text-xs',
+            'text-text-primary dark:text-text-dark-primary',
+            'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+            'flex items-center gap-2 transition-colors',
+          )}
+        >
+          <SplitSquareHorizontal className="h-3 w-3" />
+          Open in split
         </Button>
       )}
       <Button

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
 import { useToggleSet } from '@/hooks/useToggleSet';
 import { cn } from '@/utils/cn';
 import { useUIStore } from '@/store/uiStore';
+import { useChatStore } from '@/store/chatStore';
 import { useStreamStore } from '@/store/streamStore';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useCurrentUserQuery, useLogoutMutation } from '@/hooks/queries/useAuthQueries';
@@ -89,11 +90,13 @@ function calculateDropdownPosition(buttonRect: DOMRect): { top: number; left: nu
 interface WorkspaceGroupProps {
   workspace: Workspace;
   selectedChatId: string | null;
+  secondaryChatId: string | null;
   dropdownChatId: string | null;
   streamingChatIdSet: Set<string>;
   isCollapsed: boolean;
   onToggleCollapse: (workspaceId: string) => void;
   onChatSelect: (chatId: string) => void;
+  onOpenInSplit?: (chatId: string) => void;
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
   onNewThread: (e: React.MouseEvent, workspaceId: string) => void;
   onWorkspaceContextMenu: (e: React.MouseEvent<HTMLButtonElement>, workspaceId: string) => void;
@@ -104,11 +107,13 @@ interface WorkspaceGroupProps {
 const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
   workspace,
   selectedChatId,
+  secondaryChatId,
   dropdownChatId,
   streamingChatIdSet,
   isCollapsed,
   onToggleCollapse,
   onChatSelect,
+  onOpenInSplit,
   onDropdownClick,
   onNewThread,
   onWorkspaceContextMenu,
@@ -185,10 +190,12 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
                   <SidebarChatItem
                     chat={chat}
                     isSelected={chat.id === selectedChatId}
+                    isActive={chat.id === selectedChatId || chat.id === secondaryChatId}
                     isHovered={hoveredChatId === chat.id}
                     isDropdownOpen={dropdownChatId === chat.id}
                     isChatStreaming={streamingChatIdSet.has(chat.id)}
                     onSelect={onChatSelect}
+                    onOpenInSplit={onOpenInSplit}
                     onDropdownClick={onDropdownClick}
                     onMouseEnter={handleMouseEnter}
                     onMouseLeave={handleMouseLeave}
@@ -201,6 +208,7 @@ const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
                     <SubThreadList
                       parentChatId={chat.id}
                       selectedChatId={selectedChatId}
+                      secondaryChatId={secondaryChatId}
                       onSelect={onChatSelect}
                       onDropdownClick={onDropdownClick}
                       streamingChatIdSet={streamingChatIdSet}
@@ -287,6 +295,7 @@ export function Sidebar({
     },
   });
   const activeStreamMetadata = useStreamStore((state) => state.activeStreamMetadata);
+  const secondaryChatId = useUIStore((state) => state.secondaryChatId);
   const streamingChatIdSet = useMemo(
     () => new Set(activeStreamMetadata.map((meta) => meta.chatId)),
     [activeStreamMetadata],
@@ -404,6 +413,28 @@ export function Sidebar({
     [onChatSelect, isMobile],
   );
 
+  const handleOpenInSplit = useCallback(
+    (chatId: string) => {
+      if (isMobile || !selectedChatId) {
+        onChatSelect(chatId);
+        return;
+      }
+      useUIStore.getState().openChatInSplit(chatId);
+      setPinnedHoveredId(null);
+    },
+    [isMobile, onChatSelect, selectedChatId],
+  );
+
+  const handleDropdownOpenInSplit = useCallback(
+    (chatId: string) => {
+      handleOpenInSplit(chatId);
+      setDropdown(null);
+    },
+    [handleOpenInSplit],
+  );
+  const canOpenInSplit = !isMobile && selectedChatId != null;
+  const dropdownCanSplit = canOpenInSplit && dropdown?.chat.id !== selectedChatId;
+
   const handleDeleteChat = useCallback((chatId: string) => {
     setChatToDelete(chatId);
     setDropdown(null);
@@ -425,9 +456,15 @@ export function Sidebar({
         'Chat deleted successfully',
         'Failed to delete chat',
       );
+      const uiState = useUIStore.getState();
+      if (chatToDelete === selectedChatId || uiState.secondaryChatId === chatToDelete) {
+        uiState.closeSplitChat();
+      }
       if (chatToDelete === selectedChatId || chatToDelete === selectedChatParentId) {
         navigate('/');
       }
+      // Release any pending File blobs held for this chat.
+      useChatStore.getState().clearAttachedFilesForChat(chatToDelete);
       onDeleteChat?.(chatToDelete);
     } catch {
       // toast already shown by mutateWithToast
@@ -616,10 +653,12 @@ export function Sidebar({
                         <SidebarChatItem
                           chat={chat}
                           isSelected={chat.id === selectedChatId}
+                          isActive={chat.id === selectedChatId || chat.id === secondaryChatId}
                           isHovered={pinnedHoveredId === chat.id}
                           isDropdownOpen={dropdown?.chat.id === chat.id}
                           isChatStreaming={streamingChatIdSet.has(chat.id)}
                           onSelect={handleChatSelect}
+                          onOpenInSplit={canOpenInSplit ? handleOpenInSplit : undefined}
                           onDropdownClick={handleDropdownClick}
                           onMouseEnter={handlePinnedMouseEnter}
                           onMouseLeave={handlePinnedMouseLeave}
@@ -634,6 +673,7 @@ export function Sidebar({
                           <SubThreadList
                             parentChatId={chat.id}
                             selectedChatId={selectedChatId}
+                            secondaryChatId={secondaryChatId}
                             onSelect={handleChatSelect}
                             onDropdownClick={handleDropdownClick}
                             streamingChatIdSet={streamingChatIdSet}
@@ -650,11 +690,13 @@ export function Sidebar({
                   key={workspace.id}
                   workspace={workspace}
                   selectedChatId={selectedChatId}
+                  secondaryChatId={secondaryChatId}
                   dropdownChatId={dropdown?.chat.id ?? null}
                   streamingChatIdSet={streamingChatIdSet}
                   isCollapsed={collapsedWorkspaces.has(workspace.id)}
                   onToggleCollapse={toggleWorkspaceCollapse}
                   onChatSelect={handleChatSelect}
+                  onOpenInSplit={canOpenInSplit ? handleOpenInSplit : undefined}
                   onDropdownClick={handleDropdownClick}
                   onNewThread={handleNewWorkspaceThread}
                   onWorkspaceContextMenu={handleWorkspaceContextMenu}
@@ -684,6 +726,7 @@ export function Sidebar({
           onRename={handleRenameClick}
           onDelete={handleDeleteChat}
           onTogglePin={handleTogglePin}
+          onOpenInSplit={dropdownCanSplit ? handleDropdownOpenInSplit : undefined}
           onClose={() => setDropdown(null)}
         />
       )}

--- a/frontend/src/components/layout/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/SidebarChatItem.tsx
@@ -9,10 +9,12 @@ import type { Chat } from '@/types/chat.types';
 interface SidebarChatItemProps {
   chat: Chat;
   isSelected: boolean;
+  isActive?: boolean;
   isHovered: boolean;
   isDropdownOpen: boolean;
   isChatStreaming: boolean;
   onSelect: (chatId: string) => void;
+  onOpenInSplit?: (chatId: string) => void;
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
   onMouseEnter: (chatId: string) => void;
   onMouseLeave: () => void;
@@ -23,10 +25,12 @@ interface SidebarChatItemProps {
 export const SidebarChatItem = memo(function SidebarChatItem({
   chat,
   isSelected,
+  isActive = isSelected,
   isHovered,
   isDropdownOpen,
   isChatStreaming,
   onSelect,
+  onOpenInSplit,
   onDropdownClick,
   onMouseEnter,
   onMouseLeave,
@@ -39,14 +43,14 @@ export const SidebarChatItem = memo(function SidebarChatItem({
     <div
       className={cn(
         'group relative -mx-2 flex items-center gap-[11px] rounded-lg px-2 py-[7px] transition-colors duration-200',
-        isSelected
+        isActive
           ? 'bg-surface-hover/50 text-text-primary dark:bg-surface-dark-hover/50 dark:text-text-dark-primary'
           : 'text-text-secondary hover:bg-surface-hover/50 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover/50 dark:hover:text-text-dark-secondary',
       )}
       onMouseEnter={() => onMouseEnter(chat.id)}
       onMouseLeave={onMouseLeave}
     >
-      {isSelected && !isChatStreaming && (
+      {isActive && !isChatStreaming && (
         <div className="absolute bottom-2 left-0 top-2 w-0.5 rounded-full bg-text-primary dark:bg-text-dark-primary" />
       )}
 
@@ -57,8 +61,12 @@ export const SidebarChatItem = memo(function SidebarChatItem({
       )}
 
       <Button
-        onClick={() => {
-          // Always navigate to the chat; additionally toggle sub-threads if present
+        onClick={(e) => {
+          if (e.shiftKey && onOpenInSplit && !isActive) {
+            e.preventDefault();
+            onOpenInSplit(chat.id);
+            return;
+          }
           onSelect(chat.id);
           if (hasSubThreads) {
             onToggleSubThreads(chat.id);
@@ -67,11 +75,11 @@ export const SidebarChatItem = memo(function SidebarChatItem({
         aria-current={isSelected ? 'page' : undefined}
         aria-expanded={hasSubThreads ? isSubThreadsExpanded : undefined}
         variant="unstyled"
-        title={chat.title}
+        title={onOpenInSplit ? `${chat.title} (Shift-click to open in split)` : chat.title}
         className="min-w-0 flex-1 pr-10 text-left text-[13px]"
       >
         <span className="flex min-w-0 items-center gap-1.5">
-          <span className={cn('min-w-0 truncate', isSelected && 'font-medium')}>
+          <span className={cn('min-w-0 truncate', isActive && 'font-medium')}>
             {stripMarkdownTitle(chat.title)}
           </span>
           {/* Sub-thread count pill — only shown when collapsed so the user knows there are expandable threads */}
@@ -87,7 +95,7 @@ export const SidebarChatItem = memo(function SidebarChatItem({
         className={cn(
           'absolute right-2 text-[10px] tabular-nums text-text-quaternary dark:text-text-dark-quaternary',
           'transition-opacity duration-200',
-          isHovered || isSelected || isDropdownOpen ? 'opacity-0' : 'opacity-100',
+          isHovered || isActive || isDropdownOpen ? 'opacity-0' : 'opacity-100',
         )}
       >
         {getRelativeTime(chat.updated_at)}
@@ -101,7 +109,7 @@ export const SidebarChatItem = memo(function SidebarChatItem({
           'absolute right-2 flex-shrink-0 rounded-md p-0.5 transition-all duration-200',
           'text-text-quaternary dark:text-text-dark-quaternary',
           'hover:text-text-primary dark:hover:text-text-dark-primary',
-          isHovered || isSelected || isDropdownOpen
+          isHovered || isActive || isDropdownOpen
             ? 'opacity-100'
             : 'opacity-0 group-hover:opacity-100',
         )}

--- a/frontend/src/components/layout/SubThreadList.tsx
+++ b/frontend/src/components/layout/SubThreadList.tsx
@@ -10,6 +10,7 @@ import type { Chat } from '@/types/chat.types';
 interface SubThreadListProps {
   parentChatId: string;
   selectedChatId: string | null;
+  secondaryChatId?: string | null;
   onSelect: (chatId: string) => void;
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
   streamingChatIdSet: Set<string>;
@@ -18,6 +19,7 @@ interface SubThreadListProps {
 export const SubThreadList = memo(function SubThreadList({
   parentChatId,
   selectedChatId,
+  secondaryChatId,
   onSelect,
   onDropdownClick,
   streamingChatIdSet,
@@ -54,6 +56,7 @@ export const SubThreadList = memo(function SubThreadList({
 
       {subThreads.map((thread) => {
         const isSelected = thread.id === selectedChatId;
+        const isActive = isSelected || thread.id === secondaryChatId;
         const isStreaming = streamingChatIdSet.has(thread.id);
         const isHovered = hoveredId === thread.id;
 
@@ -62,7 +65,7 @@ export const SubThreadList = memo(function SubThreadList({
             key={thread.id}
             className={cn(
               'group relative flex items-center rounded-lg transition-colors duration-200',
-              isSelected
+              isActive
                 ? 'bg-surface-hover/50 dark:bg-surface-dark-hover/50'
                 : 'hover:bg-surface-hover/50 dark:hover:bg-surface-dark-hover/50',
             )}
@@ -71,7 +74,7 @@ export const SubThreadList = memo(function SubThreadList({
           >
             <div className="absolute -left-[22px] top-1/2 h-px w-[18px] bg-border-secondary dark:bg-border-dark-secondary" />
 
-            {isSelected && !isStreaming && (
+            {isActive && !isStreaming && (
               <div className="absolute bottom-1.5 left-0 top-1.5 w-0.5 rounded-full bg-text-primary dark:bg-text-dark-primary" />
             )}
 
@@ -82,7 +85,7 @@ export const SubThreadList = memo(function SubThreadList({
               title={thread.title}
               className={cn(
                 'flex w-full items-center gap-2 px-2 py-1.5 pr-10 transition-colors duration-200',
-                isSelected
+                isActive
                   ? 'text-text-primary dark:text-text-dark-primary'
                   : 'text-text-tertiary hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-secondary',
               )}
@@ -90,7 +93,7 @@ export const SubThreadList = memo(function SubThreadList({
               {isStreaming && (
                 <div className="h-[5px] w-[5px] flex-shrink-0 animate-pulse rounded-full bg-warning-500" />
               )}
-              <span className={cn('truncate text-xs', isSelected && 'font-medium')}>
+              <span className={cn('truncate text-xs', isActive && 'font-medium')}>
                 {stripMarkdownTitle(thread.title)}
               </span>
             </Button>
@@ -99,7 +102,7 @@ export const SubThreadList = memo(function SubThreadList({
               className={cn(
                 'absolute right-2 text-[10px] tabular-nums text-text-quaternary dark:text-text-dark-quaternary',
                 'transition-opacity duration-200',
-                isHovered || isSelected ? 'opacity-0' : 'opacity-100',
+                isHovered || isActive ? 'opacity-0' : 'opacity-100',
               )}
             >
               {getRelativeTime(thread.updated_at)}
@@ -113,7 +116,7 @@ export const SubThreadList = memo(function SubThreadList({
                 'absolute right-2 flex-shrink-0 rounded-md p-0.5 transition-all duration-200',
                 'text-text-quaternary dark:text-text-dark-quaternary',
                 'hover:text-text-primary dark:hover:text-text-dark-primary',
-                isHovered || isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+                isHovered || isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
               )}
               aria-label="Sub-thread options"
             >

--- a/frontend/src/components/sandbox/git/PRReviewView.tsx
+++ b/frontend/src/components/sandbox/git/PRReviewView.tsx
@@ -24,12 +24,14 @@ function PRComments({
   repo,
   number,
   workspaceId,
+  chatId,
   headRef,
 }: {
   owner: string;
   repo: string;
   number: number;
   workspaceId?: string;
+  chatId?: string;
   headRef?: string;
 }) {
   const navigate = useNavigate();
@@ -45,9 +47,13 @@ function PRComments({
 
   const handleFixInThisChat = useCallback(
     (comment: ReviewComment) => {
-      useUIStore.getState().setPendingChatMessage(buildPrompt(comment));
+      if (!chatId) return;
+      useUIStore.getState().setPendingChatMessage({
+        chatId,
+        message: buildPrompt(comment),
+      });
     },
-    [buildPrompt],
+    [buildPrompt, chatId],
   );
 
   const handleFixInNewChat = useCallback(
@@ -276,6 +282,7 @@ export const PRReviewView = memo(function PRReviewView() {
                         repo={repo}
                         number={pr.number}
                         workspaceId={currentChat?.workspace_id}
+                        chatId={currentChat?.id}
                         headRef={pr.head.ref}
                       />
                     </div>

--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -38,7 +38,7 @@ import { useActiveViews } from '@/hooks/useActiveViews';
 import { useChatContext } from '@/hooks/useChatContext';
 import { useGitBranchesQuery, useCheckoutBranchMutation } from '@/hooks/queries/useSandboxQueries';
 import { fuzzySearch } from '@/utils/fuzzySearch';
-import { getLeaves } from '@/utils/mosaicHelpers';
+import { getLeafViewTypes, viewTypeToPrimaryTile } from '@/utils/mosaicHelpers';
 import { traverseFileStructure, getFileName } from '@/utils/file';
 import { HighlightMatch } from '@/components/ui/shared/HighlightMatch';
 import { SearchPanel } from '@/components/editor/file-search/SearchPanel';
@@ -297,9 +297,14 @@ export function executeCommand(
   const ui = useUIStore.getState();
 
   if (cmd.type === 'view') {
-    const leaves = getLeaves(ui.mosaicLayout ?? ui.currentView);
-    if (toggle && leaves.includes(cmd.id)) {
-      ui.removeTileFromMosaic(cmd.id);
+    const layout = ui.mosaicLayout ?? viewTypeToPrimaryTile(ui.currentView);
+    const leafKinds = getLeafViewTypes(layout);
+    if (toggle && leafKinds.includes(cmd.id)) {
+      if (cmd.id === 'agent' && ui.secondaryChatId) {
+        ui.closeSplitChat();
+      } else {
+        ui.removeTileFromMosaic(viewTypeToPrimaryTile(cmd.id));
+      }
     } else {
       ui.handleViewClick(cmd.id, true);
     }

--- a/frontend/src/components/ui/MosaicSplitView.tsx
+++ b/frontend/src/components/ui/MosaicSplitView.tsx
@@ -4,8 +4,13 @@ import { Mosaic, MosaicWindow } from 'react-mosaic-component';
 import { X, SplitSquareHorizontal } from 'lucide-react';
 import { useUIStore } from '@/store/uiStore';
 import { cn } from '@/utils/cn';
-import { mosaicLayoutToLibrary, libraryToMosaicLayout, getLeaves } from '@/utils/mosaicHelpers';
-import type { ViewType, MosaicLayoutNode } from '@/types/ui.types';
+import {
+  mosaicLayoutToLibrary,
+  libraryToMosaicLayout,
+  getLeaves,
+  tileIdToViewType,
+} from '@/utils/mosaicHelpers';
+import type { ViewType, MosaicLayoutNode, MosaicTileId } from '@/types/ui.types';
 
 import 'react-mosaic-component/react-mosaic-component.css';
 import '@/styles/mosaic-theme.css';
@@ -19,16 +24,38 @@ const VIEW_LABELS: Record<ViewType, string> = {
   secrets: 'Secrets',
 };
 
-interface MosaicSplitViewProps {
-  mosaicLayout: MosaicLayoutNode;
-  renderView: (view: ViewType, slot: string) => ReactNode;
+function getTileLabel(
+  tileId: MosaicTileId,
+  agentTitles: Partial<Record<MosaicTileId, string>>,
+): string {
+  return agentTitles[tileId] ?? VIEW_LABELS[tileIdToViewType(tileId)] ?? tileId;
 }
 
-export function MosaicSplitView({ mosaicLayout, renderView }: MosaicSplitViewProps) {
+interface MosaicSplitViewProps {
+  mosaicLayout: MosaicLayoutNode;
+  renderView: (tileId: MosaicTileId, slot: string) => ReactNode;
+  agentTitles?: Partial<Record<MosaicTileId, string>>;
+  onCloseTile?: (tileId: MosaicTileId) => void;
+}
+
+export function MosaicSplitView({
+  mosaicLayout,
+  renderView,
+  agentTitles,
+  onCloseTile,
+}: MosaicSplitViewProps) {
   const handleMosaicChange = useCallback((newNode: Parameters<typeof libraryToMosaicLayout>[0]) => {
     const layout = libraryToMosaicLayout(newNode);
     useUIStore.getState().setMosaicLayout(layout);
   }, []);
+
+  const handleCloseTile = useCallback(
+    (tileId: MosaicTileId) => {
+      if (onCloseTile) onCloseTile(tileId);
+      else useUIStore.getState().removeTileFromMosaic(tileId);
+    },
+    [onCloseTile],
+  );
 
   const leaves = useMemo(() => getLeaves(mosaicLayout), [mosaicLayout]);
   const libraryValue = useMemo(() => mosaicLayoutToLibrary(mosaicLayout), [mosaicLayout]);
@@ -39,53 +66,56 @@ export function MosaicSplitView({ mosaicLayout, renderView }: MosaicSplitViewPro
         value={libraryValue}
         onChange={handleMosaicChange}
         className=""
-        renderTile={(id, path) => (
-          <MosaicWindow<string>
-            path={path}
-            title={VIEW_LABELS[id as ViewType] ?? id}
-            toolbarControls={
-              <div className="flex items-center gap-0.5 pr-0.5">
-                {leaves.length > 1 && (
-                  <Button
-                    variant="unstyled"
-                    onClick={() => useUIStore.getState().removeTileFromMosaic(id as ViewType)}
-                    className={cn(
-                      'flex items-center justify-center',
-                      'h-5 w-5 rounded-md',
-                      'text-text-tertiary dark:text-text-dark-tertiary',
-                      'hover:text-text-primary dark:hover:text-text-dark-primary',
-                      'transition-colors duration-200',
-                    )}
-                    title="Close tile"
-                  >
-                    <X className="h-3 w-3" />
-                  </Button>
-                )}
-              </div>
-            }
-            renderToolbar={(props) => (
-              <div
-                className={cn(
-                  'flex h-7 items-center justify-between px-2',
-                  'bg-surface-secondary dark:bg-surface-dark-secondary',
-                  'border-b border-border/50 dark:border-border-dark/50',
-                )}
-              >
-                <div className="flex items-center gap-1.5">
-                  <SplitSquareHorizontal className="h-3 w-3 text-text-quaternary dark:text-text-dark-quaternary" />
-                  <span className="text-2xs font-medium text-text-secondary dark:text-text-dark-secondary">
-                    {props.title}
-                  </span>
+        renderTile={(id, path) => {
+          const tileId = id as MosaicTileId;
+          return (
+            <MosaicWindow<string>
+              path={path}
+              title={getTileLabel(tileId, agentTitles ?? {})}
+              toolbarControls={
+                <div className="flex items-center gap-0.5 pr-0.5">
+                  {leaves.length > 1 && (
+                    <Button
+                      variant="unstyled"
+                      onClick={() => handleCloseTile(tileId)}
+                      className={cn(
+                        'flex items-center justify-center',
+                        'h-5 w-5 rounded-md',
+                        'text-text-tertiary dark:text-text-dark-tertiary',
+                        'hover:text-text-primary dark:hover:text-text-dark-primary',
+                        'transition-colors duration-200',
+                      )}
+                      title="Close tile"
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  )}
                 </div>
-                <div className="flex items-center">{props.toolbarControls}</div>
+              }
+              renderToolbar={(props) => (
+                <div
+                  className={cn(
+                    'flex h-7 items-center justify-between px-2',
+                    'bg-surface-secondary dark:bg-surface-dark-secondary',
+                    'border-b border-border/50 dark:border-border-dark/50',
+                  )}
+                >
+                  <div className="flex items-center gap-1.5">
+                    <SplitSquareHorizontal className="h-3 w-3 text-text-quaternary dark:text-text-dark-quaternary" />
+                    <span className="text-2xs font-medium text-text-secondary dark:text-text-dark-secondary">
+                      {props.title}
+                    </span>
+                  </div>
+                  <div className="flex items-center">{props.toolbarControls}</div>
+                </div>
+              )}
+            >
+              <div className="flex h-full w-full overflow-hidden">
+                {renderView(tileId, `tile-${tileId}`)}
               </div>
-            )}
-          >
-            <div className="flex h-full w-full overflow-hidden">
-              {renderView(id as ViewType, `tile-${id}`)}
-            </div>
-          </MosaicWindow>
-        )}
+            </MosaicWindow>
+          );
+        }}
         resize={{ minimumPaneSizePercentage: 15 }}
       />
     </div>

--- a/frontend/src/components/ui/SplitViewContainer.tsx
+++ b/frontend/src/components/ui/SplitViewContainer.tsx
@@ -1,20 +1,24 @@
 import { memo, lazy, Suspense, ReactNode } from 'react';
 import { useUIStore } from '@/store/uiStore';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { isMosaicSplitNode } from '@/utils/mosaicHelpers';
+import { isMosaicSplitNode, viewTypeToPrimaryTile } from '@/utils/mosaicHelpers';
 import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback';
-import type { ViewType } from '@/types/ui.types';
+import type { MosaicTileId } from '@/types/ui.types';
 
 const MosaicSplitView = lazy(() =>
   import('@/components/ui/MosaicSplitView').then((m) => ({ default: m.MosaicSplitView })),
 );
 
 interface SplitViewContainerProps {
-  renderView: (view: ViewType, slot: string) => ReactNode;
+  renderView: (tileId: MosaicTileId, slot: string) => ReactNode;
+  agentTitles?: Partial<Record<MosaicTileId, string>>;
+  onCloseTile?: (tileId: MosaicTileId) => void;
 }
 
 export const SplitViewContainer = memo(function SplitViewContainer({
   renderView,
+  agentTitles,
+  onCloseTile,
 }: SplitViewContainerProps) {
   const currentView = useUIStore((state) => state.currentView);
   const mosaicLayout = useUIStore((state) => state.mosaicLayout);
@@ -23,13 +27,19 @@ export const SplitViewContainer = memo(function SplitViewContainer({
   const isSingleView = isMobile || !mosaicLayout || !isMosaicSplitNode(mosaicLayout);
 
   if (isSingleView) {
-    const view: ViewType = typeof mosaicLayout === 'string' ? mosaicLayout : currentView;
-    return <div className="flex h-full flex-1 overflow-hidden">{renderView(view, 'single')}</div>;
+    const tileId: MosaicTileId =
+      typeof mosaicLayout === 'string' ? mosaicLayout : viewTypeToPrimaryTile(currentView);
+    return <div className="flex h-full flex-1 overflow-hidden">{renderView(tileId, 'single')}</div>;
   }
 
   return (
     <Suspense fallback={viewLoadingFallback}>
-      <MosaicSplitView mosaicLayout={mosaicLayout} renderView={renderView} />
+      <MosaicSplitView
+        mosaicLayout={mosaicLayout}
+        renderView={renderView}
+        agentTitles={agentTitles}
+        onCloseTile={onCloseTile}
+      />
     </Suspense>
   );
 });

--- a/frontend/src/contexts/ChatContext.tsx
+++ b/frontend/src/contexts/ChatContext.tsx
@@ -13,6 +13,7 @@ const EMPTY_PERSONAS: Persona[] = [];
 interface ChatProviderProps {
   chatId?: string;
   sandboxId?: string;
+  worktreeCwd?: string;
   parentChatId?: string;
   fileStructure?: FileStructure[] | null;
   customSkills?: CustomSkill[] | null;
@@ -24,6 +25,7 @@ interface ChatProviderProps {
 export function ChatProvider({
   chatId,
   sandboxId,
+  worktreeCwd,
   parentChatId,
   fileStructure,
   customSkills,
@@ -40,6 +42,7 @@ export function ChatProvider({
     () => ({
       chatId,
       sandboxId,
+      worktreeCwd,
       parentChatId,
       fileStructure: resolvedFileStructure,
       customSkills: resolvedCustomSkills,
@@ -49,6 +52,7 @@ export function ChatProvider({
     [
       chatId,
       sandboxId,
+      worktreeCwd,
       parentChatId,
       resolvedFileStructure,
       resolvedCustomSkills,

--- a/frontend/src/contexts/ChatContextDefinition.ts
+++ b/frontend/src/contexts/ChatContextDefinition.ts
@@ -7,6 +7,7 @@ import type { AgentKind } from '@/types/chat.types';
 interface ChatContextValue {
   chatId: string | undefined;
   sandboxId: string | undefined;
+  worktreeCwd: string | undefined;
   parentChatId: string | undefined;
   fileStructure: FileStructure[];
   customSkills: CustomSkill[];

--- a/frontend/src/hooks/useActiveViews.ts
+++ b/frontend/src/hooks/useActiveViews.ts
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import { useUIStore } from '@/store/uiStore';
-import { getLeaves } from '@/utils/mosaicHelpers';
+import { getLeafViewTypes, tileIdToViewType } from '@/utils/mosaicHelpers';
 import type { ViewType } from '@/types/ui.types';
 
 function arraysEqual(a: ViewType[], b: ViewType[]): boolean {
@@ -11,9 +11,10 @@ function arraysEqual(a: ViewType[], b: ViewType[]): boolean {
   return true;
 }
 
-// Derives the list of visible view panes from the mosaic layout. Uses a ref
-// to return a referentially stable array when the leaf set hasn't changed,
-// preventing downstream re-renders from Zustand selector identity changes.
+// Derives the deduped list of visible view *kinds* (ViewType) from the mosaic
+// layout. Two agent panes collapse to a single 'agent' entry here — consumers
+// that need per-tile awareness should read mosaicLayout directly. Uses a ref
+// to return a referentially stable array when the set hasn't changed.
 export function useActiveViews(): ViewType[] {
   const prevRef = useRef<ViewType[]>([]);
 
@@ -23,9 +24,9 @@ export function useActiveViews(): ViewType[] {
     if (!mosaicLayout) {
       next = [currentView];
     } else if (typeof mosaicLayout === 'string') {
-      next = [mosaicLayout as ViewType];
+      next = [tileIdToViewType(mosaicLayout)];
     } else {
-      next = getLeaves(mosaicLayout);
+      next = getLeafViewTypes(mosaicLayout);
     }
     if (arraysEqual(prevRef.current, next)) return prevRef.current;
     prevRef.current = next;

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -9,12 +9,15 @@ import { CommandMenu } from '@/components/ui/CommandMenu';
 import { useCommandMenu } from '@/hooks/useCommandMenu';
 import { useActiveViews } from '@/hooks/useActiveViews';
 import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback';
-import type { ViewType } from '@/types/ui.types';
+import type { MosaicTileId, ViewType } from '@/types/ui.types';
 import { Chat as ChatComponent } from '@/components/chat/chat-window/Chat';
 import { ChatSessionOrchestrator } from '@/components/chat/chat-window/ChatSessionOrchestrator';
+import { AgentPane } from '@/components/chat/chat-window/AgentPane';
 import { useEditorState } from '@/hooks/useEditorState';
 import { usePendingFileOpen } from '@/hooks/usePendingFileOpen';
 import { useChatData } from '@/hooks/useChatData';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { useChatQuery } from '@/hooks/queries/useChatQueries';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
 import {
   useWorkspacesQuery,
@@ -63,8 +66,33 @@ export function ChatPage() {
   const createBranchDialogOpen = useUIStore((s) => s.createBranchDialogOpen);
 
   const activeViews = useActiveViews();
+  const secondaryChatId = useUIStore((s) => s.secondaryChatId);
+  const isMobile = useIsMobile();
 
   const { currentChat, fetchedMessages, hasFetchedMessages, messagesQuery } = useChatData(chatId);
+
+  // Shares the chat-query cache with AgentPane. Used as error guard
+  // (a deleted secondary chat collapses the split) and tile-label source.
+  const secondaryQuery = useChatQuery(secondaryChatId ?? undefined, {
+    enabled: !!secondaryChatId,
+  });
+  const secondaryQueryIsError = secondaryQuery.isError;
+  useEffect(() => {
+    if (secondaryChatId && secondaryQueryIsError) {
+      useUIStore.getState().closeSplitChat();
+    }
+  }, [secondaryChatId, secondaryQueryIsError]);
+
+  // mosaicLayout isn't persisted; rebuild it on refresh and when returning to desktop.
+  useEffect(() => {
+    if (secondaryChatId === chatId) {
+      useUIStore.getState().closeSplitChat();
+      return;
+    }
+    if (!isMobile && secondaryChatId) {
+      useUIStore.getState().openChatInSplit(secondaryChatId);
+    }
+  }, [chatId, isMobile, secondaryChatId]);
 
   const { fileStructure, isFileMetadataLoading, refetchFilesMetadata } = useSandboxFiles(
     currentChat,
@@ -117,7 +145,13 @@ export function ChatPage() {
   if (prevChatIdForResetRef.current !== chatId) {
     prevChatIdForResetRef.current = chatId;
     setSelectedFile(null);
-    useUIStore.getState().setCurrentView('agent');
+    const ui = useUIStore.getState();
+    if (ui.secondaryChatId === chatId) {
+      ui.closeSplitChat();
+    }
+    if (!ui.secondaryChatId) {
+      ui.setCurrentView('agent');
+    }
     useUIStore.setState({
       pendingFilePath: null,
       pendingFileJump: null,
@@ -168,10 +202,14 @@ export function ChatPage() {
   useLayoutSidebar(sidebarContent);
 
   const renderNonTerminalView = useCallback(
-    (view: ViewType): ReactNode => {
+    (tileId: MosaicTileId): ReactNode => {
+      if (tileId === 'agent:primary') return <ChatComponent />;
+      if (tileId === 'agent:secondary') {
+        if (!secondaryChatId) return null;
+        return <AgentPane chatId={secondaryChatId} />;
+      }
+      const view: ViewType = tileId;
       switch (view) {
-        case 'agent':
-          return <ChatComponent />;
         case 'editor':
           return (
             <Suspense fallback={viewLoadingFallback}>
@@ -219,12 +257,13 @@ export function ChatPage() {
       handleRefresh,
       isRefreshing,
       worktreeCwd,
+      secondaryChatId,
     ],
   );
 
   const renderView = useCallback(
-    (view: ViewType, slot: string): ReactNode => {
-      const isTerminal = view === 'terminal';
+    (tileId: MosaicTileId, slot: string): ReactNode => {
+      const isTerminal = tileId === 'terminal';
       return (
         <div className="relative flex h-full w-full">
           <div className={isTerminal ? 'flex h-full w-full' : 'hidden'}>
@@ -238,7 +277,7 @@ export function ChatPage() {
             </Suspense>
           </div>
           <div className={isTerminal ? 'hidden' : 'flex h-full w-full'}>
-            {renderNonTerminalView(view)}
+            {renderNonTerminalView(tileId)}
           </div>
         </div>
       );
@@ -246,12 +285,42 @@ export function ChatPage() {
     [currentChat, renderNonTerminalView],
   );
 
+  const handleCloseTile = useCallback(
+    (tileId: MosaicTileId) => {
+      const ui = useUIStore.getState();
+      if (tileId === 'agent:secondary') {
+        ui.closeSplitChat();
+        return;
+      }
+      if (tileId === 'agent:primary' && ui.secondaryChatId && chatId) {
+        const newPrimary = ui.swapChatPanes(chatId);
+        if (newPrimary) {
+          navigate(`/chat/${newPrimary}`);
+          ui.closeSplitChat();
+          return;
+        }
+      }
+      ui.removeTileFromMosaic(tileId);
+    },
+    [chatId, navigate],
+  );
+
+  const agentTitles = useMemo<Partial<Record<MosaicTileId, string>>>(() => {
+    const titles: Partial<Record<MosaicTileId, string>> = {};
+    if (currentChat?.title) titles['agent:primary'] = currentChat.title;
+    if (secondaryChatId && secondaryQuery.data?.title) {
+      titles['agent:secondary'] = secondaryQuery.data.title;
+    }
+    return titles;
+  }, [currentChat?.title, secondaryChatId, secondaryQuery.data?.title]);
+
   if (!chatId) return <Navigate to="/" />;
 
   return (
     <ChatProvider
       chatId={chatId}
       sandboxId={currentChat?.sandbox_id}
+      worktreeCwd={worktreeCwd}
       parentChatId={currentChat?.parent_chat_id ?? undefined}
       fileStructure={fileStructure}
       customSkills={workspaceResources?.skills}
@@ -268,7 +337,11 @@ export function ChatPage() {
       >
         <div className="relative flex h-full">
           <div className="flex h-full flex-1 overflow-hidden bg-surface text-text-primary dark:bg-surface-dark dark:text-text-dark-primary">
-            <SplitViewContainer renderView={renderView} />
+            <SplitViewContainer
+              renderView={renderView}
+              agentTitles={agentTitles}
+              onCloseTile={handleCloseTile}
+            />
           </div>
           <CommandMenu />
           {subThreadDialogOpen && currentChat && !currentChat.parent_chat_id && (

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -38,7 +38,8 @@ import { useCommandMenu } from '@/hooks/useCommandMenu';
 import { useEditorState } from '@/hooks/useEditorState';
 import { usePendingFileOpen } from '@/hooks/usePendingFileOpen';
 import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback';
-import type { ViewType } from '@/types/ui.types';
+import { PENDING_NEW_CHAT_KEY, type MosaicTileId } from '@/types/ui.types';
+import { tileIdToViewType } from '@/utils/mosaicHelpers';
 
 const Editor = lazy(() =>
   import('@/components/editor/editor-core/Editor').then((m) => ({ default: m.Editor })),
@@ -57,7 +58,9 @@ export function LandingPage() {
   const navigate = useNavigate();
   const location = useLocation();
   useCommandMenu();
-  const attachedFiles = useChatStore((state) => state.attachedFiles);
+  const attachedFiles = useChatStore(
+    (state) => state.attachedFilesByChat[PENDING_NEW_CHAT_KEY] ?? null,
+  );
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { selectedModelId, selectModel } = useModelSelection({
     enabled: isAuthenticated,
@@ -144,7 +147,7 @@ export function LandingPage() {
   });
 
   const handleFileAttach = useCallback((files: File[]) => {
-    useChatStore.getState().setAttachedFiles(files);
+    useChatStore.getState().setAttachedFilesForChat(PENDING_NEW_CHAT_KEY, files);
   }, []);
 
   const handleNewChat = useCallback(
@@ -179,6 +182,7 @@ export function LandingPage() {
         useModelStore.getState().selectModel(newChat.id, selectedModelId);
         useChatSettingsStore.getState().initChatFromDefaults(newChat.id);
         setMessage('');
+        useChatStore.getState().promoteAttachedFiles(PENDING_NEW_CHAT_KEY, newChat.id);
         navigate(`/chat/${newChat.id}`, { state: { initialPrompt: trimmedPrompt } });
       } catch (error) {
         toast.error(error instanceof Error ? error.message : 'Failed to create chat');
@@ -215,8 +219,8 @@ export function LandingPage() {
   useLayoutSidebar(sidebarContent);
 
   const renderView = useCallback(
-    (view: ViewType): ReactNode => {
-      switch (view) {
+    (tileId: MosaicTileId): ReactNode => {
+      switch (tileIdToViewType(tileId)) {
         case 'agent':
           return (
             <div className="flex h-full w-full items-center justify-center px-4 pb-10">

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -2,12 +2,40 @@ import { create } from 'zustand';
 import type { Chat } from '@/types/chat.types';
 import type { UIActions, UIState } from '@/types/ui.types';
 
-type ChatStoreType = Pick<UIState, 'currentChat' | 'attachedFiles'> &
-  Pick<UIActions, 'setCurrentChat' | 'setAttachedFiles'>;
+type ChatStoreType = Pick<UIState, 'currentChat' | 'attachedFilesByChat'> &
+  Pick<
+    UIActions,
+    | 'setCurrentChat'
+    | 'setAttachedFilesForChat'
+    | 'clearAttachedFilesForChat'
+    | 'promoteAttachedFiles'
+  >;
 
+// Per-chat one-shot attachment slot. Files attached pre-send (landing page or
+// the "open in split" affordance) live here keyed by chatId; the orchestrator
+// consumes and clears its slot after the first message ships.
 export const useChatStore = create<ChatStoreType>((set) => ({
   currentChat: null,
-  attachedFiles: [],
+  attachedFilesByChat: {},
   setCurrentChat: (chat: Chat | null) => set({ currentChat: chat }),
-  setAttachedFiles: (files) => set({ attachedFiles: files }),
+  setAttachedFilesForChat: (chatId, files) =>
+    set((state) => {
+      if (state.attachedFilesByChat[chatId] === files) return state;
+      return { attachedFilesByChat: { ...state.attachedFilesByChat, [chatId]: files } };
+    }),
+  clearAttachedFilesForChat: (chatId) =>
+    set((state) => {
+      if (!(chatId in state.attachedFilesByChat)) return state;
+      const next = { ...state.attachedFilesByChat };
+      delete next[chatId];
+      return { attachedFilesByChat: next };
+    }),
+  promoteAttachedFiles: (fromChatId, toChatId) =>
+    set((state) => {
+      const files = state.attachedFilesByChat[fromChatId];
+      if (!files) return state;
+      const next = { ...state.attachedFilesByChat, [toChatId]: files };
+      delete next[fromChatId];
+      return { attachedFilesByChat: next };
+    }),
 }));

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -7,9 +7,16 @@ import type {
   SplitViewState,
   SplitViewActions,
   ViewType,
+  MosaicTileId,
 } from '@/types/ui.types';
 import { MOBILE_BREAKPOINT } from '@/config/constants';
-import { getLeaves, isMosaicSplitNode, removeTileFromLayout } from '@/utils/mosaicHelpers';
+import {
+  getLeaves,
+  isMosaicSplitNode,
+  removeTileFromLayout,
+  tileIdToViewType,
+  viewTypeToPrimaryTile,
+} from '@/utils/mosaicHelpers';
 
 type UIStoreState = ThemeState &
   Pick<UIState, 'sidebarOpen'> &
@@ -35,14 +42,17 @@ type UIStoreState = ThemeState &
     pendingDiffFile: string | null;
     openInDiffView: (path: string) => void;
     consumeDiffFileJump: () => void;
-    pendingChatMessage: string | null;
-    setPendingChatMessage: (message: string | null) => void;
+    pendingChatMessage: { chatId: string; message: string } | null;
+    setPendingChatMessage: (payload: { chatId: string; message: string } | null) => void;
   };
 
 const getInitialSidebarState = (): boolean => {
   if (typeof window === 'undefined') return false;
   return window.innerWidth >= MOBILE_BREAKPOINT;
 };
+
+const isDesktop = (): boolean =>
+  typeof window !== 'undefined' && window.innerWidth >= MOBILE_BREAKPOINT;
 
 // Mobile switches the sole view; desktop appends a tile to the mosaic
 // unless the view is already present.
@@ -51,22 +61,23 @@ function ensureViewVisible(
   get: () => UIStoreState,
   view: ViewType,
 ): void {
-  const isMobile = typeof window !== 'undefined' && window.innerWidth < MOBILE_BREAKPOINT;
-  if (isMobile) {
-    set({ currentView: view, mosaicLayout: view });
+  const tileId = viewTypeToPrimaryTile(view);
+  if (!isDesktop()) {
+    set({ currentView: view, mosaicLayout: tileId });
     return;
   }
   const state = get();
   const layout = state.mosaicLayout;
   if (layout && isMosaicSplitNode(layout)) {
-    if (!getLeaves(layout).includes(view)) {
-      set({ mosaicLayout: { direction: 'row', first: layout, second: view } });
+    if (!getLeaves(layout).includes(tileId)) {
+      set({ mosaicLayout: { direction: 'row', first: layout, second: tileId } });
     }
     return;
   }
-  const currentView = (layout ?? state.currentView) as ViewType;
-  if (currentView !== view) {
-    set({ mosaicLayout: { direction: 'row', first: currentView, second: view } });
+  const currentTile: MosaicTileId =
+    typeof layout === 'string' ? layout : viewTypeToPrimaryTile(state.currentView);
+  if (currentTile !== tileId) {
+    set({ mosaicLayout: { direction: 'row', first: currentTile, second: tileId } });
   }
 }
 
@@ -96,7 +107,7 @@ export const useUIStore = create<UIStoreState>()(
       setCreateCommitDialogOpen: (open) => set({ createCommitDialogOpen: open }),
 
       pendingChatMessage: null,
-      setPendingChatMessage: (message) => set({ pendingChatMessage: message }),
+      setPendingChatMessage: (payload) => set({ pendingChatMessage: payload }),
 
       pendingFilePath: null,
       pendingFileJump: null,
@@ -119,16 +130,21 @@ export const useUIStore = create<UIStoreState>()(
       currentView: 'agent',
       splitDirection: 'row',
       mosaicLayout: null,
+      secondaryChatId: null,
 
       setCurrentView: (view) =>
         set({
           currentView: view,
-          mosaicLayout: view,
+          mosaicLayout: viewTypeToPrimaryTile(view),
+          secondaryChatId: null,
         }),
 
       exitSplitMode: () => {
         const state = get();
-        set({ mosaicLayout: state.currentView });
+        set({
+          mosaicLayout: viewTypeToPrimaryTile(state.currentView),
+          secondaryChatId: null,
+        });
       },
 
       setSplitDirection: (direction) => set({ splitDirection: direction }),
@@ -139,46 +155,60 @@ export const useUIStore = create<UIStoreState>()(
           return;
         }
         if (typeof layout === 'string') {
+          const leaf: MosaicTileId = layout === 'agent:secondary' ? 'agent:primary' : layout;
           set({
-            mosaicLayout: layout,
-            currentView: layout as ViewType,
+            mosaicLayout: leaf,
+            currentView: tileIdToViewType(leaf),
+            ...(layout === 'agent:secondary' ? { secondaryChatId: null } : {}),
           });
         } else {
           const leaves = getLeaves(layout);
           set({
             mosaicLayout: layout,
-            currentView: leaves[0] as ViewType,
+            currentView: tileIdToViewType(leaves[0]),
+            ...(leaves.includes('agent:secondary') ? {} : { secondaryChatId: null }),
           });
         }
       },
 
       addTileToMosaic: (view, direction) => {
+        const tileId = viewTypeToPrimaryTile(view);
         const state = get();
-        const currentLayout = state.mosaicLayout ?? state.currentView;
+        const currentLayout = state.mosaicLayout ?? viewTypeToPrimaryTile(state.currentView);
 
-        const leaves =
+        const leaves: MosaicTileId[] =
           typeof currentLayout === 'string' ? [currentLayout] : getLeaves(currentLayout);
-        if (leaves.includes(view)) return;
+        if (leaves.includes(tileId)) return;
 
         set({
           mosaicLayout: {
             direction,
             first: currentLayout,
-            second: view,
+            second: tileId,
           },
-          currentView: leaves[0] as ViewType,
         });
       },
 
-      removeTileFromMosaic: (view) => {
+      removeTileFromMosaic: (tileId) => {
         const layout = get().mosaicLayout;
         if (!layout || typeof layout === 'string') return;
-        const remaining = getLeaves(layout).filter((v) => v !== view);
+        const leaves = getLeaves(layout);
+        if (!leaves.includes(tileId)) return;
+        const remaining = leaves.filter((v) => v !== tileId);
         if (remaining.length === 0) return;
         if (remaining.length === 1) {
-          set({ currentView: remaining[0], mosaicLayout: remaining[0] });
+          // A lone 'agent:secondary' is hoisted to 'agent:primary' so the
+          // secondary slot is never occupied without a primary.
+          const collapseTo: MosaicTileId =
+            remaining[0] === 'agent:secondary' ? 'agent:primary' : remaining[0];
+          const hadSecondary = leaves.includes('agent:secondary');
+          set({
+            currentView: tileIdToViewType(collapseTo),
+            mosaicLayout: collapseTo,
+            ...(hadSecondary ? { secondaryChatId: null } : {}),
+          });
         } else {
-          const newLayout = removeTileFromLayout(layout, view);
+          const newLayout = removeTileFromLayout(layout, tileId);
           if (newLayout) get().setMosaicLayout(newLayout);
         }
       },
@@ -186,38 +216,77 @@ export const useUIStore = create<UIStoreState>()(
       // Shift-click adds the view as a new tile in the mosaic (split mode);
       // regular click switches to it as the sole view.
       handleViewClick: (view, isShiftClick) => {
-        if (
-          isShiftClick &&
-          typeof window !== 'undefined' &&
-          window.innerWidth >= MOBILE_BREAKPOINT
-        ) {
+        const tileId = viewTypeToPrimaryTile(view);
+        if (isShiftClick && isDesktop()) {
           get().addTileToMosaic(view, get().splitDirection);
         } else {
           set({
             currentView: view,
-            mosaicLayout: view,
+            mosaicLayout: tileId,
+            secondaryChatId: null,
           });
         }
+      },
+
+      openChatInSplit: (chatId) => {
+        const state = get();
+        if (!isDesktop()) {
+          if (state.secondaryChatId === chatId) return;
+          set({ secondaryChatId: chatId });
+          return;
+        }
+        const nextLayout = buildSplitChatLayout(state.mosaicLayout);
+        if (state.secondaryChatId === chatId && !nextLayout) return;
+        set({
+          secondaryChatId: chatId,
+          ...(nextLayout ? { mosaicLayout: nextLayout } : {}),
+        });
+      },
+
+      closeSplitChat: () => {
+        const state = get();
+        const layout = state.mosaicLayout;
+        if (layout && isMosaicSplitNode(layout)) {
+          const newLayout = removeTileFromLayout(layout, 'agent:secondary');
+          set({
+            secondaryChatId: null,
+            mosaicLayout: newLayout ?? 'agent:primary',
+          });
+        } else if (state.secondaryChatId !== null) {
+          set({ secondaryChatId: null });
+        }
+      },
+
+      swapChatPanes: (currentPrimaryChatId) => {
+        const state = get();
+        const newPrimary = state.secondaryChatId;
+        if (!newPrimary) return null;
+        set({ secondaryChatId: currentPrimaryChatId });
+        return newPrimary;
       },
     }),
     {
       name: 'ui-storage',
-      version: 6,
+      version: 7,
       partialize: (state) => ({
         theme: state.theme,
         currentView: state.currentView,
         splitDirection: state.splitDirection,
         sidebarOpen: state.sidebarOpen,
+        secondaryChatId: state.secondaryChatId,
       }),
-      migrate: (persisted) => {
+      migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
         delete state.isSplitMode;
         delete state.secondaryView;
         delete state.permissionMode;
         delete state.thinkingMode;
+        // v7: mosaic leaves changed from ViewType to MosaicTileId. We don't
+        // persist mosaicLayout anyway, so just drop any stale shape.
         delete state.mosaicLayout;
         if (state.splitDirection === 'horizontal') state.splitDirection = 'row';
         if (state.splitDirection === 'vertical') state.splitDirection = 'column';
+        if (version < 7) state.secondaryChatId = null;
         return state;
       },
       merge: (persisted, current) => ({
@@ -227,3 +296,30 @@ export const useUIStore = create<UIStoreState>()(
     },
   ),
 );
+
+// Returns a layout that includes both agent tiles, or null if `layout` already does.
+function buildSplitChatLayout(
+  layout: SplitViewState['mosaicLayout'],
+): SplitViewState['mosaicLayout'] | null {
+  if (!layout) {
+    return { direction: 'row', first: 'agent:primary', second: 'agent:secondary' };
+  }
+  if (typeof layout === 'string') {
+    if (layout === 'agent:primary') {
+      return { direction: 'row', first: 'agent:primary', second: 'agent:secondary' };
+    }
+    return {
+      direction: 'row',
+      first: 'agent:primary',
+      second: { direction: 'row', first: layout, second: 'agent:secondary' },
+    };
+  }
+  const leaves = getLeaves(layout);
+  const needsPrimary = !leaves.includes('agent:primary');
+  const needsSecondary = !leaves.includes('agent:secondary');
+  if (!needsPrimary && !needsSecondary) return null;
+  let next = layout;
+  if (needsPrimary) next = { direction: 'row', first: 'agent:primary', second: next };
+  if (needsSecondary) next = { direction: 'row', first: next, second: 'agent:secondary' };
+  return next;
+}

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -30,6 +30,13 @@ export interface ModelSelectionState {
 
 export type ViewType = 'agent' | 'diff' | 'editor' | 'prReview' | 'terminal' | 'secrets';
 
+// Mosaic leaves used to be ViewType strings, but to render two `agent` panes
+// simultaneously (split chat view) the agent slot needs to be disambiguated.
+// Non-agent tile ids are identical to their ViewType.
+export type AgentTileId = 'agent:primary' | 'agent:secondary';
+export type NonAgentTileId = Exclude<ViewType, 'agent'>;
+export type MosaicTileId = AgentTileId | NonAgentTileId;
+
 export type MosaicDirection = 'row' | 'column';
 
 export interface MosaicSplitNode {
@@ -39,12 +46,14 @@ export interface MosaicSplitNode {
   splitPercentages?: number[];
 }
 
-export type MosaicLayoutNode = MosaicSplitNode | ViewType;
+export type MosaicLayoutNode = MosaicSplitNode | MosaicTileId;
 
 export interface SplitViewState {
   currentView: ViewType;
   splitDirection: MosaicDirection;
   mosaicLayout: MosaicLayoutNode | null;
+  // Secondary chat for split-chat view. Primary chat is always the route param.
+  secondaryChatId: string | null;
 }
 
 export interface SplitViewActions {
@@ -54,20 +63,32 @@ export interface SplitViewActions {
   setSplitDirection: (direction: MosaicDirection) => void;
   setMosaicLayout: (layout: MosaicLayoutNode | null) => void;
   addTileToMosaic: (view: ViewType, direction: MosaicDirection) => void;
-  removeTileFromMosaic: (view: ViewType) => void;
+  removeTileFromMosaic: (tileId: MosaicTileId) => void;
+  openChatInSplit: (chatId: string) => void;
+  closeSplitChat: () => void;
+  // Returns the chatId that should become the new route primary (caller navigates).
+  swapChatPanes: (currentPrimaryChatId: string) => string | null;
 }
 
 export interface UIState {
   currentChat: Chat | null;
-  attachedFiles: File[];
+  // Per-chat one-shot attachments. Cleared after the first message for that
+  // chat ships. The PENDING_NEW_CHAT_KEY sentinel holds files attached before
+  // the chat id exists; landing page promotes them once the chat is created.
+  attachedFilesByChat: Record<string, File[]>;
   sidebarOpen: boolean;
 }
 
 export interface UIActions {
-  setAttachedFiles: (files: File[]) => void;
+  setAttachedFilesForChat: (chatId: string, files: File[]) => void;
+  clearAttachedFilesForChat: (chatId: string) => void;
+  promoteAttachedFiles: (fromChatId: string, toChatId: string) => void;
   setCurrentChat: (chat: Chat | null) => void;
   setSidebarOpen: (isOpen: boolean) => void;
 }
+
+// Prefixed with __ to guarantee no collision with real chat ids (UUIDs).
+export const PENDING_NEW_CHAT_KEY = '__pending_new__';
 
 export interface SlashCommand {
   value: string;

--- a/frontend/src/utils/mosaicHelpers.ts
+++ b/frontend/src/utils/mosaicHelpers.ts
@@ -1,13 +1,32 @@
-import type { MosaicLayoutNode, MosaicSplitNode, ViewType } from '@/types/ui.types';
+import type { MosaicLayoutNode, MosaicSplitNode, MosaicTileId, ViewType } from '@/types/ui.types';
 import type { MosaicNode } from 'react-mosaic-component';
 
 export function isMosaicSplitNode(node: MosaicLayoutNode): node is MosaicSplitNode {
   return typeof node === 'object' && 'direction' in node;
 }
 
-export function getLeaves(node: MosaicLayoutNode): ViewType[] {
-  if (typeof node === 'string') return [node as ViewType];
+export function getLeaves(node: MosaicLayoutNode): MosaicTileId[] {
+  if (typeof node === 'string') return [node as MosaicTileId];
   return [...getLeaves(node.first), ...getLeaves(node.second)];
+}
+
+// Maps a stored mosaic tile id back to its ViewType for label/render lookups.
+export function tileIdToViewType(tileId: MosaicTileId): ViewType {
+  if (tileId === 'agent:primary' || tileId === 'agent:secondary') return 'agent';
+  return tileId;
+}
+
+// Maps a ViewType to its canonical primary tile id. The agent slot is special:
+// "the agent view" always means agent:primary; agent:secondary is only created
+// by the split-chat affordance.
+export function viewTypeToPrimaryTile(view: ViewType): MosaicTileId {
+  return view === 'agent' ? 'agent:primary' : view;
+}
+
+// Returns the leaves' view types, deduped, preserving order. Two agent panes
+// (primary + secondary) collapse to a single 'agent' entry.
+export function getLeafViewTypes(node: MosaicLayoutNode): ViewType[] {
+  return Array.from(new Set(getLeaves(node).map(tileIdToViewType)));
 }
 
 // Converts our internal binary-tree layout to the react-mosaic n-ary format.
@@ -58,8 +77,8 @@ function flattenSameDirection(
 // active tab since our model doesn't support tabs).
 export function libraryToMosaicLayout(node: MosaicNode<string> | null): MosaicLayoutNode | null {
   if (node === null) return null;
-  if (typeof node === 'string') return node as ViewType;
-  if (typeof node === 'number') return String(node) as ViewType;
+  if (typeof node === 'string') return node as MosaicTileId;
+  if (typeof node === 'number') return String(node) as MosaicTileId;
 
   // Handle tabs node: flatten to the active tab (our internal model doesn't support tabs)
   if ('type' in node && node.type === 'tabs' && 'tabs' in node) {
@@ -129,7 +148,7 @@ export function libraryToMosaicLayout(node: MosaicNode<string> | null): MosaicLa
 
 export function removeTileFromLayout(
   layout: MosaicLayoutNode,
-  tileToRemove: ViewType,
+  tileToRemove: MosaicTileId,
 ): MosaicLayoutNode | null {
   if (typeof layout === 'string') {
     return layout === tileToRemove ? null : layout;

--- a/plans/completed/split_chat_view.md
+++ b/plans/completed/split_chat_view.md
@@ -1,0 +1,118 @@
+# Split chat view — view two chats side-by-side
+
+**Status:** completed
+**Owner:** mngback
+**Created:** 2026-05-17
+**Last updated:** 2026-05-17
+**Related:** (no issue yet — feature request from product)
+
+---
+
+## Context
+
+Today, opening a chat navigates to `/chat/:chatId` and `ChatPage.tsx` mounts a single `ChatSessionOrchestrator` for that one id. Everything downstream — messages query, streaming state, model selector, per-chat settings — assumes one active chat per page.
+
+We already have a working split-pane layer for *view types* (agent / diff / editor / terminal / secrets) built on `react-mosaic-component` and driven by `useUIStore.mosaicLayout` (`frontend/src/store/uiStore.ts:73+`, `frontend/src/components/ui/SplitViewContainer.tsx:16+`). Shift-clicking sidebar items adds tiles to that layout. But the `agent` tile renders against whichever single `chatId` the route has.
+
+Product wants the ability to view two different chats simultaneously — e.g. run two agents in parallel and watch both stream — without juggling browser tabs.
+
+## Goal
+
+A user can open chat A, then add chat B as a second pane next to it via a sidebar action (shift-click a chat, or an explicit "open in split" affordance). Both panes stream independently, each with their own messages, input bar, model selector, and per-chat settings. Closing the second pane returns to the single-chat view. The split state survives a page refresh.
+
+## Non-goals
+
+- **No 3+ chat panes.** Layout supports the tree, but the UI only exposes "add second chat." Revisit later if asked.
+- **No cross-chat sync, drag-message-between-panes, or shared context.** The two chats are independent.
+- **No shareable split URLs in v1.** Refresh-survival via persisted UI store state is enough; deep-link-with-split can be a follow-up.
+- **No mobile split.** Mobile already collapses the mosaic to a single view; the second-chat affordance is hidden under `MOBILE_BREAKPOINT`.
+- **No backend changes.** Streaming already routes by `envelope.chatId` (see `docs/domains/streaming.md`); the existing SSE/EventSource pipeline is sufficient.
+- **No changes to `frontend/backend-sidecar/`** (hard rule).
+
+## Approach
+
+The core move: **make chat panes first-class mosaic tiles, then scope both `ChatProvider` and `ChatSessionOrchestrator` per agent tile.** The route remains the source of truth for the *primary* chat; the *secondary* chat lives in `uiStore`.
+
+Important current-state constraint: mosaic leaves are currently just `ViewType` strings (`agent`, `editor`, `terminal`, ...). That model cannot represent two `agent` panes because `addTileToMosaic` de-dupes leaves and `react-mosaic-component` requires stable unique tile ids. v1 needs a small tile identity layer before rendering two chats.
+
+### Phase 1 — Foundations (state + provider scoping)
+
+- [x] Extend `frontend/src/types/ui.types.ts` with explicit tile ids:
+  - `type MosaicTileId = ViewType | 'agent:primary' | 'agent:secondary'` (or a stricter equivalent).
+  - `MosaicLayoutNode` leaves become `MosaicTileId`, not `ViewType`.
+  - Add a resolver helper like `getViewTypeForTile(tileId): ViewType` so non-agent views do not need to know about chat slots.
+- [x] Update `mosaicHelpers.ts`, `MosaicSplitView.tsx`, `SplitViewContainer.tsx`, and `useActiveViews.ts` to operate on tile ids while deriving `ViewType` for labels/rendering. Preserve existing single-view behavior for `editor`, `terminal`, `diff`, `secrets`, and `prReview`.
+- [x] Extend `SplitViewState` in `frontend/src/types/ui.types.ts`: add `secondaryChatId: string | null`. Do **not** add a generalized `tileChatIds` map in v1 unless implementation pressure requires it; the explicit primary/secondary invariant is easier to reason about and test.
+- [x] Add actions to `useUIStore` (`frontend/src/store/uiStore.ts`): `openChatInSplit(chatId)`, `closeSplitChat()`, `swapChatPanes()`. `openChatInSplit` creates/keeps a layout containing `agent:primary` and `agent:secondary`; it must not call the existing duplicate-preventing `addTileToMosaic('agent', ...)` path.
+- [x] Persist `secondaryChatId` and enough layout state to restore the split. Current `partialize` excludes `mosaicLayout`, so either:
+  - persist only `secondaryChatId` and reconstruct `{ first: 'agent:primary', second: 'agent:secondary' }` on chat-page mount, or
+  - add a versioned, migrated `mosaicLayout` persist shape that supports tile ids.
+- [x] Bump the `uiStore` persist `version` and migrate old `mosaicLayout`/view leaves to the new tile-id shape. Keep deleting unsupported legacy persisted `mosaicLayout` if preserving old split layouts is not worth the migration complexity.
+- [x] Clear `secondaryChatId` if the secondary chat no longer exists. Prefer a null-check/query failure in the secondary pane over cross-store subscriptions; delete flow can also call `closeSplitChat()` if the deleted id matches.
+- [x] Introduce an `AgentPane`/`ChatPane` component that owns the per-chat data hooks: `useChatData(chatId)`, `useSandboxFiles(currentChat, chatId)`, `useWorkspaceResourcesQuery(currentChat?.workspace_id)`, then wraps its children in `ChatProvider` and `ChatSessionOrchestrator`.
+- [x] Audit every `useChatContext()` and `useChatSessionContext()` consumer (grep). Each pane-scoped consumer must read chat/sandbox/session data from the nearest provider. Anything intentionally primary-chat-scoped must keep using route/page state and be named accordingly.
+- [x] Replace or explicitly document remaining `useChatStore.currentChat` reads in chat-scoped UI. Known risky reads include branch selector, input controls, and GitHub dialogs; these can cross-talk in split mode unless they move to context or are intentionally primary-only.
+
+### Phase 2 — Render the split
+
+- [x] In the tile renderer, route `agent:primary` to the route `chatId` and `agent:secondary` to `uiStore.secondaryChatId`. Non-agent tiles continue to render against the primary chat/workspace/sandbox.
+- [x] Move `ChatProvider` and `ChatSessionOrchestrator` out of the page-wide wrapper and into the `AgentPane` renderer. `ChatPage` remains responsible for route-level layout, sidebar, dialogs, editor/diff/terminal data tied to the primary chat, and global command menu.
+- [x] Keep page-level `useChatStore.setCurrentChat(currentChat)` scoped to the primary chat only. Do not rely on it for secondary chat rendering.
+- [x] Verify `ChatSettingsStore` (`thinkingModeByChat[chatId]`, etc.) keeps working — it already keys by chatId, so each pane reads its own slice. Spot-check 2–3 settings.
+- [x] Verify `attachedFiles` isolation. `ChatSessionOrchestrator` currently reads/writes `useChatStore.attachedFiles`, which is global; split chat likely needs pane-local attachment state or a `attachedFilesByChat` shape to avoid sending pane A's files from pane B.
+
+### Phase 3 — Affordances + polish
+
+- [x] Sidebar chat list: shift-click (desktop only) calls `openChatInSplit(chatId)` instead of `navigate(...)`. Add a tooltip hint. Reuse the shift-click pattern already used for views (see `uiStore.ts:186` comment).
+- [x] Add a small "open in split" menu item to the chat row's existing kebab menu, for discoverability.
+- [x] Each agent pane gets a header strip showing the chat title + a close (`×`) button. For `agent:secondary`, close calls `closeSplitChat()`. For `agent:primary`, close navigates to the secondary chat and then collapses the split; implement this as one action or carefully order `navigate(...)` + `closeSplitChat()` so stale route state does not flash.
+- [x] Hide the split affordance when `window.innerWidth < MOBILE_BREAKPOINT` — same gate `ensureViewVisible` uses.
+- [x] Define mobile restore behavior explicitly: below `MOBILE_BREAKPOINT`, render only `agent:primary`; keep `secondaryChatId` persisted so returning to desktop restores the split unless the user explicitly closed it.
+- [x] Streaming sanity: confirm two agent panes can stream concurrently. The SSE/EventSource callbacks route by `envelope.chatId` (see `docs/domains/streaming.md`); each `ChatSessionProvider` owns its own chatId-scoped session state.
+
+### Phase 4 — Cleanup
+
+- [x] Update `docs/artifacts/frontend/components.md` and `docs/artifacts/frontend/state.md` to note that `ChatSessionOrchestrator` is now per-tile, not per-page.
+- [x] Add a note to `docs/domains/chat.md` describing the split-chat invariant (primary = route, secondary = uiStore).
+- [x] Add a Playwright/Vitest smoke covering the open-split → both-stream → close-split flow if the harness supports it; otherwise document manual steps in PR.
+
+## Open questions
+
+- ⏳ Should secondary chat attachments be fully pane-local, or should attachment state become `attachedFilesByChat` in `chatStore`? Current global `attachedFiles` is not safe for two simultaneous input bars.
+- ⏳ Do GitHub dialogs / branch selector / command menu actions operate on the focused pane or always on the primary chat? Plan default: dialogs and non-agent views stay primary-only in v1; chat input/model/settings are pane-scoped.
+- ⏳ Does *anything* outside `useChatContext()` / `useChatSessionContext()` reach for the route's `chatId` or `useChatStore.currentChat` to do chat-scoped work (analytics, breadcrumbs, document title)? If yes, those need explicit "I want the primary chat" wiring. Will know after Phase 1 audit.
+- ⏳ When the secondary chat is the one being actively typed into, should the input focus / command palette target it? Plan default: the *focused* pane is the active one for keyboard shortcuts; visual focus ring on the pane container. Confirm with design.
+
+## Decision log
+
+- **2026-05-17:** updated plan after source review: duplicate `agent` leaves are impossible with the current `ViewType`-as-tile-id mosaic model, so split chat needs unique tile ids (`agent:primary`, `agent:secondary`) before provider scoping can work.
+- **2026-05-17:** updated plan after source review: `ChatSessionOrchestrator` already accepts `chatId`; the actual lift is per-pane ownership of `useChatData`, `useSandboxFiles`, `ChatProvider`, and `ChatSessionOrchestrator`.
+- **2026-05-17:** decided to **lift `ChatSessionOrchestrator` per agent tile** rather than introduce a global `MultiChatProvider` keyed by chatId. Per-tile lift keeps every existing `useChatSessionContext()` consumer working unchanged (React's nearest-provider lookup does the right thing). A global multi-chat provider would have required every consumer to know its slot id — much wider blast radius.
+- **2026-05-17:** decided to keep **route = primary chat** and put **secondary chat in `uiStore`** (persisted) rather than encode both in the URL. Avoids touching `App.tsx:131` route shape and keeps existing bookmarks valid. Shareable split URLs are a follow-up if requested.
+- **2026-05-17:** rejected a third pane in v1. The `react-mosaic-component` tree supports it trivially, but the affordance/UX of "which pane gets the new chat?" isn't worth designing before we know users want it.
+
+## Verification
+
+- **Manual:**
+  - Open chat A, shift-click chat B in sidebar → both render side-by-side with independent messages.
+  - Send a message in A, send a message in B at the same time → both stream concurrently without interleaving.
+  - Toggle thinking-mode in A → B is unaffected (confirms per-chat settings still isolated).
+  - Refresh the page → split persists with A on left, B on right.
+  - Close the secondary pane → returns to single-pane view of A.
+  - Close the *primary* pane → route navigates to B, layout collapses to single pane.
+  - Delete chat B from the sidebar while it's open in split → secondary pane closes cleanly.
+  - Resize the browser below `MOBILE_BREAKPOINT` → secondary pane hides; restore above → it returns.
+- **Tests:** unit-test the new `uiStore` actions (`openChatInSplit`, `closeSplitChat`, `swapChatPanes`) including persistence shape. If a Playwright harness exists, add a smoke as above.
+- **Regression:** verify existing split views still work: command-menu split editor/diff/terminal/secrets, close tile, drag/reorder mosaic, mobile single-view fallback.
+- **Gates:** `npm run lint && npm run typecheck` in `frontend/`. No backend changes → no `pytest` impact.
+
+## Done when
+
+- [x] User can open a second chat in split via shift-click and the kebab menu.
+- [x] Both panes have independent messages, streaming, model selector, and settings.
+- [x] Split state survives refresh; deleting a chat clears it from the split.
+- [x] Primary-pane close swaps secondary in and updates the route.
+- [x] Mobile is unaffected — no split affordance below `MOBILE_BREAKPOINT`.
+- [x] `docs/artifacts/frontend/components.md`, `docs/artifacts/frontend/state.md`, `docs/domains/chat.md` updated.
+- [x] `npm run lint && npm run typecheck` clean.
+- [x] Plan moved to `plans/completed/`.


### PR DESCRIPTION
## Summary
- Make agent panes first-class mosaic tiles (`agent:primary`, `agent:secondary`) so two chats can render simultaneously without collapsing under the existing `ViewType`-as-tile-id model.
- Lift `ChatProvider` + `ChatSessionOrchestrator` per tile via a new `AgentPane` component; each pane owns its own `useChatData`, `useSandboxFiles`, streaming session, and per-chat settings.
- Add `secondaryChatId` to `useUIStore` with `openChatInSplit` / `closeSplitChat` / `swapChatPanes` actions, persisted across refresh and migrated via a bumped persist version.
- Sidebar shift-click and kebab "open in split" trigger the split (desktop only); each pane gets a header strip with a close affordance.
- Docs updated: `docs/artifacts/frontend/components.md`, `docs/artifacts/frontend/state.md`, `docs/domains/chat.md`. Plan moved to `plans/completed/split_chat_view.md`.

## Test plan
- [ ] Open chat A, shift-click chat B in the sidebar — both render side-by-side with independent messages.
- [ ] Send messages in A and B concurrently — both stream without interleaving.
- [ ] Toggle thinking mode in A — B unaffected.
- [ ] Refresh the page — split persists with the same chats and orientation.
- [ ] Close the secondary pane — collapses to single-pane view of A.
- [ ] Close the primary pane — route swaps to B, layout collapses cleanly.
- [ ] Delete the secondary chat from the sidebar while open in split — secondary closes without orphaned state.
- [ ] Resize below `MOBILE_BREAKPOINT` — secondary pane hides; restore above — it returns.
- [ ] `cd frontend && npm run lint && npm run typecheck` clean.