### PR TITLE
fix: render Cursor web search as a web tool card

### DIFF
--- a/frontend/src/components/chat/tools/cursor/SearchTool.tsx
+++ b/frontend/src/components/chat/tools/cursor/SearchTool.tsx
@@ -1,24 +1,56 @@
 import { memo } from 'react';
-import { FileSearch, FolderSearch } from 'lucide-react';
+import { FileSearch, FolderSearch, Globe } from 'lucide-react';
 import type { ToolAggregate } from '@/types/tools.types';
 import { ToolCard } from '../common/ToolCard';
 import { SearchLoadingDots } from '../common/SearchLoadingDots';
 import type { CursorSearchOutput } from './cursorPayload';
 
+const ICON_CLASS = 'h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary';
+
 const SearchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
   const result = tool.result as CursorSearchOutput | undefined;
+  const title = tool.title?.trim() || 'search';
+
+  // Cursor reports its web search with the same `search` kind as grep/glob,
+  // distinguished only by the title "Web Search". rawInput is empty (no query
+  // to show) and the result carries just a referenceCount — the findings stream
+  // back as assistant text — so render a minimal web variant instead of the
+  // file-search "Found N files" copy.
+  if (/^web search$/i.test(title)) {
+    const refs = result?.referenceCount;
+    return (
+      <ToolCard
+        icon={<Globe className={ICON_CLASS} />}
+        status={tool.status}
+        title={(status) => {
+          switch (status) {
+            case 'completed':
+              return typeof refs === 'number'
+                ? `Searched the web · ${refs} reference${refs === 1 ? '' : 's'}`
+                : 'Searched the web';
+            case 'failed':
+              return 'Web search failed';
+            default:
+              return 'Searching the web...';
+          }
+        }}
+        loadingContent={<SearchLoadingDots label="Searching the web" />}
+        error={tool.error}
+      />
+    );
+  }
+
   // Cursor uses the same `search` kind for grep-style content search (title
   // "grep") and file-name glob search (title "Find"). totalMatches is present
   // for grep, totalFiles for Find — use whichever is defined.
-  const title = tool.title?.trim() || 'search';
   const isGlob = /^find$/i.test(title);
   const count = result?.totalMatches ?? result?.totalFiles;
   const truncated = result?.truncated ?? false;
 
   const icon = isGlob ? (
-    <FolderSearch className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />
+    <FolderSearch className={ICON_CLASS} />
   ) : (
-    <FileSearch className="h-3.5 w-3.5 text-text-secondary dark:text-text-dark-tertiary" />
+    <FileSearch className={ICON_CLASS} />
   );
 
   return (

--- a/frontend/src/components/chat/tools/cursor/cursorPayload.ts
+++ b/frontend/src/components/chat/tools/cursor/cursorPayload.ts
@@ -6,7 +6,9 @@
 // Output shapes observed live:
 //   execute  → { exitCode: number, stdout: string, stderr: string }
 //   read     → { content: string }
-//   search   → { totalMatches?: number, totalFiles?: number, truncated: boolean }
+//   search   → grep:  { totalMatches?: number, truncated: boolean }
+//              glob:  { totalFiles?: number, truncated: boolean }
+//              web:   { referenceCount?: number }  (title "Web Search", empty rawInput)
 //   edit     → ACP content blocks [{type:"diff", path, oldText, newText}],
 //              surfaced by the backend as { diffs: [...] } on tool.result.
 
@@ -24,6 +26,9 @@ export interface CursorSearchOutput {
   totalMatches?: number;
   totalFiles?: number;
   truncated?: boolean;
+  // Web search ("Web Search" title) returns only a reference count; the actual
+  // results stream back as assistant text, not as tool output.
+  referenceCount?: number;
 }
 
 export interface CursorDiffBlock {


### PR DESCRIPTION
## Summary

Cursor's web search arrives over ACP with `kind="search"` — the same kind as grep and glob — plus `title="Web Search"`, empty `rawInput`, and `rawOutput={referenceCount: N}`. Because the tool registry routes Cursor tools by ACP `kind`, web searches landed in the file `SearchTool` and rendered as **"Searching files" / "Found N files"** with a file-search icon.

This adds a web-search branch in `cursor/SearchTool.tsx`, keyed on `title === "Web Search"` — the same title-based discrimination the component already uses to tell grep from glob. The web variant renders a globe icon and web-appropriate copy ("Searching the web", "Searched the web · N references"). The actual results stream back as assistant text; the tool output only carries a `referenceCount`, now documented on `CursorSearchOutput`.

Also extracted the repeated icon className into a local `ICON_CLASS` const (consistent with `cursor/ExecuteTool.tsx`).

### How it was diagnosed
Confirmed via live ACP traces from a Cursor `agent`-mode session:
- `tool-start … kind=search title="Web Search" raw_input={}`
- `tool-terminal … raw_output={'referenceCount': 1} content=None meta=None`

(Note: the related "agent mode still asks for permission" behavior was investigated and confirmed to be **working as Cursor intends** — Cursor delegates gating to the client and only emits `request_permission` for tools it chooses to gate — so no change was made there.)

## Test plan

- [ ] In a Cursor chat, trigger a web search → renders with a globe icon and "Searching the web" / "Searched the web" (not "Searching files" / "Found N files").
- [ ] A grep search still renders "Found N matches" with the file-search icon.
- [ ] A glob/`Find` search still renders "Found N files" with the folder-search icon.
- [ ] `npm run typecheck`, `npm run lint`, `prettier --check` all clean.