### PR TITLE
fix: terminal scrolling, reattach repaint, and reconnect

### DIFF
--- a/backend/app/api/endpoints/websocket.py
+++ b/backend/app/api/endpoints/websocket.py
@@ -114,13 +114,10 @@ async def terminal_websocket(
                     )
                 )
 
-                if is_reattach and session.pty_id is not None:
-                    # Force a redraw after reattaching to an existing tmux
-                    # session so the terminal repaints without injecting a
-                    # literal space into the active shell buffer.
-                    await session.sandbox_service.send_pty_input(
-                        session.sandbox_id, session.pty_id, b"\x0c"
-                    )
+                if is_reattach:
+                    # Repaint through tmux rather than the pane's stdin — the
+                    # foreground app (e.g. a TUI) may swallow injected keys.
+                    await session.refresh_tmux_client()
 
             elif data_type == WS_MSG_RESIZE:
                 rows = parse_pty_dimension(

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -108,14 +108,13 @@ class SandboxService:
         tmux_session: str,
         on_data: PtyDataCallbackType,
     ) -> str:
-        pty_session = await self.provider.create_pty(
+        return await self.provider.create_pty(
             sandbox_id,
             rows,
             cols,
             tmux_session,
             on_data=on_data,
         )
-        return pty_session.id
 
     async def send_pty_input(
         self, sandbox_id: str, pty_session_id: str, data: bytes

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -11,7 +11,6 @@ from app.services.sandbox_providers.types import (
     FileContent,
     FileMetadata,
     PtyDataCallbackType,
-    PtySession,
     PtySize,
     SandboxProviderType,
 )
@@ -120,8 +119,9 @@ class SandboxProvider:
         rows: int,
         cols: int,
         tmux_session: str,
-        on_data: PtyDataCallbackType | None = None,
-    ) -> PtySession:
+        on_data: PtyDataCallbackType,
+    ) -> str:
+        # Returns the new PTY session id.
         raise NotImplementedError
 
     async def send_pty_input(

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -23,7 +23,6 @@ from app.services.sandbox_providers.types import (
     FileContent,
     FileMetadata,
     PtyDataCallbackType,
-    PtySession,
     PtySize,
 )
 
@@ -374,8 +373,8 @@ class LocalDockerProvider(SandboxProvider):
         rows: int,
         cols: int,
         tmux_session: str,
-        on_data: PtyDataCallbackType | None = None,
-    ) -> PtySession:
+        on_data: PtyDataCallbackType,
+    ) -> str:
         # Spawn a PTY-attached shell inside the container via docker exec.
         # Tries tmux for session persistence across WebSocket reconnections,
         # falls back to bare bash if tmux is not installed.
