### PR TITLE
Add Cursor Composer 2.5 models

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -154,6 +154,10 @@ MODELS: dict[str, ModelInfo] = {
     "copilot:gpt-5-mini": ModelInfo("GPT 5 Mini", AgentKind.COPILOT, 160_000),
     "copilot:gpt-4.1": ModelInfo("GPT 4.1", AgentKind.COPILOT, 80_000),
     "cursor:auto": ModelInfo("Auto", AgentKind.CURSOR, None),
+    "cursor:composer-2.5-fast": ModelInfo(
+        "Composer 2.5 Fast", AgentKind.CURSOR, 200_000
+    ),
+    "cursor:composer-2.5": ModelInfo("Composer 2.5", AgentKind.CURSOR, 200_000),
     "cursor:composer-2-fast": ModelInfo("Composer 2", AgentKind.CURSOR, 200_000),
     "cursor:composer-1.5": ModelInfo("Composer 1.5", AgentKind.CURSOR, 200_000),
     "cursor:gpt-5.4-medium": ModelInfo("GPT 5.4", AgentKind.CURSOR, 272_000),


### PR DESCRIPTION
## Summary
- Register Cursor Composer 2.5 and Composer 2.5 Fast in the backend model catalog.
- Keep the existing Cursor ACP adapter mapping unchanged because it already strips the internal `cursor:` namespace before sending model IDs to `cursor-agent`.

## Plan
- Confirm the Cursor model IDs exposed by `cursor-agent models`.
- Add the new namespaced model IDs to `MODELS`.
- Avoid adapter changes because the existing model ID passthrough handles these entries.

## Test plan
- [x] `cd backend && .venv/bin/python -m pytest tests/test_models.py`
- [x] `cursor-agent models` to verify `composer-2.5` and `composer-2.5-fast`