### PR TITLE
fix: even out stream action toggle/icon spacing

### DIFF
--- a/frontend/src/components/settings/tabs/StreamActionsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/StreamActionsSettingsTab.tsx
@@ -53,6 +53,9 @@ export const StreamActionsSettingsTab: React.FC<StreamActionsSettingsTabProps> =
       renderItemActions={(action, index) => (
         <Switch
           size="sm"
+          // Toggle pill is flush to its box while edit/delete glyphs sit inside ~7px button padding;
+          // match that with a right margin so the toggle→edit gap reads the same as edit→delete
+          className="mr-1.5"
           checked={action.enabled}
           onCheckedChange={(enabled) => onToggle(index, enabled)}
           aria-label={action.enabled ? 'Disable action' : 'Enable action'}


### PR DESCRIPTION
## Summary
- The post-stream action row places a flush `Switch` next to two `h-7 w-7` icon buttons (edit/delete). The toggle pill fills its box with zero internal padding, while each icon glyph sits inside ~7px of button padding.
- With a uniform `gap-0.5`, this made the toggle→edit gap read noticeably tighter (~9px) than edit→delete (~16px).
- Added `mr-1.5` to the toggle to compensate for the missing button padding, so the optical spacing across toggle → edit → delete is even.

## Test plan
- [ ] Open Settings → Stream Actions with at least one action configured
- [ ] Confirm the spacing between the toggle, edit, and delete controls looks even