### PR TITLE
fix: macOS title bar minimize and per-button traffic light hover

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.1.0"
 dependencies = [
  "dirs 5.0.1",
  "libc",
+ "objc2-app-kit",
  "rand 0.9.2",
  "serde",
  "serde_json",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -22,3 +22,4 @@ tauri-plugin-opener = "2.5.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
+objc2-app-kit = { version = "0.3", features = ["NSWindow", "NSButton", "NSControl", "NSView", "NSResponder"] }

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -7,6 +7,8 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use libc;
+#[cfg(target_os = "macos")]
+use objc2_app_kit::{NSWindow, NSWindowButton};
 use rand::Rng;
 use tauri::Manager;
 
@@ -199,10 +201,25 @@ fn main() {
         .manage(backend_port.clone())
         .invoke_handler(tauri::generate_handler![get_backend_port])
         .setup(move |app| {
-            // Hide native title bar on macOS only — the frontend renders custom traffic lights
+            // The window stays titled (overlay title bar in tauri.conf.json) so minimize works —
+            // borderless windows can't miniaturize on macOS. Hide the native traffic lights here
+            // since the frontend renders custom ones.
             #[cfg(target_os = "macos")]
             if let Some(window) = app.get_webview_window("main") {
-                let _ = window.set_decorations(false);
+                if let Ok(ns_window) = window.ns_window() {
+                    unsafe {
+                        let ns_window = &*(ns_window as *const NSWindow);
+                        for kind in [
+                            NSWindowButton::CloseButton,
+                            NSWindowButton::MiniaturizeButton,
+                            NSWindowButton::ZoomButton,
+                        ] {
+                            if let Some(button) = ns_window.standardWindowButton(kind) {
+                                button.setHidden(true);
+                            }
+                        }
+                    }
+                }
             }
 
             let child = spawn_backend(app.handle(), &data_dir, &secret_key, port);

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -20,7 +20,9 @@
         "resizable": true,
         "visible": false,
         "devtools": true,
-        "dragDropEnabled": false
+        "dragDropEnabled": false,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/frontend/src/components/layout/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { Command } from 'lucide-react';
 import { useMatch } from 'react-router-dom';
 import { isTauri } from '@tauri-apps/api/core';
@@ -14,12 +14,10 @@ async function getTauriWindow() {
   return getCurrentWindow();
 }
 
-// Decorations are only removed on macOS — traffic lights and custom drag region are macOS-only
+// The native title bar is only hidden on macOS — traffic lights and custom drag region are macOS-only
 const IS_MACOS_DESKTOP = isTauri() && IS_MAC_PLATFORM;
 
 export function TrafficLights() {
-  const [isHovered, setIsHovered] = useState(false);
-
   const handleClose = useCallback(async () => {
     await (await getTauriWindow()).close();
   }, []);
@@ -33,11 +31,7 @@ export function TrafficLights() {
   }, []);
 
   return (
-    <div
-      className="flex items-center gap-2 pl-3"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
+    <div className="flex items-center gap-2 pl-3">
       <Button
         type="button"
         variant="unstyled"
@@ -45,16 +39,19 @@ export function TrafficLights() {
         className="group flex h-3 w-3 items-center justify-center rounded-full bg-traffic-close transition-opacity hover:opacity-90"
         aria-label="Close window"
       >
-        {isHovered && (
-          <svg width="6" height="6" viewBox="0 0 6 6" className="text-black/60">
-            <path
-              d="M0.5 0.5L5.5 5.5M5.5 0.5L0.5 5.5"
-              stroke="currentColor"
-              strokeWidth="1.2"
-              strokeLinecap="round"
-            />
-          </svg>
-        )}
+        <svg
+          width="6"
+          height="6"
+          viewBox="0 0 6 6"
+          className="text-black/60 opacity-0 group-hover:opacity-100"
+        >
+          <path
+            d="M0.5 0.5L5.5 5.5M5.5 0.5L0.5 5.5"
+            stroke="currentColor"
+            strokeWidth="1.2"
+            strokeLinecap="round"
+          />
+        </svg>
       </Button>
       <Button
         type="button"
@@ -63,11 +60,14 @@ export function TrafficLights() {
         className="group flex h-3 w-3 items-center justify-center rounded-full bg-traffic-minimize transition-opacity hover:opacity-90"
         aria-label="Minimize window"
       >
-        {isHovered && (
-          <svg width="6" height="2" viewBox="0 0 6 2" className="text-black/60">
-            <path d="M0.5 1H5.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-          </svg>
-        )}
+        <svg
+          width="6"
+          height="2"
+          viewBox="0 0 6 2"
+          className="text-black/60 opacity-0 group-hover:opacity-100"
+        >
+          <path d="M0.5 1H5.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        </svg>
       </Button>
       <Button
         type="button"
@@ -76,17 +76,20 @@ export function TrafficLights() {
         className="group flex h-3 w-3 items-center justify-center rounded-full bg-traffic-maximize transition-opacity hover:opacity-90"
         aria-label="Maximize window"
       >
-        {isHovered && (
-          <svg width="6" height="6" viewBox="0 0 6 6" className="text-black/60">
-            <path
-              d="M1 2L3 0.5L5 2M1 4L3 5.5L5 4"
-              stroke="currentColor"
-              strokeWidth="1"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        )}
+        <svg
+          width="6"
+          height="6"
+          viewBox="0 0 6 6"
+          className="text-black/60 opacity-0 group-hover:opacity-100"
+        >
+          <path
+            d="M1 2L3 0.5L5 2M1 4L3 5.5L5 4"
+            stroke="currentColor"
+            strokeWidth="1"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
       </Button>
     </div>
   );


### PR DESCRIPTION
## Summary
- The minimize button was a no-op on macOS. The app called `set_decorations(false)`, which makes the window borderless — and macOS silently ignores minimize requests for borderless windows. The window now stays titled via an overlay title bar (`titleBarStyle: "Overlay"`, `hiddenTitle: true`) and the native traffic-light buttons are hidden via `objc2-app-kit` (`standardWindowButton(...).setHidden(true)`), so the custom controls remain the only visible ones while minimize/zoom/close work natively.
- Hovering any traffic light lit up the glyphs on all three. The shared `isHovered` container state is gone; each button now reveals its own glyph via `opacity-0 group-hover:opacity-100`.

## Test plan
- [ ] `tauri dev` (full restart — Rust deps recompile), confirm the minimize button minimizes the window
- [ ] Confirm zoom/maximize and close still work
- [ ] Hover each traffic light and confirm only the hovered button shows its glyph
- [ ] Confirm the window still looks borderless (no native title bar visible) and drag/double-click-to-maximize still work