### PR TITLE
fix: gate chat status polling on in-memory check before DB

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -405,9 +405,24 @@ async def stream_events(
 @router.get("/chats/{chat_id}/status", response_model=ChatStatusResponse)
 async def get_stream_status(
     chat_id: UUID,
-    _chat: Chat = Depends(ensure_chat_access),
+    current_user: User = Depends(get_current_user),
     chat_service: ChatService = Depends(get_chat_service),
 ) -> dict[str, Any]:
+    # In-memory gate first: every open chat polls this endpoint on a short
+    # interval, but a stream is almost never live. Short-circuit inactive polls
+    # before any chat/message DB query so the bursts don't drain the connection
+    # pool. Ownership is validated only on the rare active path below.
+    if not ChatStreamRuntime.has_active_chat(str(chat_id)):
+        return INACTIVE_TASK_RESPONSE.copy()
+
+    try:
+        await chat_service.get_chat(chat_id, current_user)
+    except ChatException:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Chat not found or access denied",
+        )
+
     try:
         latest_assistant_message = (
             await chat_service.message_service.get_latest_assistant_message(chat_id)
@@ -417,9 +432,6 @@ async def get_stream_status(
             not latest_assistant_message
             or latest_assistant_message.stream_status != MessageStreamStatus.IN_PROGRESS
         ):
-            return INACTIVE_TASK_RESPONSE.copy()
-
-        if not ChatStreamRuntime.has_active_chat(str(chat_id)):
             return INACTIVE_TASK_RESPONSE.copy()
 
         return {


### PR DESCRIPTION
## Summary
- The `GET /chats/{id}/status` endpoint is polled on a short interval for every open chat. It ran its DB dependencies — `ensure_chat_access` (which eager-loads messages + attachments + workspace) and `get_latest_assistant_message` — **before** the zero-I/O `has_active_chat` lookup.
- For the ~99% of polls where no stream is live, those DB hits were pure waste. Under polling bursts they saturated the default SQLite pool (`pool_size=5` + `max_overflow=10` = 15), and queued requests waited the full 30s `pool_timeout` before erroring.
- Fix: run the in-memory `has_active_chat` gate first and short-circuit inactive polls with zero chat/message queries. Ownership validation (`get_chat`) and the latest-message read now happen only on the rare active path. Auth (`get_current_user`) is retained.

## Test plan
- [ ] Inactive chat: `GET /chats/{id}/status` returns `has_active_task: false` and issues no chat/message query (only auth).
- [ ] Active stream: status returns `has_active_task: true` with `message_id` / `stream_id` / `last_seq`.
- [ ] Non-owned chat id: returns inactive (no leak); owned active chat still 404s correctly if access fails.
- [ ] Burst of concurrent status polls no longer exhausts the connection pool / hits 30s timeouts.