### PR TITLE
chore: remove border-left from tool call details

### DIFF
--- a/frontend/src/components/chat/tools/common/ToolCard.tsx
+++ b/frontend/src/components/chat/tools/common/ToolCard.tsx
@@ -42,7 +42,7 @@ const ToolCardInner: React.FC<ToolCardProps> = ({
   const showChildren = !hasExpandableContent || expanded;
   const details =
     children || hasDetailsError ? (
-      <div className="mt-1.5 space-y-1.5 border-l border-border pl-3 dark:border-border-dark">
+      <div className="mt-1.5 space-y-1.5">
         {children}
         {hasDetailsError &&
           (React.isValidElement(error) ? (


### PR DESCRIPTION
## Summary
- Drops the `border-l` + `pl-3` indent from the expanded details container in `ToolCard` so tool call output no longer renders with a vertical nesting bar.
- Applies globally across all tool renderers (Claude, Codex, Copilot, Cursor, OpenCode) since they all share `ToolCard`.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] Expand a few tool cards (Bash, Read, Edit, Grep) in the chat UI and confirm the left vertical line is gone
- [ ] Trigger a failed tool call and confirm the error block also renders without the left border
- [ ] Sanity-check that nested sub-tool lists in `TaskTool` / `AgentTool` still keep their own border-l (out of scope here)