### PR TITLE
fix: deliver full-replace system prompt for one-shot text generation

### DIFF
--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -6,6 +6,8 @@ from enum import Enum
 from dataclasses import dataclass, field
 from typing import Any
 
+from app.models.types import PermissionMode
+
 
 class AgentKind(str, Enum):
     CLAUDE = "claude"
@@ -63,6 +65,18 @@ CURSOR_SESSION_MODES = frozenset({"agent", "plan", "ask"})
 # OpenCode's built-in primary agents double as ACP session modes; `plan`
 # restricts edits to `.opencode/plans/*.md`, `build` has full tool access.
 OPENCODE_SESSION_MODES = frozenset({"build", "plan"})
+
+# Each agent's normal (full-execution) session mode. Used for permission-
+# irrelevant background calls — one-shot text generation makes no tool calls, so
+# we just need a mode the adapter accepts (Codex rejects unknown modes) and that
+# isn't a plan/read-only mode that could distort the response.
+NORMAL_SESSION_MODE: dict[AgentKind, PermissionMode] = {
+    AgentKind.CLAUDE: "default",
+    AgentKind.CODEX: "auto",
+    AgentKind.COPILOT: "agent",
+    AgentKind.CURSOR: "agent",
+    AgentKind.OPENCODE: "build",
+}
 
 # Agents that can have their base system prompt replaced by a persona.
 # Claude/Codex expose a first-class mechanism (ACP _meta.systemPrompt for

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -87,7 +87,7 @@ class AcpSessionConfig:
     reasoning_effort: str | None = None
     session_meta: dict[str, Any] = field(default_factory=dict)
     # Codex-only: absolute path to a model_instructions_file written before spawn
-    # when doing a full system prompt replacement (persona mode).
+    # when doing a full system prompt replacement (personas, one-shot text tasks).
     codex_instructions_file_path: str | None = None
 
 
@@ -291,23 +291,22 @@ class AcpSession:
         )
         spawn_config = replace(config, cwd=provider.resolve_workspace_path(config.cwd))
 
-        # Codex ignores base_instructions for full system prompt replacement,
-        # so we write the prompt to a sandbox file and point Codex at it via
-        # model_instructions_file (emitted by the Codex adapter).
+        # Codex ignores base_instructions for full system prompt replacement, so
+        # we write the prompt to a file and point Codex at it via
+        # model_instructions_file (emitted by the Codex adapter). The file goes to
+        # a temp path outside the workspace — create() rewrites it on every spawn
+        # (including resume), so nothing needs to persist in the user's project.
         if (
             config.system_prompt_is_full_replace
             and config.system_prompt
             and config.agent_kind == AgentKind.CODEX
         ):
-            instructions_rel_path = ".codex/instructions.md"
-            await provider.write_file(
-                config.sandbox_id, instructions_rel_path, config.system_prompt
+            instructions_abs_path = await provider.write_temp_file(
+                config.sandbox_id, config.system_prompt
             )
             spawn_config = replace(
                 spawn_config,
-                codex_instructions_file_path=provider.resolve_workspace_path(
-                    instructions_rel_path
-                ),
+                codex_instructions_file_path=instructions_abs_path,
             )
 
         process = await cls._spawn_process(spawn_config)

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 from collections.abc import AsyncIterator
 from typing import Any, cast
 from uuid import UUID
@@ -24,7 +23,7 @@ from app.prompts.generate_pr_description import (
 )
 from app.prompts.system_prompt import DEFAULT_PERSONA_NAME
 from app.prompts.generate_title import GENERATE_TITLE_SYSTEM_PROMPT
-from app.services.acp.adapters import AGENT_ADAPTERS, AgentKind
+from app.services.acp.adapters import AGENT_ADAPTERS, NORMAL_SESSION_MODE, AgentKind
 from app.services.acp.client import AcpClientHandler
 from app.services.acp.session import AcpSession, AcpSessionConfig
 from app.services.exceptions import AgentException, ChatException, ErrorCode
@@ -314,32 +313,36 @@ class AgentService:
         chat: Chat | None = None,
     ) -> str:
         user_settings = await self._get_user_settings(user.id)
-
         agent_kind = MODELS[model_id].agent_kind
-        env = self._build_custom_env(user_settings)
 
         if chat and chat.sandbox_id:
             sandbox_id = chat.sandbox_id
             sandbox_provider = SandboxProviderType(chat.sandbox_provider)
             workspace_path = chat.workspace_path
         else:
