### PR TITLE
feat: configurable post-stream action buttons

### DIFF
--- a/backend/app/models/db_models/user.py
+++ b/backend/app/models/db_models/user.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import relationship, Mapped, mapped_column
 from app.models.types import (
     CustomEnvVarDict,
     PersonaDict,
+    StreamActionDict,
 )
 
 from app.db.base_class import Base
@@ -82,6 +83,9 @@ class UserSettings(Base):
         JSON, nullable=True
     )
     personas: Mapped[list[PersonaDict] | None] = mapped_column(JSON, nullable=True)
+    stream_actions: Mapped[list[StreamActionDict] | None] = mapped_column(
+        JSON, nullable=True
+    )
     notifications_enabled: Mapped[bool] = mapped_column(
         Boolean, default=True, server_default="true", nullable=False
     )

--- a/backend/app/models/schemas/settings.py
+++ b/backend/app/models/schemas/settings.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.prompts.system_prompt import DEFAULT_PERSONA_NAME
 
 
 class CustomEnvVar(BaseModel):
@@ -14,16 +16,29 @@ class Persona(BaseModel):
     content: str
 
 
+# A post-stream action button: runs `command` on `model_id` in a new sub-thread.
+class StreamAction(BaseModel):
+    label: str = Field(min_length=1, max_length=60)
+    enabled: bool = True
+    model_id: str = Field(min_length=1, max_length=200)
+    command: str = Field(min_length=1, max_length=4000)
+    persona_name: str = Field(default=DEFAULT_PERSONA_NAME, max_length=100)
+    permission_mode: str = Field(default="bypassPermissions", max_length=50)
+    thinking_mode: str = Field(default="high", max_length=50)
+
+
 class UserSettingsBase(BaseModel):
     github_personal_access_token: str | None = None
     custom_instructions: str | None = None
     custom_env_vars: list[CustomEnvVar] | None = None
     personas: list[Persona] | None = None
+    stream_actions: list[StreamAction] | None = None
     notifications_enabled: bool = True
 
     @field_validator(
         "custom_env_vars",
         "personas",
+        "stream_actions",
         mode="before",
     )
     @classmethod

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -34,6 +34,16 @@ class PersonaDict(TypedDict):
     content: str
 
 
+class StreamActionDict(TypedDict):
+    label: str
+    enabled: bool
+    model_id: str
+    command: str
+    persona_name: str
+    permission_mode: str
+    thinking_mode: str
+
+
 class MessageAttachmentDict(TypedDict):
     file_url: str
     file_path: str | None

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -89,6 +89,7 @@ class UserService(BaseDbService[UserSettings]):
         json_fields = {
             "custom_env_vars",
             "personas",
+            "stream_actions",
         }
 
         for field, value in settings_update.items():

