### PR TITLE
feat: generate chat title with AI from rename dialog

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -32,7 +32,7 @@ from app.core.deps import (
 )
 from app.core.security import get_current_user
 from app.models.db_models.chat import Chat
-from app.models.db_models.enums import MessageStreamStatus
+from app.models.db_models.enums import MessageRole, MessageStreamStatus
 from app.models.db_models.user import User
 from app.models.types import MessageAttachmentDict, PermissionMode
 from app.models.schemas.chat import (
@@ -45,6 +45,7 @@ from app.models.schemas.chat import (
     ChatRequest,
     ContextUsage,
     EnhancePromptResponse,
+    GenerateTitleResponse,
     Message as MessageSchema,
     MessageEvent,
     PermissionRespondResponse,
@@ -171,6 +172,42 @@ async def enhance_prompt(
     except AgentException as e:
         raise HTTPException(status_code=e.status_code, detail=str(e)) from e
     return {"enhanced_prompt": enhanced_prompt}
+
+
+@router.post("/chats/{chat_id}/generate-title", response_model=GenerateTitleResponse)
+async def generate_chat_title(
+    chat: Chat = Depends(ensure_chat_access),
+    current_user: User = Depends(get_current_user),
+    ai_service: AgentService = Depends(get_agent_service),
+) -> dict[str, str]:
+    # Title from the first user message — same source the automatic
+    # background titling uses when a chat starts.
+    user_messages = [
+        m
+        for m in chat.messages
+        if m.role == MessageRole.USER and m.content_text.strip()
+    ]
+    # model_id is only stored on assistant messages, so pick the most
+    # recent one — that's the model the chat is currently using.
+    model_ids = [
+        (m.created_at, m.model_id) for m in chat.messages if m.model_id is not None
+    ]
+    if not user_messages or not model_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Chat has no messages to generate a title from",
+        )
+
+    prompt = min(user_messages, key=lambda m: m.created_at).content_text
+    model_id = max(model_ids)[1]
+
+    title = await ai_service.generate_title(prompt, model_id, current_user, chat=chat)
+    if not title:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Title generation failed",
+        )
+    return {"title": title[:255]}
 
 
 @router.get("/chats", response_model=PaginatedResponse[ChatSchema])

--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -107,6 +107,10 @@ class EnhancePromptResponse(BaseModel):
     enhanced_prompt: str
 
 
+class GenerateTitleResponse(BaseModel):
+    title: str
+
+
 class ChatStatusResponse(BaseModel):
     has_active_task: bool
     message_id: UUID | None = None

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { RenameModal } from '@/components/ui/RenameModal';
 import {
   useDeleteChatMutation,
+  useGenerateChatTitleMutation,
   useUpdateChatMutation,
   usePinChatMutation,
   useInfiniteChatsQuery,
@@ -324,6 +325,7 @@ export function Sidebar({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const deleteChat = useDeleteChatMutation();
   const updateChat = useUpdateChatMutation();
+  const generateChatTitle = useGenerateChatTitleMutation();
   const pinChat = usePinChatMutation();
   const deleteWorkspace = useDeleteWorkspaceMutation();
   const updateWorkspace = useUpdateWorkspaceMutation();
@@ -520,6 +522,16 @@ export function Sidebar({
     },
     [chatToRename, updateChat],
   );
+
+  const handleGenerateChatTitle = useCallback(async () => {
+    if (!chatToRename) return '';
+    try {
+      return await generateChatTitle.mutateAsync(chatToRename.id);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to generate title');
+      return '';
+    }
+  }, [chatToRename, generateChatTitle]);
 
   const handleTogglePin = useCallback(
     async (chat: Chat) => {
@@ -790,6 +802,8 @@ export function Sidebar({
         onSave={handleSaveRename}
         currentTitle={chatToRename?.title || ''}
         isLoading={updateChat.isPending}
+        onGenerateTitle={handleGenerateChatTitle}
+        isGenerating={generateChatTitle.isPending}
       />
 
       <RenameModal

--- a/frontend/src/components/ui/RenameModal.tsx
+++ b/frontend/src/components/ui/RenameModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { Sparkles } from 'lucide-react';
 import { BaseModal } from './shared/BaseModal';
 import { ModalHeader } from './shared/ModalHeader';
 import { Button } from './primitives/Button';
@@ -11,6 +12,9 @@ interface RenameModalProps {
   onSave: (newTitle: string) => Promise<void>;
   currentTitle: string;
   isLoading?: boolean;
+  // Resolves to '' on failure (caller shows the toast) so the input is left untouched.
+  onGenerateTitle?: () => Promise<string>;
+  isGenerating?: boolean;
 }
 
 export function RenameModal({
@@ -19,6 +23,8 @@ export function RenameModal({
   onSave,
   currentTitle,
   isLoading = false,
+  onGenerateTitle,
+  isGenerating = false,
 }: RenameModalProps) {
   const [title, setTitle] = useState(currentTitle);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -42,6 +48,16 @@ export function RenameModal({
 
     await onSave(trimmedTitle);
   }, [title, onSave]);
+
+  const handleGenerate = useCallback(async () => {
+    if (!onGenerateTitle) return;
+
+    const generated = await onGenerateTitle();
+    if (generated) {
+      setTitle(generated);
+      inputRef.current?.focus();
+    }
+  }, [onGenerateTitle]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -68,7 +84,7 @@ export function RenameModal({
     <BaseModal isOpen={isOpen} onClose={onClose} size="md" zIndex="modalHighest">
       <ModalHeader title="Rename Chat" onClose={onClose} />
 
-      <div className="p-4">
+      <div className="flex items-center gap-2 p-4">
         <Input
           ref={inputRef}
           value={title}
@@ -78,6 +94,19 @@ export function RenameModal({
           className="w-full"
           aria-label="New name"
         />
+        {onGenerateTitle && (
+          <Button
+            type="button"
+            variant="unstyled"
+            onClick={handleGenerate}
+            disabled={isLoading || isGenerating}
+            className="shrink-0 rounded-md p-2 text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+            aria-label={isGenerating ? 'Generating title…' : 'Generate title with AI'}
+            title={isGenerating ? 'Generating title…' : 'Generate title with AI'}
+          >
+            <Sparkles className={`h-3.5 w-3.5 ${isGenerating ? 'animate-spin' : ''}`} />
+          </Button>
+        )}
       </div>
 
       <div className="flex justify-end gap-2 border-t border-border p-4 dark:border-border-dark">

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -332,6 +332,12 @@ export const useCreateSubThreadMutation = (parentChatId: string) => {
   });
 };
 
+export const useGenerateChatTitleMutation = () => {
+  return useMutation({
+    mutationFn: (chatId: string) => chatService.generateChatTitle(chatId),
+  });
+};
+
 export const useEnhancePromptMutation = (
   options?: UseMutationOptions<string, Error, EnhancePromptParams>,
 ) => {

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -290,6 +290,18 @@ async function enhancePrompt(prompt: string, modelId: string): Promise<string> {
   });
 }
 
+async function generateChatTitle(chatId: string): Promise<string> {
+  validateId(chatId, 'Chat ID');
+
+  return serviceCall(async () => {
+    const response = await apiClient.post<{ title: string }>(
+      `/chat/chats/${chatId}/generate-title`,
+    );
+
+    return ensureResponse(response, 'Failed to generate title').title;
+  });
+}
+
 async function getMessageChanges(messageId: string): Promise<ChangedFilesData> {
   validateId(messageId, 'Message ID');
 
@@ -338,6 +350,7 @@ export const chatService = {
   deleteAllChats,
   getContextUsage,
   enhancePrompt,
+  generateChatTitle,
   getMessageChanges,
   getMessageFileDiff,
   restoreMessageCheckpoint,


### PR DESCRIPTION
## Summary
- Add a sparkles button to the chat rename dialog that generates a new title with AI
- New `POST /chat/chats/{chat_id}/generate-title` endpoint reusing the existing `generate_title` agent path; prompt is the first user message, model is taken from the latest assistant message
- Generated title fills the input for review/edit — nothing is persisted until the user clicks Save
- Wired only into the chat rename modal; the workspace rename modal is unchanged

## Test plan
- [ ] Open a chat's rename dialog and click the sparkles button — input fills with an AI-generated title
- [ ] Edit and Save — chat title updates
- [ ] Generate on a chat with no messages returns a 400 and shows an error toast
- [ ] Workspace rename dialog shows no generate button