### PR TITLE
fix: streaming flow bugs and dead-code cleanup

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -647,7 +647,7 @@ async def send_now_queued_message(
             detail="Queued message not found",
         )
 
-    if ChatStreamRuntime.is_chat_streaming(str(chat_id)):
+    if ChatStreamRuntime.has_active_chat(str(chat_id)):
         # Cancel the active generation so the runtime picks up the
         # send-now flag immediately instead of waiting for the agent
         # to finish its current turn.

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -30,7 +30,7 @@ from app.services.agent import (
     AgentService,
     StreamResult,
 )
-from app.services.session_registry import ChatSession, session_registry
+from app.services.session_registry import session_registry
 from app.services.db import SessionFactoryType
 from app.services.exceptions import AgentException
 from app.services.message import MessageService
@@ -85,7 +85,7 @@ class ChatStreamRuntime:
         self.chat = chat
         self.chat_id = str(chat.id)
         self.stream_id = uuid4()
-        self.session_container: dict[str, Any] = {"session_id": request.session_id}
+        self.session_id: str | None = request.session_id
         self.assistant_message_id = request.assistant_message_id
         self.model_id = request.model_id
         self.context_window = request.context_window
@@ -101,7 +101,6 @@ class ChatStreamRuntime:
         self.message_service = MessageService(session_factory=session_factory)
         self._event_buffer: list[tuple[str, dict[str, Any], dict[str, Any] | None]] = []
 
-        self._session: ChatSession | None = None
         self.cache: CacheStore | None = None
         self._cancel_event: asyncio.Event | None = None
         self._cancelled: bool = False
@@ -112,7 +111,6 @@ class ChatStreamRuntime:
 
     async def run(
         self,
-        ai_service: AgentService,
         stream_result: StreamResult,
         stream: AsyncIterator[StreamEvent],
     ) -> str:
@@ -140,7 +138,7 @@ class ChatStreamRuntime:
                     "system",
                     {"data": {"worktree_cwd": self.chat.worktree_cwd}},
                 )
-            await self._consume_stream(ai_service, stream_result, stream)
+            await self._consume_stream(stream_result, stream)
             await self._emit_prompt_suggestions()
 
             if self._cancelled:
@@ -148,7 +146,10 @@ class ChatStreamRuntime:
                     stream_result, MessageStreamStatus.INTERRUPTED
                 )
 
-            if self.last_seq <= start_seq:
+            # Buffered events may not have flushed yet (debounce) — a fast turn
+            # can finish with last_seq still at start_seq, so check the buffer
+            # too before declaring the stream empty.
+            if self.last_seq <= start_seq and not self._event_buffer:
                 # Cancel/send-now may have arrived after the last event was
                 # consumed but before _consume_stream returned — the stream
                 # ended naturally (via StopAsyncIteration) so CancelledError
@@ -175,7 +176,6 @@ class ChatStreamRuntime:
 
     async def _consume_stream(
         self,
-        ai_service: AgentService,
         stream_result: StreamResult,
         stream: AsyncIterator[StreamEvent],
     ) -> None:
@@ -192,14 +192,15 @@ class ChatStreamRuntime:
                     k: v for k, v in event_dict.items() if k != "type"
                 }
 
-                session_data: dict[str, Any] = payload.get("data") or {}
-                if kind == "system" and session_data.get("session_id"):
-                    task = asyncio.create_task(
-                        self._handle_session_update(session_data)
-                    )
-                    self._bg_tasks.add(task)
-                    task.add_done_callback(self._bg_tasks.discard)
-                    task.add_done_callback(self._on_session_update_done)
+                if kind == "system":
+                    session_data: dict[str, Any] = payload.get("data") or {}
+                    if session_data.get("session_id"):
+                        task = asyncio.create_task(
+                            self._handle_session_update(session_data)
+                        )
+                        self._bg_tasks.add(task)
+                        task.add_done_callback(self._bg_tasks.discard)
+                        task.add_done_callback(self._on_session_update_done)
 
                 if kind == "usage":
                     usage_data = payload.get("data")
