### PR TITLE
fix: queue concurrent permission requests and dedupe replays by seq

### DIFF
--- a/frontend/src/hooks/useExitPlanMode.ts
+++ b/frontend/src/hooks/useExitPlanMode.ts
@@ -2,32 +2,33 @@ import { useState, useCallback } from 'react';
 import { permissionService } from '@/services/permissionService';
 import { usePermissionStore } from '@/store/permissionStore';
 import { useChatSettingsStore } from '@/store/chatSettingsStore';
-import {
-  executePermissionResponse,
-  clearPermissionRequestForChat,
-} from '@/utils/permissionResponse';
+import { executePermissionResponse, clearPermissionRequest } from '@/utils/permissionResponse';
 
 export function useExitPlanMode(chatId: string | undefined) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const pendingRequest = usePermissionStore((state) =>
-    chatId ? (state.pendingRequests.get(chatId) ?? null) : null,
-  );
-  const isExitPlanModeRequest = pendingRequest?.tool_name === 'ExitPlanMode';
+  // The ExitPlanMode request renders in its own tool card, independent of the
+  // inline permission prompt, so pick it out of the queue wherever it sits
+  // rather than only checking the head.
+  const pendingRequest = usePermissionStore((state) => {
+    if (!chatId) return null;
+    const queue = state.pendingRequests.get(chatId);
+    return queue?.find((r) => r.tool_name === 'ExitPlanMode') ?? null;
+  });
 
   const handleApprove = useCallback(
     async (optionId: string) => {
-      if (!chatId || !pendingRequest || !isExitPlanModeRequest) return;
+      if (!chatId || !pendingRequest) return;
 
       const result = await executePermissionResponse(
-        pendingRequest.request_id,
         () => permissionService.respondToPermission(chatId, pendingRequest.request_id, optionId),
         {
           setIsLoading,
           setError,
           errorMessage: 'Failed to approve plan',
-          clearRequest: () => clearPermissionRequestForChat(chatId),
+          clearRequest: () =>
+            clearPermissionRequest(chatId, pendingRequest.request_id, pendingRequest.seq),
         },
       );
       if (result === 'success' || result === 'expired') {
@@ -40,29 +41,29 @@ export function useExitPlanMode(chatId: string | undefined) {
         useChatSettingsStore.getState().setPlanMode(chatId, false);
       }
     },
-    [chatId, pendingRequest, isExitPlanModeRequest],
+    [chatId, pendingRequest],
   );
 
   const handleReject = useCallback(
     async (optionId: string) => {
-      if (!chatId || !pendingRequest || !isExitPlanModeRequest) return;
+      if (!chatId || !pendingRequest) return;
 
       await executePermissionResponse(
-        pendingRequest.request_id,
         () => permissionService.respondToPermission(chatId, pendingRequest.request_id, optionId),
         {
           setIsLoading,
           setError,
           errorMessage: 'Failed to reject plan',
-          clearRequest: () => clearPermissionRequestForChat(chatId),
+          clearRequest: () =>
+            clearPermissionRequest(chatId, pendingRequest.request_id, pendingRequest.seq),
         },
       );
     },
-    [chatId, pendingRequest, isExitPlanModeRequest],
+    [chatId, pendingRequest],
   );
 
   return {
-    pendingRequest: isExitPlanModeRequest ? pendingRequest : null,
+    pendingRequest,
     isLoading,
     error,
     handleApprove,

--- a/frontend/src/hooks/usePermissionRequest.ts
+++ b/frontend/src/hooks/usePermissionRequest.ts
@@ -1,13 +1,10 @@
 import { useState, useCallback, useRef } from 'react';
 import { permissionService } from '@/services/permissionService';
 import { usePermissionStore } from '@/store/permissionStore';
-import { isRequestResolved } from '@/utils/permissionStorage';
+import { isPermissionResolved } from '@/utils/permissionStorage';
 import { notifyPermissionRequest } from '@/utils/notifications';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
-import {
-  executePermissionResponse,
-  clearPermissionRequestForChat,
-} from '@/utils/permissionResponse';
+import { executePermissionResponse, clearPermissionRequest } from '@/utils/permissionResponse';
 import type { PermissionRequest } from '@/types/chat.types';
 
 interface UsePermissionRequestReturn {
@@ -28,10 +25,14 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
   const [error, setError] = useState<string | null>(null);
   const { data: settings } = useSettingsQuery();
 
-  // Select only this chat's request to avoid re-renders from other chats' permission changes
-  const pendingRequest = usePermissionStore((state) =>
-    chatId ? (state.pendingRequests.get(chatId) ?? null) : null,
-  );
+  // Surface the head of this chat's permission queue. Selecting only this
+  // chat's queue avoids re-renders from other chats' permission changes; we
+  // process requests one at a time in FIFO order.
+  const pendingRequest = usePermissionStore((state) => {
+    if (!chatId) return null;
+    const queue = state.pendingRequests.get(chatId);
+    return queue && queue.length > 0 ? queue[0] : null;
+  });
   const prevRequestIdRef = useRef(pendingRequest?.request_id);
 
   // Clear stale error when a new permission request arrives, so errors from
@@ -44,14 +45,15 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
   const handlePermissionRequest = useCallback(
     (request: PermissionRequest) => {
       if (!chatId) return;
-      if (isRequestResolved(request.request_id)) return;
-      const existingRequest = usePermissionStore.getState().pendingRequests.get(chatId);
-      if (existingRequest?.request_id === request.request_id) {
-        return;
-      }
+      // Drop permission events the user already answered — the backend persists
+      // and replays them after `after_seq` on refresh/reconnect.
+      if (isPermissionResolved(chatId, request.seq)) return;
 
-      usePermissionStore.getState().setPermissionRequest(chatId, request);
-      if (settings?.notifications_enabled ?? true) {
+      // The store dedupes against requests already pending in this chat's
+      // queue; only notify when it was a genuinely new request, not a
+      // duplicate envelope for one still awaiting a response.
+      const added = usePermissionStore.getState().enqueuePermissionRequest(chatId, request);
+      if (added && (settings?.notifications_enabled ?? true)) {
         void notifyPermissionRequest(request);
       }
     },
@@ -63,13 +65,13 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
       if (!chatId || !pendingRequest) return;
 
       await executePermissionResponse(
-        pendingRequest.request_id,
         () => permissionService.respondToPermission(chatId, pendingRequest.request_id, optionId),
         {
           setIsLoading,
           setError,
           errorMessage: 'Failed to approve permission',
-          clearRequest: () => clearPermissionRequestForChat(chatId),
+          clearRequest: () =>
+            clearPermissionRequest(chatId, pendingRequest.request_id, pendingRequest.seq),
         },
       );
     },
@@ -81,13 +83,13 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
       if (!chatId || !pendingRequest) return;
 
       await executePermissionResponse(
-        pendingRequest.request_id,
         () => permissionService.respondToPermission(chatId, pendingRequest.request_id, optionId),
         {
           setIsLoading,
           setError,
           errorMessage: 'Failed to reject permission',
-          clearRequest: () => clearPermissionRequestForChat(chatId),
+          clearRequest: () =>
+            clearPermissionRequest(chatId, pendingRequest.request_id, pendingRequest.seq),
         },
       );
     },

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -444,6 +444,7 @@ export function useStreamCallbacks({
             tool_name,
             tool_input,
             options,
+            seq: envelope.seq,
           });
         }
         return;

--- a/frontend/src/store/permissionStore.ts
+++ b/frontend/src/store/permissionStore.ts
@@ -2,26 +2,47 @@ import { create } from 'zustand';
 import type { PermissionRequest } from '@/types/chat.types';
 
 interface PermissionState {
-  pendingRequests: Map<string, PermissionRequest>;
-  setPermissionRequest: (chatId: string, request: PermissionRequest) => void;
-  clearPermissionRequest: (chatId: string) => void;
+  // chatId -> FIFO queue of pending requests. Each chat can have several
+  // permission requests in flight at once (the agent may emit a batch of tool
+  // calls), so we keep a queue and surface them to the UI one at a time. Keying
+  // by a single request per chat would drop all but the last, leaving the
+  // backend blocked forever on the unanswered ones.
+  pendingRequests: Map<string, PermissionRequest[]>;
+  // Returns true if the request was newly enqueued, false if it was a duplicate
+  // that got deduped — callers use this to gate one-time side effects (e.g.
+  // notifications) without re-scanning the queue themselves.
+  enqueuePermissionRequest: (chatId: string, request: PermissionRequest) => boolean;
+  resolvePermissionRequest: (chatId: string, requestId: string) => void;
 }
 
-export const usePermissionStore = create<PermissionState>((set) => ({
-  pendingRequests: new Map<string, PermissionRequest>(),
+export const usePermissionStore = create<PermissionState>((set, get) => ({
+  pendingRequests: new Map<string, PermissionRequest[]>(),
 
-  setPermissionRequest: (chatId: string, request: PermissionRequest) => {
-    set((state) => {
-      const nextRequests = new Map(state.pendingRequests);
-      nextRequests.set(chatId, request);
-      return { pendingRequests: nextRequests };
-    });
+  enqueuePermissionRequest: (chatId: string, request: PermissionRequest) => {
+    const queue = get().pendingRequests.get(chatId) ?? [];
+    // Dedupe by request_id so duplicate SSE envelopes (e.g. after a
+    // reconnect) don't enqueue the same request twice.
+    if (queue.some((r) => r.request_id === request.request_id)) {
+      return false;
+    }
+    const nextRequests = new Map(get().pendingRequests);
+    nextRequests.set(chatId, [...queue, request]);
+    set({ pendingRequests: nextRequests });
+    return true;
   },
 
-  clearPermissionRequest: (chatId: string) => {
+  resolvePermissionRequest: (chatId: string, requestId: string) => {
     set((state) => {
+      const queue = state.pendingRequests.get(chatId);
+      if (!queue) return state;
+      const nextQueue = queue.filter((r) => r.request_id !== requestId);
+      if (nextQueue.length === queue.length) return state;
       const nextRequests = new Map(state.pendingRequests);
-      nextRequests.delete(chatId);
+      if (nextQueue.length === 0) {
+        nextRequests.delete(chatId);
+      } else {
+        nextRequests.set(chatId, nextQueue);
+      }
       return { pendingRequests: nextRequests };
     });
   },

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -160,4 +160,9 @@ export interface PermissionRequest {
   tool_name: string;
   tool_input: Record<string, unknown>;
   options: PermissionOption[];
+  // Monotonic stream sequence of the originating envelope. Used to dedupe
+  // replayed permission events (the backend persists and re-streams them after
+  // `after_seq` on reconnect/refresh) without relying on request_id, which some
+  // providers reuse across turns.
+  seq: number;
 }

--- a/frontend/src/utils/permissionResponse.ts
+++ b/frontend/src/utils/permissionResponse.ts
@@ -1,5 +1,5 @@
 import { usePermissionStore } from '@/store/permissionStore';
-import { addResolvedRequestId } from '@/utils/permissionStorage';
+import { addResolvedPermission } from '@/utils/permissionStorage';
 
 type ApiError = Error & { status?: number };
 
@@ -8,10 +8,9 @@ function isExpiredRequestError(error: unknown): boolean {
 }
 
 // Wraps a permission service call with standard loading/error/cleanup behavior:
-// on success or 404 (expired), marks the request resolved and clears the pending
-// state; on other errors, sets the provided error message.
+// on success or 404 (expired), clears the pending state; on other errors, sets
+// the provided error message.
 export async function executePermissionResponse(
-  requestId: string,
   serviceFn: () => Promise<void>,
   opts: {
     setIsLoading: (v: boolean) => void;
@@ -24,7 +23,6 @@ export async function executePermissionResponse(
   opts.setError(null);
   try {
     await serviceFn();
-    addResolvedRequestId(requestId);
     opts.clearRequest();
     return 'success';
   } catch (err) {
@@ -32,7 +30,6 @@ export async function executePermissionResponse(
       // This request is already gone on the backend (timeout/session moved on),
       // so clear the local pending state but let the caller decide whether any
       // success-only UI transitions should still happen.
-      addResolvedRequestId(requestId);
       opts.clearRequest();
       return 'expired';
     } else {
@@ -44,6 +41,10 @@ export async function executePermissionResponse(
   return 'error';
 }
 
-export function clearPermissionRequestForChat(chatId: string): void {
-  usePermissionStore.getState().clearPermissionRequest(chatId);
+// Called once a request has been answered (or found already-expired). Records
+// the resolved seq so a replayed permission event is not re-shown after a
+// refresh/reconnect, then drops the request from the in-memory queue.
+export function clearPermissionRequest(chatId: string, requestId: string, seq: number): void {
+  addResolvedPermission(chatId, seq);
+  usePermissionStore.getState().resolvePermissionRequest(chatId, requestId);
 }

--- a/frontend/src/utils/permissionStorage.ts
+++ b/frontend/src/utils/permissionStorage.ts
@@ -7,36 +7,45 @@ export function filterOptions(
   return options.filter((o) => o.kind.startsWith(prefix));
 }
 
-// Tracks recently resolved permission request IDs in localStorage so that
-// duplicate SSE permission_request envelopes (e.g., after reconnection) are
-// silently ignored instead of re-showing the approval dialog. Capped at 100
-// entries to bound storage usage.
-const RESOLVED_REQUESTS_KEY = 'agentrove_resolved_permission_requests';
-const MAX_RESOLVED_REQUESTS = 100;
+// Tracks resolved permission requests by their stream sequence so that
+// permission events the backend replays after `after_seq` (page refresh,
+// reconnect from a stale cursor) are not re-shown once the user has already
+// answered them. Keyed by `${chatId}:${seq}` rather than request_id: seq is
+// monotonic per chat and unique per emission, so a new request in a later turn
+// is never blocked even when a provider reuses tool-call ids. Persisted across
+// reloads (that is the whole point — the in-memory queue is empty on refresh)
+// and capped to bound storage.
+const RESOLVED_PERMISSIONS_KEY = 'agentrove_resolved_permission_seqs';
+const MAX_RESOLVED_PERMISSIONS = 200;
 
-function getResolvedRequestIds(): Set<string> {
+function resolvedKey(chatId: string, seq: number): string {
+  return `${chatId}:${seq}`;
+}
+
+function getResolvedPermissions(): string[] {
   try {
-    const stored = localStorage.getItem(RESOLVED_REQUESTS_KEY);
-    return stored ? new Set(JSON.parse(stored) as string[]) : new Set();
+    const stored = localStorage.getItem(RESOLVED_PERMISSIONS_KEY);
+    return stored ? (JSON.parse(stored) as string[]) : [];
   } catch {
-    return new Set();
+    return [];
   }
 }
 
-export function addResolvedRequestId(requestId: string): void {
+export function addResolvedPermission(chatId: string, seq: number): void {
   try {
-    const resolved = getResolvedRequestIds();
-    resolved.add(requestId);
-    const arr = Array.from(resolved);
-    if (arr.length > MAX_RESOLVED_REQUESTS) {
-      arr.splice(0, arr.length - MAX_RESOLVED_REQUESTS);
+    const key = resolvedKey(chatId, seq);
+    const resolved = getResolvedPermissions();
+    if (resolved.includes(key)) return;
+    resolved.push(key);
+    if (resolved.length > MAX_RESOLVED_PERMISSIONS) {
+      resolved.splice(0, resolved.length - MAX_RESOLVED_PERMISSIONS);
     }
-    localStorage.setItem(RESOLVED_REQUESTS_KEY, JSON.stringify(arr));
+    localStorage.setItem(RESOLVED_PERMISSIONS_KEY, JSON.stringify(resolved));
   } catch {
     // Ignore localStorage errors
   }
 }
 
-export function isRequestResolved(requestId: string): boolean {
-  return getResolvedRequestIds().has(requestId);
+export function isPermissionResolved(chatId: string, seq: number): boolean {
+  return getResolvedPermissions().includes(resolvedKey(chatId, seq));
 }


### PR DESCRIPTION
## Summary

Fixes two related bugs in the tool-permission approval flow.

**1. Concurrent permission requests hang.** The permission store kept a single request per chat (`Map<chatId, PermissionRequest>`), so when an agent emitted a batch of gated tool calls, the second request overwrote the first. The first was never shown, and the backend — which tracks each request by `request_id` — awaited the lost one forever (tool cards spin indefinitely). Requests are now held in a per-chat **FIFO queue** (`enqueuePermissionRequest` / `resolvePermissionRequest`) and surfaced one at a time.

**2. Resolved permissions re-appear / new ones get silently blocked.** Non-snapshot events (incl. `permission_request`) are persisted with a monotonic `seq` and re-streamed after `after_seq` on refresh/reconnect (see PR #59). The previous `request_id`-keyed localStorage filter suppressed those replays, but because some ACP providers **reuse `tool_call_id` (→ `request_id`) across turns**, a resolved id permanently blocked a legitimately-new request — a silent hang with no prompt shown. Dedup is now keyed by the envelope's **`seq`** (`agentrove_resolved_permission_seqs`, scoped `${chatId}:${seq}`), which is replay-stable *and* unique per emission, so it suppresses replays without poisoning future requests.

### Notable changes
- `store/permissionStore.ts` — per-chat FIFO queue; `enqueue` returns whether it added (gates one-time side effects like notifications).
- `hooks/usePermissionRequest.ts` — reads the queue head; `seq`-based resolved check.
- `hooks/useExitPlanMode.ts` — finds the `ExitPlanMode` request anywhere in the queue (it renders in its own card).
- `hooks/useStreamCallbacks.ts` — threads `envelope.seq` into the request.
- `utils/permissionStorage.ts` — `seq`-keyed resolved store replacing the `request_id` one.
- `types/chat.types.ts` — `PermissionRequest.seq`.

A follow-up for the deeper fix (durable reconnect cursor so the backend doesn't replay answered events at all) is tracked separately.

## Test plan
- [ ] Trigger two concurrent gated tool calls (e.g. two web searches) → both prompts appear and resolve one after the other; neither hangs.
- [ ] Run the same prompt twice → the repeat run still shows prompts (no silent hang from reused ids).
- [ ] Approve a permission, then refresh → the prompt does not re-appear and no duplicate notification fires.
- [ ] Trigger a prompt, refresh **before** answering → the still-pending prompt re-appears and answering unblocks the backend.
- [ ] ExitPlanMode approval still renders in its plan card and applies the selected permission mode.
- [ ] `npm run typecheck`, `npm run lint`, `npm run format:check` all clean.