### PR TITLE
fix: collapse file tree folders by default

### DIFF
--- a/frontend/src/components/editor/file-tree/Tree.tsx
+++ b/frontend/src/components/editor/file-tree/Tree.tsx
@@ -84,7 +84,7 @@ export const Tree = memo(function Tree({
 
   const { model } = useFileTree({
     paths: initialPathsRef.current,
-    initialExpansion: 'open',
+    initialExpansion: 'closed',
     // Seeding also seeds focus, which makes cold-mount reveal a same-path no-op.
     initialSelectedPaths: [],
     search: true,


### PR DESCRIPTION
## Summary
- File tree folders rendered fully expanded on mount (`initialExpansion: 'open'`), which is noisy for large repos.
- Default to `'closed'` so folders start collapsed.
- The existing selected-file effect still expands ancestor folders to reveal the active file.

## Test plan
- [ ] Open the editor — top-level and nested folders start collapsed
- [ ] Open a file via command menu / external selection — its ancestor folders expand to reveal it