### PR TITLE
feat: add icon view switcher to title bar

### DIFF
--- a/frontend/src/components/layout/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
 import { Button } from '@/components/ui/primitives/Button';
 import { ToggleButton } from '@/components/ui/ToggleButton';
+import { ViewSwitcher } from './ViewSwitcher';
 import { cn } from '@/utils/cn';
 import { IS_MAC_PLATFORM } from '@/utils/platform';
 
@@ -195,7 +196,9 @@ export function TitleBar() {
       </div>
 
       {/* Main content area — matches main bg */}
-      <div className="flex-1 bg-surface dark:bg-surface-dark" />
+      <div className="flex flex-1 items-center justify-end bg-surface px-3 dark:bg-surface-dark">
+        {isChatPage && <ViewSwitcher />}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/layout/ViewSwitcher.tsx
+++ b/frontend/src/components/layout/ViewSwitcher.tsx
@@ -1,0 +1,60 @@
+import { Code, GitCompareArrows, KeyRound, SquareTerminal } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { useUIStore } from '@/store/uiStore';
+import { cn } from '@/utils/cn';
+import {
+  getEffectiveLayout,
+  getLeaves,
+  isSecondaryPaneActive,
+  VIEW_LABELS,
+  viewTypeToTileId,
+} from '@/utils/mosaicHelpers';
+import type { ViewType } from '@/types/ui.types';
+
+// Non-agent secondary views, in the order Cursor lays them out: diff (git),
+// editor (file), terminal, secrets. Icons mirror the command registry.
+const SWITCHABLE_VIEWS: { view: Exclude<ViewType, 'agent'>; icon: typeof Code }[] = [
+  { view: 'diff', icon: GitCompareArrows },
+  { view: 'editor', icon: Code },
+  { view: 'terminal', icon: SquareTerminal },
+  { view: 'secrets', icon: KeyRound },
+];
+
+export function ViewSwitcher() {
+  const activeAgentTile = useUIStore((s) => s.activeAgentTile);
+  const secondaryChatId = useUIStore((s) => s.secondaryChatId);
+  const mosaicLayout = useUIStore((s) => s.mosaicLayout);
+  const currentView = useUIStore((s) => s.currentView);
+
+  // Resolve active state against the exact tile toggleView() will act on, so the
+  // highlight (and the close-on-click) tracks the focused pane in split-chat mode.
+  const secondary = isSecondaryPaneActive(activeAgentTile, secondaryChatId);
+  const leaves = getLeaves(getEffectiveLayout(mosaicLayout, currentView));
+
+  return (
+    <div className="flex items-center gap-0.5">
+      {SWITCHABLE_VIEWS.map(({ view, icon: Icon }) => {
+        const isActive = leaves.includes(viewTypeToTileId(view, secondary));
+        return (
+          <Button
+            key={view}
+            variant="unstyled"
+            // Toggle: open the view as a tile, or close it if already visible
+            onClick={() => useUIStore.getState().toggleView(view, true)}
+            className={cn(
+              'rounded-md p-1.5 transition-colors duration-200',
+              isActive
+                ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
+                : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-quaternary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary',
+            )}
+            aria-label={`Toggle ${VIEW_LABELS[view]} view`}
+            aria-pressed={isActive}
+            title={VIEW_LABELS[view]}
+          >
+            <Icon className="h-3.5 w-3.5" />
+          </Button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a `ViewSwitcher` component — a row of icon buttons in the title bar that toggle the **Diff**, **Editor**, **Terminal**, and **Secrets** views into the mosaic, mirroring Cursor's panel-header affordance.
- Icons match the command registry (`GitCompareArrows`, `Code`, `SquareTerminal`, `KeyRound`); each button calls the existing `toggleView(view, true)` store action.
- Rendered in the previously-empty right region of the `TitleBar`, gated to chat pages only.
- Active highlight is resolved against the same pane-scoped target tile that `toggleView()` acts on (via `isSecondaryPaneActive` + `viewTypeToTileId`), so the highlight — and the close-on-click — tracks the focused pane in split-chat mode instead of lighting up whenever any pane shows that view kind.

## Test plan
- [ ] On a chat page, click each icon — the corresponding view opens as a mosaic tile and the icon highlights.
- [ ] Click an active icon — the tile closes.
- [ ] In split-chat mode, focus the secondary pane and confirm a secondary diff/editor tile highlights its button; switch focus to the primary pane and confirm the highlight/close target follows.
- [ ] Verify light and dark modes, and that the switcher is hidden off chat pages.