### PR TITLE
fix: save drawn-on image attachments in the desktop app

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
     ],
     "security": {
       "dangerousDisableAssetCspModification": ["script-src"],
-      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdn.jsdelivr.net; connect-src 'self' ipc: ipc://localhost http://localhost:* ws://localhost:* http://127.0.0.1:* ws://127.0.0.1:* https: wss:; frame-src 'self' tauri://localhost http://localhost:* http://127.0.0.1:*; child-src 'self' tauri://localhost http://localhost:* http://127.0.0.1:*",
+      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdn.jsdelivr.net; connect-src 'self' blob: data: ipc: ipc://localhost http://localhost:* ws://localhost:* http://127.0.0.1:* ws://127.0.0.1:* https: wss:; frame-src 'self' tauri://localhost http://localhost:* http://127.0.0.1:*; child-src 'self' tauri://localhost http://localhost:* http://127.0.0.1:*",
       "capabilities": ["main-capability"]
     }
   },

--- a/frontend/src/components/ui/DrawingModal.tsx
+++ b/frontend/src/components/ui/DrawingModal.tsx
@@ -46,6 +46,7 @@ export const DrawingModal = memo(function DrawingModal({
 
     contextRef.current = ctx;
 
+    let cancelled = false;
     const img = new Image();
 
     img.onload = () => {
@@ -62,9 +63,28 @@ export const DrawingModal = memo(function DrawingModal({
       setCanvasReady(false);
     };
 
-    img.src = imageUrl;
+    // WKWebView (Tauri desktop) taints the canvas when an image loads from a
+    // blob: URL, making toDataURL throw on save — convert to a data URL first.
+    fetch(imageUrl)
+      .then((res) => res.blob())
+      .then(
+        (blob) =>
+          new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result as string);
+            reader.onerror = () => reject(reader.error);
+            reader.readAsDataURL(blob);
+          }),
+      )
+      .then((dataUrl) => {
+        if (!cancelled) img.src = dataUrl;
+      })
+      .catch(() => {
+        if (!cancelled) setCanvasReady(false);
+      });
 
     return () => {
+      cancelled = true;
       if (imageRef.current) {
         imageRef.current.src = '';
         imageRef.current = null;


### PR DESCRIPTION
## Summary
- In the Tauri desktop app, opening an image attachment in the drawing modal worked, but **Save** silently did nothing.
- Root cause: WKWebView taints the canvas when an `<img>` loads from a `blob:` URL, so `canvas.toDataURL()` threw a `SecurityError` on save (caught and logged, so it failed silently).
- Fix: convert the preview `blob:` URL to a `data:` URL before drawing it into the canvas, so the canvas stays clean and `toDataURL` succeeds.
- The blob→data conversion (and the downstream `data:`→`File` conversion in `convertDataUrlToUploadedFile`) use `fetch`, which the Tauri CSP refused — so `blob:` and `data:` were added to the `connect-src` directive.

## Test plan
- [ ] Rebuild/restart the desktop app (CSP changes only apply on a fresh build).
- [ ] Attach an image, open it in the drawing modal, draw on it, and click Save.
- [ ] Confirm the attachment is replaced with the edited image and there are no CSP errors in the console.
- [ ] Verify the same flow still works in the web build.