### PR TITLE
fix: render stream actions under last message instead of above input

### DIFF
--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -396,7 +396,7 @@ export const Chat = memo(function Chat() {
   const showThinking = isLoading || (isStreaming && !lastBotHasContent);
 
   const listFooter = useMemo(() => {
-    if (!showThinking && !showPermissionAtEnd) {
+    if (!showThinking && !showPermissionAtEnd && !(showStreamActions && chatId)) {
       return null;
     }
 
@@ -404,9 +404,10 @@ export const Chat = memo(function Chat() {
       <div className="w-full lg:mx-auto lg:max-w-3xl">
         {showThinking && <ThinkingIndicator />}
         {showPermissionAtEnd && <MessageInlinePermission />}
+        {showStreamActions && chatId && <StreamActionsBar chatId={chatId} />}
       </div>
     );
-  }, [showPermissionAtEnd, showThinking]);
+  }, [chatId, showPermissionAtEnd, showStreamActions, showThinking]);
 
   return (
     <div className="relative flex min-w-0 flex-1 flex-col">
@@ -447,11 +448,6 @@ export const Chat = memo(function Chat() {
                     />
                   ))}
                 </div>
-              </div>
-            )}
-            {showStreamActions && chatId && (
-              <div className="relative z-10">
-                <StreamActionsBar chatId={chatId} />
               </div>
             )}
             <div className="relative z-10">


### PR DESCRIPTION
## Summary
- The post-stream RUN action bar was pinned to the input region, separate from the message list.
- The message list area is `flex-1`, so on short conversations it fills the viewport and leaves empty scroll space below the last message — putting a large gap between the message actions and the RUN bar.
- Moved `StreamActionsBar` into the list footer so it renders directly under the last message (same `lg:max-w-3xl` wrapper and `px-4 sm:px-6` padding as messages), regardless of scroll fill.

## Test plan
- [ ] On a short completed chat, RUN buttons appear directly under the last message's actions (no large gap).
- [ ] On a long/scrolled chat, RUN buttons still appear under the last message, above the input.
- [ ] RUN bar is horizontally aligned with message content.
- [ ] Bar is hidden while streaming/loading and for sub-thread chats.