### PR TITLE
Add Claude Fable 5 support

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.42.0 @zed-industries/codex-acp@0.15.0 @openai/codex@0.125.0 @github/copilot@1.0.36
+RUN npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.44.0 @zed-industries/codex-acp@0.15.0 @openai/codex@0.125.0 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to /root/.local/bin) — used for the Cursor
 # ACP server (`cursor-agent acp`). The install script downloads the binary for

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -131,6 +131,7 @@ MODELS: dict[str, ModelInfo] = {
     "sonnet": ModelInfo("Sonnet", AgentKind.CLAUDE, 200_000),
     "opus": ModelInfo("Opus", AgentKind.CLAUDE, 1_000_000),
     "haiku": ModelInfo("Haiku", AgentKind.CLAUDE, 200_000),
+    "claude-fable-5": ModelInfo("Fable 5", AgentKind.CLAUDE, 1_000_000),
     "gpt-5.5": ModelInfo("GPT 5.5", AgentKind.CODEX, 1_000_000),
     "gpt-5.4": ModelInfo("GPT 5.4", AgentKind.CODEX, 1_000_000),
     "gpt-5.4-mini": ModelInfo("GPT 5.4 Mini", AgentKind.CODEX, 400_000),

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -52,7 +52,8 @@ COPILOT_SESSION_MODE_IDS: dict[str, str] = {
 }
 
 CLAUDE_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "max"})
-CLAUDE_OPUS_VALID_THINKING_MODES = CLAUDE_VALID_THINKING_MODES | {"xhigh"}
+CLAUDE_XHIGH_VALID_THINKING_MODES = CLAUDE_VALID_THINKING_MODES | {"xhigh"}
+CLAUDE_XHIGH_MODEL_IDS = frozenset({"opus", "claude-fable-5"})
 CODEX_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
 COPILOT_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
 
@@ -200,12 +201,11 @@ class ClaudeAgentAdapter(AgentAdapter):
 
         # Claude exposes thinking budget as the "effort" session config option,
         # applied post-handshake via set_config_option; the UI's named tiers
-        # are passed through directly as effort level IDs. `xhigh` is currently
-        # only valid for the Opus model we expose, so other Claude models keep
-        # the narrower tier set and coerce unsupported persisted values.
+        # are passed through directly as effort level IDs. `xhigh` is only
+        # valid for selected Claude models, so others keep the narrower tier set.
         valid_modes = (
-            CLAUDE_OPUS_VALID_THINKING_MODES
-            if model_id == "opus"
+            CLAUDE_XHIGH_VALID_THINKING_MODES
+            if model_id in CLAUDE_XHIGH_MODEL_IDS
             else CLAUDE_VALID_THINKING_MODES
         )
         reasoning_effort = coerce_thinking_mode(thinking_mode, valid_modes)

--- a/desktop/run_build.mjs
+++ b/desktop/run_build.mjs
@@ -22,7 +22,7 @@ const PYTHON_VERSION = '3.12.12';
 const NODE_VERSION = '22.12.0';
 const RELEASE_TAG = '20260211';
 const RIPGREP_VERSION = '14.1.1';
-const CLAUDE_AGENT_ACP_VERSION = '0.42.0';
+const CLAUDE_AGENT_ACP_VERSION = '0.44.0';
 const CODEX_ACP_VERSION = '0.15.0';
 const GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py';
 

--- a/frontend/src/components/chat/sub-threads/CreateSubThreadDialog.tsx
+++ b/frontend/src/components/chat/sub-threads/CreateSubThreadDialog.tsx
@@ -52,7 +52,7 @@ export function CreateSubThreadDialog({ parentChat, onClose }: CreateSubThreadDi
   const [personaName, setPersonaName] = useState(DEFAULT_PERSONA);
   const [message, setMessage] = useState('');
   const [thinkingMode, setThinkingMode] = useState<ThinkingModeOption>(
-    THINKING_MODES_BY_AGENT['claude'][1],
+    THINKING_MODES_BY_AGENT['claude'][2],
   );
   const [permissionMode, setPermissionMode] = useState<PermissionMode>(DEFAULT_PERMISSION_MODE);
 

--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -11,13 +11,14 @@ const CLAUDE_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'high', label: 'High' },
   { value: 'max', label: 'Max' },
 ];
-const CLAUDE_OPUS_THINKING_MODES: ThinkingModeOption[] = [
+const CLAUDE_XHIGH_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'low', label: 'Low' },
   { value: 'medium', label: 'Medium' },
   { value: 'high', label: 'High' },
   { value: 'xhigh', label: 'XHigh' },
   { value: 'max', label: 'Max' },
 ];
+const CLAUDE_XHIGH_MODEL_IDS = new Set(['opus', 'claude-fable-5']);
 
 const CODEX_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'low', label: 'Low' },
@@ -51,9 +52,9 @@ export function getThinkingModesForAgent(
   agentKind: AgentKind,
   modelId?: string,
 ): ThinkingModeOption[] {
-  // Claude exposes `xhigh` only for Opus.
-  if (agentKind === 'claude' && modelId === 'opus') {
-    return CLAUDE_OPUS_THINKING_MODES;
+  // Claude only exposes `xhigh` on selected high-capability models.
+  if (agentKind === 'claude' && modelId && CLAUDE_XHIGH_MODEL_IDS.has(modelId)) {
+    return CLAUDE_XHIGH_THINKING_MODES;
   }
 
   return THINKING_MODES_BY_AGENT[agentKind];

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -57,7 +57,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.42.0 @zed-industries/codex-acp@0.15.0 @openai/codex@0.125.0 @github/copilot@1.0.36
+    npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.44.0 @zed-industries/codex-acp@0.15.0 @openai/codex@0.125.0 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to ~/.local/bin, which is already on PATH).
 RUN curl -fsS https://cursor.com/install | bash


### PR DESCRIPTION
## Summary
- bump claude-agent-acp to 0.44.0 across backend, sandbox, and desktop builds
- expose Claude Fable 5 without changing the implicit default model ordering
- allow xhigh thinking mode for Fable while keeping unsupported Claude models on the narrower tier set
- default new sub-thread thinking mode to high

## Test plan
- [x] pre-commit hooks: eslint --fix, prettier --write, ruff, ruff format
- [ ] not run: full test suite