@@ -385,7 +384,7 @@ class LocalDockerProvider(SandboxProvider):
         cmd = [
             "bash",
             "-c",
-            f"command -v tmux >/dev/null && tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off || exec bash",
+            f"command -v tmux >/dev/null && tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off \\; set -g mouse on || exec bash",
         ]
 
         exec_obj = await container.exec(
@@ -400,9 +399,7 @@ class LocalDockerProvider(SandboxProvider):
         # WebSocket to the Docker daemon. No public API exists for this.
         await stream._init()
 
-        reader_task = (
-            asyncio.create_task(self._pty_reader(stream, on_data)) if on_data else None
-        )
+        reader_task = asyncio.create_task(self._pty_reader(stream, on_data))
         self.register_pty_session(
             sandbox_id,
             session_id,
@@ -416,12 +413,7 @@ class LocalDockerProvider(SandboxProvider):
         if rows > 0 and cols > 0:
             await self.resize_pty(sandbox_id, session_id, PtySize(rows=rows, cols=cols))
 
-        return PtySession(
-            id=session_id,
-            pid=None,
-            rows=rows,
-            cols=cols,
-        )
+        return session_id
 
     async def _pty_reader(
         self,
@@ -483,12 +475,11 @@ class LocalDockerProvider(SandboxProvider):
             return
 
         reader_task = session["reader_task"]
-        if reader_task:
-            reader_task.cancel()
-            try:
-                await reader_task
-            except asyncio.CancelledError:
-                pass
+        reader_task.cancel()
+        try:
+            await reader_task
+        except asyncio.CancelledError:
+            pass
 
         try:
             await session["stream"].close()

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -25,7 +25,6 @@ from app.services.sandbox_providers.types import (
     FileContent,
     FileMetadata,
     PtyDataCallbackType,
-    PtySession,
     PtySize,
 )
 from app.utils.sandbox import normalize_relative_path
@@ -199,8 +198,8 @@ class LocalHostProvider(SandboxProvider):
         rows: int,
         cols: int,
         tmux_session: str,
-        on_data: PtyDataCallbackType | None = None,
-    ) -> PtySession:
+        on_data: PtyDataCallbackType,
+    ) -> str:
         # Spawn a PTY-attached shell in the workspace directory. Tries tmux
         # for session persistence across WebSocket reconnections, falls back
         # to the user's default shell if tmux is not installed.
@@ -223,7 +222,7 @@ class LocalHostProvider(SandboxProvider):
         shell = env.get("SHELL", "/bin/bash")
         cmd = (
             "command -v tmux >/dev/null && "
-            f"tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off || exec {shlex.quote(shell)}"
+            f"tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off \\; set -g mouse on || exec {shlex.quote(shell)}"
         )
         process = await asyncio.to_thread(
             subprocess.Popen,
@@ -238,10 +237,8 @@ class LocalHostProvider(SandboxProvider):
         )
         os.close(slave_fd)
 
-        reader_task = (
-            asyncio.create_task(self._pty_reader(session_id, master_fd, on_data))
-            if on_data
-            else None
+        reader_task = asyncio.create_task(
+            self._pty_reader(session_id, master_fd, on_data)
         )
         self.register_pty_session(
             sandbox_id,
@@ -253,7 +250,7 @@ class LocalHostProvider(SandboxProvider):
             },
         )
 
-        return PtySession(id=session_id, pid=process.pid, rows=rows, cols=cols)
+        return session_id
 
     async def _pty_reader(
         self,
@@ -320,10 +317,9 @@ class LocalHostProvider(SandboxProvider):
         if not session:
             return
 
-        if session["reader_task"]:
-            session["reader_task"].cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await session["reader_task"]
+        session["reader_task"].cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await session["reader_task"]
 
         process = session["process"]
         if process.poll() is None:

--- a/backend/app/services/sandbox_providers/types.py
+++ b/backend/app/services/sandbox_providers/types.py
@@ -33,14 +33,6 @@ class FileContent:
 
 
 @dataclass
-class PtySession:
-    id: str
-    pid: int | None
-    rows: int
-    cols: int
-
-
-@dataclass
 class PtySize:
     rows: int
     cols: int

--- a/backend/app/services/terminal.py
+++ b/backend/app/services/terminal.py
@@ -122,6 +122,22 @@ class TerminalSessionRecord:
         await self.kill_tmux_session()
         await self.close()
 
+    async def refresh_tmux_client(self) -> None:
+        # Repaint the reattached terminal via tmux itself — Ctrl-L to the pane's
+        # stdin only redraws shells; full-screen TUIs swallow it, leaving the
+        # fresh xterm blank.
+        session_name = shlex.quote(self._get_tmux_session_name())
+        command = (
+            "for c in $(tmux list-clients -t "
+            + session_name
+            + " -F '#{client_name}'); "
+            'do tmux refresh-client -t "$c"; done'
+        )
+        try:
+            await self.sandbox_service.execute_command(self.sandbox_id, command)
+        except (OSError, RuntimeError, SandboxException):
+            pass
+
     async def kill_tmux_session(self) -> None:
         session_name = self._get_tmux_session_name()
         try:

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -17,7 +17,6 @@ from app.services.sandbox_providers.types import (
     FileContent,
     FileMetadata,
     PtyDataCallbackType,
-    PtySession,
     PtySize,
 )
 
@@ -151,9 +150,9 @@ class FakeSandboxProvider(SandboxProvider):
         rows: int,
         cols: int,
         tmux_session: str,
-        on_data: PtyDataCallbackType | None = None,
-    ) -> PtySession:
-        return PtySession(id="pty-1", pid=None, rows=rows, cols=cols)
+        on_data: PtyDataCallbackType,
+    ) -> str:
+        return "pty-1"
 
     async def send_pty_input(
         self,

--- a/frontend/src/components/sandbox/terminal/TerminalTab.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab.tsx
@@ -3,6 +3,7 @@ import { logger } from '@/utils/logger';
 import type { FC } from 'react';
 import 'xterm/css/xterm.css';
 
+import { Button } from '@/components/ui/primitives/Button';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { authService } from '@/services/authService';
 import { WS_BASE_URL } from '@/lib/api';
@@ -19,7 +20,7 @@ export interface TerminalTabProps {
   onClosed?: () => void;
 }
 
-type SessionState = 'idle' | 'connecting' | 'ready' | 'error';
+type SessionState = 'idle' | 'connecting' | 'ready' | 'error' | 'disconnected';
 
 const encoder = new TextEncoder();
 
@@ -37,13 +38,13 @@ export const TerminalTab: FC<TerminalTabProps> = ({
   const theme = useResolvedTheme();
   const [sessionState, setSessionState] = useState<SessionState>('idle');
   const [closeReason, setCloseReason] = useState<string | null>(null);
+  const [connectAttempt, setConnectAttempt] = useState(0);
 
   const lastSentSizeRef = useRef<TerminalSize | null>(null);
   const hasSentInitRef = useRef(false);
   const wsRef = useRef<WebSocket | null>(null);
   const isClosingRef = useRef(false);
   const shouldCloseRef = useRef(shouldClose);
-  const lastSessionKeyRef = useRef<string | null>(null);
 
   const backgroundClass = getTerminalBackgroundClass(theme);
 
@@ -90,13 +91,9 @@ export const TerminalTab: FC<TerminalTabProps> = ({
   useEffect(() => {
     if (!sandboxId || !isReady) return;
 
-    const sessionKey = sandboxId + ':' + (terminalId ?? '');
-    if (lastSessionKeyRef.current !== sessionKey) {
-      // Reset the terminal when rebinding to a different session so stale
-      // screen contents and cursor position do not leak into the next PTY.
-      terminalRef.current?.reset();
-      lastSessionKeyRef.current = sessionKey;
-    }
+    // Reset on every (re)connect so stale screen contents and cursor position
+    // do not leak into the next PTY — the server repaints via tmux on reattach.
+    terminalRef.current?.reset();
 
     const token = authService.getToken();
     if (!token) return;
@@ -164,6 +161,11 @@ export const TerminalTab: FC<TerminalTabProps> = ({
 
     const handleClose = (event: CloseEvent) => {
       resetWsRefs();
+      // User-initiated tab close tears the socket down on purpose — don't
+      // surface that as an unexpected disconnect.
+      if (isClosingRef.current) {
+        return;
+      }
       // The server closes with WS_CLOSE_AUTH_FAILED / WS_CLOSE_SANDBOX_NOT_FOUND
       // and a human-readable reason. Surface both so the overlay can tell the
       // user why the connection dropped instead of showing a generic message.
@@ -172,7 +174,9 @@ export const TerminalTab: FC<TerminalTabProps> = ({
         setSessionState('error');
         return;
       }
-      setSessionState((prev) => (prev === 'error' ? prev : 'idle'));
+      // Any other close while this effect is live (backend restart, network
+      // drop) is unexpected — offer a reconnect instead of a frozen terminal.
+      setSessionState((prev) => (prev === 'error' ? prev : 'disconnected'));
     };
 
     const handleBeforeUnload = () => {
@@ -200,10 +204,9 @@ export const TerminalTab: FC<TerminalTabProps> = ({
       }
       ws.close();
       resetWsRefs();
-      lastSessionKeyRef.current = null;
       setSessionState('idle');
     };
-  }, [sandboxId, terminalId, isReady, fitTerminal, terminalRef, resetWsRefs]);
+  }, [sandboxId, terminalId, isReady, connectAttempt, fitTerminal, terminalRef, resetWsRefs]);
 
   useEffect(() => {
     if (!shouldClose || isClosingRef.current) {
@@ -237,7 +240,9 @@ export const TerminalTab: FC<TerminalTabProps> = ({
       ? 'Connecting to sandbox terminal...'
       : sessionState === 'error'
         ? (closeReason ?? 'Terminal connection interrupted')
-        : null;
+        : sessionState === 'disconnected'
+          ? 'Terminal disconnected'
+          : null;
 
   return (
     <div className={`relative flex h-full flex-col ${backgroundClass}`}>
@@ -245,10 +250,21 @@ export const TerminalTab: FC<TerminalTabProps> = ({
         <div ref={wrapperRef} className={`h-full w-full ${isVisible ? 'block' : 'hidden'}`} />
       </div>
       {isVisible && overlayMessage && (
-        <div className={`absolute inset-0 flex items-center justify-center ${backgroundClass}`}>
+        <div
+          className={`absolute inset-0 flex flex-col items-center justify-center gap-3 ${backgroundClass}`}
+        >
           <div className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
             {overlayMessage}
           </div>
+          {sessionState === 'disconnected' && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setConnectAttempt((attempt) => attempt + 1)}
+            >
+              Reconnect
+            </Button>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/hooks/useXterm.ts
+++ b/frontend/src/hooks/useXterm.ts
@@ -19,11 +19,10 @@ function hasRenderer(terminal: XTerm): boolean {
 }
 
 interface UseXtermOptions {
-  disableStdin?: boolean;
   isVisible: boolean;
   mode: 'light' | 'dark';
-  onData?: (data: string) => void;
-  onFit?: (size: TerminalSize) => void;
+  onData: (data: string) => void;
+  onFit: (size: TerminalSize) => void;
 }
 
 interface UseXtermReturn {
@@ -33,13 +32,7 @@ interface UseXtermReturn {
   wrapperRef: MutableRefObject<HTMLDivElement | null>;
 }
 
-export const useXterm = ({
-  disableStdin = false,
-  isVisible,
-  mode,
-  onData,
-  onFit,
-}: UseXtermOptions): UseXtermReturn => {
+export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): UseXtermReturn => {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddonType | null>(null);
@@ -74,9 +67,7 @@ export const useXterm = ({
       cols: terminal.cols,
     };
 
-    if (onFit) {
-      onFit(size);
-    }
+    onFit(size);
 
     return size;
   }, [onFit]);
@@ -121,7 +112,6 @@ export const useXterm = ({
         fontSize: 12,
         fontFamily: 'monospace',
         theme: buildTerminalTheme(modeRef.current),
-        disableStdin,
       });
       const fitAddon = new FitAddon();
 
@@ -164,14 +154,12 @@ export const useXterm = ({
       setIsReady(false);
       hasInitializedRef.current = false;
     };
-  }, [disableStdin, shouldInitialize, initAttempt]);
+  }, [shouldInitialize, initAttempt]);
 
   useEffect(() => {
     const terminal = terminalRef.current;
 
-    if (!terminal || !onData || disableStdin) {
-      inputHandlerRef.current?.dispose();
-      inputHandlerRef.current = null;
+    if (!terminal) {
       return;
     }
 
@@ -182,7 +170,7 @@ export const useXterm = ({
       inputHandlerRef.current?.dispose();
       inputHandlerRef.current = null;
     };
-  }, [onData, disableStdin]);
+  }, [onData]);
 
   useEffect(() => {
     const terminal = terminalRef.current;
@@ -191,7 +179,6 @@ export const useXterm = ({
     }
 
     try {
-      terminal.options.disableStdin = disableStdin;
       terminal.options.theme = buildTerminalTheme(mode);
     } catch {
       return;
@@ -205,7 +192,7 @@ export const useXterm = ({
     }
 
     return undefined;
-  }, [mode, disableStdin, isReady, isVisible, fitTerminal]);
+  }, [mode, isReady, isVisible, fitTerminal]);
 
   useEffect(() => {
     const container = wrapperRef.current;


### PR DESCRIPTION
## Summary

Fixes three terminal issues and removes dead plumbing uncovered along the way.

- **Can't scroll** — the shell runs inside tmux (a full-screen app), so output never reached xterm.js's scrollback and, with tmux mouse mode off, wheel events went nowhere. Enabled `set -g mouse on` in the tmux startup command in both sandbox providers. (Tradeoff: native text selection now needs Shift-drag — standard for tmux-backed web terminals.)
- **Blank terminal after hide/reopen with a TUI running** (e.g. Claude Code on `/usage`) — reopening reattached to the surviving tmux session and injected `Ctrl-L` into the pane's stdin to repaint, but foreground TUIs swallow it. Replaced with a new `TerminalSessionRecord.refresh_tmux_client()` that runs `tmux refresh-client`, repainting regardless of the foreground app.
- **Silent freeze on unexpected disconnect** — when the WebSocket dropped (backend restart, network blip), the tab went to an overlay-less `idle` state and just froze. Added a `disconnected` state with a **Reconnect** button that reopens the socket and reattaches to the live PTY/tmux session.

### Cleanup (dead code / no-value abstractions)
- Frontend: removed the never-passed `disableStdin` option from `useXterm` and the always-true `lastSessionKeyRef` guard in `TerminalTab`.
- Backend: dropped the `PtySession` dataclass (only `.id` was read — `create_pty` now returns the id string) and the unused optional `on_data=None` branches across both providers.

## Test plan

- [ ] Scroll up/down in the terminal with the mouse wheel (shell history and inside a TUI)
- [ ] Shift-drag still selects text
- [ ] Open Claude Code, run `/usage`, hide and reopen the terminal panel — screen repaints, not blank
- [ ] Restart the backend with the terminal open — overlay shows "Terminal disconnected" with a Reconnect button; clicking it restores the session
- [ ] Backend tests pass; frontend typecheck passes