### PR TITLE
fix: widen file tree and tighten indent for readability

### DIFF
--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -194,7 +194,7 @@ export const CodeView = memo(function CodeView({
         <Panel
           ref={fileTreePanelRef}
           defaultSize={0}
-          minSize={15}
+          minSize={25}
           maxSize={40}
           collapsible
           collapsedSize={0}

--- a/frontend/src/styles/pierre-tree-theme.css
+++ b/frontend/src/styles/pierre-tree-theme.css
@@ -33,6 +33,8 @@ file-tree-container {
   --trees-input-bg-override: transparent;
   --trees-padding-inline-override: 10px;
   --trees-item-padding-x-override: 6px;
+  /* Tighter than the 8px default so deep paths stay readable in the narrow panel. */
+  --trees-level-gap-override: 6px;
   --trees-indent-guide-bg-override: rgb(226 226 226 / 0.5);
   --trees-scrollbar-thumb-override: #94a3b8;
 


### PR DESCRIPTION
## Summary
- In split view the editor pane is only half-width, so the file-tree panel's `minSize={15}` (15% of the pane) collapsed file names to bare icons and pushed deep-folder labels entirely off-screen.
- Raise the panel `minSize` from 15% to 25% so the tree opens wide enough to read names.
- Reduce pierre's per-level indent via `--trees-level-gap-override: 6px` (down from the 8px default) so deeply nested paths fit in the narrow panel.

## Test plan
- [ ] Open the editor in split view (chat + editor side by side) and expand the file tree — file names are readable, not clipped to icons.
- [ ] Expand deeply nested folders (e.g. `backend/app/...`) and confirm labels remain visible.
- [ ] Verify the tree still respects the 40% max width and collapses/expands as before.
- [ ] Check both light and dark themes.