@@ -450,10 +451,9 @@ class ChatStreamRuntime:
         new_session_id = payload.get("session_id")
         if not new_session_id:
             return
-        prev_session_id = self.session_container.get("session_id")
-        if new_session_id == prev_session_id:
+        if new_session_id == self.session_id:
             return
-        self.session_container["session_id"] = new_session_id
+        self.session_id = new_session_id
         agent_kind = MODELS[self.model_id].agent_kind
         self.chat.session_id = new_session_id
         self.chat.session_agent_kind = agent_kind.value
@@ -547,7 +547,7 @@ class ChatStreamRuntime:
                     queued_msg=next_msg,
                     user_settings=user_settings,
                     assistant_message_id=str(assistant_message.id),
-                    session_id_override=self.session_container.get("session_id"),
+                    session_id_override=self.session_id,
                 )
             )
         except Exception as exc:
@@ -708,7 +708,7 @@ class ChatStreamRuntime:
         return chat_id in cls._background_task_chat_ids.values()
 
     @classmethod
-    def _on_background_task_done(cls, task_id: str, task: asyncio.Task[str]) -> None:
+    def _on_background_task_done(cls, chat_id: str, task: asyncio.Task[str]) -> None:
         try:
             if task.cancelled():
                 return
@@ -716,13 +716,14 @@ class ChatStreamRuntime:
                 error = task.exception()
             except Exception:
                 logger.exception(
-                    "Failed to inspect in-process chat task %s result", task_id
+                    "Failed to inspect in-process chat task result for chat %s",
+                    chat_id,
                 )
                 return
             if error:
                 logger.error(
-                    "In-process chat task %s failed: %s",
-                    task_id,
+                    "In-process chat task for chat %s failed: %s",
+                    chat_id,
                     error,
                     exc_info=error,
                 )
@@ -733,8 +734,7 @@ class ChatStreamRuntime:
     def start_background_chat(
         cls,
         request: ChatStreamRequest,
-    ) -> str:
-        resolved_task_id = str(uuid4())
+    ) -> None:
         chat_id = str(request.chat_data["id"])
         background_task = asyncio.create_task(
             cls._bootstrap_and_execute(
@@ -743,16 +743,7 @@ class ChatStreamRuntime:
         )
         cls._background_task_chat_ids[background_task] = chat_id
         background_task.add_done_callback(
-            partial(cls._on_background_task_done, resolved_task_id)
-        )
-        return resolved_task_id
-
-    @classmethod
-    def is_chat_streaming(cls, chat_id: str) -> bool:
-        return any(
-            cid == chat_id
-            for task, cid in cls._background_task_chat_ids.items()
-            if not task.done()
+            partial(cls._on_background_task_done, chat_id)
         )
 
     @staticmethod
@@ -809,7 +800,7 @@ class ChatStreamRuntime:
         chat_id: str,
         session_factory: SessionFactoryType,
     ) -> bool:
-        if cls.is_chat_streaming(chat_id):
+        if cls.has_active_chat(chat_id):
             return False
 
         async with cache_connection() as cache:
@@ -1030,7 +1021,6 @@ class ChatStreamRuntime:
                 session.cancel_event.set()
             runtime._cancel_event = session.cancel_event
             session.active_generation_task = asyncio.current_task()
-            runtime._session = session
             stream: AsyncIterator[StreamEvent] | None = None
             try:
                 session_updates: list[Any] = []
@@ -1060,7 +1050,7 @@ class ChatStreamRuntime:
                     plan_mode=request.plan_mode,
                     attachments=request.attachments,
                 )
