### PR TITLE
feat: default thinking mode to high

### DIFF
--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -40,11 +40,11 @@ export const THINKING_MODES_BY_AGENT: Record<AgentKind, ThinkingModeOption[]> = 
 };
 
 const DEFAULT_BY_AGENT: Record<AgentKind, string> = {
-  claude: 'medium',
-  codex: 'medium',
-  copilot: 'medium',
-  cursor: 'medium',
-  opencode: 'medium',
+  claude: 'high',
+  codex: 'high',
+  copilot: 'high',
+  cursor: 'high',
+  opencode: 'high',
 };
 
 export function getThinkingModesForAgent(

--- a/frontend/src/hooks/useMessageActions.ts
+++ b/frontend/src/hooks/useMessageActions.ts
@@ -7,6 +7,7 @@ import {
   useChatSettingsStore,
   DEFAULT_CHAT_SETTINGS_KEY,
   DEFAULT_PERSONA,
+  DEFAULT_THINKING_MODE,
 } from '@/store/chatSettingsStore';
 import type { PermissionMode } from '@/store/chatSettingsStore';
 import { resolvePersona } from '@/utils/settings';
@@ -109,7 +110,7 @@ export function useMessageActions({
           modelMap.get(selectedModelId)?.agent_kind ?? getAgentKindForModelId(selectedModelId);
         const effectivePermissionMode = coercePermissionModeForAgent(permissionMode, agentKind);
         const effectiveThinkingMode = coerceThinkingModeForAgent(
-          thinkingMode ?? 'medium',
+          thinkingMode ?? DEFAULT_THINKING_MODE,
           agentKind,
           selectedModelId,
         );

--- a/frontend/src/store/chatSettingsStore.ts
+++ b/frontend/src/store/chatSettingsStore.ts
@@ -16,7 +16,7 @@ type PermissionMode =
 
 const DEFAULT_KEY = '__default__';
 export const DEFAULT_PERMISSION_MODE: PermissionMode = 'bypassPermissions';
-export const DEFAULT_THINKING_MODE: string = 'medium';
+export const DEFAULT_THINKING_MODE: string = 'high';
 export const DEFAULT_WORKTREE = false;
 export const DEFAULT_PLAN_MODE = false;
 export const DEFAULT_PERSONA = 'Default';


### PR DESCRIPTION
## Summary
- Raise the default thinking/reasoning effort from `medium` to `high` so new chats start with more capable thinking without manual selection.
- Update `DEFAULT_THINKING_MODE` in the chat settings store.
- Update `DEFAULT_BY_AGENT` per-agent fallbacks in the thinking-mode selector.
- Replace the hardcoded `'medium'` fallback in `useMessageActions` with the shared `DEFAULT_THINKING_MODE` constant.

## Test plan
- [ ] Open a new chat and confirm the thinking-mode selector defaults to High (Claude/Codex/Copilot).
- [ ] Confirm sending a message without changing the selector uses High.
- [ ] Confirm Cursor/OpenCode (selector hidden) are unaffected.