-            # No chat/sandbox (title/commit-message/etc. one-shot calls) — use
-            # $HOME as the workspace root so the session-create edge still
-            # resolves cwd uniformly via the provider.
+            # No chat/sandbox (title/commit-message/etc. one-shot calls). cwd is
+            # irrelevant for these text-only tasks; use the app storage dir as a
+            # stable workspace root.
             sandbox_id = ""
             sandbox_provider = SandboxProviderType.HOST
-            workspace_path = os.environ.get("HOME", "/tmp")
-        cwd = ""
+            workspace_path = settings.STORAGE_PATH
 
-        config = AcpSessionConfig(
-            sandbox_id=sandbox_id,
-            sandbox_provider=sandbox_provider,
-            cwd=cwd,
+        # Pure text tasks — fully replace the agent's default coding persona so it
+        # doesn't bleed into the output. Built via _build_acp_config so the system
+        # prompt is actually delivered (Claude/Copilot systemPrompt _meta, Codex
+        # model_instructions_file) and the model env override is set — a bare
+        # AcpSessionConfig skips the adapter and sends neither.
+        config = await self._build_acp_config(
+            user_settings=user_settings,
             agent_kind=agent_kind,
-            env=env,
-            model=model_id,
+            permission_mode=NORMAL_SESSION_MODE[agent_kind],
+            model_id=model_id,
+            session_id=None,
+            sandbox_provider=sandbox_provider,
+            sandbox_id=sandbox_id,
             workspace_path=workspace_path,
             system_prompt=system_prompt,
+            system_prompt_is_full_replace=True,
         )
 
         try:

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -361,7 +361,15 @@ class AgentService:
 
             result_parts: list[str] = []
             async for event in self._consume_events(handler.event_queue, prompt_task):
-                if event.get("type") == "assistant_text":
+                event_type = event.get("type")
+                if event_type == "permission_request":
+                    # Unattended text task — no UI to approve gated tool calls, so
+                    # deny them instead of blocking forever on the permission
+                    # future. The agent falls back to a text answer.
+                    request_id = event.get("request_id")
+                    if request_id:
+                        handler.resolve_permission(request_id)
+                elif event_type == "assistant_text":
                     text = event.get("text", "")
                     if text:
                         result_parts.append(text)

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -98,6 +98,13 @@ class SandboxProvider:
     ) -> None:
         raise NotImplementedError
 
