### PR TITLE
feat: route cloud chats to their owning backend for desktop parity

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { setApiPort } from '@/lib/api';
 import { isTauri, invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { authStorage, cloudAuthStorage } from '@/utils/storage';
+import { clearCloudOrigins } from '@/utils/chatOrigin';
 import { checkDesktopUpdate } from '@/services/desktopUpdateService';
 import { DesktopDragRegion } from '@/components/layout/TitleBar';
 
@@ -180,6 +181,9 @@ export default function App() {
         const cloud = useCloudSettingsStore.getState();
         if (cloud.connectedEmail && !cloudAuthStorage.getRefreshToken()) {
           cloud.clearCloud();
+          // Drop persisted cloud origin IDs too — otherwise stale IDs keep routing
+          // through remoteApiClient after the UI shows cloud as disconnected.
+          clearCloudOrigins();
         }
         setAuthHydrated(true);
       });

--- a/frontend/src/components/chat/chat-window/AgentPane.tsx
+++ b/frontend/src/components/chat/chat-window/AgentPane.tsx
@@ -17,7 +17,10 @@ interface AgentPaneProps {
 export const AgentPane = memo(function AgentPane({ chatId }: AgentPaneProps) {
   const { currentChat, fetchedMessages, hasFetchedMessages, messagesQuery } = useChatData(chatId);
   const { fileStructure, refetchFilesMetadata } = useSandboxFiles(currentChat, chatId);
-  const { data: workspaceResources } = useWorkspaceResourcesQuery(currentChat?.workspace_id);
+  const { data: workspaceResources } = useWorkspaceResourcesQuery(
+    currentChat?.workspace_id,
+    chatId,
+  );
   const { data: settings } = useSettingsQuery();
 
   return (

--- a/frontend/src/components/chat/message-bubble/ChangedFilesPanel.tsx
+++ b/frontend/src/components/chat/message-bubble/ChangedFilesPanel.tsx
@@ -32,7 +32,9 @@ const STATUS_COLOR: Record<ChangedFileStatus, string> = {
 
 const ChangedFilesPanelInner: React.FC<ChangedFilesPanelProps> = ({ messageId }) => {
   const [expanded, setExpanded] = useState(false);
-  const { data } = useMessageChangesQuery(messageId);
+  // chatId routes the message-keyed request to the backend that owns this pane's chat.
+  const { chatId } = useChatContext();
+  const { data } = useMessageChangesQuery(chatId, messageId);
 
   const files = data?.files ?? [];
   const cwd = data?.cwd ?? '';
@@ -164,7 +166,8 @@ const FileDiffSection: React.FC<{
   messageId: string;
   path: string;
 }> = ({ messageId, path }) => {
-  const { data, isLoading, isError } = useMessageFileDiffQuery(messageId, path);
+  const { chatId } = useChatContext();
+  const { data, isLoading, isError } = useMessageFileDiffQuery(chatId, messageId, path);
 
   return (
     <div className="bg-surface-primary dark:bg-surface-dark-primary border-b border-border/50 px-3 py-2 last:border-b-0 dark:border-border-dark/50">

--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -93,7 +93,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   const onSuggestionSelect = isLastBotMessage ? setInputMessage : undefined;
   const modelMap = useModelMap();
   const [restoreOpen, setRestoreOpen] = useState(false);
-  const { restore, isRestoring } = useCheckpointRestore(id, sandboxId);
+  const { restore, isRestoring } = useCheckpointRestore(chatId, id, sandboxId);
 
   const relativeTime = createdAt ? formatRelativeTime(createdAt) : '';
   const fullTimestamp = createdAt ? formatFullTimestamp(createdAt) : '';

--- a/frontend/src/components/chat/message-bubble/MessageAttachments.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageAttachments.tsx
@@ -6,10 +6,11 @@ interface MessageAttachmentsProps {
   attachments: MessageAttachment[];
   uploadingAttachmentIds?: string[];
   className?: string;
+  chatId?: string;
 }
 
 export const MessageAttachments = memo(
-  ({ attachments, uploadingAttachmentIds, className = '' }: MessageAttachmentsProps) => {
+  ({ attachments, uploadingAttachmentIds, className = '', chatId }: MessageAttachmentsProps) => {
     if (attachments.length === 0) {
       return null;
     }
@@ -19,6 +20,7 @@ export const MessageAttachments = memo(
         <AttachmentViewer
           attachments={attachments}
           uploadingAttachmentIds={uploadingAttachmentIds}
+          chatId={chatId}
         />
       </div>
     );

--- a/frontend/src/components/chat/message-bubble/MessageContent.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageContent.tsx
@@ -28,6 +28,7 @@ export const UserMessageContent = memo(function UserMessageContent({
       <MessageAttachments
         attachments={attachments}
         uploadingAttachmentIds={uploadingAttachmentIds}
+        chatId={chatId}
       />
       <MessageRenderer events={contentRender.events} isStreaming={isStreaming} chatId={chatId} />
     </div>
@@ -60,7 +61,7 @@ export const AssistantMessageContent = memo(function AssistantMessageContent({
         agentKind={agentKind}
       />
 
-      <MessageAttachments attachments={attachments} className="mt-3" />
+      <MessageAttachments attachments={attachments} className="mt-3" chatId={chatId} />
     </div>
   );
 });

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,12 +1,11 @@
-import { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react';
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useNavigate } from 'react-router-dom';
-import { Plus, MoreHorizontal, SquarePen, ChevronDown } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import toast from 'react-hot-toast';
 import type { Chat } from '@/types/chat.types';
 import type { Workspace } from '@/types/workspace.types';
 import { Button } from '@/components/ui/primitives/Button';
-import { Spinner } from '@/components/ui/primitives/Spinner';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { RenameModal } from '@/components/ui/RenameModal';
 import {
@@ -20,6 +19,7 @@ import {
   useDeleteWorkspaceMutation,
   useUpdateWorkspaceMutation,
 } from '@/hooks/queries/useWorkspaceQueries';
+import { useCloudWorkspacesQuery } from '@/hooks/queries/useCloudQueries';
 import { useToggleSet } from '@/hooks/useToggleSet';
 import { cn } from '@/utils/cn';
 import { useUIStore } from '@/store/uiStore';
@@ -32,10 +32,9 @@ import { UserProfileMenu } from './UserProfileMenu';
 import { SidebarChatItem } from './SidebarChatItem';
 import { SidebarResizeHandle } from './SidebarResizeHandle';
 import { SubThreadList } from './SubThreadList';
+import { SidebarWorkspaceGroup, SidebarCloudGroup } from './SidebarChatGroup';
 import { ChatDropdown } from './ChatDropdown';
 import { DROPDOWN_WIDTH, DROPDOWN_HEIGHT, DROPDOWN_MARGIN } from '@/config/constants';
-
-const CHATS_PER_WORKSPACE = 5;
 
 async function mutateWithToast<T>(
   mutateFn: () => Promise<T>,
@@ -88,184 +87,6 @@ function calculateDropdownPosition(buttonRect: DOMRect): { top: number; left: nu
 
   return { top, left };
 }
-
-interface WorkspaceGroupProps {
-  workspace: Workspace;
-  selectedChatId: string | null;
-  secondaryChatId: string | null;
-  dropdownChatId: string | null;
-  streamingChatIdSet: Set<string>;
-  isCollapsed: boolean;
-  onToggleCollapse: (workspaceId: string) => void;
-  onChatSelect: (chatId: string) => void;
-  onOpenInSplit?: (chatId: string) => void;
-  onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
-  onNewThread: (e: React.MouseEvent, workspaceId: string) => void;
-  onWorkspaceContextMenu: (e: React.MouseEvent<HTMLButtonElement>, workspaceId: string) => void;
-  expandedSubThreads: Set<string>;
-  onToggleSubThreads: (chatId: string) => void;
-}
-
-const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
-  workspace,
-  selectedChatId,
-  secondaryChatId,
-  dropdownChatId,
-  streamingChatIdSet,
-  isCollapsed,
-  onToggleCollapse,
-  onChatSelect,
-  onOpenInSplit,
-  onDropdownClick,
-  onNewThread,
-  onWorkspaceContextMenu,
-  expandedSubThreads,
-  onToggleSubThreads,
-}: WorkspaceGroupProps) {
-  const [isChatsExpanded, setIsChatsExpanded] = useState(false);
-  const [hoveredChatId, setHoveredChatId] = useState<string | null>(null);
-  const handleMouseEnter = useCallback((chatId: string) => setHoveredChatId(chatId), []);
-  const handleMouseLeave = useCallback(() => setHoveredChatId(null), []);
-
-  // Each non-collapsed workspace fires its own query on mount. Collapsing a
-  // workspace disables its query. If N simultaneous requests becomes a problem
-  // with many workspaces, default new/inactive workspaces to collapsed.
-  const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteChatsQuery(
-    {
-      workspaceId: workspace.id,
-      pinned: false,
-      enabled: !isCollapsed,
-    },
-  );
-
-  const chats = useMemo(() => {
-    if (!data?.pages) return [];
-    return data.pages.flatMap((page) => page.items);
-  }, [data?.pages]);
-
-  const visibleChats = isChatsExpanded ? chats : chats.slice(0, CHATS_PER_WORKSPACE);
-  const hasMoreLocalChats = chats.length > CHATS_PER_WORKSPACE;
-  const showLoadMore = isChatsExpanded && hasNextPage;
-
-  return (
-    <div>
-      <div className="group flex items-center gap-1 pb-2 pt-3.5">
-        <Button
-          variant="unstyled"
-          type="button"
-          onClick={() => onToggleCollapse(workspace.id)}
-          className="min-w-0 flex-1 text-left"
-        >
-          <span className="text-2xs font-medium uppercase tracking-wider text-text-quaternary transition-colors duration-200 group-hover:text-text-tertiary dark:text-text-dark-quaternary dark:group-hover:text-text-dark-tertiary">
-            {workspace.name}
-          </span>
-        </Button>
-        <Button
-          variant="unstyled"
-          type="button"
-          title="New thread"
-          onClick={(e) => onNewThread(e, workspace.id)}
-          className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-        >
-          <SquarePen className="h-3 w-3" />
-        </Button>
-        <Button
-          variant="unstyled"
-          type="button"
-          data-ws-dropdown-trigger
-          onClick={(e) => onWorkspaceContextMenu(e, workspace.id)}
-          className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-        >
-          <MoreHorizontal className="h-3 w-3" />
-        </Button>
-      </div>
-      {!isCollapsed && (
-        <div>
-          {isLoading ? null : chats.length === 0 ? (
-            <p className="py-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-              No threads
-            </p>
-          ) : (
-            <>
-              {visibleChats.map((chat) => (
-                <div key={chat.id}>
-                  <SidebarChatItem
-                    chat={chat}
-                    isSelected={chat.id === selectedChatId}
-                    isActive={chat.id === selectedChatId || chat.id === secondaryChatId}
-                    isHovered={hoveredChatId === chat.id}
-                    isDropdownOpen={dropdownChatId === chat.id}
-                    isChatStreaming={streamingChatIdSet.has(chat.id)}
-                    onSelect={onChatSelect}
-                    onOpenInSplit={onOpenInSplit}
-                    onDropdownClick={onDropdownClick}
-                    onMouseEnter={handleMouseEnter}
-                    onMouseLeave={handleMouseLeave}
-                    onToggleSubThreads={chat.sub_thread_count > 0 ? onToggleSubThreads : undefined}
-                    isSubThreadsExpanded={
-                      chat.sub_thread_count > 0 ? expandedSubThreads.has(chat.id) : undefined
-                    }
-                  />
-                  {chat.sub_thread_count > 0 && expandedSubThreads.has(chat.id) && (
-                    <SubThreadList
-                      parentChatId={chat.id}
-                      selectedChatId={selectedChatId}
-                      secondaryChatId={secondaryChatId}
-                      onSelect={onChatSelect}
-                      onDropdownClick={onDropdownClick}
-                      streamingChatIdSet={streamingChatIdSet}
-                    />
-                  )}
-                </div>
-              ))}
-              {hasMoreLocalChats && !isChatsExpanded && (
-                <Button
-                  variant="unstyled"
-                  type="button"
-                  onClick={() => setIsChatsExpanded(true)}
-                  className="flex w-full items-center gap-1 py-1.5 text-left text-xs text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
-                >
-                  Show more ({chats.length - CHATS_PER_WORKSPACE})
-                  <ChevronDown className="h-3 w-3" />
-                </Button>
-              )}
-              {(hasMoreLocalChats || showLoadMore) && isChatsExpanded && (
-                <div className="flex items-center gap-2 py-1.5">
-                  <Button
-                    variant="unstyled"
-                    type="button"
-                    onClick={() => setIsChatsExpanded(false)}
-                    className="text-2xs text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
-                  >
-                    Show less
-                  </Button>
-                  {showLoadMore && (
-                    <Button
-                      variant="unstyled"
-                      type="button"
-                      onClick={() => fetchNextPage()}
-                      disabled={isFetchingNextPage}
-                      className="flex items-center gap-1 text-2xs text-text-tertiary transition-colors duration-200 hover:text-text-primary disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
-                    >
-                      {isFetchingNextPage ? (
-                        <>
-                          <Spinner size="xs" />
-                          Loading…
-                        </>
-                      ) : (
-                        'Load more'
-                      )}
-                    </Button>
-                  )}
-                </div>
-              )}
-            </>
-          )}
-        </div>
-      )}
-    </div>
-  );
-});
 
 export interface SidebarProps {
   workspaces: Workspace[];
@@ -336,7 +157,12 @@ export function Sidebar({
     return pinnedChatsData.pages.flatMap((page) => page.items);
   }, [pinnedChatsData?.pages]);
 
-  const hasAnyContent = pinnedChats.length > 0 || workspaces.length > 0;
+  // Cloud projects (workspaces on the connected VPS, desktop only). Each renders
+  // its own paginated group, mirroring the local per-workspace groups.
+  const { data: cloudWorkspaces } = useCloudWorkspacesQuery(true);
+
+  const hasAnyContent =
+    pinnedChats.length > 0 || workspaces.length > 0 || (cloudWorkspaces?.length ?? 0) > 0;
 
   useEffect(() => {
     if (!selectedChatWorkspaceId) return;
@@ -713,6 +539,24 @@ export function Sidebar({
                   onDropdownClick={handleDropdownClick}
                   onNewThread={handleNewWorkspaceThread}
                   onWorkspaceContextMenu={handleWorkspaceContextMenu}
+                  expandedSubThreads={expandedSubThreads}
+                  onToggleSubThreads={handleToggleSubThreads}
+                />
+              ))}
+
+              {cloudWorkspaces?.map((workspace) => (
+                <SidebarCloudGroup
+                  key={workspace.id}
+                  workspace={workspace}
+                  selectedChatId={selectedChatId}
+                  secondaryChatId={secondaryChatId}
+                  dropdownChatId={dropdown?.chat.id ?? null}
+                  streamingChatIdSet={streamingChatIdSet}
+                  isCollapsed={collapsedWorkspaces.has(workspace.id)}
+                  onToggleCollapse={toggleWorkspaceCollapse}
+                  onChatSelect={handleChatSelect}
+                  onOpenInSplit={canOpenInSplit ? handleOpenInSplit : undefined}
+                  onDropdownClick={handleDropdownClick}
                   expandedSubThreads={expandedSubThreads}
                   onToggleSubThreads={handleToggleSubThreads}
                 />

--- a/frontend/src/components/layout/SidebarChatGroup.tsx
+++ b/frontend/src/components/layout/SidebarChatGroup.tsx
@@ -1,0 +1,332 @@
+import { useState, useMemo, useCallback, memo } from 'react';
+import type { InfiniteData } from '@tanstack/react-query';
+import { ChevronDown, SquarePen, MoreHorizontal } from 'lucide-react';
+import type { Chat } from '@/types/chat.types';
+import type { Workspace } from '@/types/workspace.types';
+import type { PaginatedChats } from '@/types/api.types';
+import { Button } from '@/components/ui/primitives/Button';
+import { Spinner } from '@/components/ui/primitives/Spinner';
+import { useInfiniteChatsQuery } from '@/hooks/queries/useChatQueries';
+import { useInfiniteCloudChatsQuery } from '@/hooks/queries/useCloudQueries';
+import { useStreamRestoration } from '@/hooks/useStreamRestoration';
+import { SidebarChatItem } from './SidebarChatItem';
+import { SubThreadList } from './SubThreadList';
+
+const CHATS_PER_WORKSPACE = 5;
+
+function flattenChatPages(data: InfiniteData<PaginatedChats> | undefined): Chat[] {
+  return data?.pages.flatMap((page) => page.items) ?? [];
+}
+
+interface ChatHoverProps {
+  isHovered: boolean;
+  onMouseEnter: (chatId: string) => void;
+  onMouseLeave: () => void;
+}
+
+// Selection + handler bundle every chat row needs, threaded through the group shell
+// unchanged. Kept as one object so the shell forwards it instead of re-listing nine props.
+interface ChatRowProps {
+  selectedChatId: string | null;
+  secondaryChatId: string | null;
+  dropdownChatId: string | null;
+  streamingChatIdSet: Set<string>;
+  onChatSelect: (chatId: string) => void;
+  onOpenInSplit?: (chatId: string) => void;
+  onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
+  expandedSubThreads: Set<string>;
+  onToggleSubThreads: (chatId: string) => void;
+}
+
+// One chat row: the item plus its expanded sub-thread list. Local and cloud render
+// this identically, so it lives in the shell instead of a per-group render prop.
+function SidebarChatRow({
+  chat,
+  hover,
+  rowProps,
+}: {
+  chat: Chat;
+  hover: ChatHoverProps;
+  rowProps: ChatRowProps;
+}) {
+  const {
+    selectedChatId,
+    secondaryChatId,
+    dropdownChatId,
+    streamingChatIdSet,
+    onChatSelect,
+    onOpenInSplit,
+    onDropdownClick,
+    expandedSubThreads,
+    onToggleSubThreads,
+  } = rowProps;
+  const hasSubThreads = chat.sub_thread_count > 0;
+
+  return (
+    <div>
+      <SidebarChatItem
+        chat={chat}
+        isSelected={chat.id === selectedChatId}
+        isActive={chat.id === selectedChatId || chat.id === secondaryChatId}
+        isHovered={hover.isHovered}
+        isDropdownOpen={dropdownChatId === chat.id}
+        isChatStreaming={streamingChatIdSet.has(chat.id)}
+        onSelect={onChatSelect}
+        onOpenInSplit={onOpenInSplit}
+        onDropdownClick={onDropdownClick}
+        onMouseEnter={hover.onMouseEnter}
+        onMouseLeave={hover.onMouseLeave}
+        onToggleSubThreads={hasSubThreads ? onToggleSubThreads : undefined}
+        isSubThreadsExpanded={hasSubThreads ? expandedSubThreads.has(chat.id) : undefined}
+      />
+      {hasSubThreads && expandedSubThreads.has(chat.id) && (
+        <SubThreadList
+          parentChatId={chat.id}
+          selectedChatId={selectedChatId}
+          secondaryChatId={secondaryChatId}
+          onSelect={onChatSelect}
+          onDropdownClick={onDropdownClick}
+          streamingChatIdSet={streamingChatIdSet}
+        />
+      )}
+    </div>
+  );
+}
+
+interface ChatGroupProps {
+  name: string;
+  // Set only for cloud groups, which need disambiguating from local projects of
+  // the same name; local groups render no tag.
+  originLabel?: 'cloud';
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  isLoading: boolean;
+  chats: Chat[];
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+  // Local groups supply new-thread + context-menu buttons; cloud groups none.
+  headerActions?: React.ReactNode;
+  rowProps: ChatRowProps;
+}
+
+// Shared sidebar group: collapse header (name + optional origin tag + actions),
+// loading/empty state, and the show-more / show-less / load-more pagination.
+// Owns the per-group hover + expand state so the local and cloud wrappers only
+// pick a query hook and fill the slots.
+const SidebarChatGroup = memo(function SidebarChatGroup({
+  name,
+  originLabel,
+  isCollapsed,
+  onToggleCollapse,
+  isLoading,
+  chats,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+  headerActions,
+  rowProps,
+}: ChatGroupProps) {
+  const [isChatsExpanded, setIsChatsExpanded] = useState(false);
+  const [hoveredChatId, setHoveredChatId] = useState<string | null>(null);
+  const handleMouseEnter = useCallback((chatId: string) => setHoveredChatId(chatId), []);
+  const handleMouseLeave = useCallback(() => setHoveredChatId(null), []);
+
+  const visibleChats = isChatsExpanded ? chats : chats.slice(0, CHATS_PER_WORKSPACE);
+  const hasMore = chats.length > CHATS_PER_WORKSPACE;
+  const showLoadMore = isChatsExpanded && hasNextPage;
+
+  return (
+    <div>
+      <div className="group flex items-center gap-1 pb-2 pt-3.5">
+        <Button
+          variant="unstyled"
+          type="button"
+          onClick={onToggleCollapse}
+          className="min-w-0 flex-1 text-left"
+        >
+          <span className="text-2xs font-medium uppercase tracking-wider text-text-quaternary transition-colors duration-200 group-hover:text-text-tertiary dark:text-text-dark-quaternary dark:group-hover:text-text-dark-tertiary">
+            {name}
+          </span>
+          {originLabel && (
+            <span className="ml-1 text-2xs lowercase text-text-quaternary dark:text-text-dark-quaternary">
+              ({originLabel})
+            </span>
+          )}
+        </Button>
+        {headerActions}
+      </div>
+      {!isCollapsed && (
+        <div>
+          {isLoading ? null : chats.length === 0 ? (
+            <p className="py-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+              No threads
+            </p>
+          ) : (
+            <>
+              {visibleChats.map((chat) => (
+                <SidebarChatRow
+                  key={chat.id}
+                  chat={chat}
+                  hover={{
+                    isHovered: hoveredChatId === chat.id,
+                    onMouseEnter: handleMouseEnter,
+                    onMouseLeave: handleMouseLeave,
+                  }}
+                  rowProps={rowProps}
+                />
+              ))}
+              {hasMore && !isChatsExpanded && (
+                <Button
+                  variant="unstyled"
+                  type="button"
+                  onClick={() => setIsChatsExpanded(true)}
+                  className="flex w-full items-center gap-1 py-1.5 text-left text-xs text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+                >
+                  Show more ({chats.length - CHATS_PER_WORKSPACE})
+                  <ChevronDown className="h-3 w-3" />
+                </Button>
+              )}
+              {(hasMore || showLoadMore) && isChatsExpanded && (
+                <div className="flex items-center gap-2 py-1.5">
+                  <Button
+                    variant="unstyled"
+                    type="button"
+                    onClick={() => setIsChatsExpanded(false)}
+                    className="text-2xs text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+                  >
+                    Show less
+                  </Button>
+                  {showLoadMore && (
+                    <Button
+                      variant="unstyled"
+                      type="button"
+                      onClick={onLoadMore}
+                      disabled={isFetchingNextPage}
+                      className="flex items-center gap-1 text-2xs text-text-tertiary transition-colors duration-200 hover:text-text-primary disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+                    >
+                      {isFetchingNextPage ? (
+                        <>
+                          <Spinner size="xs" />
+                          Loading…
+                        </>
+                      ) : (
+                        'Load more'
+                      )}
+                    </Button>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
+
+interface WorkspaceGroupProps extends ChatRowProps {
+  workspace: Workspace;
+  isCollapsed: boolean;
+  onToggleCollapse: (workspaceId: string) => void;
+  onNewThread: (e: React.MouseEvent, workspaceId: string) => void;
+  onWorkspaceContextMenu: (e: React.MouseEvent<HTMLButtonElement>, workspaceId: string) => void;
+}
+
+export const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
+  workspace,
+  isCollapsed,
+  onToggleCollapse,
+  onNewThread,
+  onWorkspaceContextMenu,
+  ...rowProps
+}: WorkspaceGroupProps) {
+  // Each non-collapsed workspace fires its own query on mount. Collapsing a
+  // workspace disables its query. If N simultaneous requests becomes a problem
+  // with many workspaces, default new/inactive workspaces to collapsed.
+  const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteChatsQuery(
+    {
+      workspaceId: workspace.id,
+      pinned: false,
+      enabled: !isCollapsed,
+    },
+  );
+  const chats = useMemo(() => flattenChatPages(data), [data]);
+
+  return (
+    <SidebarChatGroup
+      name={workspace.name}
+      isCollapsed={isCollapsed}
+      onToggleCollapse={() => onToggleCollapse(workspace.id)}
+      isLoading={isLoading}
+      chats={chats}
+      hasNextPage={!!hasNextPage}
+      isFetchingNextPage={isFetchingNextPage}
+      onLoadMore={() => void fetchNextPage()}
+      headerActions={
+        <>
+          <Button
+            variant="unstyled"
+            type="button"
+            title="New thread"
+            onClick={(e) => onNewThread(e, workspace.id)}
+            className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+          >
+            <SquarePen className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="unstyled"
+            type="button"
+            data-ws-dropdown-trigger
+            onClick={(e) => onWorkspaceContextMenu(e, workspace.id)}
+            className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+          >
+            <MoreHorizontal className="h-3 w-3" />
+          </Button>
+        </>
+      }
+      rowProps={rowProps}
+    />
+  );
+});
+
+interface CloudGroupProps extends ChatRowProps {
+  workspace: Workspace;
+  isCollapsed: boolean;
+  onToggleCollapse: (workspaceId: string) => void;
+}
+
+// A cloud project's chats — same shell as local, minus local-only affordances
+// (new thread, workspace context menu, which aren't wired for cloud).
+export const SidebarCloudGroup = memo(function SidebarCloudGroup({
+  workspace,
+  isCollapsed,
+  onToggleCollapse,
+  ...rowProps
+}: CloudGroupProps) {
+  const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } =
+    useInfiniteCloudChatsQuery(workspace.id, !isCollapsed);
+  const chats = useMemo(() => flattenChatPages(data), [data]);
+
+  // App-level restoration only sees local chats — restore cloud streams here from
+  // this group's fetched pages so reopened active VPS runs show the sidebar pulse
+  // and get tracked by the global watcher without first opening the chat. Continuous
+  // because cloud is polled (no push): each poll that surfaces a newly active run
+  // must register it, not just the first pass.
+  useStreamRestoration({ chats, isLoading, enabled: !isCollapsed, continuous: true });
+
+  return (
+    <SidebarChatGroup
+      name={workspace.name}
+      originLabel="cloud"
+      isCollapsed={isCollapsed}
+      onToggleCollapse={() => onToggleCollapse(workspace.id)}
+      isLoading={isLoading}
+      chats={chats}
+      hasNextPage={!!hasNextPage}
+      isFetchingNextPage={isFetchingNextPage}
+      onLoadMore={() => void fetchNextPage()}
+      rowProps={rowProps}
+    />
+  );
+});

--- a/frontend/src/components/sandbox/terminal/TerminalTab.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab.tsx
@@ -5,8 +5,7 @@ import 'xterm/css/xterm.css';
 
 import { Button } from '@/components/ui/primitives/Button';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
-import { authService } from '@/services/authService';
-import { WS_BASE_URL } from '@/lib/api';
+import { resolveSandboxWs } from '@/lib/api';
 
 import { getTerminalBackgroundClass } from '@/utils/terminal';
 import { useXterm } from '@/hooks/useXterm';
@@ -95,11 +94,12 @@ export const TerminalTab: FC<TerminalTabProps> = ({
     // do not leak into the next PTY — the server repaints via tmux on reattach.
     terminalRef.current?.reset();
 
-    const token = authService.getToken();
+    // Route to the cloud VPS WS host when the sandbox lives there, else local.
+    const { baseUrl, token } = resolveSandboxWs(sandboxId);
     if (!token) return;
 
     const terminalParam = terminalId ? `?terminalId=${encodeURIComponent(terminalId)}` : '';
-    const wsUrl = `${WS_BASE_URL}/${sandboxId}/terminal${terminalParam}`;
+    const wsUrl = `${baseUrl}/${sandboxId}/terminal${terminalParam}`;
 
     setSessionState('connecting');
     setCloseReason(null);

--- a/frontend/src/components/ui/AttachmentViewer.tsx
+++ b/frontend/src/components/ui/AttachmentViewer.tsx
@@ -7,7 +7,7 @@ import type { MessageAttachment } from '@/types/chat.types';
 import { Button } from './primitives/Button';
 import { Spinner } from './primitives/Spinner';
 import { cn } from '@/utils/cn';
-import { apiClient } from '@/lib/api';
+import { resolveChatClient } from '@/lib/api';
 import { fetchAttachmentBlob, downloadAttachmentFile } from '@/utils/file';
 import { isBrowserObjectUrl } from '@/utils/attachmentUrl';
 import { ImagePreviewModal } from './ImagePreviewModal';
@@ -15,6 +15,9 @@ import { ImagePreviewModal } from './ImagePreviewModal';
 interface AttachmentViewerProps {
   attachments: MessageAttachment[];
   uploadingAttachmentIds?: string[];
+  // Routes attachment fetch/download to the chat's backend — cloud messages carry
+  // relative /api/v1/attachments URLs that only resolve on the owning VPS.
+  chatId?: string;
 }
 
 interface ImageState {
@@ -207,7 +210,11 @@ function ImageThumbnail({
   return null;
 }
 
-function AttachmentViewerInner({ attachments, uploadingAttachmentIds }: AttachmentViewerProps) {
+function AttachmentViewerInner({
+  attachments,
+  uploadingAttachmentIds,
+  chatId,
+}: AttachmentViewerProps) {
   const [imageStates, setImageStates] = useState<Record<string, ImageState>>({});
   // Index into imageAttachments of the image currently shown in the lightbox; null means closed.
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
@@ -218,15 +225,18 @@ function AttachmentViewerInner({ attachments, uploadingAttachmentIds }: Attachme
     [uploadingAttachmentIds],
   );
 
-  const handleDownload = useCallback(async (url: string, fileName: string) => {
-    if (!url) return;
-    try {
-      await downloadAttachmentFile(url, fileName, apiClient);
-    } catch (error) {
-      logger.error('File download failed', 'AttachmentViewer', error);
-      throw error;
-    }
-  }, []);
+  const handleDownload = useCallback(
+    async (url: string, fileName: string) => {
+      if (!url) return;
+      try {
+        await downloadAttachmentFile(url, fileName, resolveChatClient(chatId));
+      } catch (error) {
+        logger.error('File download failed', 'AttachmentViewer', error);
+        throw error;
+      }
+    },
+    [chatId],
+  );
 
   const imageAttachments = useMemo(
     () => attachments.filter((a) => a.file_type === 'image'),
@@ -276,7 +286,7 @@ function AttachmentViewerInner({ attachments, uploadingAttachmentIds }: Attachme
             return;
           }
 
-          const blob = await fetchAttachmentBlob(attachment.file_url, apiClient);
+          const blob = await fetchAttachmentBlob(attachment.file_url, resolveChatClient(chatId));
           if (cancelled) return;
           const blobUrl = URL.createObjectURL(blob);
           ownedObjectUrlsRef.current.add(blobUrl);

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -7,9 +7,12 @@ export const queryKeys = {
   chat: (chatId?: string) => ['chat', chatId] as const,
   messages: (chatId?: string) => ['messages', chatId] as const,
   contextUsage: (chatId?: string) => ['chat', chatId, 'context-usage'] as const,
-  messageChanges: (messageId?: string) => ['message', messageId, 'changes'] as const,
-  messageFileDiff: (messageId?: string, path?: string) =>
-    ['message', messageId, 'changes', 'diff', path] as const,
+  // chatId is the routing dimension (local vs cloud backend) — keep it in the key so a
+  // message-keyed entry can't serve data fetched from the wrong backend under staleTime.
+  messageChanges: (chatId?: string, messageId?: string) =>
+    ['message', chatId, messageId, 'changes'] as const,
+  messageFileDiff: (chatId?: string, messageId?: string, path?: string) =>
+    ['message', chatId, messageId, 'changes', 'diff', path] as const,
   subThreads: (chatId?: string) => ['chat', chatId, 'sub-threads'] as const,
   auth: {
     user: 'auth-user',
@@ -59,9 +62,14 @@ export const queryKeys = {
     searchAll: (sandboxId?: string) => ['sandbox', sandboxId, 'search'] as const,
   },
   workspaces: ['workspaces'] as const,
-  workspaceResources: (workspaceId?: string) => ['workspaces', workspaceId, 'resources'] as const,
+  workspaceResources: (workspaceId?: string, chatId?: string) =>
+    ['workspaces', workspaceId, 'resources', chatId] as const,
   cloudWorkspaces: (cloudUrl?: string, connectedEmail?: string | null) =>
     ['cloud', 'workspaces', cloudUrl, connectedEmail] as const,
+  cloudChats: (cloudUrl?: string, connectedEmail?: string | null) =>
+    ['cloud', 'chats', cloudUrl, connectedEmail] as const,
+  // Prefix key for invalidating every cloud chats query regardless of instance/account.
+  cloudChatsAll: ['cloud', 'chats'] as const,
   models: 'models',
   github: {
     repos: (query: string) => ['github-repos', query] as const,

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -10,8 +10,10 @@ import type {
   UseQueryOptions,
   InfiniteData,
   Query,
+  QueryClient,
 } from '@tanstack/react-query';
 import { chatService } from '@/services/chatService';
+import { isCloudChat } from '@/utils/chatOrigin';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
 import type { Chat, ChatSearchResponse, ContextUsage, CreateChatRequest } from '@/types/chat.types';
 import type { ChangedFilesData, FileDiffData } from '@/types/sandbox.types';
@@ -29,6 +31,14 @@ const GLOBAL_WORKSPACE_SENTINEL = 'all';
 function isGlobalChatsQuery(query: Query): boolean {
   const key = query.queryKey;
   return key.length >= 5 && key[3] === GLOBAL_WORKSPACE_SENTINEL && key[4] === null;
+}
+
+// Cloud chats live in a separate query the local infinite-chats cache patches don't touch.
+// Centralized so a new chat mutation can't silently forget to refresh the cloud sidebar.
+function invalidateCloudChats(queryClient: QueryClient, chatId: string) {
+  if (isCloudChat(chatId)) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.cloudChatsAll });
+  }
 }
 
 export const useInfiniteChatsQuery = (options?: {
@@ -125,12 +135,13 @@ export const useContextUsageQuery = (
 };
 
 export const useMessageChangesQuery = (
+  chatId: string | undefined,
   messageId: string | undefined,
   options?: Partial<UseQueryOptions<ChangedFilesData>>,
 ) => {
   return useQuery({
-    queryKey: queryKeys.messageChanges(messageId),
-    queryFn: () => chatService.getMessageChanges(messageId!),
+    queryKey: queryKeys.messageChanges(chatId, messageId),
+    queryFn: () => chatService.getMessageChanges(chatId, messageId!),
     enabled: !!messageId,
     staleTime: Infinity,
     ...options,
@@ -138,13 +149,14 @@ export const useMessageChangesQuery = (
 };
 
 export const useMessageFileDiffQuery = (
+  chatId: string | undefined,
   messageId: string | undefined,
   path: string | undefined,
   options?: Partial<UseQueryOptions<FileDiffData>>,
 ) => {
   return useQuery({
-    queryKey: queryKeys.messageFileDiff(messageId, path),
-    queryFn: () => chatService.getMessageFileDiff(messageId!, path!),
+    queryKey: queryKeys.messageFileDiff(chatId, messageId, path),
+    queryFn: () => chatService.getMessageFileDiff(chatId, messageId!, path!),
     enabled: !!messageId && !!path,
     staleTime: Infinity,
     gcTime: 1000 * 60 * 5,
@@ -217,6 +229,7 @@ export const useUpdateChatMutation = createMutation<
     // Search results embed the chat title, so a rename leaves a stale title
     // visible until the search query is refetched.
     queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
+    invalidateCloudChats(queryClient, updatedChat.id);
 
     if (updatedChat.parent_chat_id) {
       queryClient.invalidateQueries({
@@ -239,6 +252,7 @@ export const usePinChatMutation = createMutation<Chat, Error, { chatId: string; 
       queryKey: [queryKeys.chats, 'infinite'],
     });
     queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
+    invalidateCloudChats(queryClient, updatedChat.id);
   },
 );
 
@@ -288,6 +302,7 @@ export const useDeleteChatMutation = createMutation<void, Error, string>(
     queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
     queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
     queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
+    invalidateCloudChats(queryClient, chatId);
     useMessageQueueStore.getState().cleanupChat(chatId);
   },
 );
@@ -328,6 +343,9 @@ export const useCreateSubThreadMutation = (parentChatId: string) => {
         queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] }),
         queryClient.invalidateQueries({ queryKey: queryKeys.workspaces }),
       ]);
+      // A cloud parent lives in the cloud sidebar list, not the local infinite query —
+      // refetch it so the parent's bumped sub_thread_count unlocks the expand control.
+      invalidateCloudChats(queryClient, parentChatId);
     },
   });
 };

--- a/frontend/src/hooks/queries/useCloudQueries.ts
+++ b/frontend/src/hooks/queries/useCloudQueries.ts
@@ -1,8 +1,10 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { cloudChatService } from '@/services/cloudChatService';
 import { queryKeys } from '@/hooks/queries/queryKeys';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import type { Workspace } from '@/types/workspace.types';
+
+const CLOUD_CHATS_PER_PAGE = 25;
 
 // Keyed by cloudUrl + connectedEmail so switching instance or account never
 // serves the previous connection's cached list.
@@ -14,5 +16,33 @@ export const useCloudWorkspacesQuery = (enabled: boolean) => {
     queryFn: () => cloudChatService.listWorkspaces(),
     enabled: enabled && !!cloudUrl,
     staleTime: 30_000,
+  });
+};
+
+// Cloud chats for one project, paginated like the local sidebar groups. The
+// queryFn registers returned IDs as cloud-owned (markCloudChats), so opening one
+// routes its messages/status/SSE to the VPS. Polled so cloud-side activity (new
+// chats, runs starting) surfaces without a manual refresh — the desktop has no
+// push channel for cloud state. Key extends queryKeys.cloudChats so the
+// LandingPage invalidation prefix-matches every project's query.
+export const useInfiniteCloudChatsQuery = (workspaceId: string, enabled: boolean) => {
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
+  const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
+  return useInfiniteQuery({
+    queryKey: [...queryKeys.cloudChats(cloudUrl, connectedEmail), 'infinite', workspaceId] as const,
+    queryFn: ({ pageParam }) =>
+      cloudChatService.listChats({
+        page: pageParam as number,
+        per_page: CLOUD_CHATS_PER_PAGE,
+        workspace_id: workspaceId,
+      }),
+    getNextPageParam: (lastPage) => {
+      const nextPage = lastPage.page + 1;
+      return nextPage <= lastPage.pages ? nextPage : undefined;
+    },
+    initialPageParam: 1,
+    enabled: enabled && !!cloudUrl,
+    staleTime: 10_000,
+    refetchInterval: 15_000,
   });
 };

--- a/frontend/src/hooks/queries/useWorkspaceQueries.ts
+++ b/frontend/src/hooks/queries/useWorkspaceQueries.ts
@@ -15,11 +15,12 @@ import { queryKeys } from './queryKeys';
 
 export const useWorkspaceResourcesQuery = (
   workspaceId: string | undefined,
+  chatId?: string,
   options?: Partial<UseQueryOptions<WorkspaceResources>>,
 ) => {
   return useQuery({
-    queryKey: queryKeys.workspaceResources(workspaceId),
-    queryFn: () => workspaceService.getWorkspaceResources(workspaceId!),
+    queryKey: queryKeys.workspaceResources(workspaceId, chatId),
+    queryFn: () => workspaceService.getWorkspaceResources(workspaceId!, chatId),
     enabled: !!workspaceId,
     staleTime: 30_000,
     ...options,

--- a/frontend/src/hooks/useCheckpointRestore.ts
+++ b/frontend/src/hooks/useCheckpointRestore.ts
@@ -4,18 +4,24 @@ import { chatService } from '@/services/chatService';
 import { invalidateAfterGitRestore } from '@/hooks/queries/useSandboxQueries';
 import { queryKeys } from '@/hooks/queries/queryKeys';
 
-export function useCheckpointRestore(messageId: string, sandboxId?: string) {
+export function useCheckpointRestore(
+  chatId: string | undefined,
+  messageId: string,
+  sandboxId?: string,
+) {
   const queryClient = useQueryClient();
 
   const restoreMutation = useMutation({
-    mutationFn: () => chatService.restoreMessageCheckpoint(messageId),
+    mutationFn: () => chatService.restoreMessageCheckpoint(chatId, messageId),
     onSuccess: async (result) => {
       if (!result.success) {
         toast.error(result.error || 'Failed to restore checkpoint');
         return;
       }
       toast.success('Workspace restored to before this run');
-      await queryClient.invalidateQueries({ queryKey: queryKeys.messageChanges(messageId) });
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.messageChanges(chatId, messageId),
+      });
       if (sandboxId) {
         await invalidateAfterGitRestore(queryClient, sandboxId);
       }

--- a/frontend/src/hooks/useStreamRestoration.ts
+++ b/frontend/src/hooks/useStreamRestoration.ts
@@ -9,6 +9,10 @@ interface UseStreamRestorationOptions {
   chats: Chat[] | undefined;
   isLoading: boolean;
   enabled?: boolean;
+  // Cloud has no push channel, so the list is polled — rerun restoration on each
+  // changed list (deduping already-tracked chats) instead of latching after the
+  // first pass. Local stays single-pass: its global SSE surfaces new runs live.
+  continuous?: boolean;
 }
 
 // After the chat list loads, writes StreamMetadata entries for any chat (or
@@ -19,20 +23,30 @@ export function useStreamRestoration({
   chats,
   isLoading,
   enabled = true,
+  continuous = false,
 }: UseStreamRestorationOptions) {
   const hasRestoredRef = useRef(false);
 
   useEffect(() => {
-    if (!enabled || hasRestoredRef.current || isLoading || !chats || chats.length === 0) {
+    if (!enabled || isLoading || !chats || chats.length === 0) {
+      return;
+    }
+    if (!continuous && hasRestoredRef.current) {
       return;
     }
 
     hasRestoredRef.current = true;
 
     const discoverActiveStreams = async () => {
+      // Skip chats already tracked — avoids redundant status checks on reruns and
+      // keeps an existing entry's startTime from resetting on each poll.
+      const tracked = new Set(
+        useStreamStore.getState().activeStreamMetadata.map((meta) => meta.chatId),
+      );
       const chatsToCheck = chats.slice(0, 20);
 
       const checkAndRegister = async (chatId: string) => {
+        if (tracked.has(chatId)) return;
         try {
           const status = await chatService.checkChatStatus(chatId);
           if (status?.has_active_task && status.message_id) {
@@ -76,7 +90,7 @@ export function useStreamRestoration({
     discoverActiveStreams().catch((error) => {
       logger.error('Stream restoration failed', 'useStreamRestoration', error);
     });
-  }, [chats, isLoading, enabled]);
+  }, [chats, isLoading, enabled, continuous]);
 
   return { hasRestored: hasRestoredRef.current };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { authStorage, cloudAuthStorage } from '@/utils/storage';
 import { invalidateSessionAndRedirect } from '@/utils/authSession';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
+import { isCloudChat, isCloudSandbox, clearCloudOrigins } from '@/utils/chatOrigin';
 
 type RequestMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 
@@ -70,6 +71,10 @@ const cloudAuth: ClientAuth = {
   // cloud credentials so the settings UI reflects a disconnected state.
   onSessionExpired: () => {
     cloudAuthStorage.clear();
+    // Drop persisted cloud origin IDs too, matching manual disconnect — otherwise
+    // stale IDs keep routing to the (now-gone) VPS and can misroute links after
+    // reconnecting to a different VPS/account.
+    clearCloudOrigins();
     useCloudSettingsStore.getState().clearCloud();
   },
 };
@@ -105,6 +110,12 @@ class APIClient {
 
   getBaseUrl(): string {
     return this.baseURL;
+  }
+
+  // Exposes the client's own token so callers (e.g. the SSE query-param) don't
+  // re-derive the client↔token-store pairing already encoded in `auth`.
+  getToken(): string | null {
+    return this.auth.getToken();
   }
 
   setBaseUrl(url: string): void {
@@ -278,6 +289,9 @@ class APIClient {
 
 let API_BASE_URL: string = resolveHttpBaseUrl(import.meta.env.VITE_API_BASE_URL);
 export let WS_BASE_URL: string = resolveWsBaseUrl(import.meta.env.VITE_WS_URL);
+// Cloud WS origin, set alongside the cloud HTTP base so sandbox terminals on the
+// VPS connect to the right host. Empty until a VPS is connected.
+let CLOUD_WS_BASE_URL = '';
 
 export const apiClient = new APIClient(API_BASE_URL, localAuth);
 
@@ -288,6 +302,26 @@ export const remoteApiClient = new APIClient('', cloudAuth);
 const savedCloudUrl = useCloudSettingsStore.getState().cloudUrl;
 if (savedCloudUrl) setCloudApiBaseUrl(savedCloudUrl);
 
+// Route a per-chat request to the backend that owns the chat: the cloud VPS if
+// the chat was created there, otherwise the local instance.
+export function resolveChatClient(chatId: string | undefined): APIClient {
+  return chatId && isCloudChat(chatId) ? remoteApiClient : apiClient;
+}
+
+// Same routing for per-sandbox calls (files, git, secrets, search).
+export function resolveSandboxClient(sandboxId: string | undefined): APIClient {
+  return sandboxId && isCloudSandbox(sandboxId) ? remoteApiClient : apiClient;
+}
+
+// Terminal WebSockets bypass APIClient, so resolve the base URL + token for the
+// backend that owns the sandbox.
+export function resolveSandboxWs(sandboxId: string): { baseUrl: string; token: string | null } {
+  if (isCloudSandbox(sandboxId)) {
+    return { baseUrl: CLOUD_WS_BASE_URL, token: remoteApiClient.getToken() };
+  }
+  return { baseUrl: WS_BASE_URL, token: apiClient.getToken() };
+}
+
 export function setApiPort(port: number): void {
   const origin = `http://127.0.0.1:${port}`;
   API_BASE_URL = `${origin}/api/v1`;
@@ -297,5 +331,7 @@ export function setApiPort(port: number): void {
 
 // `url` is the VPS origin (e.g. https://vps.example.com); the API lives under /api/v1.
 export function setCloudApiBaseUrl(url: string): void {
-  remoteApiClient.setBaseUrl(`${trimTrailingSlash(url)}/api/v1`);
+  const base = trimTrailingSlash(url);
+  remoteApiClient.setBaseUrl(`${base}/api/v1`);
+  CLOUD_WS_BASE_URL = resolveWsBaseUrl(`${base}/api/v1/ws`);
 }

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -136,7 +136,10 @@ export function ChatPage() {
   const workspaces = useWorkspacesList();
   const { data: settings } = useSettingsQuery();
 
-  const { data: workspaceResources } = useWorkspaceResourcesQuery(currentChat?.workspace_id);
+  const { data: workspaceResources } = useWorkspaceResourcesQuery(
+    currentChat?.workspace_id,
+    chatId,
+  );
 
   const prevChatIdForResetRef = useRef(chatId);
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -30,9 +30,11 @@ import {
   DEFAULT_PLAN_MODE,
   DEFAULT_PERSONA,
 } from '@/store/chatSettingsStore';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import { cloudChatService } from '@/services/cloudChatService';
-import { openExternalUrl } from '@/utils/openExternal';
+import { markCloudChats } from '@/utils/chatOrigin';
+import { queryKeys } from '@/hooks/queries/queryKeys';
 import { useAuthStore } from '@/store/authStore';
 import { useCreateChatMutation } from '@/hooks/queries/useChatQueries';
 import { useWorkspacesList, useWorkspaceResourcesQuery } from '@/hooks/queries/useWorkspaceQueries';
@@ -81,6 +83,7 @@ export function LandingPage() {
   const modelMap = useModelMap(isAuthenticated);
 
   const createChat = useCreateChatMutation();
+  const queryClient = useQueryClient();
   const [message, setMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const consumedInitialMessageRef = useRef(false);
@@ -118,6 +121,7 @@ export function LandingPage() {
   // @file mentions don't apply there.
   const { data: workspaceResources } = useWorkspaceResourcesQuery(
     selectedWorkspaceId ?? undefined,
+    undefined,
     {
       enabled: isAuthenticated && !!selectedWorkspaceId && !isCloud,
     },
@@ -234,27 +238,20 @@ export function LandingPage() {
           setMessage('');
           useChatStore.getState().setAttachedFilesForChat(PENDING_NEW_CHAT_KEY, []);
 
-          // cloudChatService.connect stores cloudUrl slash-trimmed.
-          const chatUrl = `${useCloudSettingsStore.getState().cloudUrl}/chat/${newChat.id}`;
-          toast.success(
-            (t) => (
-              <span className="flex items-center gap-2">
-                Started on your cloud instance.
-                <Button
-                  type="button"
-                  variant="unstyled"
-                  onClick={() => {
-                    void openExternalUrl(chatUrl);
-                    toast.dismiss(t.id);
-                  }}
-                  className="font-medium underline underline-offset-2 hover:text-text-primary dark:hover:text-text-dark-primary"
-                >
-                  Open
-                </Button>
-              </span>
-            ),
-            { duration: 8000 },
-          );
+          // Register the chat as cloud-owned and refresh the sidebar's Cloud list
+          // so it appears immediately and routes to the VPS when opened.
+          markCloudChats([newChat.id]);
+          const cloud = useCloudSettingsStore.getState();
+          void queryClient.invalidateQueries({
+            queryKey: queryKeys.cloudChats(cloud.cloudUrl, cloud.connectedEmail),
+          });
+
+          useModelStore.getState().selectModel(newChat.id, selectedModelId);
+          useChatSettingsStore.getState().initChatFromDefaults(newChat.id);
+          // Run is already started on the VPS — open the chat without an
+          // initialPrompt so the page reconnects to the live stream instead of
+          // firing a second turn.
+          navigate(`/chat/${newChat.id}`);
         } catch (error) {
           toast.error(error instanceof Error ? error.message : 'Failed to start cloud chat');
         } finally {

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -1,8 +1,8 @@
-import { apiClient, StreamResponse } from '@/lib/api';
+import { apiClient, resolveChatClient, StreamResponse } from '@/lib/api';
 import { ensureResponse, serviceCall, buildQueryString } from '@/services/base/BaseService';
-import { authService } from '@/services/authService';
 import { validateRequired, validateId } from '@/utils/validation';
 import { chatStorage } from '@/utils/storage';
+import { isCloudChat, markCloudChats, markCloudSandboxes } from '@/utils/chatOrigin';
 import type {
   ChatRequest,
   Chat,
@@ -54,7 +54,7 @@ async function createCompletion(
     async () => {
       const formData = buildChatFormData(request);
 
-      const taskResponse = await apiClient.postForm<{
+      const taskResponse = await resolveChatClient(request.chat_id).postForm<{
         chat_id: string;
         message_id: string;
         last_seq?: number;
@@ -82,7 +82,7 @@ async function startCompletion(request: ChatRequest): Promise<{ messageId: strin
 
   return serviceCall(async () => {
     const formData = buildChatFormData(request);
-    const response = await apiClient.postForm<{
+    const response = await resolveChatClient(request.chat_id).postForm<{
       chat_id: string;
       message_id: string;
     }>('/chat/chat', formData);
@@ -97,7 +97,7 @@ async function checkChatStatus(chatId: string): Promise<{
   stream_id?: string;
   last_seq?: number;
 } | null> {
-  return serviceCall(() => apiClient.get(`/chat/chats/${chatId}/status`));
+  return serviceCall(() => resolveChatClient(chatId).get(`/chat/chats/${chatId}/status`));
 }
 
 async function reconnectToStream(
@@ -119,7 +119,7 @@ async function reconnectToStream(
 
 async function stopStream(chatId: string): Promise<void> {
   await serviceCall(async () => {
-    await apiClient.delete(`/chat/chats/${chatId}/stream`);
+    await resolveChatClient(chatId).delete(`/chat/chats/${chatId}/stream`);
   });
 }
 
@@ -137,7 +137,7 @@ async function getMessages(
     const queryString = buildQueryString(params);
     const endpoint = `/chat/chats/${chatId}/messages${queryString}`;
 
-    const response = await apiClient.get<PaginatedMessages>(endpoint);
+    const response = await resolveChatClient(chatId).get<PaginatedMessages>(endpoint);
     return ensureResponse(response, 'Failed to fetch messages');
   });
 }
@@ -169,15 +169,30 @@ async function getChat(chatId: string): Promise<Chat> {
   validateId(chatId, 'Chat ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.get<Chat>(`/chat/chats/${chatId}`);
-    return ensureResponse(response, 'Failed to fetch chat');
+    const response = await resolveChatClient(chatId).get<Chat>(`/chat/chats/${chatId}`);
+    const chat = ensureResponse(response, 'Failed to fetch chat');
+    // Register a cloud chat's sandbox so its files/git/terminal route to the VPS
+    // even on a cold deep-link, before the sidebar list has run.
+    if (isCloudChat(chatId) && chat.sandbox_id) {
+      markCloudSandboxes([chat.sandbox_id]);
+    }
+    return chat;
   });
 }
 
 async function createChat(data: CreateChatRequest): Promise<Chat> {
   return serviceCall(async () => {
-    const response = await apiClient.post<Chat>('/chat/chats', data);
-    return ensureResponse(response, 'Failed to create chat');
+    // A sub-thread inherits its parent's backend — route to the cloud VPS when the
+    // parent lives there, then mark the child (and its sandbox) cloud-owned so its
+    // turns, files, and terminal follow it instead of falling back to local.
+    const parentChatId = data.parent_chat_id;
+    const response = await resolveChatClient(parentChatId).post<Chat>('/chat/chats', data);
+    const chat = ensureResponse(response, 'Failed to create chat');
+    if (parentChatId && isCloudChat(parentChatId)) {
+      markCloudChats([chat.id]);
+      if (chat.sandbox_id) markCloudSandboxes([chat.sandbox_id]);
+    }
+    return chat;
   });
 }
 
@@ -185,7 +200,10 @@ async function updateChat(chatId: string, updateData: { title?: string }): Promi
   validateId(chatId, 'Chat ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.patch<Chat>(`/chat/chats/${chatId}`, updateData);
+    const response = await resolveChatClient(chatId).patch<Chat>(
+      `/chat/chats/${chatId}`,
+      updateData,
+    );
     return ensureResponse(response, 'Failed to update chat');
   });
 }
@@ -194,7 +212,7 @@ async function deleteChat(chatId: string): Promise<void> {
   validateId(chatId, 'Chat ID');
 
   await serviceCall(async () => {
-    await apiClient.delete(`/chat/chats/${chatId}`);
+    await resolveChatClient(chatId).delete(`/chat/chats/${chatId}`);
   });
 }
 
@@ -208,7 +226,9 @@ async function getContextUsage(chatId: string): Promise<ContextUsage> {
   validateId(chatId, 'Chat ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.get<ContextUsage>(`/chat/chats/${chatId}/context-usage`);
+    const response = await resolveChatClient(chatId).get<ContextUsage>(
+      `/chat/chats/${chatId}/context-usage`,
+    );
     return ensureResponse(response, 'Failed to fetch context usage');
   });
 }
@@ -226,7 +246,8 @@ function createEventSource(
   signal?: AbortSignal,
   baselineSeq?: number,
 ): EventSource {
-  const token = authService.getToken();
+  const client = resolveChatClient(chatId);
+  const token = client.getToken();
   if (!token) {
     throw new Error('Authentication token required');
   }
@@ -238,7 +259,7 @@ function createEventSource(
     chatStorage.setEventId(chatId, String(afterSeq));
   }
 
-  const baseUrl = `${apiClient.getBaseUrl()}/chat/chats/${chatId}/stream`;
+  const baseUrl = `${client.getBaseUrl()}/chat/chats/${chatId}/stream`;
 
   const params = new URLSearchParams();
   params.append('token', token);
@@ -266,8 +287,19 @@ function createEventSource(
 async function getSubThreads(chatId: string): Promise<Chat[]> {
   validateId(chatId, 'Chat ID');
   return serviceCall(async () => {
-    const response = await apiClient.get<Chat[]>(`/chat/chats/${chatId}/sub-threads`);
-    return ensureResponse(response, 'Failed to fetch sub-threads');
+    const response = await resolveChatClient(chatId).get<Chat[]>(
+      `/chat/chats/${chatId}/sub-threads`,
+    );
+    const subThreads = ensureResponse(response, 'Failed to fetch sub-threads');
+    // A cloud parent's sub-threads live on the VPS too — register them so opening
+    // one routes its stream/files/terminal to the cloud, not local.
+    if (isCloudChat(chatId)) {
+      markCloudChats(subThreads.map((chat) => chat.id));
+      markCloudSandboxes(
+        subThreads.map((chat) => chat.sandbox_id).filter((id): id is string => !!id),
+      );
+    }
+    return subThreads;
   });
 }
 
@@ -275,7 +307,9 @@ async function pinChat(chatId: string): Promise<Chat> {
   validateId(chatId, 'Chat ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.patch<Chat>(`/chat/chats/${chatId}`, { pinned: true });
+    const response = await resolveChatClient(chatId).patch<Chat>(`/chat/chats/${chatId}`, {
+      pinned: true,
+    });
     return ensureResponse(response, 'Failed to pin chat');
   });
 }
@@ -284,7 +318,9 @@ async function unpinChat(chatId: string): Promise<Chat> {
   validateId(chatId, 'Chat ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.patch<Chat>(`/chat/chats/${chatId}`, { pinned: false });
+    const response = await resolveChatClient(chatId).patch<Chat>(`/chat/chats/${chatId}`, {
+      pinned: false,
+    });
     return ensureResponse(response, 'Failed to unpin chat');
   });
 }
@@ -311,7 +347,7 @@ async function generateChatTitle(chatId: string): Promise<string> {
   validateId(chatId, 'Chat ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.post<{ title: string }>(
+    const response = await resolveChatClient(chatId).post<{ title: string }>(
       `/chat/chats/${chatId}/generate-title`,
     );
 
@@ -319,33 +355,47 @@ async function generateChatTitle(chatId: string): Promise<string> {
   });
 }
 
-async function getMessageChanges(messageId: string): Promise<ChangedFilesData> {
+// These endpoints are keyed by messageId but live on whichever backend owns the
+// chat, so callers thread chatId through purely for routing.
+async function getMessageChanges(
+  chatId: string | undefined,
+  messageId: string,
+): Promise<ChangedFilesData> {
   validateId(messageId, 'Message ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.get<ChangedFilesData>(`/chat/messages/${messageId}/changes`);
+    const response = await resolveChatClient(chatId).get<ChangedFilesData>(
+      `/chat/messages/${messageId}/changes`,
+    );
     return ensureResponse(response, 'Failed to load changed files');
   });
 }
 
-async function getMessageFileDiff(messageId: string, path: string): Promise<FileDiffData> {
+async function getMessageFileDiff(
+  chatId: string | undefined,
+  messageId: string,
+  path: string,
+): Promise<FileDiffData> {
   validateId(messageId, 'Message ID');
   validateRequired(path, 'Path');
 
   return serviceCall(async () => {
     const queryString = buildQueryString({ path });
-    const response = await apiClient.get<FileDiffData>(
+    const response = await resolveChatClient(chatId).get<FileDiffData>(
       `/chat/messages/${messageId}/changes/diff${queryString}`,
     );
     return ensureResponse(response, 'Failed to load file diff');
   });
 }
 
-async function restoreMessageCheckpoint(messageId: string): Promise<GitCommitResult> {
+async function restoreMessageCheckpoint(
+  chatId: string | undefined,
+  messageId: string,
+): Promise<GitCommitResult> {
   validateId(messageId, 'Message ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.post<GitCommitResult>(
+    const response = await resolveChatClient(chatId).post<GitCommitResult>(
       `/chat/messages/${messageId}/checkpoint/restore-all`,
     );
     return ensureResponse(response, 'Failed to restore checkpoint');

--- a/frontend/src/services/cloudChatService.ts
+++ b/frontend/src/services/cloudChatService.ts
@@ -1,12 +1,13 @@
 import { remoteApiClient, setCloudApiBaseUrl, trimTrailingSlash } from '@/lib/api';
-import { ensureResponse, serviceCall } from '@/services/base/BaseService';
+import { ensureResponse, serviceCall, buildQueryString } from '@/services/base/BaseService';
 import { buildChatFormData } from '@/services/chatService';
 import { cloudAuthStorage } from '@/utils/storage';
+import { markCloudChats, markCloudSandboxes, clearCloudOrigins } from '@/utils/chatOrigin';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import type { AuthResponse } from '@/types/user.types';
 import type { Workspace } from '@/types/workspace.types';
 import type { Chat, ChatRequest, CreateChatRequest } from '@/types/chat.types';
-import type { PaginatedResponse } from '@/types/api.types';
+import type { PaginatedChats, PaginatedResponse } from '@/types/api.types';
 
 // Log into the VPS and persist its refresh token. The remote client mints
 // access tokens from it on demand, so the desktop stays connected across restarts.
@@ -28,7 +29,28 @@ async function connect(url: string, email: string, password: string): Promise<vo
 
 function disconnect(): void {
   cloudAuthStorage.clear();
+  clearCloudOrigins();
   useCloudSettingsStore.getState().clearCloud();
+}
+
+// List chats on the VPS and register their chat + sandbox IDs as cloud-owned so
+// chatService and sandboxService route their reads, status checks, SSE streams,
+// stops, files, git, and terminal back to the VPS.
+async function listChats(params?: {
+  page?: number;
+  per_page?: number;
+  workspace_id?: string;
+}): Promise<PaginatedChats> {
+  return serviceCall(async () => {
+    const queryString = buildQueryString(params);
+    const response = await remoteApiClient.get<PaginatedChats>(`/chat/chats${queryString}`);
+    const data = ensureResponse(response, 'Failed to load cloud chats');
+    markCloudChats(data.items.map((chat) => chat.id));
+    markCloudSandboxes(
+      data.items.map((chat) => chat.sandbox_id).filter((id): id is string => !!id),
+    );
+    return data;
+  });
 }
 
 async function listWorkspaces(): Promise<Workspace[]> {
@@ -57,6 +79,7 @@ export const cloudChatService = {
   connect,
   disconnect,
   listWorkspaces,
+  listChats,
   createChat,
   startCompletion,
 };

--- a/frontend/src/services/permissionService.ts
+++ b/frontend/src/services/permissionService.ts
@@ -1,4 +1,4 @@
-import { apiClient } from '@/lib/api';
+import { resolveChatClient } from '@/lib/api';
 import { serviceCall } from '@/services/base/BaseService';
 import { validateId } from '@/utils/validation';
 
@@ -14,7 +14,10 @@ async function respondToPermission(
     const formData = new FormData();
     formData.append('option_id', optionId);
 
-    await apiClient.postForm(`/chat/chats/${chatId}/permissions/${requestId}/respond`, formData);
+    await resolveChatClient(chatId).postForm(
+      `/chat/chats/${chatId}/permissions/${requestId}/respond`,
+      formData,
+    );
   });
 }
 

--- a/frontend/src/services/queueService.ts
+++ b/frontend/src/services/queueService.ts
@@ -1,4 +1,4 @@
-import { apiClient } from '@/lib/api';
+import { resolveChatClient } from '@/lib/api';
 import { ensureResponse, serviceCall } from '@/services/base/BaseService';
 import { DEFAULT_PERSONA, DEFAULT_PERMISSION_MODE } from '@/store/chatSettingsStore';
 import type { PermissionMode } from '@/store/chatSettingsStore';
@@ -42,7 +42,7 @@ async function queueMessage(
       });
     }
 
-    const response = await apiClient.postForm<QueueAddResponse>(
+    const response = await resolveChatClient(chatId).postForm<QueueAddResponse>(
       `/chat/chats/${chatId}/queue`,
       formData,
     );
@@ -54,7 +54,9 @@ async function getQueue(chatId: string): Promise<QueuedMessage[]> {
   validateId(chatId, 'Chat ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.get<QueuedMessage[]>(`/chat/chats/${chatId}/queue`);
+    const response = await resolveChatClient(chatId).get<QueuedMessage[]>(
+      `/chat/chats/${chatId}/queue`,
+    );
     return ensureResponse(response, 'Failed to fetch queue');
   });
 }
@@ -69,7 +71,7 @@ async function updateQueuedMessage(
   validateRequired(content, 'Content');
 
   return serviceCall(async () => {
-    const response = await apiClient.patch<QueuedMessage>(
+    const response = await resolveChatClient(chatId).patch<QueuedMessage>(
       `/chat/chats/${chatId}/queue/${messageId}`,
       { content },
     );
@@ -82,7 +84,7 @@ async function deleteQueuedMessage(chatId: string, messageId: string): Promise<v
   validateId(messageId, 'Message ID');
 
   await serviceCall(async () => {
-    await apiClient.delete(`/chat/chats/${chatId}/queue/${messageId}`);
+    await resolveChatClient(chatId).delete(`/chat/chats/${chatId}/queue/${messageId}`);
   });
 }
 
@@ -91,7 +93,7 @@ async function sendNow(chatId: string, messageId: string): Promise<void> {
   validateId(messageId, 'Message ID');
 
   await serviceCall(async () => {
-    await apiClient.post(`/chat/chats/${chatId}/queue/${messageId}/send-now`);
+    await resolveChatClient(chatId).post(`/chat/chats/${chatId}/queue/${messageId}/send-now`);
   });
 }
 
@@ -99,7 +101,7 @@ async function clearQueue(chatId: string): Promise<void> {
   validateId(chatId, 'Chat ID');
 
   await serviceCall(async () => {
-    await apiClient.delete(`/chat/chats/${chatId}/queue`);
+    await resolveChatClient(chatId).delete(`/chat/chats/${chatId}/queue`);
   });
 }
 

--- a/frontend/src/services/sandboxService.ts
+++ b/frontend/src/services/sandboxService.ts
@@ -1,4 +1,4 @@
-import { apiClient } from '@/lib/api';
+import { resolveSandboxClient } from '@/lib/api';
 import { buildQueryString, ensureResponse, serviceCall } from '@/services/base/BaseService';
 import { NotFoundError, ValidationError } from '@/services/base/ServiceError';
 import type {
@@ -24,7 +24,7 @@ async function getSandboxFilesMetadata(sandboxId: string): Promise<FileMetadata[
 
   return serviceCall(async () => {
     const url = `/sandbox/${sandboxId}/files/metadata`;
-    const response = await apiClient.get<{ files: FileMetadata[] }>(url);
+    const response = await resolveSandboxClient(sandboxId).get<{ files: FileMetadata[] }>(url);
 
     if (!response || !response.files) {
       return [];
@@ -40,7 +40,7 @@ async function getFileContent(sandboxId: string, filePath: string): Promise<File
 
   return serviceCall(async () => {
     const url = `/sandbox/${sandboxId}/files/content/${filePath}`;
-    const response = await apiClient.get<FileContent>(url);
+    const response = await resolveSandboxClient(sandboxId).get<FileContent>(url);
 
     if (!response) {
       throw new NotFoundError('File not found');
@@ -62,10 +62,13 @@ async function updateFile(
   }
 
   return serviceCall(async () => {
-    const response = await apiClient.put<UpdateFileResult>(`/sandbox/${sandboxId}/files`, {
-      file_path: filePath,
-      content,
-    });
+    const response = await resolveSandboxClient(sandboxId).put<UpdateFileResult>(
+      `/sandbox/${sandboxId}/files`,
+      {
+        file_path: filePath,
+        content,
+      },
+    );
 
     return ensureResponse(response, 'Update file operation returned no response');
   });
@@ -75,7 +78,9 @@ async function getSecrets(sandboxId: string): Promise<Secret[]> {
   validateRequired(sandboxId, 'Sandbox ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.get<{ secrets: Secret[] }>(`/sandbox/${sandboxId}/secrets`);
+    const response = await resolveSandboxClient(sandboxId).get<{ secrets: Secret[] }>(
+      `/sandbox/${sandboxId}/secrets`,
+    );
 
     if (!response || !response.secrets) {
       return [];
@@ -91,7 +96,7 @@ async function addSecret(sandboxId: string, key: string, value: string): Promise
   validateRequired(value, 'Secret value');
 
   await serviceCall(async () => {
-    await apiClient.post(`/sandbox/${sandboxId}/secrets`, { key, value });
+    await resolveSandboxClient(sandboxId).post(`/sandbox/${sandboxId}/secrets`, { key, value });
   });
 }
 
@@ -101,7 +106,7 @@ async function updateSecret(sandboxId: string, key: string, value: string): Prom
   validateRequired(value, 'Secret value');
 
   await serviceCall(async () => {
-    await apiClient.put(`/sandbox/${sandboxId}/secrets/${key}`, { value });
+    await resolveSandboxClient(sandboxId).put(`/sandbox/${sandboxId}/secrets/${key}`, { value });
   });
 }
 
@@ -110,7 +115,7 @@ async function deleteSecret(sandboxId: string, key: string): Promise<void> {
   validateRequired(key, 'Secret key');
 
   await serviceCall(async () => {
-    await apiClient.delete(`/sandbox/${sandboxId}/secrets/${key}`);
+    await resolveSandboxClient(sandboxId).delete(`/sandbox/${sandboxId}/secrets/${key}`);
   });
 }
 
@@ -118,7 +123,9 @@ async function downloadZip(sandboxId: string): Promise<Blob> {
   validateRequired(sandboxId, 'Sandbox ID');
 
   return serviceCall(async () => {
-    const response = await apiClient.getBlob(`/sandbox/${sandboxId}/download-zip`);
+    const response = await resolveSandboxClient(sandboxId).getBlob(
+      `/sandbox/${sandboxId}/download-zip`,
+    );
     return ensureResponse(response, 'Download failed: No response received');
   });
 }
@@ -137,7 +144,9 @@ async function getGitDiff(
       full_context: fullContext || undefined,
       cwd,
     });
-    const response = await apiClient.get<GitDiffData>(`/sandbox/${sandboxId}/git/diff${qs}`);
+    const response = await resolveSandboxClient(sandboxId).get<GitDiffData>(
+      `/sandbox/${sandboxId}/git/diff${qs}`,
+    );
     return ensureResponse(response, 'Failed to get git diff');
   });
 }
@@ -147,7 +156,7 @@ async function getGitBranches(sandboxId: string, cwd?: string): Promise<GitBranc
 
   return serviceCall(async () => {
     const qs = buildQueryString({ cwd });
-    const response = await apiClient.get<GitBranchesData>(
+    const response = await resolveSandboxClient(sandboxId).get<GitBranchesData>(
       `/sandbox/${sandboxId}/git/branches${qs}`,
     );
     return ensureResponse(response, 'Failed to get git branches');
@@ -163,10 +172,13 @@ async function checkoutGitBranch(
   validateRequired(branch, 'Branch name');
 
   return serviceCall(async () => {
-    const response = await apiClient.post<GitCheckoutData>(`/sandbox/${sandboxId}/git/checkout`, {
-      branch,
-      cwd: cwd ?? null,
-    });
+    const response = await resolveSandboxClient(sandboxId).post<GitCheckoutData>(
+      `/sandbox/${sandboxId}/git/checkout`,
+      {
+        branch,
+        cwd: cwd ?? null,
+      },
+    );
     return ensureResponse(response, 'Checkout failed');
   });
 }
@@ -180,10 +192,13 @@ async function gitCommit(
   validateRequired(message, 'Commit message');
 
   return serviceCall(async () => {
-    const response = await apiClient.post<GitCommitResult>(`/sandbox/${sandboxId}/git/commit`, {
-      message,
-      cwd: cwd ?? null,
-    });
+    const response = await resolveSandboxClient(sandboxId).post<GitCommitResult>(
+      `/sandbox/${sandboxId}/git/commit`,
+      {
+        message,
+        cwd: cwd ?? null,
+      },
+    );
     return ensureResponse(response, 'Commit failed');
   });
 }
@@ -193,7 +208,9 @@ async function gitPush(sandboxId: string, cwd?: string): Promise<GitPushPullResu
 
   return serviceCall(async () => {
     const qs = buildQueryString({ cwd });
-    const response = await apiClient.post<GitPushPullResult>(`/sandbox/${sandboxId}/git/push${qs}`);
+    const response = await resolveSandboxClient(sandboxId).post<GitPushPullResult>(
+      `/sandbox/${sandboxId}/git/push${qs}`,
+    );
     return ensureResponse(response, 'Push failed');
   });
 }
@@ -203,7 +220,9 @@ async function gitPull(sandboxId: string, cwd?: string): Promise<GitPushPullResu
 
   return serviceCall(async () => {
     const qs = buildQueryString({ cwd });
-    const response = await apiClient.post<GitPushPullResult>(`/sandbox/${sandboxId}/git/pull${qs}`);
+    const response = await resolveSandboxClient(sandboxId).post<GitPushPullResult>(
+      `/sandbox/${sandboxId}/git/pull${qs}`,
+    );
     return ensureResponse(response, 'Pull failed');
   });
 }
@@ -218,7 +237,7 @@ async function gitRestoreFile(
   validateRequired(filePath, 'File path');
 
   return serviceCall(async () => {
-    const response = await apiClient.post<GitCommitResult>(
+    const response = await resolveSandboxClient(sandboxId).post<GitCommitResult>(
       `/sandbox/${sandboxId}/git/restore-file`,
       {
         file_path: filePath,
@@ -235,7 +254,7 @@ async function gitRestoreAll(sandboxId: string, cwd?: string): Promise<GitCommit
 
   return serviceCall(async () => {
     const qs = buildQueryString({ cwd });
-    const response = await apiClient.post<GitCommitResult>(
+    const response = await resolveSandboxClient(sandboxId).post<GitCommitResult>(
       `/sandbox/${sandboxId}/git/restore-all${qs}`,
     );
     return ensureResponse(response, 'Restore all failed');
@@ -252,7 +271,7 @@ async function gitCreateBranch(
   validateRequired(name, 'Branch name');
 
   return serviceCall(async () => {
-    const response = await apiClient.post<GitCreateBranchResult>(
+    const response = await resolveSandboxClient(sandboxId).post<GitCreateBranchResult>(
       `/sandbox/${sandboxId}/git/create-branch`,
       { name, base_branch: baseBranch ?? null, cwd: cwd ?? null },
     );
@@ -265,7 +284,7 @@ async function getGitRemoteUrl(sandboxId: string, cwd?: string): Promise<GitRemo
 
   return serviceCall(async () => {
     const qs = buildQueryString({ cwd });
-    const response = await apiClient.get<GitRemoteUrlData>(
+    const response = await resolveSandboxClient(sandboxId).get<GitRemoteUrlData>(
       `/sandbox/${sandboxId}/git/remote-url${qs}`,
     );
     return ensureResponse(response, 'Failed to get remote URL');
@@ -286,7 +305,9 @@ async function searchInFiles(sandboxId: string, params: SearchParams): Promise<S
       include: params.include || undefined,
       exclude: params.exclude || undefined,
     });
-    const response = await apiClient.get<SearchResponse>(`/sandbox/${sandboxId}/search${qs}`);
+    const response = await resolveSandboxClient(sandboxId).get<SearchResponse>(
+      `/sandbox/${sandboxId}/search${qs}`,
+    );
     return ensureResponse(response, 'Failed to search files');
   });
 }

--- a/frontend/src/services/workspaceService.ts
+++ b/frontend/src/services/workspaceService.ts
@@ -1,4 +1,4 @@
-import { apiClient } from '@/lib/api';
+import { apiClient, resolveChatClient } from '@/lib/api';
 import { ensureResponse, serviceCall, buildQueryString } from '@/services/base/BaseService';
 import type {
   Workspace,
@@ -41,9 +41,14 @@ async function deleteWorkspace(workspaceId: string): Promise<void> {
   });
 }
 
-async function getWorkspaceResources(workspaceId: string): Promise<WorkspaceResources> {
+// chatId routes by the owning chat: a cloud chat's workspace lives on the VPS, so
+// its skills/slash-commands must come from there, not the local backend.
+async function getWorkspaceResources(
+  workspaceId: string,
+  chatId?: string,
+): Promise<WorkspaceResources> {
   return serviceCall(async () => {
-    const response = await apiClient.get<WorkspaceResources>(
+    const response = await resolveChatClient(chatId).get<WorkspaceResources>(
       `/workspaces/${workspaceId}/resources`,
     );
     return ensureResponse(response, 'Failed to fetch workspace resources');

--- a/frontend/src/utils/chatOrigin.ts
+++ b/frontend/src/utils/chatOrigin.ts
@@ -1,0 +1,68 @@
+// Tracks which chat IDs and sandbox IDs live on the cloud VPS rather than the
+// local instance, so chatService and sandboxService can route per-chat and
+// per-sandbox API calls (reads, status, SSE, files, git, terminal) to the
+// backend that owns them. Single-user app: IDs are unique across the two
+// backends, so flat sets are enough — no need to namespace by origin.
+//
+// Persisted to localStorage and hydrated synchronously at module load: a reload
+// or a direct deep-link to /chat/:id must resolve origin before the chat and
+// sandbox queries fire, otherwise they would fall back to the local backend.
+const CHATS_KEY = 'cloud-chat-ids';
+const SANDBOXES_KEY = 'cloud-sandbox-ids';
+
+function load(key: string): Set<string> {
+  try {
+    const raw = localStorage.getItem(key);
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((id): id is string => typeof id === 'string'));
+  } catch {
+    return new Set();
+  }
+}
+
+const cloudChatIds = load(CHATS_KEY);
+const cloudSandboxIds = load(SANDBOXES_KEY);
+
+function persist(key: string, ids: Set<string>): void {
+  try {
+    localStorage.setItem(key, JSON.stringify([...ids]));
+  } catch {
+    // localStorage unavailable/full — routing still works for this session in-memory.
+  }
+}
+
+function add(ids: string[], set: Set<string>, key: string): void {
+  let changed = false;
+  for (const id of ids) {
+    if (!set.has(id)) {
+      set.add(id);
+      changed = true;
+    }
+  }
+  if (changed) persist(key, set);
+}
+
+export function markCloudChats(ids: string[]): void {
+  add(ids, cloudChatIds, CHATS_KEY);
+}
+
+export function isCloudChat(id: string): boolean {
+  return cloudChatIds.has(id);
+}
+
+export function markCloudSandboxes(ids: string[]): void {
+  add(ids, cloudSandboxIds, SANDBOXES_KEY);
+}
+
+export function isCloudSandbox(id: string): boolean {
+  return cloudSandboxIds.has(id);
+}
+
+// Reset all cloud-origin tracking — called on VPS disconnect.
+export function clearCloudOrigins(): void {
+  cloudChatIds.clear();
+  cloudSandboxIds.clear();
+  persist(CHATS_KEY, cloudChatIds);
+  persist(SANDBOXES_KEY, cloudSandboxIds);
+}


### PR DESCRIPTION
## Summary
- Cloud-VPS chats opened in the desktop (Tauri) app were silently routing through the **local** backend, breaking streaming, attachments, sandbox/file/git/terminal, sub-threads, checkpoints, and workspace resources for cloud-owned chats.
- Adds a `chatOrigin` registry (`utils/chatOrigin.ts`) — localStorage-persisted sets of cloud chat/sandbox IDs — and `resolveChatClient` / `resolveSandboxClient` helpers in `lib/api.ts` so every per-chat request picks the local vs cloud `APIClient` at a single seam (no `isCloud` boolean threaded everywhere).
- Threads `chatId` through the changed-files / diff / checkpoint / attachment paths purely for routing, and adds `chatId` to the affected query keys so a `staleTime: Infinity` entry can't serve data from the wrong backend.
- Restores cloud stream metadata in the sidebar (`SidebarCloudGroup` runs `useStreamRestoration({ continuous: true })`) so reopened/active VPS runs show the streaming pulse and get tracked by the global watcher without first opening the chat.
- Clears the origin registry on every cloud-disconnect path (manual, session-expired, failed hydration) so stale IDs don't keep routing to a dead VPS.
- Refactors the sidebar: extracts a shared `SidebarChatGroup` shell + `SidebarChatRow`, collapsing the local/cloud group wrappers to their genuine differences (query hook, header actions, origin label, cloud stream restoration). Centralizes the cloud-sidebar cache invalidation in `invalidateCloudChats()` across the four chat mutations.

## Test plan
- [ ] Sign in to a cloud VPS; open a cloud chat and confirm streaming, message diffs, checkpoint restore, and attachment previews/downloads all hit the cloud backend.
- [ ] Start a run on a cloud chat, navigate away, reload — confirm the sidebar shows the streaming pulse before the chat is reopened.
- [ ] Create a sub-thread under a cloud parent with `sub_thread_count === 0` — confirm the expand control appears without a manual refresh.
- [ ] Rename / pin / delete a cloud chat — confirm the cloud sidebar list updates.
- [ ] Disconnect cloud (and trigger a failed hydration) — confirm subsequent requests route to the local backend.
- [ ] Local-only chats behave exactly as before (regression check).