### PR TITLE
fix: enable bypassPermissions mode on root deployments

### DIFF
--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -411,6 +411,12 @@ class AgentService:
     ) -> AcpSessionConfig:
         env: dict[str, str] = {}
 
+        # claude-agent-acp hides the bypassPermissions session mode when running
+        # as root unless IS_SANDBOX is set. Our agents always run inside an
+        # isolated sandbox (Docker container or host sandbox dir), so force it on
+        # — otherwise setting bypass mode fails on root deployments (e.g. VPS).
+        env["IS_SANDBOX"] = "1"
+
         # Skip in desktop mode — host git credentials handle auth natively
         if user_settings.github_personal_access_token and not settings.DESKTOP_MODE:
             env["GITHUB_TOKEN"] = user_settings.github_personal_access_token


### PR DESCRIPTION
## Summary
- On cloud/VPS deployments where the agent process runs as root, selecting **Bypass Permissions** mode still prompted for every tool — but it worked fine on the desktop app.
- Root cause: `claude-agent-acp` only advertises the `bypassPermissions` session mode when `ALLOW_BYPASS` is true (`const ALLOW_BYPASS = !IS_ROOT || !!process.env.IS_SANDBOX`). When running as root without `IS_SANDBOX`, the mode is dropped, so `set_session_mode("bypassPermissions")` throws and the swallowing try/except in `session.py` silently leaves the session in `default` mode.
- Desktop spawns the agent as the non-root host user, so bypass already worked there.
- Fix: set `IS_SANDBOX=1` in the agent env. Our agents always run inside an isolated sandbox (Docker container or host sandbox dir), so this is semantically correct, harmless to the non-root desktop path, and only read by `claude-agent-acp`.

## Test plan
- [ ] Redeploy backend on a root/VPS instance, start a new chat with Bypass Permissions mode, confirm tools run without prompting.
- [ ] Confirm desktop app behavior is unchanged.