### PR TITLE
feat: enable cloud parity on landing composer

### DIFF
--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -66,6 +66,13 @@ export const queryKeys = {
     ['workspaces', workspaceId, 'resources', chatId] as const,
   cloudWorkspaces: (cloudUrl?: string, connectedEmail?: string | null) =>
     ['cloud', 'workspaces', cloudUrl, connectedEmail] as const,
+  cloudWorkspaceResources: (
+    cloudUrl?: string,
+    connectedEmail?: string | null,
+    workspaceId?: string,
+  ) => ['cloud', 'workspaces', cloudUrl, connectedEmail, 'resources', workspaceId] as const,
+  cloudSettings: (cloudUrl?: string, connectedEmail?: string | null) =>
+    ['cloud', 'settings', cloudUrl, connectedEmail] as const,
   cloudChats: (cloudUrl?: string, connectedEmail?: string | null) =>
     ['cloud', 'chats', cloudUrl, connectedEmail] as const,
   // Prefix key for invalidating every cloud chats query regardless of instance/account.

--- a/frontend/src/hooks/queries/useCloudQueries.ts
+++ b/frontend/src/hooks/queries/useCloudQueries.ts
@@ -2,7 +2,8 @@ import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { cloudChatService } from '@/services/cloudChatService';
 import { queryKeys } from '@/hooks/queries/queryKeys';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
-import type { Workspace } from '@/types/workspace.types';
+import type { Workspace, WorkspaceResources } from '@/types/workspace.types';
+import type { UserSettings } from '@/types/user.types';
 
 const CLOUD_CHATS_PER_PAGE = 25;
 
@@ -14,6 +15,37 @@ export const useCloudWorkspacesQuery = (enabled: boolean) => {
   return useQuery<Workspace[]>({
     queryKey: queryKeys.cloudWorkspaces(cloudUrl, connectedEmail),
     queryFn: () => cloudChatService.listWorkspaces(),
+    enabled: enabled && !!cloudUrl,
+    staleTime: 30_000,
+  });
+};
+
+// VPS workspace skills and builtin slash-commands for the landing composer
+// before a chat exists. Keyed by cloudUrl + connectedEmail + workspaceId so
+// switching instance or account never serves the previous connection's cache.
+export const useCloudWorkspaceResourcesQuery = (
+  workspaceId: string | undefined,
+  enabled: boolean,
+) => {
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
+  const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
+  return useQuery<WorkspaceResources>({
+    queryKey: queryKeys.cloudWorkspaceResources(cloudUrl, connectedEmail, workspaceId),
+    queryFn: () => cloudChatService.getWorkspaceResources(workspaceId!),
+    enabled: enabled && !!cloudUrl && !!workspaceId,
+    staleTime: 30_000,
+  });
+};
+
+// VPS user settings. Only personas are consumed on the landing page — local
+// settings (env vars, GitHub token, etc.) are separate. Keyed by cloudUrl +
+// connectedEmail so switching instance or account never serves stale cache.
+export const useCloudSettingsQuery = (enabled: boolean) => {
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
+  const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
+  return useQuery<UserSettings>({
+    queryKey: queryKeys.cloudSettings(cloudUrl, connectedEmail),
+    queryFn: () => cloudChatService.getSettings(),
     enabled: enabled && !!cloudUrl,
     staleTime: 30_000,
   });

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -18,6 +18,11 @@ import { WorkspaceSelector } from '@/components/chat/workspace-selector/Workspac
 import { RunLocationSelector } from '@/components/chat/run-location-selector/RunLocationSelector';
 import { WorktreeToggle } from '@/components/chat/worktree-selector/WorktreeToggle';
 import { CloudWorkspaceSelector } from '@/components/chat/cloud/CloudWorkspaceSelector';
+import {
+  useCloudWorkspacesQuery,
+  useCloudWorkspaceResourcesQuery,
+  useCloudSettingsQuery,
+} from '@/hooks/queries/useCloudQueries';
 import { useChatStore } from '@/store/chatStore';
 import { useUIStore } from '@/store/uiStore';
 import { useModelStore } from '@/store/modelStore';
@@ -117,8 +122,9 @@ export function LandingPage() {
     setMessage(initialMessage);
   }
 
-  // Cloud runs target a remote workspace — local skills/slash-commands and
-  // @file mentions don't apply there.
+  // Skills and slash-commands are per-instance. Local runs fetch from the local
+  // backend; cloud runs fetch from the VPS so its skills/commands appear in the
+  // landing composer before a chat exists.
   const { data: workspaceResources } = useWorkspaceResourcesQuery(
     selectedWorkspaceId ?? undefined,
     undefined,
@@ -126,12 +132,25 @@ export function LandingPage() {
       enabled: isAuthenticated && !!selectedWorkspaceId && !isCloud,
     },
   );
+  const { data: cloudWorkspaceResources } = useCloudWorkspaceResourcesQuery(
+    selectedCloudWorkspaceId ?? undefined,
+    isAuthenticated && isCloud,
+  );
+  const resolvedWorkspaceResources = isCloud ? cloudWorkspaceResources : workspaceResources;
 
-  // Enable @ file mentions in the input bar before a chat is created
-  const selectedSandboxId =
-    !isCloud && selectedWorkspaceId
-      ? workspaces.find((ws) => ws.id === selectedWorkspaceId)?.sandbox_id
-      : undefined;
+  // Personas are per-instance — fetch from the VPS for cloud runs so the
+  // persona selector shows the VPS's personas and chat creation resolves the
+  // selected persona against the VPS's list.
+  const { data: settings } = useSettingsQuery({ enabled: isAuthenticated });
+  const { data: cloudSettings } = useCloudSettingsQuery(isAuthenticated && isCloud);
+  const resolvedPersonas = isCloud ? cloudSettings?.personas : settings?.personas;
+
+  // Resolve the sandbox for both local and cloud so the editor, @file mentions,
+  // and branch selector route to the backend that owns the workspace.
+  const { data: cloudWorkspaces } = useCloudWorkspacesQuery(isAuthenticated && isCloud);
+  const selectedSandboxId = isCloud
+    ? cloudWorkspaces?.find((ws) => ws.id === selectedCloudWorkspaceId)?.sandbox_id
+    : workspaces.find((ws) => ws.id === selectedWorkspaceId)?.sandbox_id;
 
   const { data: filesMetadata = [], refetch: refetchFilesMetadata } = useFilesMetadataQuery(
     selectedSandboxId,
@@ -156,10 +175,6 @@ export function LandingPage() {
 
   // No chat exists on the landing page, so there are no chat-bound file jumps.
   usePendingFileOpen(fileStructure, setSelectedFile, undefined);
-
-  const { data: settings } = useSettingsQuery({
-    enabled: isAuthenticated,
-  });
 
   useMountEffect(() => {
     useChatStore.getState().setCurrentChat(null);
@@ -228,10 +243,9 @@ export function LandingPage() {
                   chatSettings.worktreeByChat[DEFAULT_CHAT_SETTINGS_KEY] ?? DEFAULT_WORKTREE,
                 planMode:
                   chatSettings.planModeByChat[DEFAULT_CHAT_SETTINGS_KEY] ?? DEFAULT_PLAN_MODE,
-                // Personas are per-instance — let the remote use its default.
-                persona: DEFAULT_PERSONA,
+                persona: chatSettings.personaByChat[DEFAULT_CHAT_SETTINGS_KEY] ?? DEFAULT_PERSONA,
               },
-              [],
+              resolvedPersonas ?? [],
             ),
           });
 
@@ -295,6 +309,7 @@ export function LandingPage() {
       selectedCloudWorkspaceId,
       attachedFiles,
       modelMap,
+      resolvedPersonas,
     ],
   );
 
@@ -420,9 +435,9 @@ export function LandingPage() {
     <ChatProvider
       sandboxId={selectedSandboxId}
       fileStructure={fileStructure}
-      customSkills={workspaceResources?.skills}
-      builtinSlashCommands={workspaceResources?.builtin_slash_commands}
-      personas={isCloud ? undefined : settings?.personas}
+      customSkills={resolvedWorkspaceResources?.skills}
+      builtinSlashCommands={resolvedWorkspaceResources?.builtin_slash_commands}
+      personas={resolvedPersonas}
     >
       <div className="flex h-full flex-1 overflow-hidden bg-surface text-text-primary dark:bg-surface-dark dark:text-text-dark-primary">
         <SplitViewContainer renderView={renderView} />

--- a/frontend/src/services/cloudChatService.ts
+++ b/frontend/src/services/cloudChatService.ts
@@ -4,8 +4,8 @@ import { buildChatFormData } from '@/services/chatService';
 import { cloudAuthStorage } from '@/utils/storage';
 import { markCloudChats, markCloudSandboxes, clearCloudOrigins } from '@/utils/chatOrigin';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
-import type { AuthResponse } from '@/types/user.types';
-import type { Workspace } from '@/types/workspace.types';
+import type { AuthResponse, UserSettings } from '@/types/user.types';
+import type { Workspace, WorkspaceResources } from '@/types/workspace.types';
 import type { Chat, ChatRequest, CreateChatRequest } from '@/types/chat.types';
 import type { PaginatedChats, PaginatedResponse } from '@/types/api.types';
 
@@ -56,7 +56,11 @@ async function listChats(params?: {
 async function listWorkspaces(): Promise<Workspace[]> {
   return serviceCall(async () => {
     const response = await remoteApiClient.get<PaginatedResponse<Workspace>>('/workspaces');
-    return ensureResponse(response, 'Failed to load cloud workspaces').items;
+    const workspaces = ensureResponse(response, 'Failed to load cloud workspaces').items;
+    // Register sandbox IDs as cloud-owned so per-sandbox calls (git, files,
+    // terminal) route to the VPS, not the local backend.
+    markCloudSandboxes(workspaces.map((ws) => ws.sandbox_id).filter((id): id is string => !!id));
+    return workspaces;
   });
 }
 
@@ -64,6 +68,28 @@ async function createChat(data: CreateChatRequest): Promise<Chat> {
   return serviceCall(async () => {
     const response = await remoteApiClient.post<Chat>('/chat/chats', data);
     return ensureResponse(response, 'Failed to create cloud chat');
+  });
+}
+
+// Fetch a VPS workspace's skills and builtin slash-commands. The landing
+// composer needs these before a chat exists, so there's no chatId to route by —
+// call the VPS directly instead of going through resolveChatClient.
+async function getWorkspaceResources(workspaceId: string): Promise<WorkspaceResources> {
+  return serviceCall(async () => {
+    const response = await remoteApiClient.get<WorkspaceResources>(
+      `/workspaces/${workspaceId}/resources`,
+    );
+    return ensureResponse(response, 'Failed to fetch cloud workspace resources');
+  });
+}
+
+// Fetch VPS user settings. Only personas are consumed from the landing page —
+// the local settings (env vars, GitHub token, etc.) are separate. The VPS runs
+// the same backend, so the endpoint shape matches.
+async function getSettings(): Promise<UserSettings> {
+  return serviceCall(async () => {
+    const response = await remoteApiClient.get<UserSettings>('/settings/');
+    return ensureResponse(response, 'Failed to fetch cloud settings');
   });
 }
 
@@ -81,5 +107,7 @@ export const cloudChatService = {
   listWorkspaces,
   listChats,
   createChat,
+  getWorkspaceResources,
+  getSettings,
   startCompletion,
 };


### PR DESCRIPTION
## Summary
- The landing composer dropped the branch selector, @file mentions, slash commands, and persona selector when `RunLocation` was set to Cloud, because the sandbox ID, workspace resources, and personas were only resolved for local workspaces.
- Register cloud workspace sandbox IDs as cloud-owned in `listWorkspaces` so per-sandbox calls (git branches, files, terminal) route to the VPS instead of falling back to local.
- Resolve `selectedSandboxId` for cloud workspaces so `useFilesMetadataQuery` fires against the VPS, enabling the editor, @file mentions, and the `InputControls` branch selector for cloud.
- Add `cloudChatService.getWorkspaceResources` + `useCloudWorkspaceResourcesQuery` so the landing composer shows the VPS's slash commands and custom skills before a chat exists (inside an existing cloud chat this already worked via `resolveChatClient(chatId)`).
- Add `cloudChatService.getSettings` + `useCloudSettingsQuery` so the persona selector shows VPS personas, and cloud chat creation resolves the selected persona against the VPS's list instead of hardcoding `DEFAULT_PERSONA`.
- Hoist `useSettingsQuery` above its first use to avoid a `const` temporal-dead-zone crash on the local (default) path.

## Test plan
- [ ] On the landing page with Local selected: workspace selector, branch selector (below input), @file mentions, `/` slash commands, and persona selector all behave as before.
- [ ] Switch RunLocation to Cloud with a VPS connected: the cloud workspace selector shows, the branch selector appears below the input for git workspaces, `@` mentions list VPS files, `/` shows VPS slash commands + skills, and the persona selector lists VPS personas.
- [ ] Start a cloud chat with a non-default persona selected — the VPS run uses the selected persona (verify in the run's system prompt).
- [ ] Reload the landing page while Cloud is selected — no white screen, no console errors.