### PR TITLE
chore: bump claude-agent-acp to 0.38.0 and codex-acp to 0.15.0

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.31.0 @zed-industries/codex-acp@0.12.0 @openai/codex@0.125.0 @github/copilot@1.0.36
+RUN npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.38.0 @zed-industries/codex-acp@0.15.0 @openai/codex@0.125.0 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to /root/.local/bin) — used for the Cursor
 # ACP server (`cursor-agent acp`). The install script downloads the binary for

--- a/desktop/run_build.mjs
+++ b/desktop/run_build.mjs
@@ -22,8 +22,8 @@ const PYTHON_VERSION = '3.12.12';
 const NODE_VERSION = '22.12.0';
 const RELEASE_TAG = '20260211';
 const RIPGREP_VERSION = '14.1.1';
-const CLAUDE_AGENT_ACP_VERSION = '0.31.0';
-const CODEX_ACP_VERSION = '0.12.0';
+const CLAUDE_AGENT_ACP_VERSION = '0.38.0';
+const CODEX_ACP_VERSION = '0.15.0';
 const GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py';
 
 const platform = process.platform;

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -57,7 +57,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.31.0 @zed-industries/codex-acp@0.12.0 @openai/codex@0.125.0 @github/copilot@1.0.36
+    npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.38.0 @zed-industries/codex-acp@0.15.0 @openai/codex@0.125.0 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to ~/.local/bin, which is already on PATH).
 RUN curl -fsS https://cursor.com/install | bash


### PR DESCRIPTION
## Summary
- Bump `@agentclientprotocol/claude-agent-acp` from 0.31.0 → 0.38.0
- Bump `@zed-industries/codex-acp` from 0.12.0 → 0.15.0
- Aligns `backend/Dockerfile` and `sandbox/docker/Dockerfile` with the versions already set in `desktop/run_build.mjs`

## Test plan
- [ ] `docker compose build` succeeds
- [ ] Desktop sidecar build (`node desktop/run_build.mjs`) succeeds
- [ ] Smoke-test a Claude and a Codex session through the ACP adapters