### PR TITLE
fix: serialize timestamps as UTC-aware so clients show correct times

### DIFF
--- a/backend/app/db/base_class.py
+++ b/backend/app/db/base_class.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, func
+from sqlalchemy import func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from app.db.types import UTCDateTime
 
 
 def _utc_now() -> datetime:
@@ -10,13 +12,13 @@ def _utc_now() -> datetime:
 
 class Base(DeclarativeBase):
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
+        UTCDateTime(),
         default=_utc_now,
         server_default=func.now(),
         nullable=False,
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
+        UTCDateTime(),
         default=_utc_now,
         onupdate=_utc_now,
         server_default=func.now(),

--- a/backend/app/db/types.py
+++ b/backend/app/db/types.py
@@ -1,16 +1,43 @@
 import json
 import uuid as uuid_module
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
 from cryptography.fernet import InvalidToken
-from sqlalchemy import CHAR, String, Text
+from sqlalchemy import CHAR, DateTime, String, Text
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.types import TypeDecorator
 
 
 def enum_values(enum_class: type[Enum]) -> list[str]:
     return [entry.value for entry in enum_class]
+
+
+class UTCDateTime(TypeDecorator[datetime]):
+    impl = DateTime(timezone=True)
+    cache_ok = True
+
+    def process_bind_param(
+        self, value: datetime | None, _dialect: Dialect
+    ) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    def process_result_value(
+        self, value: datetime | None, _dialect: Dialect
+    ) -> datetime | None:
+        # SQLite drops tzinfo on read, returning naive datetimes that serialize
+        # without a UTC marker and get misread as local time by clients — assume
+        # UTC for naive values so timestamps carry an explicit offset.
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
 
 
 class GUID(TypeDecorator[uuid_module.UUID]):

--- a/backend/app/models/db_models/chat.py
+++ b/backend/app/models/db_models/chat.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 from sqlalchemy import (
     BigInteger,
-    DateTime,
     Float,
     ForeignKey,
     Index,
@@ -18,7 +17,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base_class import Base
 from app.db.migration_helpers import uuid_server_default
-from app.db.types import GUID, enum_values
+from app.db.types import GUID, UTCDateTime, enum_values
 
 from .enums import AttachmentType, MessageRole, MessageStreamStatus
 
@@ -47,12 +46,8 @@ class Chat(Base):
     last_event_seq: Mapped[int] = mapped_column(
         BigInteger, default=0, server_default="0", nullable=False
     )
-    deleted_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    pinned_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    deleted_at: Mapped[datetime | None] = mapped_column(UTCDateTime(), nullable=True)
+    pinned_at: Mapped[datetime | None] = mapped_column(UTCDateTime(), nullable=True)
     parent_chat_id: Mapped[UUID | None] = mapped_column(
         GUID(), ForeignKey("chats.id", ondelete="SET NULL"), nullable=True
     )
@@ -175,9 +170,7 @@ class Message(Base):
         default=MessageStreamStatus.IN_PROGRESS,
         server_default="in_progress",
     )
-    deleted_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    deleted_at: Mapped[datetime | None] = mapped_column(UTCDateTime(), nullable=True)
 
     chat = relationship("Chat", back_populates="messages")
     attachments = relationship(

--- a/backend/app/models/db_models/refresh_token.py
+++ b/backend/app/models/db_models/refresh_token.py
@@ -1,11 +1,11 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy import ForeignKey, Index, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base_class import Base
-from app.db.types import GUID
+from app.db.types import GUID, UTCDateTime
 
 
 class RefreshToken(Base):
@@ -20,12 +20,8 @@ class RefreshToken(Base):
     user_id: Mapped[uuid.UUID] = mapped_column(
         GUID(), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
-    expires_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
-    )
-    revoked_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    expires_at: Mapped[datetime] = mapped_column(UTCDateTime(), nullable=False)
+    revoked_at: Mapped[datetime | None] = mapped_column(UTCDateTime(), nullable=True)
     user_agent: Mapped[str | None] = mapped_column(String(512), nullable=True)
     ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
 

--- a/backend/app/models/db_models/user.py
+++ b/backend/app/models/db_models/user.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from uuid import UUID
 
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID
-from sqlalchemy import Boolean, DateTime, ForeignKey, JSON, String, Text
+from sqlalchemy import Boolean, ForeignKey, JSON, String, Text
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from app.models.types import (
@@ -12,7 +12,7 @@ from app.models.types import (
 )
 
 from app.db.base_class import Base
-from app.db.types import GUID, EncryptedString
+from app.db.types import GUID, EncryptedString, UTCDateTime
 
 
 class User(SQLAlchemyBaseUserTableUUID, Base):
@@ -42,11 +42,11 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         String(length=128), nullable=True
     )
     verification_token_expires: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
+        UTCDateTime(), nullable=True
     )
     reset_token: Mapped[str | None] = mapped_column(String(length=128), nullable=True)
     reset_token_expires: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
