### PR TITLE
Upgrade Pierre diffs rendering

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
-        "@pierre/diffs": "^1.1.16",
+        "@pierre/diffs": "^1.2.2",
         "@pierre/trees": "^1.0.0-beta.3",
         "@tanstack/react-query": "^5.62.11",
         "@tanstack/react-query-devtools": "^5.62.11",
@@ -668,12 +668,12 @@
       }
     },
     "node_modules/@pierre/diffs": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.1.16.tgz",
-      "integrity": "sha512-p6kaS1Psx6469Qx+gtO6nV1XVe3DMlNBy1kpkZlgelxIuGUfNQNKm0WkxMBwRxyeWRaXXGRxpe6BaQTO/tsukg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.2.tgz",
+      "integrity": "sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ==",
       "license": "apache-2.0",
       "dependencies": {
-        "@pierre/theme": "0.0.28",
+        "@pierre/theme": "1.0.3",
         "@shikijs/transformers": "^3.0.0",
         "diff": "8.0.3",
         "hast-util-to-html": "9.0.5",
@@ -695,9 +695,9 @@
       }
     },
     "node_modules/@pierre/theme": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-0.0.28.tgz",
-      "integrity": "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.0.3.tgz",
+      "integrity": "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==",
       "license": "MIT",
       "engines": {
         "vscode": "^1.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
-    "@pierre/diffs": "^1.1.16",
+    "@pierre/diffs": "^1.2.2",
     "@pierre/trees": "^1.0.0-beta.3",
     "@tanstack/react-query": "^5.62.11",
     "@tanstack/react-query-devtools": "^5.62.11",

--- a/frontend/src/components/sandbox/git/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView.tsx
@@ -100,6 +100,15 @@ function extractContents(
   };
 }
 
+function hashDiffContent(content: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < content.length; i += 1) {
+    hash ^= content.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
 // Re-diff with limited context so the library emits collapsedBefore gaps for
 // the expand-on-click UI.
 function rebuildWithCollapsedContext(
@@ -109,8 +118,16 @@ function rebuildWithCollapsedContext(
   const contents = extractContents(fullFile);
   if (!contents) return fullFile;
   const rebuilt = parseDiffFromFile(
-    { name: fullFile.prevName ?? fullFile.name, contents: contents.oldContent },
-    { name: fullFile.name, contents: contents.newContent },
+    {
+      name: fullFile.prevName ?? fullFile.name,
+      contents: contents.oldContent,
+      cacheKey: fullFile.cacheKey ? `${fullFile.cacheKey}:old` : undefined,
+    },
+    {
+      name: fullFile.name,
+      contents: contents.newContent,
+      cacheKey: fullFile.cacheKey ? `${fullFile.cacheKey}:new` : undefined,
+    },
   );
   rebuilt.type = fullFile.type;
   rebuilt.prevName = fullFile.prevName;
@@ -317,11 +334,15 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
   }, [sandboxId, cwd, restoreAll]);
 
   const diffContent = diffData?.diff ?? '';
+  const diffCacheKey = useMemo(
+    () => (diffContent ? `${scopeKey}\0${hashDiffContent(diffContent)}` : undefined),
+    [diffContent, scopeKey],
+  );
 
   const parsedFiles = useMemo<FileDiffMetadata[]>(() => {
     if (!diffContent) return [];
     return (
-      parsePatchFiles(diffContent)
+      parsePatchFiles(diffContent, diffCacheKey)
         .flatMap((p) => p.files)
         // No unchanged context on new/deleted — skip the re-diff.
         .map((f) =>
@@ -330,7 +351,7 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
             : rebuildWithCollapsedContext(f, parseDiffFromFile),
         )
     );
-  }, [diffContent]);
+  }, [diffContent, diffCacheKey]);
 
   const options = useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- Upgrade `@pierre/diffs` from 1.1.16 to 1.2.2 and refresh the locked `@pierre/theme` transitive dependency
- Add content-scoped cache keys when parsing DiffView patches so Pierre's worker pool can reuse/coalesce highlight work safely
- Preserve the existing AgentRove DiffView behavior while leaving a future `CodeView` migration as a separate refactor

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [x] Synthetic headless Chrome scroll benchmark comparing current Virtualizer path with Pierre CodeView