### PR TITLE
fix: align Claude ACP model selection

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -128,8 +128,8 @@ SANDBOX_BASHRC_PATH: Final[str] = "/home/user/.bashrc"
 
 
 MODELS: dict[str, ModelInfo] = {
-    "sonnet[1m]": ModelInfo("Sonnet", AgentKind.CLAUDE, 1_000_000),
-    "opus[1m]": ModelInfo("Opus", AgentKind.CLAUDE, 1_000_000),
+    "sonnet": ModelInfo("Sonnet", AgentKind.CLAUDE, 200_000),
+    "opus": ModelInfo("Opus", AgentKind.CLAUDE, 1_000_000),
     "haiku": ModelInfo("Haiku", AgentKind.CLAUDE, 200_000),
     "gpt-5.5": ModelInfo("GPT 5.5", AgentKind.CODEX, 1_000_000),
     "gpt-5.4": ModelInfo("GPT 5.4", AgentKind.CODEX, 1_000_000),

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -201,17 +201,18 @@ class ClaudeAgentAdapter(AgentAdapter):
         # Claude exposes thinking budget as the "effort" session config option,
         # applied post-handshake via set_config_option; the UI's named tiers
         # are passed through directly as effort level IDs. `xhigh` is currently
-        # only valid for the Opus alias we expose, so other Claude models keep
+        # only valid for the Opus model we expose, so other Claude models keep
         # the narrower tier set and coerce unsupported persisted values.
         valid_modes = (
             CLAUDE_OPUS_VALID_THINKING_MODES
-            if model_id == "opus[1m]"
+            if model_id == "opus"
             else CLAUDE_VALID_THINKING_MODES
         )
         reasoning_effort = coerce_thinking_mode(thinking_mode, valid_modes)
 
         return SessionConfig(
             meta=meta,
+            env_overrides={"ANTHROPIC_MODEL": model_id},
             reasoning_effort=reasoning_effort,
             permission=PermissionConfig(session_mode=permission_mode),
         )

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -64,6 +64,7 @@ EMPTY_FROZENSET: frozenset[str] = frozenset()
 # Claude's thinking budget is advertised as the "effort" session config
 # option; value IDs are the supported Claude UI tiers.
 CLAUDE_EFFORT_CONFIG_ID = "effort"
+CLAUDE_MODEL_CONFIG_ID = "model"
 
 
 @dataclass
@@ -238,13 +239,12 @@ class AcpSession:
             logger.warning("Failed to send ACP cancel", exc_info=True)
 
     async def set_model(self, model_id: str) -> None:
-        # Translate the internal model registry key to the ACP model ID
-        # the agent expects (e.g., strip "copilot:" prefix for Copilot CLI).
-        acp_model_id = AGENT_ADAPTERS[self._agent_kind].map_model_id(model_id)
         try:
-            await self._conn.set_session_model(
-                model_id=acp_model_id,
-                session_id=self.acp_session_id,
+            await self._set_model_on_conn(
+                self._conn,
+                self._agent_kind,
+                self.acp_session_id,
+                model_id,
             )
         except Exception:
             logger.warning("Failed to set ACP model: %s", model_id, exc_info=True)
@@ -356,12 +356,11 @@ class AcpSession:
 
             if config.model:
                 try:
-                    acp_model_id = AGENT_ADAPTERS[config.agent_kind].map_model_id(
-                        config.model
-                    )
-                    await conn.set_session_model(
-                        model_id=acp_model_id,
-                        session_id=acp_session_id,
+                    await cls._set_model_on_conn(
+                        conn,
+                        config.agent_kind,
+                        acp_session_id,
+                        config.model,
                     )
                 except Exception:
                     logger.warning("Failed to set initial model: %s", config.model)
@@ -433,6 +432,28 @@ class AcpSession:
             acp_session_id=acp_session_id,
             agent_kind=config.agent_kind,
             stderr_task=stderr_task,
+        )
+
+    @staticmethod
+    async def _set_model_on_conn(
+        conn: ClientSideConnection,
+        agent_kind: AgentKind,
+        session_id: str,
+        model_id: str,
+    ) -> None:
+        # Claude's current ACP server canonicalizes aliases through the model
+        # config option; the legacy model method can drift from /context state.
+        acp_model_id = AGENT_ADAPTERS[agent_kind].map_model_id(model_id)
+        if agent_kind == AgentKind.CLAUDE:
+            await conn.set_config_option(
+                config_id=CLAUDE_MODEL_CONFIG_ID,
+                session_id=session_id,
+                value=acp_model_id,
+            )
+            return
+        await conn.set_session_model(
+            model_id=acp_model_id,
+            session_id=session_id,
         )
 
     @staticmethod

--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -51,8 +51,8 @@ export function getThinkingModesForAgent(
   agentKind: AgentKind,
   modelId?: string,
 ): ThinkingModeOption[] {
-  // Claude exposes `xhigh` only for the Opus alias we map to Opus 4.7.
-  if (agentKind === 'claude' && modelId === 'opus[1m]') {
+  // Claude exposes `xhigh` only for Opus.
+  if (agentKind === 'claude' && modelId === 'opus') {
     return CLAUDE_OPUS_THINKING_MODES;
   }
 


### PR DESCRIPTION
## Summary
- Rename Claude model IDs from long-context aliases to plain `sonnet` and `opus`
- Start Claude ACP sessions with `ANTHROPIC_MODEL` set from the selected model
- Switch Claude models through the ACP `model` config option

## Test plan
- [ ] Not run (per repo instructions)