### PR TITLE
Per-chat split-view tiles and pane-aware actions

### DIFF
--- a/frontend/src/components/chat/github/CreateBranchDialog.tsx
+++ b/frontend/src/components/chat/github/CreateBranchDialog.tsx
@@ -5,7 +5,7 @@ import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { Button } from '@/components/ui/primitives/Button';
 import { Input } from '@/components/ui/primitives/Input';
 import { Select } from '@/components/ui/primitives/Select';
-import { useChatStore } from '@/store/chatStore';
+import { useActiveChat } from '@/hooks/useActiveChat';
 import { useGitBranchesQuery, useGitCreateBranchMutation } from '@/hooks/queries/useSandboxQueries';
 
 interface CreateBranchDialogProps {
@@ -13,7 +13,7 @@ interface CreateBranchDialogProps {
 }
 
 export function CreateBranchDialog({ onClose }: CreateBranchDialogProps) {
-  const currentChat = useChatStore((s) => s.currentChat);
+  const currentChat = useActiveChat();
   const sandboxId = currentChat?.sandbox_id ?? '';
   const worktreeCwd = currentChat?.worktree_cwd ?? undefined;
   const { data: branchesData } = useGitBranchesQuery(sandboxId, !!sandboxId, worktreeCwd);

--- a/frontend/src/components/chat/github/CreateCommitDialog.tsx
+++ b/frontend/src/components/chat/github/CreateCommitDialog.tsx
@@ -4,8 +4,8 @@ import toast from 'react-hot-toast';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { Button } from '@/components/ui/primitives/Button';
 import { Textarea } from '@/components/ui/primitives/Textarea';
-import { useChatStore } from '@/store/chatStore';
-import { useChatSessionState } from '@/hooks/useChatSessionContext';
+import { useActiveChat } from '@/hooks/useActiveChat';
+import { useModelStore } from '@/store/modelStore';
 import { useGitCommitMutation, useGitDiffQuery } from '@/hooks/queries/useSandboxQueries';
 import { useGenerateCommitMessageMutation } from '@/hooks/queries/useGitHubQueries';
 import { MAX_DIFF_LENGTH } from '@/config/constants';
@@ -15,7 +15,7 @@ interface CreateCommitDialogProps {
 }
 
 export function CreateCommitDialog({ onClose }: CreateCommitDialogProps) {
-  const currentChat = useChatStore((s) => s.currentChat);
+  const currentChat = useActiveChat();
   const sandboxId = currentChat?.sandbox_id ?? '';
   const worktreeCwd = currentChat?.worktree_cwd ?? undefined;
   const commitMutation = useGitCommitMutation();
@@ -27,7 +27,11 @@ export function CreateCommitDialog({ onClose }: CreateCommitDialogProps) {
     false,
     worktreeCwd,
   );
-  const { selectedModelId } = useChatSessionState();
+  // Resolve the model from the active git chat (modelStore is keyed per chat), not
+  // the primary chat session — in split view this dialog targets the secondary pane.
+  const selectedModelId = useModelStore((s) =>
+    currentChat ? (s.modelByChat[currentChat.id] ?? '') : '',
+  );
 
   const hasDiff = !!diffData?.diff && !isPlaceholderData;
   const hasModel = !!selectedModelId.trim();

--- a/frontend/src/components/chat/github/CreatePRDialog.tsx
+++ b/frontend/src/components/chat/github/CreatePRDialog.tsx
@@ -7,8 +7,8 @@ import { Input } from '@/components/ui/primitives/Input';
 import { Link } from '@/components/ui/primitives/Link';
 import { Select } from '@/components/ui/primitives/Select';
 import { Textarea } from '@/components/ui/primitives/Textarea';
-import { useChatStore } from '@/store/chatStore';
-import { useChatSessionState } from '@/hooks/useChatSessionContext';
+import { useActiveChat } from '@/hooks/useActiveChat';
+import { useModelStore } from '@/store/modelStore';
 import { sandboxService } from '@/services/sandboxService';
 import { openExternalUrl } from '@/utils/openExternal';
 import { MAX_DIFF_LENGTH } from '@/config/constants';
@@ -53,7 +53,7 @@ function parseChangedFiles(
 }
 
 export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
-  const currentChat = useChatStore((s) => s.currentChat);
+  const currentChat = useActiveChat();
   const sandboxId = currentChat?.sandbox_id ?? '';
   const worktreeCwd = currentChat?.worktree_cwd ?? undefined;
 
@@ -124,7 +124,11 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
     setBaseBranch(detectedBase);
   }
 
-  const { selectedModelId } = useChatSessionState();
+  // Resolve the model from the active git chat (modelStore is keyed per chat), not
+  // the primary chat session — in split view this dialog targets the secondary pane.
+  const selectedModelId = useModelStore((s) =>
+    currentChat ? (s.modelByChat[currentChat.id] ?? '') : '',
+  );
   const createPR = useCreatePullRequestMutation();
   const generateDescription = useGeneratePRDescriptionMutation();
   const hasDiff = !!diffData?.diff;

--- a/frontend/src/components/chat/message-bubble/ChangedFilesPanel.tsx
+++ b/frontend/src/components/chat/message-bubble/ChangedFilesPanel.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/primitives/Button';
 import { DiffView } from '@/components/chat/tools/common/DiffView';
 import { useMessageChangesQuery, useMessageFileDiffQuery } from '@/hooks/queries/useChatQueries';
 import { useUIStore } from '@/store/uiStore';
+import { useChatContext } from '@/hooks/useChatContext';
 import type { ChangedFile, ChangedFileStatus } from '@/types/sandbox.types';
 
 interface ChangedFilesPanelProps {
@@ -88,6 +89,9 @@ const ChangedFileRow: React.FC<{
   file: ChangedFile;
   cwd: string;
 }> = ({ messageId, file, cwd }) => {
+  // This row renders inside either chat pane; bind diff jumps to the pane's
+  // chat so they open in (and are claimed by) that chat's own diff tile.
+  const { chatId } = useChatContext();
   const [open, setOpen] = useState(false);
   const isDeleted = file.status === 'D';
   const editorPath = cwd ? `${cwd}/${file.path}` : file.path;
@@ -130,7 +134,7 @@ const ChangedFileRow: React.FC<{
           <Button
             type="button"
             variant="unstyled"
-            onClick={() => useUIStore.getState().openInDiffView(file.path)}
+            onClick={() => chatId && useUIStore.getState().openInDiffView(file.path, chatId)}
             aria-label="Open in diff view"
             title="Open in diff view"
             className="text-text-quaternary transition-colors duration-150 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
@@ -141,7 +145,7 @@ const ChangedFileRow: React.FC<{
             <Button
               type="button"
               variant="unstyled"
-              onClick={() => useUIStore.getState().openFileInEditor(editorPath)}
+              onClick={() => useUIStore.getState().openFileInEditor(editorPath, chatId)}
               aria-label="Open in editor"
               title="Open in editor"
               className="text-text-quaternary transition-colors duration-150 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"

--- a/frontend/src/components/chat/tools/common/OpenInEditorButton.tsx
+++ b/frontend/src/components/chat/tools/common/OpenInEditorButton.tsx
@@ -2,16 +2,21 @@ import React from 'react';
 import { ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { useUIStore } from '@/store/uiStore';
+import { useChatContext } from '@/hooks/useChatContext';
 
-export const OpenInEditorButton: React.FC<{ filePath: string }> = ({ filePath }) => (
-  <Button
-    type="button"
-    onClick={() => useUIStore.getState().openFileInEditor(filePath)}
-    variant="unstyled"
-    className="rounded-sm opacity-0 transition-opacity duration-150 focus-visible:opacity-100 group-hover/tool:opacity-100"
-    title="Open in editor"
-    aria-label="Open in editor"
-  >
-    <ExternalLink className="h-3 w-3 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary" />
-  </Button>
-);
+export const OpenInEditorButton: React.FC<{ filePath: string }> = ({ filePath }) => {
+  // Open into the editor of the chat this tool belongs to, not always the primary.
+  const { chatId } = useChatContext();
+  return (
+    <Button
+      type="button"
+      onClick={() => useUIStore.getState().openFileInEditor(filePath, chatId)}
+      variant="unstyled"
+      className="rounded-sm opacity-0 transition-opacity duration-150 focus-visible:opacity-100 group-hover/tool:opacity-100"
+      title="Open in editor"
+      aria-label="Open in editor"
+    >
+      <ExternalLink className="h-3 w-3 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary" />
+    </Button>
+  );
+};

--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -23,6 +23,7 @@ export interface CodeViewProps {
   isSandboxSyncing?: boolean;
   onRefresh?: () => void;
   isRefreshing?: boolean;
+  chatId: string | undefined;
 }
 
 export const CodeView = memo(function CodeView({
@@ -37,6 +38,7 @@ export const CodeView = memo(function CodeView({
   isSandboxSyncing = false,
   onRefresh,
   isRefreshing = false,
+  chatId,
 }: CodeViewProps) {
   const backgroundClass = theme === 'light' ? 'bg-surface-secondary' : 'bg-surface-dark-secondary';
   const isMobile = useIsMobile();
@@ -122,14 +124,16 @@ export const CodeView = memo(function CodeView({
   // line nonce into local targetLine so View scrolls/highlights the line.
   const pendingFileJump = useUIStore((s) => s.pendingFileJump);
   useEffect(() => {
-    if (!pendingFileJump) return;
+    // Only the editor of the jump's chat reacts — the other editor leaves it
+    // for its own instance to claim.
+    if (!pendingFileJump || pendingFileJump.chatId !== chatId) return;
     setTargetLine({
       path: pendingFileJump.path,
       line: pendingFileJump.line,
       nonce: pendingFileJump.nonce,
     });
     useUIStore.getState().consumeFileJump();
-  }, [pendingFileJump]);
+  }, [pendingFileJump, chatId]);
 
   const sharedSidebarProps = {
     files,

--- a/frontend/src/components/editor/editor-core/Editor.tsx
+++ b/frontend/src/components/editor/editor-core/Editor.tsx
@@ -14,6 +14,9 @@ export interface EditorProps {
   isSandboxSyncing?: boolean;
   onRefresh?: () => void;
   isRefreshing?: boolean;
+  // Required so every editor instance consciously declares which chat's pending
+  // file opens/jumps it claims — `undefined` is the chat-less landing editor.
+  chatId: string | undefined;
 }
 
 export const Editor = memo(function Editor({
@@ -25,6 +28,7 @@ export const Editor = memo(function Editor({
   isSandboxSyncing = false,
   onRefresh,
   isRefreshing = false,
+  chatId,
 }: EditorProps) {
   const theme = useResolvedTheme();
   const [isDownloading, setIsDownloading] = useState(false);
@@ -73,6 +77,7 @@ export const Editor = memo(function Editor({
         isSandboxSyncing={isSandboxSyncing}
         onRefresh={onRefresh}
         isRefreshing={isRefreshing}
+        chatId={chatId}
       />
     </div>
   );

--- a/frontend/src/components/editor/editor-core/EditorPane.tsx
+++ b/frontend/src/components/editor/editor-core/EditorPane.tsx
@@ -1,0 +1,41 @@
+import { memo, useRef } from 'react';
+import { Editor } from '@/components/editor/editor-core/Editor';
+import { useChatQuery } from '@/hooks/queries/useChatQueries';
+import { useSandboxFiles } from '@/hooks/useSandboxFiles';
+import { useEditorState } from '@/hooks/useEditorState';
+import { usePendingFileOpen } from '@/hooks/usePendingFileOpen';
+
+// Self-contained editor for a chat, rendered once per pane in split view. It
+// owns its file data and selection so each pane tracks its own chat (mirrors
+// how AgentPane wraps the secondary chat).
+export const EditorPane = memo(function EditorPane({ chatId }: { chatId: string | undefined }) {
+  const { data: currentChat } = useChatQuery(chatId);
+  const { fileStructure, isFileMetadataLoading, refetchFilesMetadata } = useSandboxFiles(
+    currentChat,
+    chatId,
+  );
+  const { selectedFile, setSelectedFile, handleFileSelect, isRefreshing, handleRefresh } =
+    useEditorState(refetchFilesMetadata);
+  // Swapping the pane's chat reuses this same instance — drop the prior chat's
+  // selection so it doesn't show a file that belongs to the old chat.
+  const prevChatIdRef = useRef(chatId);
+  if (prevChatIdRef.current !== chatId) {
+    prevChatIdRef.current = chatId;
+    setSelectedFile(null);
+  }
+  usePendingFileOpen(fileStructure, setSelectedFile, chatId);
+
+  return (
+    <Editor
+      files={fileStructure}
+      selectedFile={selectedFile}
+      onFileSelect={handleFileSelect}
+      sandboxId={currentChat?.sandbox_id ?? undefined}
+      worktreeCwd={currentChat?.worktree_cwd ?? undefined}
+      isSandboxSyncing={isFileMetadataLoading}
+      onRefresh={handleRefresh}
+      isRefreshing={isRefreshing}
+      chatId={chatId}
+    />
+  );
+});

--- a/frontend/src/components/sandbox/git/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView.tsx
@@ -24,6 +24,7 @@ import {
   useGitRestoreFileMutation,
 } from '@/hooks/queries/useSandboxQueries';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
+import { useChatQuery } from '@/hooks/queries/useChatQueries';
 import { useUIStore } from '@/store/uiStore';
 import { parsePatchFiles, parseDiffFromFile } from '@pierre/diffs';
 import type { FileDiffMetadata, FileContents } from '@pierre/diffs';
@@ -222,12 +223,16 @@ function FileStatusBadge({ type }: { type?: string }) {
 }
 
 interface DiffViewProps {
-  sandboxId?: string;
-  cwd?: string;
+  // The chat this tile renders — resolves the sandbox/cwd it diffs and binds it
+  // to jumps so the primary and secondary diff tiles never consume each other's.
+  chatId: string | undefined;
 }
 
-export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps) {
+export const DiffView = memo(function DiffView({ chatId }: DiffViewProps) {
   const theme = useResolvedTheme();
+  const { data: chat } = useChatQuery(chatId);
+  const sandboxId = chat?.sandbox_id ?? undefined;
+  const cwd = chat?.worktree_cwd ?? undefined;
   const [expandedFiles, toggleFile, setExpandedFiles] = useToggleSet<string>();
   const [mode, setMode] = useState<DiffMode>('all');
   const [diffStyle, setDiffStyle] = useState<'unified' | 'split'>('unified');
@@ -245,13 +250,21 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
   const restoreFile = useGitRestoreFileMutation();
   const restoreAll = useGitRestoreAllMutation();
 
+  // Scopes the jump-scroll query to this tile's DOM — both diff tiles emit
+  // identical data-diff-file-path attributes, so a document-wide query could
+  // target the other tile.
+  const rootRef = useRef<HTMLDivElement>(null);
+
   // Filename keys persist across refetches, but mean different content across
-  // scopes — reset on scope change. Ref check avoids a double render.
+  // scopes — reset on scope change. Ref check avoids a double render. Discard
+  // dialog state is cleared too so a confirm can't act on the prior scope's file.
   const scopeKey = `${sandboxId ?? ''}\0${cwd ?? ''}\0${mode}`;
   const prevScopeRef = useRef(scopeKey);
   if (prevScopeRef.current !== scopeKey) {
     prevScopeRef.current = scopeKey;
     setExpandedFiles(new Set());
+    setDiscardTarget(null);
+    setDiscardAllOpen(false);
   }
 
   // Portal escapes the toolbar's overflow-x-auto clip (CSS clips both axes).
@@ -369,10 +382,15 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
   // either way to absorb cwd/repo-root prefix differences.
   const pendingDiffFile = useUIStore((s) => s.pendingDiffFile);
   useEffect(() => {
-    if (!pendingDiffFile || parsedFiles.length === 0) return;
+    // Ignore jumps bound to a different chat so this tile can't consume one
+    // meant for the other diff tile (or a since-replaced chat in this slot).
+    if (!pendingDiffFile || pendingDiffFile.chatId !== chatId) return;
+    // Wait for fresh rows — placeholder rows belong to the previous scope.
+    if (parsedFiles.length === 0 || isPlaceholderData) return;
+    const path = pendingDiffFile.path;
     const match =
-      parsedFiles.find((f) => f.name === pendingDiffFile) ??
-      parsedFiles.find((f) => f.name.endsWith(pendingDiffFile) || pendingDiffFile.endsWith(f.name));
+      parsedFiles.find((f) => f.name === path) ??
+      parsedFiles.find((f) => f.name.endsWith(path) || path.endsWith(f.name));
     if (match) {
       setExpandedFiles((prev) => {
         if (prev.has(match.name)) return prev;
@@ -381,12 +399,14 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
         return next;
       });
       requestAnimationFrame(() => {
-        const el = document.querySelector(`[data-diff-file-path="${CSS.escape(match.name)}"]`);
+        const el = rootRef.current?.querySelector(
+          `[data-diff-file-path="${CSS.escape(match.name)}"]`,
+        );
         el?.scrollIntoView({ block: 'start', behavior: 'smooth' });
       });
     }
     useUIStore.getState().consumeDiffFileJump();
-  }, [pendingDiffFile, parsedFiles, setExpandedFiles]);
+  }, [pendingDiffFile, parsedFiles, setExpandedFiles, chatId, isPlaceholderData]);
 
   const allExpanded = parsedFiles.length > 0 && parsedFiles.every((f) => expandedFiles.has(f.name));
 
@@ -421,7 +441,10 @@ export const DiffView = memo(function DiffView({ sandboxId, cwd }: DiffViewProps
       poolOptions={WORKER_POOL_OPTIONS}
       highlighterOptions={WORKER_HIGHLIGHTER_OPTIONS}
     >
-      <div className="flex h-full w-full flex-col bg-surface-secondary dark:bg-surface-dark-secondary">
+      <div
+        ref={rootRef}
+        className="flex h-full w-full flex-col bg-surface-secondary dark:bg-surface-dark-secondary"
+      >
         <div className="flex h-9 items-center gap-1.5 overflow-x-auto border-b border-border/50 px-3 [scrollbar-width:none] dark:border-border-dark/50 [&::-webkit-scrollbar]:hidden">
           <Button
             onClick={() => refetch()}

--- a/frontend/src/components/sandbox/secrets/SecretsView.tsx
+++ b/frontend/src/components/sandbox/secrets/SecretsView.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useEffect, useCallback } from 'react';
+import { memo, useState, useEffect, useCallback, useRef } from 'react';
 import { logger } from '@/utils/logger';
 import { Plus, Trash2, EyeOff, Eye, AlertTriangle } from 'lucide-react';
 import {
@@ -40,6 +40,16 @@ export const SecretsView = memo(function SecretsView({ sandboxId }: SecretsViewP
   const addSecretMutation = useAddSecretMutation();
   const updateSecretMutation = useUpdateSecretMutation();
   const deleteSecretMutation = useDeleteSecretMutation();
+
+  // Swapping the secondary chat changes the sandbox on this same instance — drop
+  // the prior sandbox's secrets (and reveal toggles) so a cached fetch can't flash
+  // another chat's values before the new data arrives.
+  const prevSandboxIdRef = useRef(sandboxId);
+  if (prevSandboxIdRef.current !== sandboxId) {
+    prevSandboxIdRef.current = sandboxId;
+    setSecrets([]);
+    setShowValues({});
+  }
 
   useEffect(() => {
     if (secretsData) {

--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -6,11 +6,17 @@ import { GitBranch, Search, PanelRight, PanelBottom, File } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 import { useUIStore } from '@/store/uiStore';
-import { useChatStore } from '@/store/chatStore';
 import { useQueryClient } from '@tanstack/react-query';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { useActiveViews } from '@/hooks/useActiveViews';
+import {
+  getEffectiveLayout,
+  getLeaves,
+  isSecondaryPaneActive,
+  viewTypeToTileId,
+} from '@/utils/mosaicHelpers';
 import { useChatContext } from '@/hooks/useChatContext';
+import { useActiveChat } from '@/hooks/useActiveChat';
+import { useSandboxFiles } from '@/hooks/useSandboxFiles';
 import { useGitBranchesQuery, useCheckoutBranchMutation } from '@/hooks/queries/useSandboxQueries';
 import { fuzzySearch } from '@/utils/fuzzySearch';
 import { HighlightMatch } from '@/components/ui/shared/HighlightMatch';
@@ -61,12 +67,43 @@ export function CommandMenu() {
   const isOpen = useUIStore((state) => state.commandMenuOpen);
   const theme = useUIStore((state) => state.theme);
   const isMobile = useIsMobile();
-  const activeLeaves = useActiveViews();
-  const activeLeafSet = useMemo(() => new Set(activeLeaves), [activeLeaves]);
+  // Leaf tile ids (not deduped view kinds) so the active-state/split affordances
+  // can distinguish a view's primary tile from its `:secondary` variant. Gated on
+  // open — layout/view churn is irrelevant while the always-mounted menu is closed.
+  const mosaicLayout = useUIStore((s) => (s.commandMenuOpen ? s.mosaicLayout : null));
+  const currentView = useUIStore((s) => (s.commandMenuOpen ? s.currentView : 'agent'));
+  const leafTileIds = useMemo(
+    () => new Set(getLeaves(getEffectiveLayout(mosaicLayout, currentView))),
+    [mosaicLayout, currentView],
+  );
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { fileStructure, sandboxId, chatId } = useChatContext();
-  const worktreeCwd = useChatStore((s) => s.currentChat?.worktree_cwd) ?? undefined;
+  const primaryCtx = useChatContext();
+
+  // File/search/branch actions target the pane the user last interacted with — in
+  // split view the secondary pane is a different chat with its own files/cwd/tiles.
+  const activeAgentTile = useUIStore((s) =>
+    s.commandMenuOpen ? s.activeAgentTile : 'agent:primary',
+  );
+  const secondaryChatId = useUIStore((s) => s.secondaryChatId);
+  const useSecondary = isSecondaryPaneActive(activeAgentTile, secondaryChatId);
+  // Resolve the active pane's chat through the canonical hook, gated on the menu
+  // being open so the always-mounted menu doesn't re-render on pane/secondary
+  // churn while closed. Only used for the secondary pane — the primary reuses the
+  // chat context directly below (its files/chatId are available there immediately).
+  const activeChat = useActiveChat(isOpen);
+  const secondaryChat = useSecondary ? activeChat : undefined;
+  const { fileStructure: secondaryFiles } = useSandboxFiles(
+    secondaryChat ?? undefined,
+    useSecondary ? (secondaryChatId ?? undefined) : undefined,
+  );
+
+  const chatId = useSecondary ? (secondaryChatId ?? undefined) : primaryCtx.chatId;
+  const fileStructure = useSecondary ? secondaryFiles : primaryCtx.fileStructure;
+  const sandboxId = useSecondary ? (secondaryChat?.sandbox_id ?? undefined) : primaryCtx.sandboxId;
+  const worktreeCwd = useSecondary
+    ? (secondaryChat?.worktree_cwd ?? undefined)
+    : primaryCtx.worktreeCwd;
 
   // Fetch branches whenever the menu is open so we can both render the branches mode and
   // filter the switch-branch command out of the list for chats without a repo. Cache is
@@ -167,18 +204,20 @@ export function CommandMenu() {
 
   const handleSelectFile = useCallback(
     (file: FlatFileItem) => {
-      useUIStore.getState().openFileInEditor(file.path);
+      // Jumps target the active chat's editor, or the chat-less landing editor
+      // (undefined chatId) when browsing workspace files before a chat exists.
+      useUIStore.getState().openFileInEditor(file.path, chatId);
       close();
     },
-    [close],
+    [close, chatId],
   );
 
   const handleOpenSearchResult = useCallback(
     (path: string, lineNumber: number) => {
-      useUIStore.getState().openFileInEditor(path, lineNumber);
+      useUIStore.getState().openFileInEditor(path, chatId, lineNumber);
       close();
     },
-    [close],
+    [close, chatId],
   );
 
   const handleOpenChatResult = useCallback(
@@ -518,8 +557,13 @@ export function CommandMenu() {
                 <>
                   {filteredCommands.map((cmd, index) => {
                     const Icon = cmd.icon;
+                    // Active/split state is scoped to the pane the user is in: the
+                    // view counts as open only if the active pane's target tile
+                    // (e.g. editor:secondary) is already a leaf, so the split
+                    // buttons stay available to open it in the other pane.
                     const isActive =
-                      (cmd.type === 'view' && activeLeafSet.has(cmd.id)) ||
+                      (cmd.type === 'view' &&
+                        leafTileIds.has(viewTypeToTileId(cmd.id, useSecondary))) ||
                       cmd.id === `theme-${theme}`;
 
                     return (

--- a/frontend/src/components/ui/MosaicSplitView.tsx
+++ b/frontend/src/components/ui/MosaicSplitView.tsx
@@ -9,19 +9,12 @@ import {
   libraryToMosaicLayout,
   getLeaves,
   tileIdToViewType,
+  VIEW_LABELS,
 } from '@/utils/mosaicHelpers';
-import type { ViewType, MosaicLayoutNode, MosaicTileId } from '@/types/ui.types';
+import type { MosaicLayoutNode, MosaicTileId } from '@/types/ui.types';
 
 import 'react-mosaic-component/react-mosaic-component.css';
 import '@/styles/mosaic-theme.css';
-
-const VIEW_LABELS: Record<ViewType, string> = {
-  agent: 'Agent',
-  diff: 'Diff',
-  editor: 'Editor',
-  terminal: 'Terminal',
-  secrets: 'Secrets',
-};
 
 function getTileLabel(
   tileId: MosaicTileId,

--- a/frontend/src/components/ui/commandRegistry.ts
+++ b/frontend/src/components/ui/commandRegistry.ts
@@ -26,10 +26,11 @@ import { useUIStore } from '@/store/uiStore';
 import { useChatStore } from '@/store/chatStore';
 import { sandboxService } from '@/services/sandboxService';
 import { queryKeys } from '@/hooks/queries/queryKeys';
-import { getLeafViewTypes, viewTypeToPrimaryTile } from '@/utils/mosaicHelpers';
+import { isSecondaryPaneActive } from '@/utils/mosaicHelpers';
 import { traverseFileStructure, getFileName } from '@/utils/file';
 import { IS_MAC_PLATFORM } from '@/utils/platform';
 import type { ViewType } from '@/types/ui.types';
+import type { Chat } from '@/types/chat.types';
 import type { FileStructure } from '@/types/file-system.types';
 import type { GitBranchesData } from '@/types/sandbox.types';
 
@@ -197,7 +198,21 @@ export function formatShortcut(key: string): string {
   return `${mod}⇧${key === '.' ? '.' : key.toUpperCase()}`;
 }
 
+// Chat-scoped actions (git, sub-threads) target the pane the user last interacted
+// with — in split view the secondary pane is a different chat. The secondary chat
+// is cache-warm here since it's rendered in the split.
+function getActiveChat(queryClient: QueryClient): Chat | null {
+  const ui = useUIStore.getState();
+  if (isSecondaryPaneActive(ui.activeAgentTile, ui.secondaryChatId) && ui.secondaryChatId) {
+    // Don't fall back to the primary chat — acting on the wrong chat is worse than
+    // a no-op if the secondary chat isn't cached yet.
+    return queryClient.getQueryData<Chat>(queryKeys.chat(ui.secondaryChatId)) ?? null;
+  }
+  return useChatStore.getState().currentChat;
+}
+
 function executeGitRemoteCommand(
+  chat: Chat | null,
   fn: (
     sandboxId: string,
     cwd?: string,
@@ -205,7 +220,6 @@ function executeGitRemoteCommand(
   label: string,
   onSuccess?: () => void,
 ) {
-  const chat = useChatStore.getState().currentChat;
   if (!chat?.sandbox_id) {
     toast.error('No sandbox connected');
     return;
@@ -231,21 +245,12 @@ export function executeCommand(
   const ui = useUIStore.getState();
 
   if (cmd.type === 'view') {
-    const layout = ui.mosaicLayout ?? viewTypeToPrimaryTile(ui.currentView);
-    const leafKinds = getLeafViewTypes(layout);
-    if (toggle && leafKinds.includes(cmd.id)) {
-      if (cmd.id === 'agent' && ui.secondaryChatId) {
-        ui.closeSplitChat();
-      } else {
-        ui.removeTileFromMosaic(viewTypeToPrimaryTile(cmd.id));
-      }
-    } else {
-      ui.handleViewClick(cmd.id, true);
-    }
+    // Toggling is scoped to the active pane (the chat the user last interacted with).
+    ui.toggleView(cmd.id, toggle);
   } else if (cmd.id === 'new-thread') {
     navigate('/');
   } else if (cmd.id === 'new-sub-thread') {
-    const chat = useChatStore.getState().currentChat;
+    const chat = getActiveChat(queryClient);
     if (!chat || chat.parent_chat_id) {
       toast.error('Open a top-level thread first');
     } else {
@@ -258,8 +263,9 @@ export function executeCommand(
   } else if (cmd.id === 'create-branch') {
     ui.setCreateBranchDialogOpen(toggle ? !ui.createBranchDialogOpen : true);
   } else if (cmd.id === 'push-remote') {
-    const sandboxId = useChatStore.getState().currentChat?.sandbox_id;
-    executeGitRemoteCommand(sandboxService.gitPush, 'Pushed to remote', () => {
+    const chat = getActiveChat(queryClient);
+    const sandboxId = chat?.sandbox_id;
+    executeGitRemoteCommand(chat, sandboxService.gitPush, 'Pushed to remote', () => {
       if (sandboxId) {
         void queryClient.invalidateQueries({
           queryKey: queryKeys.sandbox.gitBranchesAll(sandboxId),
@@ -267,8 +273,9 @@ export function executeCommand(
       }
     });
   } else if (cmd.id === 'pull-remote') {
-    const sandboxId = useChatStore.getState().currentChat?.sandbox_id;
-    executeGitRemoteCommand(sandboxService.gitPull, 'Pulled from remote', () => {
+    const chat = getActiveChat(queryClient);
+    const sandboxId = chat?.sandbox_id;
+    executeGitRemoteCommand(chat, sandboxService.gitPull, 'Pulled from remote', () => {
       if (sandboxId) {
         void Promise.all([
           queryClient.invalidateQueries({
@@ -295,7 +302,7 @@ export function executeCommand(
     ui.setPendingMenuMode('files');
     ui.setCommandMenuOpen(true);
   } else if (cmd.id === 'switch-branch') {
-    const chat = useChatStore.getState().currentChat;
+    const chat = getActiveChat(queryClient);
     if (!chat?.sandbox_id) {
       toast.error('No sandbox connected');
       return;

--- a/frontend/src/hooks/useActiveChat.ts
+++ b/frontend/src/hooks/useActiveChat.ts
@@ -1,0 +1,22 @@
+import { useChatStore } from '@/store/chatStore';
+import { useUIStore } from '@/store/uiStore';
+import { useChatQuery } from '@/hooks/queries/useChatQueries';
+import { isSecondaryPaneActive } from '@/utils/mosaicHelpers';
+import type { Chat } from '@/types/chat.types';
+
+// Resolves the chat for the pane the user last interacted with. In split view the
+// secondary pane is a different chat with its own sandbox/worktree, so actions
+// (git, sub-threads, …) target it when it's the active pane.
+//
+// `enabled` lets always-mounted callers (e.g. CommandMenu) gate the subscriptions
+// to stable values while inactive, so pane/secondary churn doesn't re-render them.
+export function useActiveChat(enabled = true): Chat | null {
+  const primaryChat = useChatStore((s) => (enabled ? s.currentChat : null));
+  const activeAgentTile = useUIStore((s) => (enabled ? s.activeAgentTile : 'agent:primary'));
+  const secondaryChatId = useUIStore((s) => (enabled ? s.secondaryChatId : null));
+  const useSecondary = isSecondaryPaneActive(activeAgentTile, secondaryChatId);
+  const { data: secondaryChat } = useChatQuery(secondaryChatId ?? undefined, {
+    enabled: enabled && useSecondary,
+  });
+  return useSecondary ? (secondaryChat ?? null) : primaryChat;
+}

--- a/frontend/src/hooks/useActiveViews.ts
+++ b/frontend/src/hooks/useActiveViews.ts
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import { useUIStore } from '@/store/uiStore';
-import { getLeafViewTypes, tileIdToViewType } from '@/utils/mosaicHelpers';
+import { getEffectiveLayout, getLeafViewTypes } from '@/utils/mosaicHelpers';
 import type { ViewType } from '@/types/ui.types';
 
 function arraysEqual(a: ViewType[], b: ViewType[]): boolean {
@@ -19,15 +19,7 @@ export function useActiveViews(): ViewType[] {
   const prevRef = useRef<ViewType[]>([]);
 
   return useUIStore((state) => {
-    const { mosaicLayout, currentView } = state;
-    let next: ViewType[];
-    if (!mosaicLayout) {
-      next = [currentView];
-    } else if (typeof mosaicLayout === 'string') {
-      next = [tileIdToViewType(mosaicLayout)];
-    } else {
-      next = getLeafViewTypes(mosaicLayout);
-    }
+    const next = getLeafViewTypes(getEffectiveLayout(state.mosaicLayout, state.currentView));
     if (arraysEqual(prevRef.current, next)) return prevRef.current;
     prevRef.current = next;
     return next;

--- a/frontend/src/hooks/usePendingFileOpen.ts
+++ b/frontend/src/hooks/usePendingFileOpen.ts
@@ -6,13 +6,17 @@ import type { FileStructure } from '@/types/file-system.types';
 export function usePendingFileOpen(
   fileStructure: FileStructure[],
   setSelectedFile: (file: FileStructure | null) => void,
+  chatId: string | undefined,
 ) {
   const pendingFilePath = useUIStore((s) => s.pendingFilePath);
 
   useEffect(() => {
-    if (!pendingFilePath || fileStructure.length === 0) return;
-    const file = findFileByToolPath(fileStructure, pendingFilePath);
-    setSelectedFile(file ?? { path: pendingFilePath, type: 'file', content: '' });
+    // Ignore opens bound to the other chat's editor so each editor claims only
+    // its own — the primary and secondary editors share this store field.
+    if (!pendingFilePath || pendingFilePath.chatId !== chatId || fileStructure.length === 0) return;
+    const path = pendingFilePath.path;
+    const file = findFileByToolPath(fileStructure, path);
+    setSelectedFile(file ?? { path, type: 'file', content: '' });
     useUIStore.setState({ pendingFilePath: null });
-  }, [pendingFilePath, setSelectedFile, fileStructure]);
+  }, [pendingFilePath, setSelectedFile, fileStructure, chatId]);
 }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -9,13 +9,13 @@ import { CommandMenu } from '@/components/ui/CommandMenu';
 import { useCommandMenu } from '@/hooks/useCommandMenu';
 import { useActiveViews } from '@/hooks/useActiveViews';
 import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback';
-import type { MosaicTileId, ViewType } from '@/types/ui.types';
+import type { AgentTileId, MosaicTileId, ViewType } from '@/types/ui.types';
+import { isSecondaryTile, tileIdToViewType, VIEW_LABELS, VIEW_TYPES } from '@/utils/mosaicHelpers';
 import { Chat as ChatComponent } from '@/components/chat/chat-window/Chat';
 import { ChatSessionOrchestrator } from '@/components/chat/chat-window/ChatSessionOrchestrator';
 import { AgentPane } from '@/components/chat/chat-window/AgentPane';
-import { useEditorState } from '@/hooks/useEditorState';
-import { usePendingFileOpen } from '@/hooks/usePendingFileOpen';
 import { useChatData } from '@/hooks/useChatData';
+import { useActiveChat } from '@/hooks/useActiveChat';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useChatQuery } from '@/hooks/queries/useChatQueries';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
@@ -24,8 +24,8 @@ import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
 import { ChatProvider } from '@/contexts/ChatContext';
 import { CreateSubThreadDialog } from '@/components/chat/sub-threads/CreateSubThreadDialog';
 
-const Editor = lazy(() =>
-  import('@/components/editor/editor-core/Editor').then((m) => ({ default: m.Editor })),
+const EditorPane = lazy(() =>
+  import('@/components/editor/editor-core/EditorPane').then((m) => ({ default: m.EditorPane })),
 );
 const SecretsView = lazy(() =>
   import('@/components/sandbox/secrets/SecretsView').then((m) => ({ default: m.SecretsView })),
@@ -49,6 +49,21 @@ const CreateCommitDialog = lazy(() =>
 const CreatePRDialog = lazy(() =>
   import('@/components/chat/github/CreatePRDialog').then((m) => ({ default: m.CreatePRDialog })),
 );
+
+// Mount-gated wrapper (matches the git dialogs' pattern) so useActiveChat's
+// pane subscriptions don't re-render the whole page on every pane switch.
+function SubThreadDialog() {
+  // Sub-threads branch off the pane the user is in — in split view that's the
+  // secondary chat when it's the active pane.
+  const parentChat = useActiveChat();
+  if (!parentChat || parentChat.parent_chat_id) return null;
+  return (
+    <CreateSubThreadDialog
+      parentChat={parentChat}
+      onClose={() => useUIStore.getState().setSubThreadDialogOpen(false)}
+    />
+  );
+}
 
 export function ChatPage() {
   const { chatId } = useParams();
@@ -88,10 +103,7 @@ export function ChatPage() {
     }
   }, [chatId, isMobile, secondaryChatId]);
 
-  const { fileStructure, isFileMetadataLoading, refetchFilesMetadata } = useSandboxFiles(
-    currentChat,
-    chatId,
-  );
+  const { fileStructure, refetchFilesMetadata } = useSandboxFiles(currentChat, chatId);
 
   const worktreeCwd = currentChat?.worktree_cwd ?? undefined;
 
@@ -126,9 +138,6 @@ export function ChatPage() {
 
   const { data: workspaceResources } = useWorkspaceResourcesQuery(currentChat?.workspace_id);
 
-  const { selectedFile, setSelectedFile, isRefreshing, handleRefresh, handleFileSelect } =
-    useEditorState(refetchFilesMetadata);
-
   const prevChatIdForResetRef = useRef(chatId);
 
   useEffect(() => {
@@ -137,7 +146,6 @@ export function ChatPage() {
 
   if (prevChatIdForResetRef.current !== chatId) {
     prevChatIdForResetRef.current = chatId;
-    setSelectedFile(null);
     const ui = useUIStore.getState();
     if (ui.secondaryChatId === chatId) {
       ui.closeSplitChat();
@@ -148,14 +156,13 @@ export function ChatPage() {
     useUIStore.setState({
       pendingFilePath: null,
       pendingFileJump: null,
+      pendingDiffFile: null,
       subThreadDialogOpen: false,
       createCommitDialogOpen: false,
       createPRDialogOpen: false,
       createBranchDialogOpen: false,
     });
   }
-
-  usePendingFileOpen(fileStructure, setSelectedFile);
 
   const handleChatSelect = useCallback(
     (selectedChatId: string) => {
@@ -201,62 +208,61 @@ export function ChatPage() {
         if (!secondaryChatId) return null;
         return <AgentPane chatId={secondaryChatId} />;
       }
-      const view: ViewType = tileId;
-      switch (view) {
+      // Secondary tiles render the second chat's own sandbox/cwd. The terminal
+      // is handled in renderView's terminal branch, so it's a no-op here.
+      const isSecondary = isSecondaryTile(tileId);
+      if (isSecondary && !secondaryChatId) return null;
+      const paneChat = isSecondary ? secondaryQuery.data : currentChat;
+      const paneChatId = isSecondary ? (secondaryChatId ?? undefined) : chatId;
+      switch (tileIdToViewType(tileId)) {
         case 'editor':
           return (
             <Suspense fallback={viewLoadingFallback}>
-              <Editor
-                files={fileStructure}
-                selectedFile={selectedFile}
-                onFileSelect={handleFileSelect}
-                sandboxId={currentChat?.sandbox_id}
-                worktreeCwd={worktreeCwd}
-                isSandboxSyncing={isFileMetadataLoading}
-                onRefresh={handleRefresh}
-                isRefreshing={isRefreshing}
-              />
+              <EditorPane chatId={paneChatId} />
             </Suspense>
           );
         case 'secrets':
           return (
             <Suspense fallback={viewLoadingFallback}>
-              <SecretsView sandboxId={currentChat?.sandbox_id} />
+              <SecretsView sandboxId={paneChat?.sandbox_id ?? undefined} />
             </Suspense>
           );
         case 'diff':
           return (
             <Suspense fallback={viewLoadingFallback}>
-              <DiffView sandboxId={currentChat?.sandbox_id} cwd={worktreeCwd} />
+              <DiffView chatId={paneChatId} />
             </Suspense>
           );
         default:
           return null;
       }
     },
-    [
-      currentChat,
-      fileStructure,
-      selectedFile,
-      handleFileSelect,
-      isFileMetadataLoading,
-      handleRefresh,
-      isRefreshing,
-      worktreeCwd,
-      secondaryChatId,
-    ],
+    [chatId, currentChat, secondaryChatId, secondaryQuery.data?.sandbox_id],
   );
 
   const renderView = useCallback(
     (tileId: MosaicTileId, slot: string): ReactNode => {
-      const isTerminal = tileId === 'terminal';
+      const isSecondary = isSecondaryTile(tileId);
+      const isTerminal = tileId === 'terminal' || tileId === 'terminal:secondary';
+      // Every tile maps to the chat it shows; recording it on any interaction
+      // keeps pane-scoped shortcuts aimed at the chat the user is actually in.
+      const activePane: AgentTileId = isSecondary ? 'agent:secondary' : 'agent:primary';
+      // The secondary terminal runs in the second chat's sandbox; the hidden
+      // terminals kept alive in other slots stay on the primary chat.
+      const terminalSandboxId = isSecondary
+        ? (secondaryQuery.data?.sandbox_id ?? undefined)
+        : currentChat?.sandbox_id;
+      const terminalChatId = isSecondary ? (secondaryChatId ?? undefined) : currentChat?.id;
       return (
-        <div className="relative flex h-full w-full">
+        <div
+          className="relative flex h-full w-full"
+          onPointerDownCapture={() => useUIStore.getState().setActiveAgentTile(activePane)}
+        >
           <div className={isTerminal ? 'flex h-full w-full' : 'hidden'}>
             <Suspense fallback={viewLoadingFallback}>
               <TerminalContainer
-                sandboxId={currentChat?.sandbox_id}
-                chatId={currentChat?.id}
+                sandboxId={terminalSandboxId}
+                chatId={terminalChatId}
                 isVisible={isTerminal}
                 panelKey={slot}
               />
@@ -268,7 +274,7 @@ export function ChatPage() {
         </div>
       );
     },
-    [currentChat, renderNonTerminalView],
+    [currentChat, renderNonTerminalView, secondaryChatId, secondaryQuery.data?.sandbox_id],
   );
 
   const handleCloseTile = useCallback(
@@ -293,9 +299,18 @@ export function ChatPage() {
 
   const agentTitles = useMemo<Partial<Record<MosaicTileId, string>>>(() => {
     const titles: Partial<Record<MosaicTileId, string>> = {};
-    if (currentChat?.title) titles['agent:primary'] = currentChat.title;
-    if (secondaryChatId && secondaryQuery.data?.title) {
-      titles['agent:secondary'] = secondaryQuery.data.title;
+    const primaryTitle = currentChat?.title;
+    const secondaryTitle = secondaryQuery.data?.title;
+    if (primaryTitle) titles['agent:primary'] = primaryTitle;
+    if (secondaryChatId && secondaryTitle) {
+      titles['agent:secondary'] = secondaryTitle;
+      // Each non-agent view's two tiles can coexist in split-chat view — name
+      // them by chat so the two copies (primary/secondary) are distinguishable.
+      for (const view of VIEW_TYPES) {
+        if (view === 'agent') continue;
+        if (primaryTitle) titles[view] = `${primaryTitle} · ${VIEW_LABELS[view]}`;
+        titles[`${view}:secondary`] = `${secondaryTitle} · ${VIEW_LABELS[view]}`;
+      }
     }
     return titles;
   }, [currentChat?.title, secondaryChatId, secondaryQuery.data?.title]);
@@ -330,12 +345,7 @@ export function ChatPage() {
             />
           </div>
           <CommandMenu />
-          {subThreadDialogOpen && currentChat && !currentChat.parent_chat_id && (
-            <CreateSubThreadDialog
-              parentChat={currentChat}
-              onClose={() => useUIStore.getState().setSubThreadDialogOpen(false)}
-            />
-          )}
+          {subThreadDialogOpen && <SubThreadDialog />}
           {createCommitDialogOpen && (
             <Suspense fallback={null}>
               <CreateCommitDialog

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -129,7 +129,8 @@ export function LandingPage() {
     setSelectedFile(null);
   }
 
-  usePendingFileOpen(fileStructure, setSelectedFile);
+  // No chat exists on the landing page, so there are no chat-bound file jumps.
+  usePendingFileOpen(fileStructure, setSelectedFile, undefined);
 
   const { data: settings } = useSettingsQuery({
     enabled: isAuthenticated,
@@ -271,6 +272,7 @@ export function LandingPage() {
                 isSandboxSyncing={false}
                 onRefresh={handleRefresh}
                 isRefreshing={isRefreshing}
+                chatId={undefined}
               />
             </Suspense>
           );

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -6,16 +6,22 @@ import type {
   UIActions,
   SplitViewState,
   SplitViewActions,
-  ViewType,
   MosaicTileId,
+  MosaicLayoutNode,
 } from '@/types/ui.types';
 import { MOBILE_BREAKPOINT } from '@/config/constants';
 import {
+  getEffectiveLayout,
+  getLeafViewTypes,
   getLeaves,
   isMosaicSplitNode,
+  isSecondaryPaneActive,
+  isSecondaryTile,
   removeTileFromLayout,
+  SECONDARY_TILE_IDS,
   tileIdToViewType,
   viewTypeToPrimaryTile,
+  viewTypeToTileId,
 } from '@/utils/mosaicHelpers';
 import type { MenuMode } from '@/components/ui/commandRegistry';
 
@@ -45,14 +51,25 @@ type UIStoreState = ThemeState &
     setCreateBranchDialogOpen: (open: boolean) => void;
     createCommitDialogOpen: boolean;
     setCreateCommitDialogOpen: (open: boolean) => void;
-    pendingFilePath: string | null;
+    // `chatId` binds the open/jump to its chat so only that chat's editor tile
+    // claims it (the primary and secondary editors share these store fields).
+    // `undefined` is the chat-less landing editor, which exposes workspace files
+    // before any chat exists.
+    pendingFilePath: { path: string; chatId: string | undefined } | null;
     // Nonce lets the consumer re-jump even when path+line repeat, so that clicking
     // the same search result after scrolling away still reveals it.
-    pendingFileJump: { path: string; line: number; nonce: number } | null;
-    openFileInEditor: (path: string, line?: number) => void;
+    pendingFileJump: {
+      path: string;
+      line: number;
+      nonce: number;
+      chatId: string | undefined;
+    } | null;
+    openFileInEditor: (path: string, chatId: string | undefined, line?: number) => void;
     consumeFileJump: () => void;
-    pendingDiffFile: string | null;
-    openInDiffView: (path: string) => void;
+    // `chatId` binds the jump to its chat so only that chat's diff tile claims
+    // it — a jump can't be consumed by a different chat mounted in the same slot.
+    pendingDiffFile: { path: string; chatId: string } | null;
+    openInDiffView: (path: string, chatId: string) => void;
     consumeDiffFileJump: () => void;
     pendingChatMessage: { chatId: string; message: string } | null;
     setPendingChatMessage: (payload: { chatId: string; message: string } | null) => void;
@@ -67,15 +84,14 @@ const isDesktop = (): boolean =>
   typeof window !== 'undefined' && window.innerWidth >= MOBILE_BREAKPOINT;
 
 // Mobile switches the sole view; desktop appends a tile to the mosaic
-// unless the view is already present.
-function ensureViewVisible(
+// unless the tile is already present.
+function ensureTileVisible(
   set: (partial: Partial<UIStoreState>) => void,
   get: () => UIStoreState,
-  view: ViewType,
+  tileId: MosaicTileId,
 ): void {
-  const tileId = viewTypeToPrimaryTile(view);
   if (!isDesktop()) {
-    set({ currentView: view, mosaicLayout: tileId });
+    set({ currentView: tileIdToViewType(tileId), mosaicLayout: tileId });
     return;
   }
   const state = get();
@@ -86,11 +102,38 @@ function ensureViewVisible(
     }
     return;
   }
-  const currentTile: MosaicTileId =
-    typeof layout === 'string' ? layout : viewTypeToPrimaryTile(state.currentView);
+  const currentTile = getEffectiveLayout(layout, state.currentView);
   if (currentTile !== tileId) {
     set({ mosaicLayout: { direction: 'row', first: currentTile, second: tileId } });
   }
+}
+
+// The diff/editor jumps are chat-bound; a jump for a chat that's going away (its
+// pane closed/replaced) is stale and would otherwise fire in the wrong tile.
+function clearJumpsForChat(state: UIStoreState, chatId: string | null): Partial<UIStoreState> {
+  const cleared: Partial<UIStoreState> = {};
+  if (state.pendingDiffFile?.chatId === chatId) cleared.pendingDiffFile = null;
+  if (state.pendingFilePath?.chatId === chatId) cleared.pendingFilePath = null;
+  if (state.pendingFileJump?.chatId === chatId) cleared.pendingFileJump = null;
+  return cleared;
+}
+
+// A pending jump can't survive its own tile being closed. Only the tile that
+// would have claimed it clears it: a secondary tile owns jumps for the secondary
+// chat, the primary owns the rest.
+function clearJumpsForTile(state: UIStoreState, tileId: MosaicTileId): Partial<UIStoreState> {
+  const view = tileIdToViewType(tileId);
+  if (view !== 'diff' && view !== 'editor') return {};
+  const owns = (jump: { chatId: string | undefined } | null) =>
+    !!jump &&
+    (isSecondaryTile(tileId)
+      ? jump.chatId === state.secondaryChatId
+      : jump.chatId !== state.secondaryChatId);
+  const cleared: Partial<UIStoreState> = {};
+  if (view === 'diff' && owns(state.pendingDiffFile)) cleared.pendingDiffFile = null;
+  if (view === 'editor' && owns(state.pendingFilePath)) cleared.pendingFilePath = null;
+  if (view === 'editor' && owns(state.pendingFileJump)) cleared.pendingFileJump = null;
+  return cleared;
 }
 
 export const useUIStore = create<UIStoreState>()(
@@ -134,23 +177,57 @@ export const useUIStore = create<UIStoreState>()(
       consumeFileJump: () => set({ pendingFileJump: null }),
       pendingDiffFile: null,
       consumeDiffFileJump: () => set({ pendingDiffFile: null }),
-      openFileInEditor: (path, line) => {
+      openFileInEditor: (path, chatId, line) => {
+        const secondary = chatId === get().secondaryChatId;
         set({
-          pendingFilePath: path,
+          pendingFilePath: { path, chatId },
           pendingFileJump:
-            line != null ? { path, line, nonce: (get().pendingFileJump?.nonce ?? 0) + 1 } : null,
+            line != null
+              ? { path, line, chatId, nonce: (get().pendingFileJump?.nonce ?? 0) + 1 }
+              : null,
         });
-        ensureViewVisible(set, get, 'editor');
+        ensureTileVisible(set, get, viewTypeToTileId('editor', secondary));
       },
-      openInDiffView: (path) => {
-        set({ pendingDiffFile: path });
-        ensureViewVisible(set, get, 'diff');
+      openInDiffView: (path, chatId) => {
+        const secondary = chatId === get().secondaryChatId;
+        set({ pendingDiffFile: { path, chatId } });
+        ensureTileVisible(set, get, viewTypeToTileId('diff', secondary));
       },
 
       currentView: 'agent',
       splitDirection: 'row',
       mosaicLayout: null,
       secondaryChatId: null,
+      activeAgentTile: 'agent:primary',
+
+      setActiveAgentTile: (tile) => {
+        if (get().activeAgentTile !== tile) set({ activeAgentTile: tile });
+      },
+
+      toggleView: (view, toggle) => {
+        const state = get();
+        const layout = getEffectiveLayout(state.mosaicLayout, state.currentView);
+        // Agent has no per-pane toggle: closing it tears down the split (or the
+        // lone primary tile); opening it goes through the regular view click.
+        if (view === 'agent') {
+          if (toggle && getLeafViewTypes(layout).includes('agent')) {
+            if (state.secondaryChatId) get().closeSplitChat();
+            else get().removeTileFromMosaic('agent:primary');
+          } else {
+            get().handleViewClick('agent', true);
+          }
+          return;
+        }
+        // Target the tile of the pane the user is in — falls back to the primary
+        // tile when there's no secondary chat to scope to.
+        const secondary = isSecondaryPaneActive(state.activeAgentTile, state.secondaryChatId);
+        const tileId = viewTypeToTileId(view, secondary);
+        if (toggle && getLeaves(layout).includes(tileId)) {
+          get().removeTileFromMosaic(tileId);
+        } else {
+          ensureTileVisible(set, get, tileId);
+        }
+      },
 
       setCurrentView: (view) =>
         set({
@@ -192,13 +269,13 @@ export const useUIStore = create<UIStoreState>()(
       },
 
       addTileToMosaic: (view, direction) => {
-        const tileId = viewTypeToPrimaryTile(view);
         const state = get();
-        const currentLayout = state.mosaicLayout ?? viewTypeToPrimaryTile(state.currentView);
+        // Split controls used from the secondary pane open <view>:secondary.
+        const secondary = isSecondaryPaneActive(state.activeAgentTile, state.secondaryChatId);
+        const tileId = viewTypeToTileId(view, secondary);
+        const currentLayout = getEffectiveLayout(state.mosaicLayout, state.currentView);
 
-        const leaves: MosaicTileId[] =
-          typeof currentLayout === 'string' ? [currentLayout] : getLeaves(currentLayout);
-        if (leaves.includes(tileId)) return;
+        if (getLeaves(currentLayout).includes(tileId)) return;
 
         set({
           mosaicLayout: {
@@ -210,10 +287,13 @@ export const useUIStore = create<UIStoreState>()(
       },
 
       removeTileFromMosaic: (tileId) => {
-        const layout = get().mosaicLayout;
+        const state = get();
+        const layout = state.mosaicLayout;
         if (!layout || typeof layout === 'string') return;
         const leaves = getLeaves(layout);
         if (!leaves.includes(tileId)) return;
+        const clearedJumps = clearJumpsForTile(state, tileId);
+        if (Object.keys(clearedJumps).length > 0) set(clearedJumps);
         const remaining = leaves.filter((v) => v !== tileId);
         if (remaining.length === 0) return;
         if (remaining.length === 1) {
@@ -250,9 +330,18 @@ export const useUIStore = create<UIStoreState>()(
 
       openChatInSplit: (chatId) => {
         const state = get();
+        // When the secondary slot shows a different chat, default the active pane
+        // back to primary and drop a jump still pending for the replaced chat.
+        const secondaryChanged = state.secondaryChatId !== chatId;
+        const resetForNewSecondary: Partial<UIStoreState> = secondaryChanged
+          ? {
+              activeAgentTile: 'agent:primary',
+              ...clearJumpsForChat(state, state.secondaryChatId),
+            }
+          : {};
         if (!isDesktop()) {
           if (state.secondaryChatId === chatId) return;
-          set({ secondaryChatId: chatId });
+          set({ secondaryChatId: chatId, ...resetForNewSecondary });
           return;
         }
         const nextLayout = buildSplitChatLayout(state.mosaicLayout);
@@ -260,20 +349,30 @@ export const useUIStore = create<UIStoreState>()(
         set({
           secondaryChatId: chatId,
           ...(nextLayout ? { mosaicLayout: nextLayout } : {}),
+          ...resetForNewSecondary,
         });
       },
 
       closeSplitChat: () => {
         const state = get();
         const layout = state.mosaicLayout;
+        // Shared reset: focus back to primary, drop any jump aimed at the now-gone
+        // secondary chat.
+        const reset: Partial<UIStoreState> = {
+          secondaryChatId: null,
+          activeAgentTile: 'agent:primary',
+          ...clearJumpsForChat(state, state.secondaryChatId),
+        };
         if (layout && isMosaicSplitNode(layout)) {
-          const newLayout = removeTileFromLayout(layout, 'agent:secondary');
-          set({
-            secondaryChatId: null,
-            mosaicLayout: newLayout ?? 'agent:primary',
-          });
+          // Every secondary tile is scoped to the closing chat — drop them all.
+          let newLayout: MosaicLayoutNode | null = layout;
+          for (const tile of SECONDARY_TILE_IDS) {
+            if (!newLayout) break;
+            newLayout = removeTileFromLayout(newLayout, tile);
+          }
+          set({ ...reset, mosaicLayout: newLayout ?? 'agent:primary' });
         } else if (state.secondaryChatId !== null) {
-          set({ secondaryChatId: null });
+          set(reset);
         }
       },
 

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -30,11 +30,15 @@ export interface ModelSelectionState {
 
 export type ViewType = 'agent' | 'diff' | 'editor' | 'terminal' | 'secrets';
 
-// Mosaic leaves used to be ViewType strings, but to render two `agent` panes
-// simultaneously (split chat view) the agent slot needs to be disambiguated.
-// Non-agent tile ids are identical to their ViewType.
+// Mosaic leaves used to be ViewType strings, but split-chat view renders two
+// panes scoped to different chats, so every view has a `:secondary` variant
+// disambiguating the second chat. Primary tile ids match their ViewType (the
+// agent slot is the one exception: 'agent:primary').
 export type AgentTileId = 'agent:primary' | 'agent:secondary';
-export type NonAgentTileId = Exclude<ViewType, 'agent'>;
+export type SecondaryTileId = `${ViewType}:secondary`;
+export type NonAgentTileId =
+  | Exclude<ViewType, 'agent'>
+  | Exclude<SecondaryTileId, 'agent:secondary'>;
 export type MosaicTileId = AgentTileId | NonAgentTileId;
 
 export type MosaicDirection = 'row' | 'column';
@@ -54,6 +58,9 @@ export interface SplitViewState {
   mosaicLayout: MosaicLayoutNode | null;
   // Secondary chat for split-chat view. Primary chat is always the route param.
   secondaryChatId: string | null;
+  // The agent pane the user last interacted with — targets pane-scoped actions
+  // (e.g. the diff shortcut) at the chat the user is actually in.
+  activeAgentTile: AgentTileId;
 }
 
 export interface SplitViewActions {
@@ -68,6 +75,10 @@ export interface SplitViewActions {
   closeSplitChat: () => void;
   // Returns the chatId that should become the new route primary (caller navigates).
   swapChatPanes: (currentPrimaryChatId: string) => string | null;
+  setActiveAgentTile: (tile: AgentTileId) => void;
+  // Opens or (when toggling) closes a view's tile for the active agent pane,
+  // so the shortcut targets the chat the user is currently in.
+  toggleView: (view: ViewType, toggle: boolean) => void;
 }
 
 export interface UIState {

--- a/frontend/src/utils/mosaicHelpers.ts
+++ b/frontend/src/utils/mosaicHelpers.ts
@@ -1,5 +1,45 @@
-import type { MosaicLayoutNode, MosaicSplitNode, MosaicTileId, ViewType } from '@/types/ui.types';
+import type {
+  AgentTileId,
+  MosaicLayoutNode,
+  MosaicSplitNode,
+  MosaicTileId,
+  SecondaryTileId,
+  ViewType,
+} from '@/types/ui.types';
 import type { MosaicNode } from 'react-mosaic-component';
+
+export const VIEW_TYPES: ViewType[] = ['agent', 'diff', 'editor', 'terminal', 'secrets'];
+
+export const VIEW_LABELS: Record<ViewType, string> = {
+  agent: 'Agent',
+  diff: 'Diff',
+  editor: 'Editor',
+  terminal: 'Terminal',
+  secrets: 'Secrets',
+};
+
+// All secondary-chat tile ids, used to tear down the second chat's panes at once.
+export const SECONDARY_TILE_IDS: SecondaryTileId[] = VIEW_TYPES.map(
+  (v): SecondaryTileId => `${v}:secondary`,
+);
+
+// The secondary pane is the action target only when it's both focused and bound
+// to a chat — otherwise everything resolves to the primary pane.
+export function isSecondaryPaneActive(
+  activeAgentTile: AgentTileId,
+  secondaryChatId: string | null,
+): boolean {
+  return activeAgentTile === 'agent:secondary' && !!secondaryChatId;
+}
+
+// The mosaic layout isn't materialized until a split happens — fall back to the
+// current single view's tile.
+export function getEffectiveLayout(
+  mosaicLayout: MosaicLayoutNode | null,
+  currentView: ViewType,
+): MosaicLayoutNode {
+  return mosaicLayout ?? viewTypeToPrimaryTile(currentView);
+}
 
 export function isMosaicSplitNode(node: MosaicLayoutNode): node is MosaicSplitNode {
   return typeof node === 'object' && 'direction' in node;
@@ -10,10 +50,15 @@ export function getLeaves(node: MosaicLayoutNode): MosaicTileId[] {
   return [...getLeaves(node.first), ...getLeaves(node.second)];
 }
 
+export function isSecondaryTile(tileId: MosaicTileId): tileId is SecondaryTileId {
+  return tileId.endsWith(':secondary');
+}
+
 // Maps a stored mosaic tile id back to its ViewType for label/render lookups.
+// Both pane suffixes ('agent:primary', '<view>:secondary') strip to the view.
 export function tileIdToViewType(tileId: MosaicTileId): ViewType {
-  if (tileId === 'agent:primary' || tileId === 'agent:secondary') return 'agent';
-  return tileId;
+  const colon = tileId.indexOf(':');
+  return (colon === -1 ? tileId : tileId.slice(0, colon)) as ViewType;
 }
 
 // Maps a ViewType to its canonical primary tile id. The agent slot is special:
@@ -21,6 +66,13 @@ export function tileIdToViewType(tileId: MosaicTileId): ViewType {
 // by the split-chat affordance.
 export function viewTypeToPrimaryTile(view: ViewType): MosaicTileId {
   return view === 'agent' ? 'agent:primary' : view;
+}
+
+// Maps a (view, pane) pair to its tile id. Agent always maps to the primary
+// slot — agent:secondary is created only by the split-chat affordance.
+export function viewTypeToTileId(view: ViewType, secondary: boolean): MosaicTileId {
+  if (secondary && view !== 'agent') return `${view}:secondary`;
+  return viewTypeToPrimaryTile(view);
 }
 
 // Returns the leaves' view types, deduped, preserving order. Two agent panes


### PR DESCRIPTION
## Summary
- Split-chat mode gives every view (diff, editor, terminal, secrets) a per-chat `:secondary` tile bound to the second chat, replacing the singleton tiles that only the primary chat could reach. A new self-contained `EditorPane` backs the secondary editor.
- File/diff opens and jumps now carry the owning chat id, so each pane's tile claims only its own pending jumps (no cross-chat consumption). Secondary tiles reset their local state (editor selection, secrets list) when the secondary chat is swapped.
- Commands and git actions follow the pane the user last interacted with (`activeAgentTile`): view toggles and the command menu's split-right/down buttons open the active pane's tile; the menu's file search and branch picker target the active chat's sandbox/worktree.
- The commit/branch/PR dialogs and push/pull/switch-branch/new-sub-thread commands now act on the active chat's sandbox, worktree, and per-chat model (via a shared `useActiveChat`/`getActiveChat` resolver) instead of always the route-primary chat.
- The command menu now also supports opening workspace files in the chat-less landing editor.

## Test plan
- [ ] Open two chats in split view; open diff/editor/terminal/secrets in each pane and confirm each shows its own chat's content.
- [ ] `Cmd/Ctrl+Shift+D/E/T/S` from the secondary pane open/close that pane's tile (not the primary's).
- [ ] Command menu from the secondary pane: go-to-file, search-in-files, switch-branch, and the split-right/down buttons all target the secondary chat.
- [ ] Create commit / branch / PR and push/pull/new-sub-thread from the secondary pane act on the secondary chat's sandbox/worktree/model; "Generate with AI" uses the secondary chat's model.
- [ ] Swap the secondary chat and confirm the editor selection and secrets list reset.
- [ ] On the landing page (no chat), go-to-file / file search opens the workspace file in the editor.
- [ ] Fresh chat page shows the correct active-view indicator with no stray split buttons for the active Agent view.