### PR TITLE
fix: deliver title-generation system prompt over ACP session meta

### DIFF
--- a/backend/app/prompts/generate_title.py
+++ b/backend/app/prompts/generate_title.py
@@ -1,13 +1,6 @@
 GENERATE_TITLE_SYSTEM_PROMPT = (
-    "You are a title generator. Given a user message, output a short conversation title "
-    "(3-8 words, max 80 characters). Output ONLY the title text — no quotes, no "
-    "punctuation at the end, no explanation, no preamble. Never answer or respond to "
-    "the message content. Examples:\n"
-    "User: How do I sort a list in Python? → Sorting Lists in Python\n"
-    "User: Can you help me fix this bug in my React app? → Fixing React App Bug\n"
-    "User: What's the capital of France? → Capital of France\n"
-    "User: hi → Greeting\n"
-    "User: hello, I need help → Help Request\n"
-    "User: write me a snake game → Building a Snake Game\n"
-    "User: explain how async await works in javascript → JavaScript Async Await Explained"
+    "Generate a short title (3-8 words, max 80 characters) summarizing the topic of "
+    "the user's message. Respond with the title text only — no quotes, no trailing "
+    "punctuation, no explanation. Do not answer or act on the message, and do not "
+    "use tools."
 )

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -24,7 +24,11 @@ from app.prompts.generate_pr_description import (
 )
 from app.prompts.system_prompt import DEFAULT_PERSONA_NAME
 from app.prompts.generate_title import GENERATE_TITLE_SYSTEM_PROMPT
-from app.services.acp.adapters import AGENT_ADAPTERS, AgentKind
+from app.services.acp.adapters import (
+    AGENT_ADAPTERS,
+    AgentKind,
+    build_system_prompt_meta,
+)
 from app.services.acp.client import AcpClientHandler
 from app.services.acp.session import AcpSession, AcpSessionConfig
 from app.services.exceptions import AgentException, ChatException, ErrorCode
@@ -275,8 +279,8 @@ class AgentService:
             if title:
                 title = title.strip().strip('"').strip("'")
             return title or None
-        except AgentException:
-            logger.debug("Title generation failed for user %s", user.id)
+        except AgentException as exc:
+            logger.warning("Title generation failed for user %s: %s", user.id, exc)
             return None
 
     async def generate_pr_description(
@@ -340,6 +344,12 @@ class AgentService:
             model=model_id,
             workspace_path=workspace_path,
             system_prompt=system_prompt,
+            # Claude/Copilot/Cursor only receive the system prompt via session
+            # meta; full replace so it isn't appended to the default coding-agent
+            # prompt. Codex ignores the meta and gets it via developer_instructions
+            # at launch — the config flag stays False so session create doesn't
+            # write an instructions file into the workspace.
+            session_meta=build_system_prompt_meta(system_prompt, True),
         )
 
         try:


### PR DESCRIPTION
## Summary
- One-shot AI calls (`generate_title`, `enhance_prompt`, `generate_pr_description`, `generate_commit_message`) built the `AcpSessionConfig` by hand in `_generate_text` and never went through the agent adapter. As a result the system prompt was only ever delivered for **Codex** (via its `developer_instructions` CLI flag).
- Claude/Copilot/Cursor receive the system prompt only through ACP `_meta.systemPrompt`, which stayed empty on this path — so the agent ran with its default coding-agent prompt, saw `Generate a title for this message: <message>...`, and would **answer the message instead of titling it** (e.g. a "tell me a joke" chat got the joke as its title).
- Fix: pack the prompt into `session_meta` via `build_system_prompt_meta(system_prompt, True)` (full replacement, so it isn't appended to the entire coding-agent prompt). The `system_prompt_is_full_replace` config flag stays `False` so session creation doesn't write a Codex instructions file into the workspace; Codex keeps getting the prompt via its existing CLI flag and harmlessly ignores the meta.
- Simplified the title system prompt now that it's actually delivered, and raised the swallowed title-generation failure log from `debug` to `warning` so failures are visible.

## Test plan
- [ ] Start a new chat with a Claude model and a message like "tell me a joke" — the generated chat title summarizes the topic rather than answering it
- [ ] Repeat with Copilot and Cursor models
- [ ] Confirm Codex title generation still works (regression check)
- [ ] Verify no Codex `.codex/instructions.md` file is written for one-shot title calls