+        UTCDateTime(), nullable=True
     )
     chats = relationship("Chat", back_populates="user", cascade="all, delete-orphan")
     workspaces = relationship(

--- a/backend/app/models/db_models/workspace.py
+++ b/backend/app/models/db_models/workspace.py
@@ -2,11 +2,11 @@ import uuid
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy import ForeignKey, Index, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base_class import Base
-from app.db.types import GUID
+from app.db.types import GUID, UTCDateTime
 from app.services.sandbox_providers.types import SandboxProviderType
 
 
@@ -32,9 +32,7 @@ class Workspace(Base):
     workspace_path: Mapped[str] = mapped_column(String(2048), nullable=False)
     source_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
     source_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
-    deleted_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    deleted_at: Mapped[datetime | None] = mapped_column(UTCDateTime(), nullable=True)
 
     user = relationship("User", back_populates="workspaces")
     chats = relationship("Chat", back_populates="workspace")

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -9,7 +9,7 @@ from app.db.base_class import Base
 from app.db.sqlite import enable_foreign_keys
 from app.models.db_models import chat, refresh_token, user, workspace  # noqa: F401
 from app.core.config import get_settings
-from app.db.types import GUID, EncryptedString, EncryptedJSON
+from app.db.types import GUID, EncryptedString, EncryptedJSON, UTCDateTime
 
 config = context.config
 
@@ -35,6 +35,9 @@ def render_item(type_, obj, autogen_context):
         if isinstance(obj, EncryptedJSON):
             autogen_context.imports.add("from app.db.types import EncryptedJSON")
             return "EncryptedJSON()"
+        if isinstance(obj, UTCDateTime):
+            autogen_context.imports.add("from app.db.types import UTCDateTime")
+            return "UTCDateTime()"
 
     if type_ == "server_default":
         arg = getattr(obj, "arg", obj)


### PR DESCRIPTION
## Summary
- New chats (and messages) were displaying wrong relative times in the sidebar and chat (e.g. "3h ago" for a fresh chat) for users in non-UTC timezones.
- Root cause: SQLite doesn't persist tzinfo, so `DateTime(timezone=True)` columns come back **naive** on read. Pydantic then serializes them without a UTC offset, and the frontend's `new Date(...)` parses the bare string as **local** time — shifting timestamps by the user's UTC offset.
- Added a `UTCDateTime` SQLAlchemy type that normalizes values to UTC-aware on both write and read, and applied it to every timestamp column (`created_at`/`updated_at` in `Base`, plus `deleted_at`, `pinned_at`, token expiry, refresh-token, and workspace fields).
- Registered `UTCDateTime` in the Alembic `render_item` handler so future autogenerated migrations emit the proper explicit import/rendering.

No migration needed — `UTCDateTime`'s underlying impl is still `DateTime(timezone=True)`, so the schema is unchanged. The fix also corrects existing rows on read (naive values assumed UTC).

## Test plan
- [ ] Create a new chat and confirm it shows "just now" / "now" instead of an offset like "3h ago"
- [ ] Verify sidebar and chat relative times match real elapsed time across a non-UTC local timezone
- [ ] Confirm API responses serialize timestamps with an explicit `+00:00` offset