--- a/backend/migrations/versions/c1a2b3d4e5f6_add_stream_actions_to_user_settings.py
+++ b/backend/migrations/versions/c1a2b3d4e5f6_add_stream_actions_to_user_settings.py
@@ -1,0 +1,25 @@
+# Revision ID: c1a2b3d4e5f6
+# Revises: 05d565131567
+# Create Date: 2026-06-17 00:00:00.000000
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "c1a2b3d4e5f6"
+down_revision: str | None = "05d565131567"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_settings",
+        sa.Column("stream_actions", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_settings", "stream_actions")

--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -12,6 +12,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { isBrowserObjectUrl } from '@/utils/attachmentUrl';
 import { UserMessage, AssistantMessage } from '@/components/chat/message-bubble/Message';
 import { QueueMessageCard } from './QueueMessageCard';
+import { StreamActionsBar } from './StreamActionsBar';
 import { Input } from '@/components/chat/message-input/Input';
 import { ChatSkeleton } from './ChatSkeleton';
 import { ScrollButton } from './ScrollButton';
@@ -317,6 +318,13 @@ export const Chat = memo(function Chat() {
     !!lastBotMessage &&
     ((lastBotMessage.content_render?.events?.length ?? 0) > 0 || !!lastBotMessage.content_text);
   const showPermissionAtEnd = canShowPermissionInline && (!lastBotMessageId || lastBotIsStreaming);
+  // Only offer actions against a cleanly completed turn — skips failed/interrupted
+  // output and the reconnect window where an in-progress message isn't yet in the stream set.
+  const showStreamActions =
+    lastBotMessage?.stream_status === 'completed' &&
+    !lastBotIsStreaming &&
+    !isStreaming &&
+    !isLoading;
 
   const renderMessage = useCallback(
     (msg: (typeof messages)[number]) => {
@@ -439,6 +447,11 @@ export const Chat = memo(function Chat() {
                     />
                   ))}
                 </div>
+              </div>
+            )}
+            {showStreamActions && chatId && (
+              <div className="relative z-10">
+                <StreamActionsBar chatId={chatId} />
               </div>
             )}
             <div className="relative z-10">

--- a/frontend/src/components/chat/chat-window/StreamActionsBar.tsx
+++ b/frontend/src/components/chat/chat-window/StreamActionsBar.tsx
@@ -1,0 +1,43 @@
+import { GitBranch } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { useChatQuery } from '@/hooks/queries/useChatQueries';
+import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
+import { useRunStreamAction } from '@/hooks/useRunStreamAction';
+
+interface StreamActionsBarProps {
+  chatId: string;
+}
+
+export function StreamActionsBar({ chatId }: StreamActionsBarProps) {
+  const { data: chat } = useChatQuery(chatId);
+  const { data: settings } = useSettingsQuery();
+  const runAction = useRunStreamAction(chat);
+
+  const enabledActions = (settings?.stream_actions ?? []).filter((action) => action.enabled);
+
+  // Only top-level threads spawn sub-thread reviews (nesting is one level).
+  if (!chat || chat.parent_chat_id || enabledActions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 px-4 pb-2 sm:px-6">
+      <span className="text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
+        Run
+      </span>
+      {enabledActions.map((action) => (
+        <Button
+          key={action.label}
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => runAction(action)}
+          className="gap-1.5"
+        >
+          <GitBranch className="h-3.5 w-3.5" />
+          {action.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/dialogs/StreamActionEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/StreamActionEditDialog.tsx
@@ -1,0 +1,221 @@
+import { useCallback, useRef } from 'react';
+import { GitBranch, Brain, Shield } from 'lucide-react';
+import type { CustomSkill, Persona, StreamAction } from '@/types/user.types';
+import type { SlashCommand } from '@/types/ui.types';
+import { Input } from '@/components/ui/primitives/Input';
+import { Label } from '@/components/ui/primitives/Label';
+import { Select } from '@/components/ui/primitives/Select';
+import { Textarea } from '@/components/ui/primitives/Textarea';
+import { Dropdown } from '@/components/ui/primitives/Dropdown';
+import { BaseModal } from '@/components/ui/shared/BaseModal';
+import { DialogFooter } from '@/components/ui/shared/DialogFooter';
+import { DialogError } from '@/components/ui/shared/DialogError';
+import { ModelSelector } from '@/components/chat/model-selector/ModelSelector';
+import { SlashCommandsPanel } from '@/components/chat/message-input/SlashCommandsPanel';
+import {
+  getThinkingModesForAgent,
+  getThinkingModeOption,
+} from '@/components/chat/thinking-mode-selector/thinkingModes';
+import {
+  MODES_BY_AGENT,
+  getPermissionModeOption,
+} from '@/components/chat/permission-mode-selector/permissionModes';
+import { useModelsQuery } from '@/hooks/queries/useModelQueries';
+import { useWorkspacesList, useWorkspaceResourcesQuery } from '@/hooks/queries/useWorkspaceQueries';
+import { useSlashCommandSuggestions } from '@/hooks/useSlashCommandSuggestions';
+import { EMPTY_BUILTIN_COMMANDS } from '@/config/constants';
+import { DEFAULT_PERSONA } from '@/store/chatSettingsStore';
+
+const EMPTY_SKILLS: CustomSkill[] = [];
+
+interface StreamActionEditDialogProps {
+  isOpen: boolean;
+  isEditing: boolean;
+  action: StreamAction;
+  personas: Persona[];
+  error: string | null;
+  onClose: () => void;
+  onSubmit: () => void;
+  onActionChange: <K extends keyof StreamAction>(field: K, value: StreamAction[K]) => void;
+}
+
+export const StreamActionEditDialog: React.FC<StreamActionEditDialogProps> = ({
+  isOpen,
+  isEditing,
+  action,
+  personas,
+  error,
+  onClose,
+  onSubmit,
+  onActionChange,
+}) => {
+  const { data: models = [] } = useModelsQuery();
+  // Builtin slash commands are static per agent, so any workspace's resources
+  // surface the same set. Custom skills are intentionally excluded — stream actions
+  // are global and run in the clicked chat's workspace, where a skill suggested here
+  // may not exist; builtins are valid everywhere.
+  const workspaces = useWorkspacesList();
+  const { data: resources } = useWorkspaceResourcesQuery(workspaces[0]?.id);
+  const builtinSlashCommands = resources?.builtin_slash_commands ?? EMPTY_BUILTIN_COMMANDS;
+
+  const selectedModel = models.find((m) => m.model_id === action.model_id);
+  const agentKind = selectedModel?.agent_kind ?? 'claude';
+
+  const permissionModes = MODES_BY_AGENT[agentKind];
+  const selectedPermissionOption = getPermissionModeOption(action.permission_mode, agentKind);
+  const thinkingModes = getThinkingModesForAgent(agentKind, action.model_id);
+  const selectedThinkingOption = getThinkingModeOption(
+    action.thinking_mode,
+    agentKind,
+    action.model_id,
+  );
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSlashCommandSelect = useCallback(
+    (command: SlashCommand) => {
+      const newCommand = `${command.value} `;
+      onActionChange('command', newCommand);
+      setTimeout(() => {
+        const textarea = textareaRef.current;
+        if (textarea) {
+          textarea.focus();
+          textarea.setSelectionRange(newCommand.length, newCommand.length);
+        }
+      }, 0);
+    },
+    [onActionChange],
+  );
+
+  const {
+    filteredCommands,
+    highlightedIndex,
+    hasSuggestions,
+    selectCommand,
+    handleKeyDown: handleSlashKeyDown,
+  } = useSlashCommandSuggestions({
+    message: action.command,
+    onSelect: handleSlashCommandSelect,
+    customSkills: EMPTY_SKILLS,
+    builtinSlashCommands,
+    agentKind,
+  });
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="sm" className="overflow-visible">
+      <div className="p-5">
+        <div className="mb-5 flex items-center gap-2.5">
+          <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-surface-tertiary dark:bg-surface-dark-tertiary">
+            <GitBranch className="h-4 w-4 text-text-tertiary dark:text-text-dark-tertiary" />
+          </div>
+          <h3 className="text-sm font-medium text-text-primary dark:text-text-dark-primary">
+            {isEditing ? 'Edit action' : 'Add action'}
+          </h3>
+        </div>
+
+        <DialogError error={error} className="mb-4" />
+
+        <div className="space-y-4">
+          <div>
+            <Label className="mb-1.5 text-xs text-text-secondary dark:text-text-dark-secondary">
+              Button label
+            </Label>
+            <Input
+              value={action.label}
+              onChange={(e) => onActionChange('label', e.target.value)}
+              placeholder="Review"
+              className="text-xs"
+            />
+          </div>
+
+          <div>
+            <Label className="mb-1.5 text-xs text-text-secondary dark:text-text-dark-secondary">
+              Model
+            </Label>
+            <ModelSelector
+              selectedModelId={action.model_id}
+              onModelChange={(modelId) => onActionChange('model_id', modelId)}
+              dropdownPosition="bottom"
+              compact={false}
+            />
+          </div>
+
+          <div>
+            <Label className="mb-1.5 text-xs text-text-secondary dark:text-text-dark-secondary">
+              Persona
+            </Label>
+            <Select
+              value={action.persona_name}
+              onChange={(e) => onActionChange('persona_name', e.target.value)}
+              className="h-8 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary dark:bg-surface-dark-secondary dark:text-text-dark-primary"
+            >
+              <option value={DEFAULT_PERSONA}>Default</option>
+              {personas.map((p) => (
+                <option key={p.name} value={p.name}>
+                  {p.name}
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {selectedThinkingOption && (
+              <Dropdown
+                value={selectedThinkingOption}
+                items={thinkingModes}
+                getItemKey={(m) => m.value}
+                getItemLabel={(m) => m.label}
+                onSelect={(m) => onActionChange('thinking_mode', m.value)}
+                leftIcon={Brain}
+                dropdownPosition="bottom"
+              />
+            )}
+            <Dropdown
+              value={selectedPermissionOption}
+              items={permissionModes}
+              getItemKey={(m) => m.value}
+              getItemLabel={(m) => m.label}
+              onSelect={(m) => onActionChange('permission_mode', m.value)}
+              leftIcon={Shield}
+              dropdownPosition="bottom"
+            />
+          </div>
+
+          <div>
+            <Label className="mb-1.5 text-xs text-text-secondary dark:text-text-dark-secondary">
+              Command
+            </Label>
+            <div className="relative">
+              {hasSuggestions && (
+                <SlashCommandsPanel
+                  suggestions={filteredCommands}
+                  highlightedIndex={highlightedIndex}
+                  onSelect={selectCommand}
+                />
+              )}
+              <Textarea
+                ref={textareaRef}
+                value={action.command}
+                onChange={(e) => onActionChange('command', e.target.value)}
+                onKeyDown={handleSlashKeyDown}
+                placeholder="/quality-review"
+                className="min-h-[120px] font-mono text-xs"
+                rows={5}
+              />
+            </div>
+            <p className="mt-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+              A slash command, skill, or prompt — sent verbatim to the sub-thread.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter
+          onCancel={onClose}
+          onSave={onSubmit}
+          saveLabel={isEditing ? 'Update' : 'Add action'}
+          disabled={!action.label.trim() || !action.model_id.trim() || !action.command.trim()}
+        />
+      </div>
+    </BaseModal>
+  );
+};

--- a/frontend/src/components/settings/sections/StreamActionsSection.tsx
+++ b/frontend/src/components/settings/sections/StreamActionsSection.tsx
@@ -1,0 +1,67 @@
+import { Suspense, useCallback } from 'react';
+import { useSettingsContext } from '@/hooks/useSettingsContext';
+import { useCrudForm } from '@/hooks/useCrudForm';
+import { createDefaultStreamActionForm, validateStreamActionForm } from '@/utils/settings';
+import { lazyNamed } from '@/utils/lazyNamed';
+
+const StreamActionsSettingsTab = lazyNamed(
+  () => import('@/components/settings/tabs/StreamActionsSettingsTab'),
+  'StreamActionsSettingsTab',
+);
+const StreamActionEditDialog = lazyNamed(
+  () => import('@/components/settings/dialogs/StreamActionEditDialog'),
+  'StreamActionEditDialog',
+);
+
+export function StreamActionsSection() {
+  const { localSettings, persistSettings } = useSettingsContext();
+
+  const actionCrud = useCrudForm(localSettings, persistSettings, {
+    createDefault: createDefaultStreamActionForm,
+    validateForm: (form, editingIndex) =>
+      validateStreamActionForm(form, editingIndex, localSettings.stream_actions ?? []),
+    getArrayKey: 'stream_actions',
+    itemName: 'action',
+  });
+
+  const handleToggle = useCallback(
+    (index: number, enabled: boolean) =>
+      persistSettings(
+        (prev) => {
+          const next = [...(prev.stream_actions ?? [])];
+          const target = next[index];
+          if (!target) return prev;
+          next[index] = { ...target, enabled };
+          return { ...prev, stream_actions: next };
+        },
+        { errorMessage: 'Failed to update action' },
+      ),
+    [persistSettings],
+  );
+
+  return (
+    <>
+      <StreamActionsSettingsTab
+        actions={localSettings.stream_actions}
+        onAdd={actionCrud.handleAdd}
+        onEdit={actionCrud.handleEdit}
+        onDelete={actionCrud.handleDelete}
+        onToggle={handleToggle}
+      />
+      {actionCrud.isDialogOpen && (
+        <Suspense fallback={null}>
+          <StreamActionEditDialog
+            isOpen={actionCrud.isDialogOpen}
+            isEditing={actionCrud.editingIndex !== null}
+            action={actionCrud.form}
+            personas={localSettings.personas ?? []}
+            error={actionCrud.formError}
+            onClose={actionCrud.handleDialogClose}
+            onSubmit={actionCrud.handleSave}
+            onActionChange={actionCrud.handleFormChange}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/settings/tabs/StreamActionsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/StreamActionsSettingsTab.tsx
@@ -1,0 +1,64 @@
+import { GitBranch } from 'lucide-react';
+import { ListManagementTab } from '@/components/ui/ListManagementTab';
+import { Switch } from '@/components/ui/primitives/Switch';
+import type { StreamAction } from '@/types/user.types';
+
+interface StreamActionsSettingsTabProps {
+  actions: StreamAction[] | null;
+  onAdd: () => void;
+  onEdit: (index: number) => void;
+  onDelete: (index: number) => void | Promise<void>;
+  onToggle: (index: number, enabled: boolean) => void | Promise<void>;
+}
+
+export const StreamActionsSettingsTab: React.FC<StreamActionsSettingsTabProps> = ({
+  actions,
+  onAdd,
+  onEdit,
+  onDelete,
+  onToggle,
+}) => {
+  return (
+    <ListManagementTab<StreamAction>
+      title="Stream actions"
+      description="Buttons shown when a thread finishes streaming. Each runs its command on the selected model in a new sub-thread."
+      items={actions}
+      emptyIcon={GitBranch}
+      emptyText="No stream actions configured yet"
+      emptyButtonText="Add your first action"
+      addButtonText="Add action"
+      deleteConfirmTitle="Delete action"
+      deleteConfirmMessage={(action) =>
+        `Are you sure you want to delete "${action.label}"? This action cannot be undone.`
+      }
+      getItemKey={(action) => action.label}
+      onAdd={onAdd}
+      onEdit={onEdit}
+      onDelete={onDelete}
+      renderItem={(action) => (
+        <>
+          <h3 className="mb-2 truncate text-xs font-medium text-text-primary dark:text-text-dark-primary">
+            {action.label}
+          </h3>
+          <div className="flex items-center gap-2 font-mono text-2xs text-text-secondary dark:text-text-dark-secondary">
+            <span className="rounded-md border border-border/50 px-1.5 py-0.5 dark:border-border-dark/50">
+              {action.model_id}
+            </span>
+            <span className="truncate text-text-quaternary dark:text-text-dark-quaternary">
+              {action.command}
+            </span>
+          </div>
+        </>
+      )}
+      renderItemActions={(action, index) => (
+        <Switch
+          size="sm"
+          checked={action.enabled}
+          onCheckedChange={(enabled) => onToggle(index, enabled)}
+          aria-label={action.enabled ? 'Disable action' : 'Enable action'}
+        />
+      )}
+      logContext="StreamActionsSettingsTab"
+    />
+  );
+};

--- a/frontend/src/components/ui/ListManagementTab.tsx
+++ b/frontend/src/components/ui/ListManagementTab.tsx
@@ -19,6 +19,8 @@ interface ListManagementTabProps<T> {
   onEdit?: (index: number) => void;
   onDelete: (index: number) => void | Promise<void>;
   renderItem: (item: T, index: number) => ReactNode;
+  // Extra controls rendered before the edit/delete buttons (e.g. an enable toggle)
+  renderItemActions?: (item: T, index: number) => ReactNode;
   footerContent?: ReactNode;
   logContext: string;
 }
@@ -38,6 +40,7 @@ export const ListManagementTab = <T,>({
   onEdit,
   onDelete,
   renderItem,
+  renderItemActions,
   footerContent,
   logContext,
 }: ListManagementTabProps<T>) => {
@@ -108,6 +111,7 @@ export const ListManagementTab = <T,>({
                 <div className="flex items-start justify-between">
                   <div className="min-w-0 flex-1">{renderItem(item, index)}</div>
                   <div className="ml-3 flex items-center gap-0.5">
+                    {renderItemActions?.(item, index)}
                     {onEdit && (
                       <Button
                         type="button"

--- a/frontend/src/hooks/useGlobalStream.ts
+++ b/frontend/src/hooks/useGlobalStream.ts
@@ -9,9 +9,24 @@ interface UseGlobalStreamOptions {
   onPruneComplete?: () => void;
 }
 
-// On app mount, reconciles the in-memory stream store with the server — streams
-// tracked locally (e.g., across a page refresh) but no longer active on the
-// backend get pruned so the UI doesn't show stale "streaming" indicators.
+const STREAM_PRUNE_INTERVAL_MS = 5000;
+
+// Re-check liveness immediately before removing — a live EventSource may have
+// attached (user opened/reconnected the sub-thread) while the status request was
+// in flight, and removeStreamMetadata would tear it down. Such streams self-clean
+// via removeStream on completion, so skip them.
+function pruneIfStillOrphan(chatId: string): void {
+  const store = useStreamStore.getState();
+  if (!store.getStreamByChat(chatId)) {
+    store.removeStreamMetadata(chatId);
+  }
+}
+
+// Reconciles the in-memory stream store with the server, pruning metadata whose
+// backend task has settled so the UI stops showing stale "streaming" indicators.
+// Runs on an interval (not just at mount) because background sub-threads — e.g.
+// stream actions — register metadata without opening a client EventSource, so
+// the normal removeStream cleanup never fires for them.
 export function useGlobalStream(options?: UseGlobalStreamOptions) {
   const hasPrunedRef = useRef(false);
   const enabled = options?.enabled ?? true;
@@ -19,34 +34,47 @@ export function useGlobalStream(options?: UseGlobalStreamOptions) {
 
   useEffect(() => {
     if (!enabled) return;
-    if (hasPrunedRef.current) return;
-    hasPrunedRef.current = true;
 
     const pruneStaleStreams = async () => {
-      const metadata = useStreamStore.getState().activeStreamMetadata;
+      const store = useStreamStore.getState();
+      // Only reconcile orphan metadata (no live EventSource). Entries with an
+      // active stream self-clean via removeStream on the completion event —
+      // pruning them here would tear down a live foreground stream at its
+      // completion boundary.
+      const orphans = store.activeStreamMetadata.filter(
+        (meta) => !store.getStreamByChat(meta.chatId),
+      );
 
-      if (metadata.length === 0) return;
+      if (orphans.length === 0) return;
 
-      const prunePromises = metadata.map(async (streamMeta) => {
+      const prunePromises = orphans.map(async (streamMeta) => {
         try {
           const status = await chatService.checkChatStatus(streamMeta.chatId);
 
           if (!status?.has_active_task) {
-            useStreamStore.getState().removeStreamMetadata(streamMeta.chatId);
+            pruneIfStillOrphan(streamMeta.chatId);
           }
         } catch (error) {
           logger.error('Stream prune check failed', 'useGlobalStream', error);
-          useStreamStore.getState().removeStreamMetadata(streamMeta.chatId);
+          pruneIfStillOrphan(streamMeta.chatId);
         }
       });
 
       await Promise.allSettled(prunePromises);
-      onPruneComplete?.();
+
+      if (!hasPrunedRef.current) {
+        hasPrunedRef.current = true;
+        onPruneComplete?.();
+      }
     };
 
-    const timeoutId = setTimeout(pruneStaleStreams, 500);
+    const initialTimeout = setTimeout(pruneStaleStreams, 500);
+    const intervalId = setInterval(pruneStaleStreams, STREAM_PRUNE_INTERVAL_MS);
 
-    return () => clearTimeout(timeoutId);
+    return () => {
+      clearTimeout(initialTimeout);
+      clearInterval(intervalId);
+    };
   }, [enabled, onPruneComplete]);
 
   const stopAllStreams = useCallback(async () => {

--- a/frontend/src/hooks/useRunStreamAction.ts
+++ b/frontend/src/hooks/useRunStreamAction.ts
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+import toast from 'react-hot-toast';
+import { chatService } from '@/services/chatService';
+import { useCreateSubThreadMutation } from '@/hooks/queries/useChatQueries';
+import { useModelStore } from '@/store/modelStore';
+import { useStreamStore } from '@/store/streamStore';
+import { useChatSettingsStore } from '@/store/chatSettingsStore';
+import { coercePermissionModeForAgent } from '@/components/chat/permission-mode-selector/permissionModes';
+import { coerceThinkingModeForAgent } from '@/components/chat/thinking-mode-selector/thinkingModes';
+import { getAgentKindForModelId } from '@/types/chat.types';
+import type { Chat } from '@/types/chat.types';
+import type { StreamAction } from '@/types/user.types';
+
+// Spawns a stream action as a background sub-thread: creates the sub-thread,
+// fires its turn server-side, and registers stream metadata so the sidebar
+// shows the pulse without the user opening it.
+export function useRunStreamAction(parentChat: Chat | undefined) {
+  const createSubThread = useCreateSubThreadMutation(parentChat?.id ?? '');
+
+  return useCallback(
+    async (action: StreamAction) => {
+      if (!parentChat) return;
+
+      const agentKind = getAgentKindForModelId(action.model_id);
+      const permissionMode = coercePermissionModeForAgent(action.permission_mode, agentKind);
+      const thinkingMode = coerceThinkingModeForAgent(
+        action.thinking_mode,
+        agentKind,
+        action.model_id,
+      );
+
+      try {
+        const newChat = await createSubThread.mutateAsync({
+          title: action.label,
+          model_id: action.model_id,
+          workspace_id: parentChat.workspace_id,
+          parent_chat_id: parentChat.id,
+        });
+
+        useModelStore.getState().selectModel(newChat.id, action.model_id);
+        const settings = useChatSettingsStore.getState();
+        settings.setPersona(newChat.id, action.persona_name);
+        settings.setPermissionMode(newChat.id, permissionMode);
+        settings.setThinkingMode(newChat.id, thinkingMode);
+
+        const { messageId } = await chatService.startCompletion({
+          prompt: action.command,
+          chat_id: newChat.id,
+          model_id: action.model_id,
+          permission_mode: permissionMode,
+          thinking_mode: thinkingMode,
+          selected_persona_name: action.persona_name,
+        });
+
+        // No client EventSource here — the global stream watcher reconciles this
+        // metadata against the server and prunes the pulse once the turn settles.
+        useStreamStore.getState().addStreamMetadata({
+          chatId: newChat.id,
+          messageId,
+          startTime: Date.now(),
+        });
+
+        toast.success(`Started "${action.label}"`);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : `Failed to start "${action.label}"`);
+      }
+    },
+    [parentChat, createSubThread],
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import {
   ScrollText,
   ChevronLeft,
   Cloud,
+  GitBranch,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { cn } from '@/utils/cn';
@@ -32,13 +33,21 @@ import { useAuthStore } from '@/store/authStore';
 import { getGeneralSecretFields } from '@/utils/settings';
 import { PersonasSection } from '@/components/settings/sections/PersonasSection';
 import { EnvVarsSection } from '@/components/settings/sections/EnvVarsSection';
+import { StreamActionsSection } from '@/components/settings/sections/StreamActionsSection';
 const InstructionsSettingsTab = lazy(() =>
   import('@/components/settings/tabs/InstructionsSettingsTab').then((m) => ({
     default: m.InstructionsSettingsTab,
   })),
 );
 
-type TabKey = 'general' | 'skills' | 'personas' | 'env_vars' | 'instructions' | 'cloud';
+type TabKey =
+  | 'general'
+  | 'skills'
+  | 'personas'
+  | 'stream_actions'
+  | 'env_vars'
+  | 'instructions'
+  | 'cloud';
 
 const getErrorMessage = (error: unknown): string | undefined =>
   error instanceof Error ? error.message : undefined;
@@ -47,6 +56,7 @@ const TAB_FIELDS: Record<TabKey, (keyof UserSettings)[]> = {
   general: ['github_personal_access_token'],
   skills: [],
   personas: ['personas'],
+  stream_actions: ['stream_actions'],
   env_vars: ['custom_env_vars'],
   instructions: ['custom_instructions'],
   cloud: [],
@@ -62,6 +72,7 @@ const SETTINGS_NAV: SettingsNavItem[] = [
   { id: 'general', label: 'General', icon: Settings2 },
   { id: 'skills', label: 'Skills', icon: Zap },
   { id: 'personas', label: 'Personas', icon: UserCircle },
+  { id: 'stream_actions', label: 'Stream Actions', icon: GitBranch },
   { id: 'env_vars', label: 'Env Variables', icon: Key },
   { id: 'instructions', label: 'Instructions', icon: ScrollText },
   { id: 'cloud', label: 'Cloud', icon: Cloud },
@@ -130,6 +141,7 @@ const SettingsPage: React.FC = () => {
         'custom_instructions',
         'custom_env_vars',
         'personas',
+        'stream_actions',
         'notifications_enabled',
       ];
 
@@ -486,6 +498,18 @@ const SettingsPage: React.FC = () => {
                     <div role="tabpanel" id="personas-panel" aria-labelledby="personas-tab">
                       <Suspense fallback={tabLoadingFallback}>
                         <PersonasSection />
+                      </Suspense>
+                    </div>
+                  )}
+
+                  {activeTab === 'stream_actions' && (
+                    <div
+                      role="tabpanel"
+                      id="stream_actions-panel"
+                      aria-labelledby="stream_actions-tab"
+                    >
+                      <Suspense fallback={tabLoadingFallback}>
+                        <StreamActionsSection />
                       </Suspense>
                     </div>
                   )}

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -74,6 +74,23 @@ async function createCompletion(
   );
 }
 
+// Fires a turn server-side without opening a client EventSource — used to start
+// background sub-threads (e.g. stream actions). The server runs the turn as a
+// background task; the client reconnects to the stream when the chat is opened.
+async function startCompletion(request: ChatRequest): Promise<{ messageId: string }> {
+  validateRequired(request.prompt, 'Prompt');
+
+  return serviceCall(async () => {
+    const formData = buildChatFormData(request);
+    const response = await apiClient.postForm<{
+      chat_id: string;
+      message_id: string;
+    }>('/chat/chat', formData);
+    const payload = ensureResponse(response, 'Failed to start chat completion');
+    return { messageId: payload.message_id };
+  });
+}
+
 async function checkChatStatus(chatId: string): Promise<{
   has_active_task: boolean;
   message_id?: string;
@@ -337,6 +354,7 @@ async function restoreMessageCheckpoint(messageId: string): Promise<GitCommitRes
 
 export const chatService = {
   createCompletion,
+  startCompletion,
   checkChatStatus,
   reconnectToStream,
   stopStream,

--- a/frontend/src/types/user.types.ts
+++ b/frontend/src/types/user.types.ts
@@ -1,3 +1,5 @@
+import type { PermissionMode } from '@/store/chatSettingsStore';
+
 export interface User {
   id: string;
   email: string;
@@ -32,6 +34,17 @@ export interface Persona {
   content: string;
 }
 
+// A post-stream action button: runs `command` on `model_id` in a new sub-thread.
+export interface StreamAction {
+  label: string;
+  enabled: boolean;
+  model_id: string;
+  command: string;
+  persona_name: string;
+  permission_mode: PermissionMode;
+  thinking_mode: string;
+}
+
 export type SandboxProviderType = 'docker' | 'host';
 
 export interface UserSettings {
@@ -41,6 +54,7 @@ export interface UserSettings {
   custom_instructions: string | null;
   custom_env_vars: CustomEnvVar[] | null;
   personas: Persona[] | null;
+  stream_actions: StreamAction[] | null;
   notifications_enabled: boolean;
   created_at: string;
   updated_at: string;

--- a/frontend/src/utils/settings.ts
+++ b/frontend/src/utils/settings.ts
@@ -1,5 +1,9 @@
-import { DEFAULT_PERSONA } from '@/store/chatSettingsStore';
-import type { CustomEnvVar, Persona } from '@/types/user.types';
+import {
+  DEFAULT_PERSONA,
+  DEFAULT_PERMISSION_MODE,
+  DEFAULT_THINKING_MODE,
+} from '@/store/chatSettingsStore';
+import type { CustomEnvVar, Persona, StreamAction } from '@/types/user.types';
 import type { GeneralSecretFieldConfig } from '@/types/settings.types';
 import { validateRequired, validateUnique } from '@/utils/validation';
 
@@ -57,6 +61,40 @@ export const validatePersonaForm = (
     validateRequired(form.name, 'Name');
     validateRequired(form.content, 'Content');
     validateUnique('name', form.name, existingItems, editingIndex, 'persona with this name', 'A');
+
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message : 'Validation failed';
+  }
+};
+
+export const createDefaultStreamActionForm = (): StreamAction => ({
+  label: '',
+  enabled: true,
+  model_id: '',
+  command: '',
+  persona_name: DEFAULT_PERSONA,
+  permission_mode: DEFAULT_PERMISSION_MODE,
+  thinking_mode: DEFAULT_THINKING_MODE,
+});
+
+export const validateStreamActionForm = (
+  form: StreamAction,
+  editingIndex: number | null,
+  existingItems: StreamAction[],
+): string | null => {
+  try {
+    validateRequired(form.label, 'Label');
+    validateRequired(form.model_id, 'Model');
+    validateRequired(form.command, 'Command');
+    validateUnique(
+      'label',
+      form.label,
+      existingItems,
+      editingIndex,
+      'action with this label',
+      'An',
+    );
 
     return null;
   } catch (error) {


### PR DESCRIPTION
## Summary
- Adds user-configurable **post-stream action buttons** that appear when a top-level thread finishes streaming (gated on `stream_status === 'completed'`, so failed/interrupted/reconnecting turns don't show them).
- Each action spawns a **background sub-thread** with its own model, persona, permission mode, and thinking mode — multiple actions run in parallel without manual sub-thread setup. Replaces the manual "finish → open sub-thread with another model to review" flow.
- Fully managed as data via a new **Stream Actions** settings tab (add / edit / enable-disable / remove), mirroring the existing Personas/EnvVars CRUD architecture (`useCrudForm`, `ListManagementTab`).
- Edit dialog includes model + persona selectors, permission/thinking dropdowns (same as the sub-thread dialog), and slash-command suggestions limited to built-in commands (global actions run in the clicked chat's workspace, where custom skills may not exist).
- The sidebar streaming pulse for these background turns is reconciled by the global stream watcher, now running on an interval over **orphan metadata only** (no live EventSource) instead of pruning once at app mount — with a re-check immediately before removal so an attaching foreground stream is never torn down.

### Backend
- New `stream_actions` JSON column on `user_settings` (`StreamActionDict` + `StreamAction` Pydantic model with `max_length` bounds; defaults: `bypassPermissions` / `high` / `Default`).
- Reuses the existing `/chat/chat` background-task endpoint; no new route.

## Test plan
- [ ] Add a stream action in Settings → Stream Actions; verify it persists across reload.
- [ ] Finish a top-level thread; confirm the RUN bar appears aligned with the composer.
- [ ] Click an action; confirm a sub-thread spawns, runs in the background, and the sidebar pulse clears once it finishes.
- [ ] Click multiple actions; confirm they run in parallel.
- [ ] Open a spawned sub-thread mid-run; confirm the foreground stream is not torn down by the pruner.
- [ ] Confirm slash-command suggestions show built-in commands for the selected model's agent kind.
- [ ] **Migration:** regenerate via Alembic autogenerate in the backend container before deploy (see note below).

> ⚠️ The migration `c1a2b3d4e5f6` is hand-authored (Docker was down + a pre-existing dev-DB revision divergence blocked autogenerate). Content is correct (one nullable JSON column chained from head `05d565131567`), but it should be regenerated via `alembic revision --autogenerate` inside the backend container before merge/deploy.