+    async def write_temp_file(self, sandbox_id: str, content: str) -> str:
+        # Write content to a unique temp path OUTSIDE the workspace and return its
+        # runtime-absolute path (host tempdir for local, container /tmp for
+        # Docker). Used for the Codex model_instructions_file so the file never
+        # lands in the user's project workspace.
+        raise NotImplementedError
+
     async def read_file(
         self,
         sandbox_id: str,

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import logging
+import posixpath
 import shlex
 import tarfile
 import uuid
@@ -306,28 +307,29 @@ class LocalDockerProvider(SandboxProvider):
 
         return CommandResult(stdout=output_str, stderr="", exit_code=exit_code)
 
+    @staticmethod
+    def _build_file_tar(filename: str, content_bytes: bytes) -> bytes:
+        # Docker's put_archive API requires a tar stream — we create a single-file
+        # tar in memory with uid/gid 1000 (the sandbox "user" account).
+        tar_stream = io.BytesIO()
+        with tarfile.open(fileobj=tar_stream, mode="w") as tar:
+            info = tarfile.TarInfo(name=filename)
+            info.size = len(content_bytes)
+            info.uid = 1000
+            info.gid = 1000
+            tar.addfile(info, io.BytesIO(content_bytes))
+        tar_stream.seek(0)
+        return tar_stream.read()
+
     async def write_file(
         self,
         sandbox_id: str,
         path: str,
         content: str | bytes,
     ) -> None:
-        # Docker's put_archive API requires a tar stream — we create a single-file
-        # tar in memory with uid/gid 1000 (the sandbox "user" account).
         container = await self._get_container(sandbox_id)
         normalized_path = self.resolve_workspace_path(path)
-
         content_bytes = content.encode("utf-8") if isinstance(content, str) else content
-
-        tar_stream = io.BytesIO()
-        with tarfile.open(fileobj=tar_stream, mode="w") as tar:
-            file_data = io.BytesIO(content_bytes)
-            info = tarfile.TarInfo(name=Path(normalized_path).name)
-            info.size = len(content_bytes)
-            info.uid = 1000
-            info.gid = 1000
-            tar.addfile(info, file_data)
-        tar_stream.seek(0)
 
         parent_dir = str(Path(normalized_path).parent)
         mkdir_exec = await container.exec(
@@ -338,7 +340,16 @@ class LocalDockerProvider(SandboxProvider):
             raise SandboxException(
                 f"Failed to create directory {parent_dir}: {mkdir_output}"
             )
-        await container.put_archive(parent_dir, tar_stream.read())
+        tar = self._build_file_tar(Path(normalized_path).name, content_bytes)
+        await container.put_archive(parent_dir, tar)
+
+    async def write_temp_file(self, sandbox_id: str, content: str) -> str:
+        # /tmp always exists and is world-writable, so no mkdir is needed.
+        container = await self._get_container(sandbox_id)
+        filename = f"agentrove-codex-{uuid.uuid4().hex}.md"
+        tar = self._build_file_tar(filename, content.encode("utf-8"))
+        await container.put_archive("/tmp", tar)
+        return posixpath.join("/tmp", filename)
 
     async def read_file(
         self,

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -7,6 +7,7 @@ import pty
 import shlex
 import signal
 import subprocess
+import tempfile
 import termios
 import uuid
 from pathlib import Path
@@ -103,6 +104,17 @@ class LocalHostProvider(SandboxProvider):
         resolved.parent.mkdir(parents=True, exist_ok=True)
         payload = content.encode("utf-8") if isinstance(content, str) else content
         await asyncio.to_thread(resolved.write_bytes, payload)
+
+    async def write_temp_file(self, sandbox_id: str, content: str) -> str:
+        return await asyncio.to_thread(self._write_temp_file, content.encode("utf-8"))
+
+    @staticmethod
+    def _write_temp_file(payload: bytes) -> str:
+        # Write through the fd mkstemp already opened — no close-and-reopen.
+        fd, path = tempfile.mkstemp(prefix="agentrove-codex-", suffix=".md")
+        with os.fdopen(fd, "wb") as f:
+            f.write(payload)
+        return path
 
     async def read_file(
         self,


### PR DESCRIPTION
## Summary

One-shot text tasks — chat **title**, **commit message**, **PR description**, and **prompt enhancement** — built the ACP session config by hand and never called the agent adapter. That adapter is the only place the Claude/Copilot `systemPrompt` `_meta` and the `ANTHROPIC_MODEL` env override get built, so **the task system prompt was silently dropped**: the model only saw the user message with its default coding persona and just replied to it (e.g. sending `hello` produced the title **"Hello"** instead of following the title prompt's `hi → Greeting` rule).

This PR:

- **Routes `_generate_text` through `_build_acp_config`** so the system prompt is actually delivered (Claude/Copilot `systemPrompt` `_meta`, Codex `model_instructions_file`) and the model env is set. These are pure text tasks, so the agent's default coding persona is **fully replaced** (no bleed-through, fewer input tokens).
- **Keeps Codex's instructions file out of the user's project.** Codex can't replace its prompt via meta — it reads a `model_instructions_file`. We now write that to a **unique temp path outside the workspace** (host tempdir via `mkstemp`, container `/tmp` via `put_archive`) instead of `.codex/instructions.md` in the repo. `create()` rewrites it before every spawn (including resume), so nothing needs to persist. Custom personas use the same path now too, so they also stop polluting the repo.
- **Adds `NORMAL_SESSION_MODE`** (per-agent full-execution mode). Routing through the adapter started invoking `map_session_mode`, and Codex *raises* on unknown modes — `"default"` would have crashed all Codex text generation. Each agent now gets a valid, non-restricted mode (Codex `auto`, Copilot/Cursor `agent`, OpenCode `build`, Claude `default`). Permission is never exercised here (no tool calls); we just need a mode the adapter accepts that won't distort output.

### New provider capability
`SandboxProvider.write_temp_file(sandbox_id, content) -> abs_path` — writes outside the workspace and returns a runtime-absolute path. Host uses `tempfile.mkstemp`; Docker reuses the existing tar/`put_archive` path (extracted into a shared `_build_file_tar` helper).

## Test plan

- [ ] New chat with message `hello` → title is a real summary (e.g. "Greeting"), not "Hello", on a **Claude** model
- [ ] Same on a **Codex** model
- [ ] Commit message, PR description, and prompt enhancement still generate correctly across Claude / Codex / Copilot
- [ ] No `.codex/instructions.md` (or any instructions file) appears in the project repo / `git status` after title generation or using a custom persona on Codex
- [ ] Custom persona chat on Codex still applies the persona (full-replace)
- [ ] Docker sandbox: confirm `write_temp_file` lands in container `/tmp` and Codex reads it (live `docker exec` round-trip)