### PR TITLE
feat: run chats on a remote cloud instance

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
     ],
     "security": {
       "dangerousDisableAssetCspModification": ["script-src"],
-      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdn.jsdelivr.net; connect-src 'self' ipc: ipc://localhost http://localhost:* ws://localhost:* http://127.0.0.1:* ws://127.0.0.1:*; frame-src 'self' tauri://localhost http://localhost:* http://127.0.0.1:*; child-src 'self' tauri://localhost http://localhost:* http://127.0.0.1:*",
+      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdn.jsdelivr.net; connect-src 'self' ipc: ipc://localhost http://localhost:* ws://localhost:* http://127.0.0.1:* ws://127.0.0.1:* https: wss:; frame-src 'self' tauri://localhost http://localhost:* http://127.0.0.1:*; child-src 'self' tauri://localhost http://localhost:* http://127.0.0.1:*",
       "capabilities": ["main-capability"]
     }
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { useMountEffect } from '@/hooks/useMountEffect';
 import { Layout } from '@/components/layout/Layout';
 import { Toaster } from 'react-hot-toast';
 import { useAuthStore } from '@/store/authStore';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { useCurrentUserQuery } from '@/hooks/queries/useAuthQueries';
 import { useInfiniteChatsQuery } from '@/hooks/queries/useChatQueries';