-                return await runtime.run(ai_service, stream_result, stream)
+                return await runtime.run(stream_result, stream)
             except (
                 AgentException,
                 asyncio.CancelledError,

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -59,16 +59,6 @@ interface UseChatStreamingResult {
   streamState: StreamState;
 }
 
-function findActiveStreamForChat(chatId: string) {
-  const activeStreams = useStreamStore.getState().activeStreams;
-  for (const stream of activeStreams.values()) {
-    if (stream.chatId === chatId && stream.isActive) {
-      return stream;
-    }
-  }
-  return undefined;
-}
-
 // Top-level hook that wires together the streaming pipeline for a single chat view.
 // Composes useStreamCallbacks (envelope processing), useStreamReconnect (resume on
 // navigation), useMessageActions (send/stop), and useInputState (draft persistence).
@@ -97,15 +87,6 @@ export function useChatStreaming({
   const pendingStopRef = useRef<Set<string>>(new Set());
   const prevChatIdRef = useRef<string | undefined>(chatId);
   const currentMessageIdRef = useRef<string | null>(null);
-  const sendMessageRef = useRef<
-    | ((
-        prompt: string,
-        chatIdOverride?: string,
-        userMessage?: Message,
-        filesToSend?: File[],
-      ) => Promise<void>)
-    | null
-  >(null);
 
   const isLoading = streamState === 'loading';
   const isStreaming = streamState === 'streaming';
@@ -159,7 +140,7 @@ export function useChatStreaming({
     if (!chatId) return;
 
     const syncCallbacksToStore = () => {
-      const existingStream = findActiveStreamForChat(chatId);
+      const existingStream = useStreamStore.getState().getStreamByChat(chatId);
       if (existingStream) {
         useStreamStore.getState().updateStreamCallbacks(chatId, existingStream.messageId, {
           onEnvelope,
@@ -198,7 +179,7 @@ export function useChatStreaming({
     if (!chatId) return;
 
     const reconcileStreamState = () => {
-      const activeStreamForChat = findActiveStreamForChat(chatId);
+      const activeStreamForChat = useStreamStore.getState().getStreamByChat(chatId);
 
       if (activeStreamForChat) {
         const isPendingStop = pendingStopRef.current.has(activeStreamForChat.messageId);
@@ -248,10 +229,6 @@ export function useChatStreaming({
     isLoading,
     isStreaming,
   });
-
-  useEffect(() => {
-    sendMessageRef.current = sendMessage;
-  }, [sendMessage]);
 
   useStreamReconnect({
     chatId,

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -569,6 +569,8 @@ export function useStreamCallbacks({
       // Session cleanup is stateless and safe for any chat; always run it.
       clearStreamSession(resolvedStreamId);
 
+      const targetChatId = sessionChatId ?? chatId;
+
       // Cache finalization must run even for off-screen chats so returning
       // to the chat within the staleTime window doesn't show a stuck message.
       if (messageId) {
@@ -577,7 +579,6 @@ export function useStreamCallbacks({
           active_stream_id: null,
           stream_status: isCancelled ? 'interrupted' : 'completed',
         });
-        const targetChatId = sessionChatId ?? chatId;
         if (targetChatId) {
           updateMessageInCacheForChat(queryClient, targetChatId, messageId, finalizeMessage);
         }
@@ -593,6 +594,13 @@ export function useStreamCallbacks({
       // (background turns) leave search results stale for up to staleTime.
       queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
 
+      // Chat metadata (title, updated_at, context usage) is mutated server-side
+      // during the turn, so it must refresh even when the completion lands while
+      // the user is viewing another chat.
+      if (targetChatId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.chat(targetChatId), exact: true });
+      }
+
       if (!isCurrentChat) return;
 
       setPendingUserMessageId(null);
@@ -603,7 +611,10 @@ export function useStreamCallbacks({
         void notifyStreamComplete();
       }
 
-      if (!isCancelled && chatId && currentChat?.sandbox_id) {
+      // Cancelled runs still leave real file/branch side effects in the sandbox,
+      // so these refreshes run regardless of terminal kind — only the
+      // notification above is kind-gated.
+      if (chatId && currentChat?.sandbox_id) {
         refetchFilesMetadata().catch(() => {});
         queryClient.removeQueries({
           queryKey: ['sandbox', currentChat.sandbox_id, 'file-content'],
@@ -619,7 +630,6 @@ export function useStreamCallbacks({
       timerIdsRef.current = [];
 
       if (chatId) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.chat(chatId), exact: true });
         if (currentChat?.parent_chat_id) {
           queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
           queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -41,19 +41,8 @@ interface StreamReconnectOptions {
 }
 
 class StreamService {
-  private store = useStreamStore.getState();
-  private queueStore = useMessageQueueStore.getState();
   private readonly maxRecentSeqPerChat = 4096;
   private readonly recentSeqByChat = new Map<string, Set<number>>();
-
-  constructor() {
-    useStreamStore.subscribe((state) => {
-      this.store = state;
-    });
-    useMessageQueueStore.subscribe((state) => {
-      this.queueStore = state;
-    });
-  }
 
   private parseStreamEvent<T>(data: string): T | null {
     try {
@@ -70,13 +59,13 @@ class StreamService {
     messageId?: string,
     streamPublicId?: string,
   ): void {
-    const currentStream = this.store.getStream(streamId);
+    const currentStream = useStreamStore.getState().getStream(streamId);
     if (!currentStream) return;
 
     const errorCallback = currentStream.callbacks?.onError;
     const streamMessageId = currentStream.messageId ?? messageId;
 
-    this.store.removeStream(streamId);
+    useStreamStore.getState().removeStream(streamId);
 
     if (error && errorCallback) {
       errorCallback(error, streamMessageId, streamPublicId);
@@ -133,13 +122,15 @@ class StreamService {
 
     if (!payload?.queued_message_id || !payload?.assistant_message_id) return;
 
-    this.queueStore.removeLocalOnly(chatId, payload.queued_message_id);
+    useMessageQueueStore.getState().removeLocalOnly(chatId, payload.queued_message_id);
 
-    const stream = this.store.getStreamByChat(chatId);
+    const stream = useStreamStore.getState().getStreamByChat(chatId);
     if (!stream) return;
 
     if (payload.assistant_message_id !== stream.messageId) {
-      this.store.updateStreamMessageId(chatId, stream.messageId, payload.assistant_message_id);
+      useStreamStore
+        .getState()
+        .updateStreamMessageId(chatId, stream.messageId, payload.assistant_message_id);
     }
 
     if (stream.callbacks?.onQueueProcess && payload.user_message_id && payload.content) {
@@ -158,7 +149,7 @@ class StreamService {
   private handleStreamEnvelope(event: MessageEvent, streamId: string, chatId: string): void {
     if (!event.data) return;
 
-    const currentStream = this.store.getStream(streamId);
+    const currentStream = useStreamStore.getState().getStream(streamId);
     if (!currentStream) return;
 
     const parsed = this.parseStreamEvent<StreamEnvelope>(event.data);
@@ -193,7 +184,7 @@ class StreamService {
 
     if (parsed.kind === 'complete' || parsed.kind === 'cancelled') {
       const { callbacks } = currentStream;
-      this.store.removeStream(streamId);
+      useStreamStore.getState().removeStream(streamId);
       callbacks?.onComplete?.(parsed.messageId, parsed.streamId, parsed.kind);
       return;
     }
@@ -210,7 +201,7 @@ class StreamService {
   }
 
   private handleGenericError(event: Event | ErrorEvent, streamId: string, messageId: string): void {
-    const currentStream = this.store.getStream(streamId);
+    const currentStream = useStreamStore.getState().getStream(streamId);
     if (!currentStream) return;
 
     // EventSource emits transport "error" while reconnecting; do not fail fast.
@@ -230,7 +221,7 @@ class StreamService {
   }
 
   private attachStreamHandlers(streamId: string, messageId: string): void {
-    const activeStream = this.store.getStream(streamId);
+    const activeStream = useStreamStore.getState().getStream(streamId);
     if (!activeStream) return;
 
     const { source, chatId } = activeStream;
@@ -276,24 +267,24 @@ class StreamService {
         },
       };
 
-      this.store.addStream(activeStream);
+      useStreamStore.getState().addStream(activeStream);
       this.attachStreamHandlers(streamId, messageId);
 
       return { messageId, checkpointId };
     } catch (error) {
-      this.store.removeStream(streamId);
+      useStreamStore.getState().removeStream(streamId);
       throw error;
     }
   }
 
   stopStream(streamId: string): void {
-    this.store.abortStream(streamId);
+    useStreamStore.getState().abortStream(streamId);
   }
 
   async stopStreamByMessage(chatId: string, messageId: string): Promise<void> {
-    const stream = this.store.getStreamByChatAndMessage(chatId, messageId);
+    const stream = useStreamStore.getState().getStreamByChatAndMessage(chatId, messageId);
     if (stream) {
-      this.store.abortStream(stream.id);
+      useStreamStore.getState().abortStream(stream.id);
 
       try {
         await chatService.stopStream(chatId);
@@ -304,14 +295,14 @@ class StreamService {
   }
 
   async stopAllStreams(): Promise<void> {
-    const activeStreams = this.store.activeStreams;
+    const { activeStreams, abortAllStreams } = useStreamStore.getState();
 
     const chatIds = new Set<string>();
     activeStreams.forEach((stream) => {
       chatIds.add(stream.chatId);
     });
 
-    this.store.abortAllStreams();
+    abortAllStreams();
 
     const chatIdArr = Array.from(chatIds);
     const results = await Promise.allSettled(
@@ -355,13 +346,13 @@ class StreamService {
         },
       };
 
-      this.store.addStream(activeStream);
+      useStreamStore.getState().addStream(activeStream);
 
       this.attachStreamHandlers(streamId, options.messageId);
 
       return options.messageId;
     } catch (error) {
-      this.store.removeStream(streamId);
+      useStreamStore.getState().removeStream(streamId);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- **Backend — false empty-stream failure**: `run()` raised "Stream completed without any events" when a turn finished before the 200ms/24-event debounce flushed the event buffer (`last_seq` hadn't advanced even though events existed). The guard now also checks `_event_buffer`.
- **Frontend — cancelled runs left sandbox UI stale**: file-metadata refetch, file-content cache removal, and git-branch invalidation in `onComplete` were gated on `!isCancelled`, but cancelled turns still leave real file/branch side effects. Invalidations now run for both terminal kinds; only the completion notification stays kind-gated.
- **Frontend — off-screen completions never refreshed the chat query**: `onComplete` returned early for off-screen chats before invalidating `queryKeys.chat(...)`, so returning within staleTime showed stale title/metadata. The invalidation now runs before the early return, targeting the stream session's own chat ID.
- **Backend cleanup**: removed unused `ai_service` params from `run()`/`_consume_stream()`, the dead `_session` field, the one-key `session_container` dict (now a plain `session_id` attribute); merged duplicate `is_chat_streaming()` into `has_active_chat()`; `start_background_chat` no longer mints a random task UUID for log labels (logs the chat ID instead) and drops its unused return value; `session_data` extraction now only runs for `system` events.
- **Frontend cleanup**: `StreamService` reads Zustand state via `getState()` at call sites instead of mirroring it through constructor subscriptions; removed dead `sendMessageRef` and the local `findActiveStreamForChat` duplicating the store's `getStreamByChat`.

## Test plan
- [ ] Send a message and confirm streaming, completion, and notifications behave as before
- [ ] Cancel a turn mid-stream that edits files; confirm the file tree and branch list refresh after cancel
- [ ] Let a turn complete while viewing a different chat; navigate back and confirm chat title/metadata are fresh
- [ ] Trigger a very short agent turn and confirm it completes without a failed-stream error
- [ ] Queue a follow-up message and confirm the send-now / queue-continuation handoff still works