### PR TITLE
fix: fill tile width in secrets view

### DIFF
--- a/frontend/src/components/sandbox/secrets/SecretsView.tsx
+++ b/frontend/src/components/sandbox/secrets/SecretsView.tsx
@@ -183,7 +183,7 @@ export const SecretsView = memo(function SecretsView({ sandboxId }: SecretsViewP
   };
 
   return (
-    <div className="flex h-full flex-col bg-surface-secondary dark:bg-surface-dark-secondary">
+    <div className="flex h-full w-full flex-col bg-surface-secondary dark:bg-surface-dark-secondary">
       <div className="flex h-9 items-center justify-between border-b border-border/50 px-3 dark:border-border-dark/50">
         <span className="text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
           Environment Variables


### PR DESCRIPTION
## Summary
- The `SecretsView` root used `flex h-full flex-col` without `w-full`, so inside its mosaic tile it collapsed to content width, leaving an empty gap on the right of the panel (header divider, rows, and footer all stopped mid-panel).
- Added `w-full` to match the sibling `DiffView` root (`flex h-full w-full flex-col`) so the view fills its tile.

## Test plan
- [ ] Open the Secrets view in a chat pane and confirm the header divider, variable rows, and "Add Variable" footer span the full panel width
- [ ] Confirm dark mode and resizing the tile still look correct