### PR TITLE
feat: open changed file in editor from git diff view

### DIFF
--- a/frontend/src/components/sandbox/git/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView.tsx
@@ -6,6 +6,7 @@ import {
   AlertCircle,
   ChevronRight,
   ChevronsUpDown,
+  ExternalLink,
   GitCompareArrows,
   MoreHorizontal,
   RotateCcw,
@@ -610,6 +611,22 @@ export const DiffView = memo(function DiffView({ chatId }: DiffViewProps) {
                         </span>
                         <FileStatusBadge type={file.type} />
                       </Button>
+                      {file.type !== 'deleted' && (
+                        <Button
+                          variant="unstyled"
+                          type="button"
+                          onClick={() =>
+                            useUIStore
+                              .getState()
+                              .openFileInEditor(cwd ? `${cwd}/${file.name}` : file.name, chatId)
+                          }
+                          className="mr-1 shrink-0 rounded-md p-1 text-text-quaternary opacity-0 transition-opacity duration-200 hover:text-text-primary focus-visible:opacity-100 group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+                          title="Open in editor"
+                          aria-label={`Open ${file.name} in editor`}
+                        >
+                          <ExternalLink className="h-3 w-3" />
+                        </Button>
+                      )}
                       {canDiscard && (
                         <Button
                           variant="unstyled"


### PR DESCRIPTION
## Summary
- Add an "Open in editor" icon button to each changed-file row in the git diff view (`DiffView.tsx`).
- Clicking it jumps to that file in the editor via `openFileInEditor`, mirroring the affordance already present in `ChangedFilesPanel`.
- Button is hidden for deleted files and uses the same hover-reveal styling as the adjacent discard button.

## Test plan
- [ ] Open the git diff view with changes present
- [ ] Hover a file row and click the open-in-editor icon → editor opens that file
- [ ] Verify deleted files do not show the button
- [ ] Verify it works in both primary and secondary diff tiles