@@ -16,7 +17,7 @@ import { AuthRoute } from '@/components/routes/AuthRoute';
 import { setApiPort } from '@/lib/api';
 import { isTauri, invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { authStorage } from '@/utils/storage';
+import { authStorage, cloudAuthStorage } from '@/utils/storage';
 import { checkDesktopUpdate } from '@/services/desktopUpdateService';
 import { DesktopDragRegion } from '@/components/layout/TitleBar';
 
@@ -167,14 +168,19 @@ export default function App() {
   useMountEffect(() => {
     let cancelled = false;
 
-    authStorage
-      .hydrate()
+    Promise.all([authStorage.hydrate(), cloudAuthStorage.hydrate()])
       .catch((error) => {
         console.error('Auth storage hydration failed:', error);
       })
       .finally(() => {
         if (cancelled) return;
         useAuthStore.getState().setAuthenticated(!!authStorage.getToken());
+        // Drop the cloud connection if its refresh token didn't hydrate —
+        // otherwise the UI shows a connected state we can't use.
+        const cloud = useCloudSettingsStore.getState();
+        if (cloud.connectedEmail && !cloudAuthStorage.getRefreshToken()) {
+          cloud.clearCloud();
+        }
         setAuthHydrated(true);
       });
 

--- a/frontend/src/components/chat/cloud/CloudWorkspaceSelector.tsx
+++ b/frontend/src/components/chat/cloud/CloudWorkspaceSelector.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Cloud, FolderOpen, Search, Check, ChevronDown } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { Input } from '@/components/ui/primitives/Input';
+import { useDropdown } from '@/hooks/useDropdown';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
+import { useCloudWorkspacesQuery } from '@/hooks/queries/useCloudQueries';
+
+const SEARCH_THRESHOLD = 8;
+
+interface CloudWorkspaceSelectorProps {
+  selectedWorkspaceId: string | null;
+  onWorkspaceChange: (id: string) => void;
+  disabled?: boolean;
+}
+
+// Shown on the landing composer when running on cloud: pick a workspace that
+// exists on the VPS, or prompt the user to connect a cloud instance first.
+// Styled to match the local workspace selector trigger.
+export function CloudWorkspaceSelector({
+  selectedWorkspaceId,
+  onWorkspaceChange,
+  disabled = false,
+}: CloudWorkspaceSelectorProps) {
+  const navigate = useNavigate();
+  const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
+  const isConnected = !!connectedEmail;
+  const { data: workspaces = [], isLoading, error } = useCloudWorkspacesQuery(isConnected);
+  const { isOpen, dropdownRef, setIsOpen } = useDropdown();
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Default to the first VPS workspace once the list loads and none is chosen.
+  useEffect(() => {
+    if (!workspaces.length) return;
+    if (selectedWorkspaceId && workspaces.some((ws) => ws.id === selectedWorkspaceId)) return;
+    onWorkspaceChange(workspaces[0].id);
+  }, [workspaces, selectedWorkspaceId, onWorkspaceChange]);
+
+  const visibleWorkspaces = useMemo(() => {
+    if (!searchQuery) return workspaces;
+    const query = searchQuery.toLowerCase();
+    return workspaces.filter((ws) => ws.name.toLowerCase().includes(query));
+  }, [workspaces, searchQuery]);
+
+  if (!isConnected) {
+    return (
+      <Button
+        type="button"
+        variant="unstyled"
+        onClick={() => navigate('/settings', { state: { tab: 'cloud' } })}
+        className="inline-flex items-center gap-1.5 rounded-md px-1.5 py-1 text-2xs text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+      >
+        <Cloud className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+        Connect a cloud instance
+      </Button>
+    );
+  }
+
+  if (error) {
+    return (
+      <span className="px-1.5 py-1 text-2xs text-error-600 dark:text-error-400">
+        Couldn&apos;t reach cloud instance
+      </span>
+    );
+  }
+
+  const selectedWorkspace = workspaces.find((ws) => ws.id === selectedWorkspaceId);
+  const label = selectedWorkspace?.name ?? (isLoading ? 'Loading…' : 'Select workspace');
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <Button
+        variant="unstyled"
+        type="button"
+        disabled={disabled || isLoading || workspaces.length === 0}
+        onClick={() => setIsOpen(!isOpen)}
+        className="inline-flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-2xs text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+      >
+        <FolderOpen className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+        <span className="max-w-[16rem] truncate">{label}</span>
+        <ChevronDown className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+      </Button>
+
+      {isOpen && (
+        <div className="absolute left-0 top-full z-[60] mt-1 w-64 rounded-xl border border-border bg-surface-secondary/95 py-1 shadow-medium backdrop-blur-xl backdrop-saturate-150 dark:border-border-dark dark:bg-surface-dark-secondary/95 dark:shadow-black/40">
+          {workspaces.length > SEARCH_THRESHOLD && (
+            <div className="border-b border-border/50 px-1.5 pb-1.5 dark:border-border-dark/50">
+              <div className="relative flex items-center">
+                <Search className="pointer-events-none absolute left-2 h-3 w-3 text-text-quaternary dark:text-text-dark-quaternary" />
+                <Input
+                  variant="unstyled"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search workspaces…"
+                  className="h-7 w-full bg-transparent pl-7 text-2xs text-text-primary placeholder:text-text-quaternary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary"
+                />
+              </div>
+            </div>
+          )}
+          <div className="max-h-64 overflow-y-auto">
+            {visibleWorkspaces.length === 0 ? (
+              <p className="px-2.5 py-2 text-center text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                No workspaces found
+              </p>
+            ) : (
+              visibleWorkspaces.map((ws) => (
+                <Button
+                  variant="unstyled"
+                  key={ws.id}
+                  type="button"
+                  onClick={() => {
+                    onWorkspaceChange(ws.id);
+                    setSearchQuery('');
+                    setIsOpen(false);
+                  }}
+                  className={`flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-2xs transition-colors duration-150 ${
+                    ws.id === selectedWorkspaceId
+                      ? 'bg-surface-hover/80 text-text-primary dark:bg-surface-dark-hover/80 dark:text-text-dark-primary'
+                      : 'text-text-secondary hover:bg-surface-hover/50 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover/50'
+                  }`}
+                >
+                  <Check
+                    className={`h-3 w-3 shrink-0 ${ws.id === selectedWorkspaceId ? 'opacity-100' : 'opacity-0'}`}
+                  />
+                  <span className="truncate" title={ws.name}>
+                    {ws.name}
+                  </span>
+                </Button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -6,6 +6,7 @@ import { PersonaSelector } from '@/components/chat/persona-selector/PersonaSelec
 import { PERSONAS_SUPPORTED_AGENTS } from '@/components/chat/persona-selector/personaSupport';
 import { BranchSelector } from '@/components/chat/branch-selector/BranchSelector';
 import { useInputState, useInputActions } from '@/hooks/useInputContext';
+import { useAuthStore } from '@/store/authStore';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
 import { useChatQuery } from '@/hooks/queries/useChatQueries';
 import { useChatContext } from '@/hooks/useChatContext';
@@ -15,7 +16,9 @@ import { SelectorDot } from '@/components/ui/primitives/SelectorDot';
 export function InputControls() {
   const state = useInputState();
   const actions = useInputActions();
-  const modelMap = useModelMap();
+  // `/models/` is auth-protected; gate so the public landing composer doesn't 401.
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const modelMap = useModelMap(isAuthenticated);
   const agentKind = modelMap.get(state.selectedModelId)?.agent_kind;
   const { data: chat } = useChatQuery(state.chatId, { enabled: !!state.chatId });
   const lockedAgentKind = chat?.session_agent_kind ?? null;

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -6,6 +6,7 @@ import { useSlashCommandSuggestions } from '@/hooks/useSlashCommandSuggestions';
 import { useEnhancePromptMutation } from '@/hooks/queries/useChatQueries';
 import { useMentionSuggestions } from '@/hooks/useMentionSuggestions';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
+import { useAuthStore } from '@/store/authStore';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
 import { coercePermissionModeForAgent } from '@/components/chat/permission-mode-selector/permissionModes';
 import { coerceThinkingModeForAgent } from '@/components/chat/thinking-mode-selector/thinkingModes';
@@ -63,7 +64,9 @@ export function InputProvider({
   children,
 }: InputProps & { children: ReactNode }) {
   const { fileStructure, customSkills, builtinSlashCommands, personas } = useChatContext();
-  const modelMap = useModelMap();
+  // `/models/` is auth-protected; gate so the public landing composer doesn't 401.
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const modelMap = useModelMap(isAuthenticated);
   const agentKind =
     modelMap.get(selectedModelId)?.agent_kind ?? getAgentKindForModelId(selectedModelId);
   // Hide the context-usage indicator for agents whose ACP servers never emit

--- a/frontend/src/components/chat/run-location-selector/RunLocationSelector.tsx
+++ b/frontend/src/components/chat/run-location-selector/RunLocationSelector.tsx
@@ -1,0 +1,31 @@
+import { memo } from 'react';
+import { Cloud, Monitor } from 'lucide-react';
+import { ToggleDropdown, type ToggleDropdownOption } from '@/components/ui/shared/ToggleDropdown';
+import { useChatSettingsStore } from '@/store/chatSettingsStore';
+
+const OPTIONS: readonly [ToggleDropdownOption, ToggleDropdownOption] = [
+  { label: 'Local', icon: Monitor },
+  { label: 'Cloud', icon: Cloud },
+];
+
+interface RunLocationSelectorProps {
+  disabled?: boolean;
+}
+
+export const RunLocationSelector = memo(function RunLocationSelector({
+  disabled = false,
+}: RunLocationSelectorProps) {
+  // Creation-time control: run a new chat locally or on the configured cloud
+  // instance. Orthogonal to worktree.
+  const runOnCloud = useChatSettingsStore((state) => state.runOnCloud);
+
+  return (
+    <ToggleDropdown
+      options={OPTIONS}
+      value={runOnCloud}
+      onSelect={(enabled) => useChatSettingsStore.getState().setRunOnCloud(enabled)}
+      width="w-32"
+      disabled={disabled}
+    />
+  );
+});

--- a/frontend/src/components/chat/worktree-selector/WorktreeToggle.tsx
+++ b/frontend/src/components/chat/worktree-selector/WorktreeToggle.tsx
@@ -1,12 +1,16 @@
 import { memo } from 'react';
-import { Button } from '@/components/ui/primitives/Button';
-import { GitFork, Check, ChevronDown } from 'lucide-react';
-import { useDropdown } from '@/hooks/useDropdown';
+import { GitFork } from 'lucide-react';
+import { ToggleDropdown, type ToggleDropdownOption } from '@/components/ui/shared/ToggleDropdown';
 import {
   useChatSettingsStore,
   DEFAULT_CHAT_SETTINGS_KEY,
   DEFAULT_WORKTREE,
 } from '@/store/chatSettingsStore';
+
+const OPTIONS: readonly [ToggleDropdownOption, ToggleDropdownOption] = [
+  { label: 'No worktree' },
+  { label: 'Worktree' },
+];
 
 interface WorktreeToggleProps {
   disabled?: boolean;
@@ -15,50 +19,22 @@ interface WorktreeToggleProps {
 export const WorktreeToggle = memo(function WorktreeToggle({
   disabled = false,
 }: WorktreeToggleProps) {
+  // Creation-time control: run the chat in an isolated git worktree. Applies to
+  // both local and cloud runs.
   const worktree = useChatSettingsStore(
     (state) => state.worktreeByChat[DEFAULT_CHAT_SETTINGS_KEY] ?? DEFAULT_WORKTREE,
   );
-  const { isOpen, dropdownRef, setIsOpen } = useDropdown();
 
   return (
-    <div className="relative" ref={dropdownRef}>
-      <Button
-        variant="unstyled"
-        type="button"
-        disabled={disabled}
-        onClick={() => setIsOpen(!isOpen)}
-        className="inline-flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-2xs text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
-      >
-        <GitFork className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
-        <span>Worktree ({worktree ? 'on' : 'off'})</span>
-        <ChevronDown className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
-      </Button>
-
-      {isOpen && (
-        <div className="absolute left-0 top-full z-[60] mt-1 w-32 rounded-xl border border-border bg-surface-secondary/95 py-1 shadow-medium backdrop-blur-xl backdrop-saturate-150 dark:border-border-dark dark:bg-surface-dark-secondary/95 dark:shadow-black/40">
-          {[false, true].map((value) => (
-            <Button
-              variant="unstyled"
-              key={String(value)}
-              type="button"
-              onClick={() => {
-                useChatSettingsStore.getState().setWorktree(DEFAULT_CHAT_SETTINGS_KEY, value);
-                setIsOpen(false);
-              }}
-              className={`flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-2xs transition-colors duration-150 ${
-                worktree === value
-                  ? 'bg-surface-hover/80 text-text-primary dark:bg-surface-dark-hover/80 dark:text-text-dark-primary'
-                  : 'text-text-secondary hover:bg-surface-hover/50 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover/50'
-              }`}
-            >
-              <Check
-                className={`h-3 w-3 shrink-0 ${worktree === value ? 'opacity-100' : 'opacity-0'}`}
-              />
-              <span>{value ? 'On' : 'Off'}</span>
-            </Button>
-          ))}
-        </div>
-      )}
-    </div>
+    <ToggleDropdown
+      options={OPTIONS}
+      value={worktree}
+      onSelect={(enabled) =>
+        useChatSettingsStore.getState().setWorktree(DEFAULT_CHAT_SETTINGS_KEY, enabled)
+      }
+      icon={GitFork}
+      width="w-36"
+      disabled={disabled}
+    />
   );
 });

--- a/frontend/src/components/settings/tabs/CloudSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/CloudSettingsTab.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import { CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { Input } from '@/components/ui/primitives/Input';
+import { Label } from '@/components/ui/primitives/Label';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
+import { cloudChatService } from '@/services/cloudChatService';
+
+// Connects the desktop to a remote AgentRove (VPS) instance so chats can be run
+// there with "Cloud" execution mode. All state here is client-side only.
+export function CloudSettingsTab() {
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
+  const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
+
+  const [url, setUrl] = useState(cloudUrl);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  const handleConnect = async () => {
+    // Normalize a bare host to https:// so the base URL is absolute, not relative.
+    let normalizedUrl = url.trim();
+    if (normalizedUrl && !/^https?:\/\//i.test(normalizedUrl)) {
+      normalizedUrl = `https://${normalizedUrl}`;
+    }
+    if (!normalizedUrl || !email.trim() || !password) {
+      toast.error('Enter the cloud URL, email, and password');
+      return;
+    }
+    try {
+      new URL(normalizedUrl);
+    } catch {
+      toast.error('Enter a valid cloud URL');
+      return;
+    }
+    setIsConnecting(true);
+    try {
+      await cloudChatService.connect(normalizedUrl, email.trim(), password);
+      setPassword('');
+      toast.success('Connected to cloud instance');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to connect to cloud instance');
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const handleDisconnect = () => {
+    cloudChatService.disconnect();
+    setEmail('');
+    toast.success('Disconnected from cloud instance');
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-border p-5 dark:border-border-dark">
+        <h2 className="mb-1 text-xs font-medium text-text-tertiary dark:text-text-dark-tertiary">
+          Cloud Instance
+        </h2>
+        <p className="mb-4 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+          Run chats on a separate AgentRove instance (e.g. your VPS) so they keep running after you
+          close this app. The instance must allow this app&apos;s origin in its{' '}
+          <span className="font-mono">ALLOWED_ORIGINS</span>.
+        </p>
+
+        {connectedEmail ? (
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2 text-xs text-text-secondary dark:text-text-dark-secondary">
+              <CheckCircle2 className="h-4 w-4 shrink-0 text-success-600 dark:text-success-400" />
+              <span>
+                Connected to <span className="font-mono">{cloudUrl}</span> as{' '}
+                <span className="font-medium">{connectedEmail}</span>
+              </span>
+            </div>
+            <Button type="button" variant="outline" size="sm" onClick={handleDisconnect}>
+              Disconnect
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div>
+              <Label className="mb-1 text-xs text-text-secondary dark:text-text-dark-secondary">
+                Cloud URL
+              </Label>
+              <Input
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://your-vps.example.com"
+                autoComplete="off"
+              />
+            </div>
+            <div>
+              <Label className="mb-1 text-xs text-text-secondary dark:text-text-dark-secondary">
+                Email
+              </Label>
+              <Input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                autoComplete="off"
+              />
+            </div>
+            <div>
+              <Label className="mb-1 text-xs text-text-secondary dark:text-text-dark-secondary">
+                Password
+              </Label>
+              <Input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="••••••••"
+                autoComplete="off"
+              />
+            </div>
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={handleConnect}
+              isLoading={isConnecting}
+              loadingText="Connecting..."
+            >
+              Connect
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/shared/ToggleDropdown.tsx
+++ b/frontend/src/components/ui/shared/ToggleDropdown.tsx
@@ -1,0 +1,84 @@
+import { memo, type ComponentType, type SVGProps } from 'react';
+import { Check, ChevronDown } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { useDropdown } from '@/hooks/useDropdown';
+
+export interface ToggleDropdownOption {
+  label: string;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
+}
+
+interface ToggleDropdownProps {
+  // Indexed by the toggle value: [off, on].
+  options: readonly [ToggleDropdownOption, ToggleDropdownOption];
+  value: boolean;
+  onSelect: (value: boolean) => void;
+  // Fixed trigger icon; a per-option icon takes precedence when provided.
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
+  width: string;
+  disabled?: boolean;
+}
+
+export const ToggleDropdown = memo(function ToggleDropdown({
+  options,
+  value,
+  onSelect,
+  icon,
+  width,
+  disabled = false,
+}: ToggleDropdownProps) {
+  // Compact two-option dropdown for the landing composer toolbar. Hand-styled to
+  // match the adjacent workspace selector trigger, not the Dropdown primitive.
+  const { isOpen, dropdownRef, setIsOpen } = useDropdown();
+  const selected = options[value ? 1 : 0];
+  const TriggerIcon = selected.icon ?? icon;
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <Button
+        variant="unstyled"
+        type="button"
+        disabled={disabled}
+        onClick={() => setIsOpen(!isOpen)}
+        className="inline-flex min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-2xs text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+      >
+        {TriggerIcon && (
+          <TriggerIcon className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+        )}
+        <span>{selected.label}</span>
+        <ChevronDown className="h-3 w-3 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+      </Button>
+
+      {isOpen && (
+        <div
+          className={`absolute left-0 top-full z-[60] mt-1 ${width} rounded-xl border border-border bg-surface-secondary/95 py-1 shadow-medium backdrop-blur-xl backdrop-saturate-150 dark:border-border-dark dark:bg-surface-dark-secondary/95 dark:shadow-black/40`}
+        >
+          {options.map((opt, index) => {
+            const optValue = index === 1;
+            return (
+              <Button
+                variant="unstyled"
+                key={opt.label}
+                type="button"
+                onClick={() => {
+                  onSelect(optValue);
+                  setIsOpen(false);
+                }}
+                className={`flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-2xs transition-colors duration-150 ${
+                  value === optValue
+                    ? 'bg-surface-hover/80 text-text-primary dark:bg-surface-dark-hover/80 dark:text-text-dark-primary'
+                    : 'text-text-secondary hover:bg-surface-hover/50 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover/50'
+                }`}
+              >
+                <Check
+                  className={`h-3 w-3 shrink-0 ${value === optValue ? 'opacity-100' : 'opacity-0'}`}
+                />
+                <span>{opt.label}</span>
+              </Button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -60,6 +60,8 @@ export const queryKeys = {
   },
   workspaces: ['workspaces'] as const,
   workspaceResources: (workspaceId?: string) => ['workspaces', workspaceId, 'resources'] as const,
+  cloudWorkspaces: (cloudUrl?: string, connectedEmail?: string | null) =>
+    ['cloud', 'workspaces', cloudUrl, connectedEmail] as const,
   models: 'models',
   github: {
     repos: (query: string) => ['github-repos', query] as const,

--- a/frontend/src/hooks/queries/useCloudQueries.ts
+++ b/frontend/src/hooks/queries/useCloudQueries.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { cloudChatService } from '@/services/cloudChatService';
+import { queryKeys } from '@/hooks/queries/queryKeys';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
+import type { Workspace } from '@/types/workspace.types';
+
+// Keyed by cloudUrl + connectedEmail so switching instance or account never
+// serves the previous connection's cached list.
+export const useCloudWorkspacesQuery = (enabled: boolean) => {
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
+  const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
+  return useQuery<Workspace[]>({
+    queryKey: queryKeys.cloudWorkspaces(cloudUrl, connectedEmail),
+    queryFn: () => cloudChatService.listWorkspaces(),
+    enabled: enabled && !!cloudUrl,
+    staleTime: 30_000,
+  });
+};

--- a/frontend/src/hooks/queries/useModelQueries.ts
+++ b/frontend/src/hooks/queries/useModelQueries.ts
@@ -59,8 +59,10 @@ export const useModelSelection = (options?: {
   return { models, selectedModelId, selectedModel, selectModel, isLoading };
 };
 
-export function useModelMap(): Map<string, Model> {
-  const { data: models } = useModelsQuery();
+// `/models/` is auth-protected — public-route callers must gate; default-on
+// keeps authenticated callers unchanged.
+export function useModelMap(enabled: boolean = true): Map<string, Model> {
+  const { data: models } = useModelsQuery({ enabled });
   return useMemo(
     () => (models ? new Map(models.map((m) => [m.model_id, m])) : EMPTY_MODEL_MAP),
     [models],

--- a/frontend/src/hooks/useMessageActions.ts
+++ b/frontend/src/hooks/useMessageActions.ts
@@ -10,12 +10,10 @@ import {
   DEFAULT_THINKING_MODE,
 } from '@/store/chatSettingsStore';
 import type { PermissionMode } from '@/store/chatSettingsStore';
-import { resolvePersona } from '@/utils/settings';
+import { buildAgentChatFields } from '@/utils/chatRequest';
 import { useChatContext } from '@/hooks/useChatContext';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
-import { coercePermissionModeForAgent } from '@/components/chat/permission-mode-selector/permissionModes';
-import { coerceThinkingModeForAgent } from '@/components/chat/thinking-mode-selector/thinkingModes';
-import { getAgentKindForModelId, type ChatRequest, type Message } from '@/types/chat.types';
+import type { ChatRequest, Message } from '@/types/chat.types';
 import type { StreamState } from '@/types/stream.types';
 
 const textEncoder = new TextEncoder();
@@ -105,26 +103,24 @@ export function useMessageActions({
         const personaKey = chatId ?? DEFAULT_CHAT_SETTINGS_KEY;
         const storedPersona =
           useChatSettingsStore.getState().personaByChat[personaKey] ?? DEFAULT_PERSONA;
-        const validPersona = resolvePersona(storedPersona, personas);
-        const agentKind =
-          modelMap.get(selectedModelId)?.agent_kind ?? getAgentKindForModelId(selectedModelId);
-        const effectivePermissionMode = coercePermissionModeForAgent(permissionMode, agentKind);
-        const effectiveThinkingMode = coerceThinkingModeForAgent(
-          thinkingMode ?? DEFAULT_THINKING_MODE,
-          agentKind,
-          selectedModelId,
-        );
 
         const request: ChatRequest = {
           prompt: normalizedPrompt,
           model_id: selectedModelId,
           ...(chatIdOverride && { chat_id: chatIdOverride }),
           attached_files: filesToSend && filesToSend.length > 0 ? filesToSend : undefined,
-          permission_mode: effectivePermissionMode,
-          thinking_mode: effectiveThinkingMode,
-          worktree: worktree ? true : undefined,
-          plan_mode: agentKind === 'codex' && planMode ? true : undefined,
-          selected_persona_name: validPersona,
+          ...buildAgentChatFields(
+            selectedModelId,
+            modelMap,
+            {
+              permissionMode,
+              thinkingMode: thinkingMode ?? DEFAULT_THINKING_MODE,
+              worktree,
+              planMode,
+              persona: storedPersona,
+            },
+            personas,
+          ),
         };
 
         const { messageId, checkpointId } = await startStream(request, startController.signal);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
-import { authStorage } from '@/utils/storage';
+import { authStorage, cloudAuthStorage } from '@/utils/storage';
 import { invalidateSessionAndRedirect } from '@/utils/authSession';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 
 type RequestMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 
@@ -27,7 +28,7 @@ class RefreshTokenError extends Error {
 
 export type { ApiStreamResponse as StreamResponse } from '@/types/stream.types';
 
-const trimTrailingSlash = (url: string): string => url.replace(/\/+$/, '');
+export const trimTrailingSlash = (url: string): string => url.replace(/\/+$/, '');
 
 const resolveHttpBaseUrl = (rawUrl: string): string =>
   trimTrailingSlash(new URL(rawUrl, window.location.origin).toString());
@@ -38,54 +39,40 @@ const resolveWsBaseUrl = (rawUrl: string): string => {
   return trimTrailingSlash(normalized.toString());
 };
 
-const getAuthHeaders = (includeContentType = true): Record<string, string> => {
-  const token = authStorage.getToken();
-  return {
-    ...(includeContentType ? { 'Content-Type': 'application/json' } : {}),
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
+// Auth source for an APIClient instance. The local client reads/writes the
+// shared authStorage; the remote (VPS) client uses cloudAuthStorage so the two
+// instances authenticate independently and don't clobber each other's tokens.
+interface ClientAuth {
+  getToken: () => string | null;
+  getRefreshToken: () => string | null;
+  setTokens: (accessToken: string, refreshToken: string) => void;
+  onSessionExpired: () => void;
+}
+
+const localAuth: ClientAuth = {
+  getToken: () => authStorage.getToken(),
+  getRefreshToken: () => authStorage.getRefreshToken(),
+  setTokens: (accessToken, refreshToken) => {
+    authStorage.setToken(accessToken);
+    authStorage.setRefreshToken(refreshToken);
+  },
+  onSessionExpired: invalidateSessionAndRedirect,
 };
 
-let refreshingPromise: Promise<TokenResponse> | null = null;
-
-async function performTokenRefresh(baseURL: string): Promise<TokenResponse> {
-  const refreshToken = authStorage.getRefreshToken();
-  if (!refreshToken) {
-    throw new RefreshTokenError(401, 'No refresh token available');
-  }
-
-  const response = await fetch(`${baseURL}/auth/jwt/refresh`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ refresh_token: refreshToken }),
-  }).catch(() => {
-    throw new RefreshTokenError(0);
-  });
-
-  if (!response.ok) {
-    throw new RefreshTokenError(response.status);
-  }
-
-  const data: TokenResponse = await response.json();
-  authStorage.setToken(data.access_token);
-  authStorage.setRefreshToken(data.refresh_token);
-  return data;
-}
-
-async function refreshTokenIfNeeded(baseURL: string): Promise<TokenResponse> {
-  if (refreshingPromise) {
-    return refreshingPromise;
-  }
-
-  refreshingPromise = performTokenRefresh(baseURL);
-
-  try {
-    const result = await refreshingPromise;
-    return result;
-  } finally {
-    refreshingPromise = null;
-  }
-}
+const cloudAuth: ClientAuth = {
+  getToken: () => cloudAuthStorage.getAccessToken(),
+  getRefreshToken: () => cloudAuthStorage.getRefreshToken(),
+  setTokens: (accessToken, refreshToken) => {
+    cloudAuthStorage.setAccessToken(accessToken);
+    cloudAuthStorage.setRefreshToken(refreshToken);
+  },
+  // A revoked/expired VPS refresh token can't be recovered silently — drop the
+  // cloud credentials so the settings UI reflects a disconnected state.
+  onSessionExpired: () => {
+    cloudAuthStorage.clear();
+    useCloudSettingsStore.getState().clearCloud();
+  },
+};
 
 // Desktop reinstalls can leave stale refresh tokens in local storage while the backend
 // identity/session store resets. Treat refresh 401 as terminal to break retry loops.
@@ -108,9 +95,12 @@ const extractErrorMessage = async (response: Response): Promise<string> => {
 
 class APIClient {
   private baseURL: string;
+  private auth: ClientAuth;
+  private refreshingPromise: Promise<TokenResponse> | null = null;
 
-  constructor(baseURL: string) {
+  constructor(baseURL: string, auth: ClientAuth) {
     this.baseURL = baseURL;
+    this.auth = auth;
   }
 
   getBaseUrl(): string {
@@ -119,6 +109,51 @@ class APIClient {
 
   setBaseUrl(url: string): void {
     this.baseURL = url;
+  }
+
+  private authHeaders(includeContentType = true): Record<string, string> {
+    const token = this.auth.getToken();
+    return {
+      ...(includeContentType ? { 'Content-Type': 'application/json' } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    };
+  }
+
+  private async performTokenRefresh(): Promise<TokenResponse> {
+    const refreshToken = this.auth.getRefreshToken();
+    if (!refreshToken) {
+      throw new RefreshTokenError(401, 'No refresh token available');
+    }
+
+    const response = await fetch(`${this.baseURL}/auth/jwt/refresh`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    }).catch(() => {
+      throw new RefreshTokenError(0);
+    });
+
+    if (!response.ok) {
+      throw new RefreshTokenError(response.status);
+    }
+
+    const data: TokenResponse = await response.json();
+    this.auth.setTokens(data.access_token, data.refresh_token);
+    return data;
+  }
+
+  private async refreshTokenIfNeeded(): Promise<TokenResponse> {
+    if (this.refreshingPromise) {
+      return this.refreshingPromise;
+    }
+
+    this.refreshingPromise = this.performTokenRefresh();
+
+    try {
+      return await this.refreshingPromise;
+    } finally {
+      this.refreshingPromise = null;
+    }
   }
 
   private async handleResponse<T>(response: Response): Promise<T | null> {
@@ -145,7 +180,7 @@ class APIClient {
     const config: RequestInit = {
       method,
       headers: {
-        ...getAuthHeaders(!formData),
+        ...this.authHeaders(!formData),
         ...additionalHeaders,
       },
       signal,
@@ -163,19 +198,23 @@ class APIClient {
     const response = await fetch(`${this.baseURL}${endpoint}`, config);
 
     if (response.status === 401 && !isRetry && !endpoint.includes('/auth/jwt/')) {
-      const hasRefreshToken = !!authStorage.getRefreshToken();
+      const hasRefreshToken = !!this.auth.getRefreshToken();
       if (hasRefreshToken) {
         try {
-          await refreshTokenIfNeeded(this.baseURL);
+          await this.refreshTokenIfNeeded();
           return this.request<T>(endpoint, method, options, additionalHeaders, true);
         } catch (error) {
           if (shouldInvalidateSession(error)) {
-            invalidateSessionAndRedirect();
+            this.auth.onSessionExpired();
             throw new Error('Session expired');
           }
           throw error;
         }
       }
+      // 401 with no refresh token — session is unusable, so tear it down rather
+      // than leave the UI looking connected.
+      this.auth.onSessionExpired();
+      throw new Error('Session expired');
     }
 
     return this.handleResponse(response);
@@ -208,19 +247,19 @@ class APIClient {
   async getBlob(endpoint: string, signal?: AbortSignal, isRetry = false): Promise<Blob> {
     const response = await fetch(`${this.baseURL}${endpoint}`, {
       method: 'GET',
-      headers: getAuthHeaders(false),
+      headers: this.authHeaders(false),
       signal,
     });
 
     if (response.status === 401 && !isRetry) {
-      const hasRefreshToken = !!authStorage.getRefreshToken();
+      const hasRefreshToken = !!this.auth.getRefreshToken();
       if (hasRefreshToken) {
         try {
-          await refreshTokenIfNeeded(this.baseURL);
+          await this.refreshTokenIfNeeded();
           return this.getBlob(endpoint, signal, true);
         } catch (error) {
           if (shouldInvalidateSession(error)) {
-            invalidateSessionAndRedirect();
+            this.auth.onSessionExpired();
             throw new Error('Session expired');
           }
           throw error;
@@ -240,11 +279,23 @@ class APIClient {
 let API_BASE_URL: string = resolveHttpBaseUrl(import.meta.env.VITE_API_BASE_URL);
 export let WS_BASE_URL: string = resolveWsBaseUrl(import.meta.env.VITE_WS_URL);
 
-export const apiClient = new APIClient(API_BASE_URL);
+export const apiClient = new APIClient(API_BASE_URL, localAuth);
+
+// Second client pointed at the user's remote VPS instance for cloud-run chats.
+// The persisted cloud settings hydrate synchronously, so the saved VPS is wired
+// up at startup and cloud chats work without re-connecting after a restart.
+export const remoteApiClient = new APIClient('', cloudAuth);
+const savedCloudUrl = useCloudSettingsStore.getState().cloudUrl;
+if (savedCloudUrl) setCloudApiBaseUrl(savedCloudUrl);
 
 export function setApiPort(port: number): void {
   const origin = `http://127.0.0.1:${port}`;
   API_BASE_URL = `${origin}/api/v1`;
   WS_BASE_URL = `ws://127.0.0.1:${port}/api/v1/ws`;
   apiClient.setBaseUrl(API_BASE_URL);
+}
+
+// `url` is the VPS origin (e.g. https://vps.example.com); the API lives under /api/v1.
+export function setCloudApiBaseUrl(url: string): void {
+  remoteApiClient.setBaseUrl(`${trimTrailingSlash(url)}/api/v1`);
 }

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -15,17 +15,31 @@ import { Sidebar } from '@/components/layout/Sidebar';
 import { useLayoutSidebar } from '@/components/layout/layoutState';
 import { Input as ChatInput } from '@/components/chat/message-input/Input';
 import { WorkspaceSelector } from '@/components/chat/workspace-selector/WorkspaceSelector';
+import { RunLocationSelector } from '@/components/chat/run-location-selector/RunLocationSelector';
 import { WorktreeToggle } from '@/components/chat/worktree-selector/WorktreeToggle';
+import { CloudWorkspaceSelector } from '@/components/chat/cloud/CloudWorkspaceSelector';
 import { useChatStore } from '@/store/chatStore';
 import { useUIStore } from '@/store/uiStore';
 import { useModelStore } from '@/store/modelStore';
-import { useChatSettingsStore } from '@/store/chatSettingsStore';
+import {
+  useChatSettingsStore,
+  DEFAULT_CHAT_SETTINGS_KEY,
+  DEFAULT_WORKTREE,
+  DEFAULT_PERMISSION_MODE,
+  DEFAULT_THINKING_MODE,
+  DEFAULT_PLAN_MODE,
+  DEFAULT_PERSONA,
+} from '@/store/chatSettingsStore';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
+import { cloudChatService } from '@/services/cloudChatService';
+import { openExternalUrl } from '@/utils/openExternal';
 import { useAuthStore } from '@/store/authStore';
 import { useCreateChatMutation } from '@/hooks/queries/useChatQueries';
 import { useWorkspacesList, useWorkspaceResourcesQuery } from '@/hooks/queries/useWorkspaceQueries';
 import { useFilesMetadataQuery } from '@/hooks/queries/useSandboxQueries';
-import { useModelSelection } from '@/hooks/queries/useModelQueries';
+import { useModelSelection, useModelMap } from '@/hooks/queries/useModelQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
+import { buildAgentChatFields } from '@/utils/chatRequest';
 import { ChatProvider } from '@/contexts/ChatContext';
 import { Button } from '@/components/ui/primitives/Button';
 import { buildFileStructureFromSandboxFiles } from '@/utils/file';
@@ -64,6 +78,7 @@ export function LandingPage() {
   });
 
   const workspaces = useWorkspacesList({ enabled: isAuthenticated });
+  const modelMap = useModelMap(isAuthenticated);
 
   const createChat = useCreateChatMutation();
   const [message, setMessage] = useState('');
@@ -75,6 +90,9 @@ export function LandingPage() {
   const consumedWorkspaceRef = useRef<string | null>(null);
 
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+
+  const isCloud = useChatSettingsStore((state) => state.runOnCloud);
+  const [selectedCloudWorkspaceId, setSelectedCloudWorkspaceId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!workspaces.length) return;
@@ -96,17 +114,20 @@ export function LandingPage() {
     setMessage(initialMessage);
   }
 
+  // Cloud runs target a remote workspace — local skills/slash-commands and
+  // @file mentions don't apply there.
   const { data: workspaceResources } = useWorkspaceResourcesQuery(
     selectedWorkspaceId ?? undefined,
     {
-      enabled: isAuthenticated && !!selectedWorkspaceId,
+      enabled: isAuthenticated && !!selectedWorkspaceId && !isCloud,
     },
   );
 
   // Enable @ file mentions in the input bar before a chat is created
-  const selectedSandboxId = selectedWorkspaceId
-    ? workspaces.find((ws) => ws.id === selectedWorkspaceId)?.sandbox_id
-    : undefined;
+  const selectedSandboxId =
+    !isCloud && selectedWorkspaceId
+      ? workspaces.find((ws) => ws.id === selectedWorkspaceId)?.sandbox_id
+      : undefined;
 
   const { data: filesMetadata = [], refetch: refetchFilesMetadata } = useFilesMetadataQuery(
     selectedSandboxId,
@@ -163,6 +184,85 @@ export function LandingPage() {
         return;
       }
 
+      const title = trimmedPrompt.replace(/\s+/g, ' ').slice(0, 80) || 'New Chat';
+
+      if (isCloud) {
+        if (!useCloudSettingsStore.getState().connectedEmail) {
+          toast.error('Connect a cloud instance in Settings first');
+          return;
+        }
+        if (!selectedCloudWorkspaceId) {
+          toast.error('Please select a cloud workspace');
+          return;
+        }
+
+        setIsLoading(true);
+        try {
+          const chatSettings = useChatSettingsStore.getState();
+          const newChat = await cloudChatService.createChat({
+            title,
+            model_id: selectedModelId,
+            workspace_id: selectedCloudWorkspaceId,
+          });
+          // Coerce toolbar defaults like useMessageActions so cloud matches local.
+          await cloudChatService.startCompletion({
+            prompt: trimmedPrompt,
+            chat_id: newChat.id,
+            model_id: selectedModelId,
+            attached_files: attachedFiles ?? undefined,
+            ...buildAgentChatFields(
+              selectedModelId,
+              modelMap,
+              {
+                permissionMode:
+                  chatSettings.permissionModeByChat[DEFAULT_CHAT_SETTINGS_KEY] ??
+                  DEFAULT_PERMISSION_MODE,
+                thinkingMode:
+                  chatSettings.thinkingModeByChat[DEFAULT_CHAT_SETTINGS_KEY] ??
+                  DEFAULT_THINKING_MODE,
+                worktree:
+                  chatSettings.worktreeByChat[DEFAULT_CHAT_SETTINGS_KEY] ?? DEFAULT_WORKTREE,
+                planMode:
+                  chatSettings.planModeByChat[DEFAULT_CHAT_SETTINGS_KEY] ?? DEFAULT_PLAN_MODE,
+                // Personas are per-instance — let the remote use its default.
+                persona: DEFAULT_PERSONA,
+              },
+              [],
+            ),
+          });
+
+          setMessage('');
+          useChatStore.getState().setAttachedFilesForChat(PENDING_NEW_CHAT_KEY, []);
+
+          // cloudChatService.connect stores cloudUrl slash-trimmed.
+          const chatUrl = `${useCloudSettingsStore.getState().cloudUrl}/chat/${newChat.id}`;
+          toast.success(
+            (t) => (
+              <span className="flex items-center gap-2">
+                Started on your cloud instance.
+                <Button
+                  type="button"
+                  variant="unstyled"
+                  onClick={() => {
+                    void openExternalUrl(chatUrl);
+                    toast.dismiss(t.id);
+                  }}
+                  className="font-medium underline underline-offset-2 hover:text-text-primary dark:hover:text-text-dark-primary"
+                >
+                  Open
+                </Button>
+              </span>
+            ),
+            { duration: 8000 },
+          );
+        } catch (error) {
+          toast.error(error instanceof Error ? error.message : 'Failed to start cloud chat');
+        } finally {
+          setIsLoading(false);
+        }
+        return;
+      }
+
       if (!selectedWorkspaceId) {
         toast.error('Please select a workspace');
         return;
@@ -170,7 +270,6 @@ export function LandingPage() {
 
       setIsLoading(true);
       try {
-        const title = trimmedPrompt.replace(/\s+/g, ' ').slice(0, 80) || 'New Chat';
         const newChat = await createChat.mutateAsync({
           title,
           model_id: selectedModelId,
@@ -195,6 +294,10 @@ export function LandingPage() {
       navigate,
       selectedModelId,
       selectedWorkspaceId,
+      isCloud,
+      selectedCloudWorkspaceId,
+      attachedFiles,
+      modelMap,
     ],
   );
 
@@ -223,12 +326,21 @@ export function LandingPage() {
             <div className="flex h-full w-full items-center justify-center px-4 pb-10">
               <div className="w-full max-w-2xl">
                 <div className="relative z-30 mb-2 flex items-center gap-1 px-4 sm:px-6">
-                  <WorkspaceSelector
-                    selectedWorkspaceId={selectedWorkspaceId}
-                    onWorkspaceChange={setSelectedWorkspaceId}
-                    enabled={isAuthenticated}
-                  />
+                  {isCloud ? (
+                    <CloudWorkspaceSelector
+                      selectedWorkspaceId={selectedCloudWorkspaceId}
+                      onWorkspaceChange={setSelectedCloudWorkspaceId}
+                      disabled={isLoading}
+                    />
+                  ) : (
+                    <WorkspaceSelector
+                      selectedWorkspaceId={selectedWorkspaceId}
+                      onWorkspaceChange={setSelectedWorkspaceId}
+                      enabled={isAuthenticated}
+                    />
+                  )}
                   <WorktreeToggle disabled={isLoading} />
+                  <RunLocationSelector disabled={isLoading} />
                 </div>
 
                 <ChatInput
@@ -296,6 +408,8 @@ export function LandingPage() {
       selectModel,
       selectedModelId,
       selectedWorkspaceId,
+      isCloud,
+      selectedCloudWorkspaceId,
       fileStructure,
       selectedFile,
       handleFileSelect,
@@ -311,7 +425,7 @@ export function LandingPage() {
       fileStructure={fileStructure}
       customSkills={workspaceResources?.skills}
       builtinSlashCommands={workspaceResources?.builtin_slash_commands}
-      personas={settings?.personas}
+      personas={isCloud ? undefined : settings?.personas}
     >
       <div className="flex h-full flex-1 overflow-hidden bg-surface text-text-primary dark:bg-surface-dark dark:text-text-dark-primary">
         <SplitViewContainer renderView={renderView} />

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -7,10 +7,11 @@ import {
   Key,
   ScrollText,
   ChevronLeft,
+  Cloud,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '@/utils/cn';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import type { UserSettings, UserSettingsUpdate } from '@/types/user.types';
 import type { ApiFieldKey } from '@/types/settings.types';
 import { useDeleteAllChatsMutation } from '@/hooks/queries/useChatQueries';
@@ -23,6 +24,7 @@ import { ErrorBoundary } from '@/components/ui/ErrorBoundary';
 import toast from 'react-hot-toast';
 import { GeneralSettingsTab } from '@/components/settings/tabs/GeneralSettingsTab';
 import { SkillsSettingsTab } from '@/components/settings/tabs/SkillsSettingsTab';
+import { CloudSettingsTab } from '@/components/settings/tabs/CloudSettingsTab';
 import { SettingsProvider } from '@/contexts/SettingsContext';
 import { UserProfileMenu } from '@/components/layout/UserProfileMenu';
 import { useCurrentUserQuery, useLogoutMutation } from '@/hooks/queries/useAuthQueries';
@@ -36,7 +38,7 @@ const InstructionsSettingsTab = lazy(() =>
   })),
 );
 
-type TabKey = 'general' | 'skills' | 'personas' | 'env_vars' | 'instructions';
+type TabKey = 'general' | 'skills' | 'personas' | 'env_vars' | 'instructions' | 'cloud';
 
 const getErrorMessage = (error: unknown): string | undefined =>
   error instanceof Error ? error.message : undefined;
@@ -47,6 +49,7 @@ const TAB_FIELDS: Record<TabKey, (keyof UserSettings)[]> = {
   personas: ['personas'],
   env_vars: ['custom_env_vars'],
   instructions: ['custom_instructions'],
+  cloud: [],
 };
 
 interface SettingsNavItem {
@@ -61,6 +64,7 @@ const SETTINGS_NAV: SettingsNavItem[] = [
   { id: 'personas', label: 'Personas', icon: UserCircle },
   { id: 'env_vars', label: 'Env Variables', icon: Key },
   { id: 'instructions', label: 'Instructions', icon: ScrollText },
+  { id: 'cloud', label: 'Cloud', icon: Cloud },
 ];
 
 const TAB_LABELS: Record<TabKey, string> = Object.fromEntries(
@@ -75,6 +79,7 @@ const tabLoadingFallback = (
 
 const SettingsPage: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { data: currentUser } = useCurrentUserQuery({ enabled: isAuthenticated });
   const userDisplayName = currentUser?.username || currentUser?.email || '';
@@ -84,7 +89,11 @@ const SettingsPage: React.FC = () => {
       navigate('/login');
     },
   });
-  const [activeTab, setActiveTab] = useState<TabKey>('general');
+  // Honor a deep-link tab (e.g. the "Connect a cloud instance" CTA → Cloud tab).
+  const [activeTab, setActiveTab] = useState<TabKey>(() => {
+    const requested = (location.state as { tab?: TabKey } | null)?.tab;
+    return requested && requested in TAB_FIELDS ? requested : 'general';
+  });
   const [isDeleteAllDialogOpen, setIsDeleteAllDialogOpen] = useState(false);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
@@ -499,6 +508,12 @@ const SettingsPage: React.FC = () => {
                           }
                         />
                       </Suspense>
+                    </div>
+                  )}
+
+                  {activeTab === 'cloud' && (
+                    <div role="tabpanel" id="cloud-panel" aria-labelledby="cloud-tab">
+                      <CloudSettingsTab />
                     </div>
                   )}
                 </div>

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -13,6 +13,37 @@ import type {
 import type { ChangedFilesData, FileDiffData, GitCommitResult } from '@/types/sandbox.types';
 import type { CursorPaginationParams, PaginatedChats, PaginatedMessages } from '@/types/api.types';
 
+export function buildChatFormData(request: ChatRequest): FormData {
+  // Single encoding of the /chat/chat multipart contract — shared with
+  // cloudChatService so new fields can't silently drift between local and cloud.
+  const formData = new FormData();
+  formData.append('prompt', request.prompt);
+
+  if (request.chat_id) {
+    formData.append('chat_id', request.chat_id);
+  }
+  if (request.model_id) {
+    formData.append('model_id', request.model_id);
+  }
+  if (request.attached_files && request.attached_files.length > 0) {
+    request.attached_files.forEach((file) => {
+      formData.append('attached_files', file);
+    });
+  }
+  if (request.thinking_mode) {
+    formData.append('thinking_mode', request.thinking_mode);
+  }
+  if (request.worktree) {
+    formData.append('worktree', 'true');
+  }
+  if (request.plan_mode) {
+    formData.append('plan_mode', 'true');
+  }
+  formData.append('selected_persona_name', request.selected_persona_name);
+  formData.append('permission_mode', request.permission_mode);
+  return formData;
+}
+
 async function createCompletion(
   request: ChatRequest,
   signal?: AbortSignal,
@@ -21,31 +52,7 @@ async function createCompletion(
 
   return serviceCall(
     async () => {
-      const formData = new FormData();
-      formData.append('prompt', request.prompt);
-
-      if (request.chat_id) {
-        formData.append('chat_id', request.chat_id);
-      }
-      if (request.model_id) {
-        formData.append('model_id', request.model_id);
-      }
-      if (request.attached_files && request.attached_files.length > 0) {
-        request.attached_files.forEach((file) => {
-          formData.append('attached_files', file);
-        });
-      }
-      if (request.thinking_mode) {
-        formData.append('thinking_mode', request.thinking_mode);
-      }
-      if (request.worktree) {
-        formData.append('worktree', 'true');
-      }
-      if (request.plan_mode) {
-        formData.append('plan_mode', 'true');
-      }
-      formData.append('selected_persona_name', request.selected_persona_name);
-      formData.append('permission_mode', request.permission_mode);
+      const formData = buildChatFormData(request);
 
       const taskResponse = await apiClient.postForm<{
         chat_id: string;

--- a/frontend/src/services/cloudChatService.ts
+++ b/frontend/src/services/cloudChatService.ts
@@ -1,0 +1,62 @@
+import { remoteApiClient, setCloudApiBaseUrl, trimTrailingSlash } from '@/lib/api';
+import { ensureResponse, serviceCall } from '@/services/base/BaseService';
+import { buildChatFormData } from '@/services/chatService';
+import { cloudAuthStorage } from '@/utils/storage';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
+import type { AuthResponse } from '@/types/user.types';
+import type { Workspace } from '@/types/workspace.types';
+import type { Chat, ChatRequest, CreateChatRequest } from '@/types/chat.types';
+import type { PaginatedResponse } from '@/types/api.types';
+
+// Log into the VPS and persist its refresh token. The remote client mints
+// access tokens from it on demand, so the desktop stays connected across restarts.
+async function connect(url: string, email: string, password: string): Promise<void> {
+  // Store the URL slash-trimmed — consumers compose paths like `${cloudUrl}/chat/{id}`.
+  const trimmedUrl = trimTrailingSlash(url);
+  setCloudApiBaseUrl(trimmedUrl);
+  const formData = new FormData();
+  formData.append('username', email);
+  formData.append('password', password);
+
+  const response = await remoteApiClient.postForm<AuthResponse>('/auth/jwt/login', formData);
+  const auth = ensureResponse(response, 'Failed to connect to cloud instance');
+
+  cloudAuthStorage.setRefreshToken(auth.refresh_token);
+  cloudAuthStorage.setAccessToken(auth.access_token);
+  useCloudSettingsStore.getState().setCloud(trimmedUrl, email);
+}
+
+function disconnect(): void {
+  cloudAuthStorage.clear();
+  useCloudSettingsStore.getState().clearCloud();
+}
+
+async function listWorkspaces(): Promise<Workspace[]> {
+  return serviceCall(async () => {
+    const response = await remoteApiClient.get<PaginatedResponse<Workspace>>('/workspaces');
+    return ensureResponse(response, 'Failed to load cloud workspaces').items;
+  });
+}
+
+async function createChat(data: CreateChatRequest): Promise<Chat> {
+  return serviceCall(async () => {
+    const response = await remoteApiClient.post<Chat>('/chat/chats', data);
+    return ensureResponse(response, 'Failed to create cloud chat');
+  });
+}
+
+// Start the run on the VPS. The desktop doesn't consume the stream — the VPS
+// owns and persists it.
+async function startCompletion(request: ChatRequest): Promise<void> {
+  await serviceCall(async () => {
+    await remoteApiClient.postForm('/chat/chat', buildChatFormData(request));
+  });
+}
+
+export const cloudChatService = {
+  connect,
+  disconnect,
+  listWorkspaces,
+  createChat,
+  startCompletion,
+};

--- a/frontend/src/store/chatSettingsStore.ts
+++ b/frontend/src/store/chatSettingsStore.ts
@@ -25,11 +25,16 @@ interface ChatSettingsState {
   permissionModeByChat: Record<string, PermissionMode>;
   thinkingModeByChat: Record<string, string>;
   worktreeByChat: Record<string, boolean>;
+  // Where a new chat runs: locally (false) or on the remote VPS instance (true).
+  // Global, not per-chat — chosen at creation time on the landing composer, and
+  // cloud chats live on the VPS so they never get a local chat ID to key by.
+  runOnCloud: boolean;
   planModeByChat: Record<string, boolean>;
   personaByChat: Record<string, string>;
   setPermissionMode: (chatId: string, mode: PermissionMode) => void;
   setThinkingMode: (chatId: string, mode: string) => void;
   setWorktree: (chatId: string, enabled: boolean) => void;
+  setRunOnCloud: (enabled: boolean) => void;
   setPlanMode: (chatId: string, enabled: boolean) => void;
   setPersona: (chatId: string, name: string) => void;
   initChatFromDefaults: (chatId: string) => void;
@@ -41,6 +46,7 @@ export const useChatSettingsStore = create<ChatSettingsState>()(
       permissionModeByChat: {},
       thinkingModeByChat: {},
       worktreeByChat: {},
+      runOnCloud: false,
       planModeByChat: {},
       personaByChat: {},
       setPermissionMode: (chatId, mode) =>
@@ -58,6 +64,7 @@ export const useChatSettingsStore = create<ChatSettingsState>()(
         set((state) => ({
           worktreeByChat: { ...state.worktreeByChat, [chatId]: enabled },
         })),
+      setRunOnCloud: (enabled) => set({ runOnCloud: enabled }),
       setPlanMode: (chatId, enabled) =>
         set((state) => ({
           planModeByChat: { ...state.planModeByChat, [chatId]: enabled },
@@ -68,7 +75,8 @@ export const useChatSettingsStore = create<ChatSettingsState>()(
         })),
       // Copies the __default__ settings to a newly created chat so the user's
       // toolbar defaults (permission mode, thinking, worktree, persona) carry
-      // over without requiring explicit selection each time.
+      // over without requiring explicit selection each time. Only reached for
+      // local chats — cloud chats live on the VPS and aren't seeded here.
       initChatFromDefaults: (chatId) => {
         const state = get();
         const permission = state.permissionModeByChat[DEFAULT_KEY];

--- a/frontend/src/store/cloudSettingsStore.ts
+++ b/frontend/src/store/cloudSettingsStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface CloudSettingsState {
+  // VPS origin (e.g. https://vps.example.com), without the /api/v1 suffix.
+  cloudUrl: string;
+  // Email the desktop is connected to the VPS as — display only.
+  connectedEmail: string | null;
+  setCloud: (url: string, email: string) => void;
+  clearCloud: () => void;
+}
+
+export const useCloudSettingsStore = create<CloudSettingsState>()(
+  persist(
+    (set) => ({
+      cloudUrl: '',
+      connectedEmail: null,
+      setCloud: (url, email) => set({ cloudUrl: url, connectedEmail: email }),
+      clearCloud: () => set({ cloudUrl: '', connectedEmail: null }),
+    }),
+    { name: 'cloud-settings-storage' },
+  ),
+);

--- a/frontend/src/utils/chatRequest.ts
+++ b/frontend/src/utils/chatRequest.ts
@@ -1,0 +1,40 @@
+import { coercePermissionModeForAgent } from '@/components/chat/permission-mode-selector/permissionModes';
+import { coerceThinkingModeForAgent } from '@/components/chat/thinking-mode-selector/thinkingModes';
+import { resolvePersona } from '@/utils/settings';
+import { getAgentKindForModelId, type ChatRequest, type Model } from '@/types/chat.types';
+import type { PermissionMode } from '@/store/chatSettingsStore';
+import type { Persona } from '@/types/user.types';
+
+// Raw toolbar settings before agent coercion.
+interface RawChatSettings {
+  permissionMode: PermissionMode;
+  thinkingMode: string;
+  worktree: boolean;
+  planMode: boolean;
+  persona: string;
+}
+
+type AgentChatFields = Pick<
+  ChatRequest,
+  'permission_mode' | 'thinking_mode' | 'worktree' | 'plan_mode' | 'selected_persona_name'
+>;
+
+// Coerce raw toolbar settings into the agent-specific ChatRequest fields. Shared
+// so local (useMessageActions) and cloud (landing) runs start with identical
+// behavior — the coercion rules can't drift between the two paths.
+export function buildAgentChatFields(
+  selectedModelId: string,
+  modelMap: Map<string, Model>,
+  raw: RawChatSettings,
+  personas: Persona[],
+): AgentChatFields {
+  const agentKind =
+    modelMap.get(selectedModelId)?.agent_kind ?? getAgentKindForModelId(selectedModelId);
+  return {
+    permission_mode: coercePermissionModeForAgent(raw.permissionMode, agentKind),
+    thinking_mode: coerceThinkingModeForAgent(raw.thinkingMode, agentKind, selectedModelId),
+    worktree: raw.worktree ? true : undefined,
+    plan_mode: agentKind === 'codex' && raw.planMode ? true : undefined,
+    selected_persona_name: resolvePersona(raw.persona, personas),
+  };
+}

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -3,6 +3,7 @@ import { isTauri } from '@tauri-apps/api/core';
 
 const AUTH_TOKEN_KEY = 'auth_token';
 const REFRESH_TOKEN_KEY = 'refresh_token';
+const CLOUD_REFRESH_TOKEN_KEY = 'cloud_refresh_token';
 const AUTH_STORE_PATH = 'auth.store.json';
 const CHAT_EVENT_ID_PREFIX = 'chat:';
 const CHAT_EVENT_ID_SUFFIX = ':lastEventId';
@@ -228,6 +229,93 @@ export const authStorage = {
 
     safeRemoveItem(AUTH_TOKEN_KEY);
     safeRemoveItem(REFRESH_TOKEN_KEY);
+  },
+};
+
+// Remote (VPS) auth: the desktop talks to a second AgentRove instance for
+// cloud-run chats. Only the long-lived refresh token is persisted (in the same
+// secure backing store as local auth, under a distinct key) — the short-lived
+// access token is kept in memory and re-minted via the VPS refresh endpoint.
+let cloudAccessToken: string | null = null;
+let cloudRefreshToken: string | null = null;
+let cloudCacheInitialized = false;
+
+async function persistCloudRefreshToken(): Promise<void> {
+  const store = await getDesktopAuthStore();
+  if (!store) {
+    return;
+  }
+
+  try {
+    if (cloudRefreshToken) {
+      await store.set(CLOUD_REFRESH_TOKEN_KEY, cloudRefreshToken);
+    } else {
+      await store.delete(CLOUD_REFRESH_TOKEN_KEY);
+    }
+    await store.save();
+  } catch (error) {
+    logger.error('Desktop cloud auth persist failed', 'storage.persistCloudRefreshToken', error);
+  }
+}
+
+export const cloudAuthStorage = {
+  hydrate: async (): Promise<void> => {
+    if (cloudCacheInitialized) {
+      return;
+    }
+
+    if (!isTauri()) {
+      cloudRefreshToken = safeGetItem(CLOUD_REFRESH_TOKEN_KEY);
+      cloudCacheInitialized = true;
+      return;
+    }
+
+    const store = await getDesktopAuthStore();
+    if (store) {
+      try {
+        cloudRefreshToken = (await store.get<string>(CLOUD_REFRESH_TOKEN_KEY)) ?? null;
+      } catch (error) {
+        logger.error('Desktop cloud auth read failed', 'storage.cloudAuthStorage.hydrate', error);
+      }
+    }
+
+    cloudCacheInitialized = true;
+  },
+  getAccessToken: (): string | null => cloudAccessToken,
+  setAccessToken: (token: string): void => {
+    cloudAccessToken = token;
+  },
+  getRefreshToken: (): string | null => {
+    if (!cloudCacheInitialized && !isTauri()) {
+      cloudRefreshToken = safeGetItem(CLOUD_REFRESH_TOKEN_KEY);
+      cloudCacheInitialized = true;
+    }
+    return cloudRefreshToken;
+  },
+  setRefreshToken: (token: string): void => {
+    cloudRefreshToken = token;
+    cloudCacheInitialized = true;
+
+    // Unlike authStorage there's no stale-localStorage cleanup on the Tauri
+    // path — this key is new and only ever written to localStorage in browsers.
+    if (isTauri()) {
+      void persistCloudRefreshToken();
+      return;
+    }
+
+    safeSetItem(CLOUD_REFRESH_TOKEN_KEY, token);
+  },
+  clear: (): void => {
+    cloudAccessToken = null;
+    cloudRefreshToken = null;
+    cloudCacheInitialized = true;
+
+    if (isTauri()) {
+      void persistCloudRefreshToken();
+      return;
+    }
+
+    safeRemoveItem(CLOUD_REFRESH_TOKEN_KEY);
   },
 };
 


### PR DESCRIPTION
## Summary
- Add a **Local / Cloud** run-location selector to the landing composer (`RunLocationSelector`), alongside a separate worktree toggle, so a chat can be launched on a remote AgentRove (VPS) instance and keep running after the desktop app is closed.
- New **Settings → Cloud** tab to connect to a VPS (URL + email/password). Stores the refresh token client-side (Tauri secure store / localStorage); the access token is minted on demand. Bare hosts are normalized to `https://` and validated.
- Second API client (`remoteApiClient`) with independent per-instance auth/refresh; `cloudChatService` creates the chat and starts the run on the VPS, then a toast links out to `<cloudUrl>/chat/<id>` (launcher model — no inline streaming in v1).
- Cloud workspace picker (`CloudWorkspaceSelector`) keyed by `cloudUrl + connectedEmail` so switching instance or account never serves a stale list.
- Shared `buildAgentChatFields` so cloud runs apply the same agent-specific permission/thinking/plan-mode coercion as local runs; cloud uses the remote's default persona.
- CSP `connect-src` widened to `https: wss:` so the Tauri webview can reach a remote VPS.

### Correctness hardening
- `/models/` (auth-protected) is now gated behind `isAuthenticated` everywhere it's reachable from the public landing (`useModelMap(enabled)`, `InputProvider`, `InputControls`) so logged-out visitors aren't bounced to login.
- A 401 with no recoverable refresh token now tears down the session (cloud: clears connection; local: redirects) instead of surfacing a generic error.
- On startup, a persisted cloud "connected" state with no hydrated refresh token is dropped.
- The "Connect a cloud instance" CTA deep-links to the Cloud settings tab.
- Cloud composer suppresses local skills/slash-commands/@file mentions and personas (per-instance, don't apply remotely).
- Status colors use the configured shaded tokens (`text-error-600 dark:text-error-400`, `text-success-600 dark:text-success-400`).

## Test plan
- [ ] Local and worktree runs behave exactly as before.
- [ ] Settings → Cloud: connect with a bare host and a full URL; both work; bad input is rejected.
- [ ] With Cloud selected, pick a VPS workspace, send a prompt → chat appears and runs in the VPS web UI via the toast link; closing the desktop doesn't stop it.
- [ ] Switching VPS instance or account refreshes the workspace list (no stale IDs).
- [ ] Logged-out visit to `/` stays on the landing/signup flow (no `/models/` 401 redirect).
- [ ] Disconnect / stale-token reconnect reflects correctly in the UI.
- [ ] VPS `ALLOWED_ORIGINS` must include the desktop origin (`tauri://localhost`, `https://tauri.localhost`).