### PR TITLE
fix: keep thinking timer accurate across chat switches

### DIFF
--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -115,6 +115,12 @@ export const Chat = memo(function Chat() {
     return ids;
   }, [activeStreams, chatId, streamIdByChatMessage]);
 
+  // Real start time of the active stream for this chat, so the thinking timer
+  // doesn't reset when switching chats and the indicator remounts.
+  const streamStartTime = useStreamStore((s) =>
+    chatId ? s.activeStreamMetadata.find((m) => m.chatId === chatId)?.startTime : undefined,
+  );
+
   const pendingMessages = useMessageQueueStore((storeState) =>
     chatId ? (storeState.queues.get(chatId) ?? EMPTY_QUEUE) : EMPTY_QUEUE,
   );
@@ -402,12 +408,12 @@ export const Chat = memo(function Chat() {
 
     return (
       <div className="w-full lg:mx-auto lg:max-w-3xl">
-        {showThinking && <ThinkingIndicator />}
+        {showThinking && <ThinkingIndicator streamStartTime={streamStartTime} />}
         {showPermissionAtEnd && <MessageInlinePermission />}
         {showStreamActions && chatId && <StreamActionsBar chatId={chatId} />}
       </div>
     );
-  }, [chatId, showPermissionAtEnd, showStreamActions, showThinking]);
+  }, [chatId, showPermissionAtEnd, showStreamActions, showThinking, streamStartTime]);
 
   return (
     <div className="relative flex min-w-0 flex-1 flex-col">

--- a/frontend/src/components/chat/chat-window/ThinkingIndicator.tsx
+++ b/frontend/src/components/chat/chat-window/ThinkingIndicator.tsx
@@ -1,9 +1,18 @@
 import { memo, useState, useRef } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 
-export const ThinkingIndicator = memo(function ThinkingIndicator() {
+interface ThinkingIndicatorProps {
+  streamStartTime?: number;
+}
+
+export const ThinkingIndicator = memo(function ThinkingIndicator({
+  streamStartTime,
+}: ThinkingIndicatorProps) {
   const [elapsed, setElapsed] = useState(0);
-  const startTime = useRef(Date.now());
+  // Seed from the active stream's start so the timer survives chat switches —
+  // the indicator sits inside the chat-keyed scroller and remounts on switch.
+  // Fall back to mount time when loading begins before the stream exists yet.
+  const startTime = useRef(streamStartTime ?? Date.now());
 
   useMountEffect(() => {
     const interval = setInterval(() => {


### PR DESCRIPTION
## Summary
- The "Thinking… · Ns" elapsed counter reset to 0 when switching chats mid-stream, because `ThinkingIndicator` seeded its start time from component mount time and the indicator remounts inside the chat-keyed scroller on every switch.
- Seed the timer ref from the active stream's real `startTime` so the counter survives the remount; fall back to mount time only during the pre-stream `isLoading` window.
- Source `startTime` via a one-line Zustand selector over the canonical `activeStreamMetadata` slice (already kept in sync on stream add/remove) rather than re-deriving it from the raw stream maps.

## Test plan
- [ ] Start a stream in chat A, wait ~5s, switch to chat B and back to A — timer continues from the original elapsed time instead of resetting to 0.
- [ ] Send a message (pre-stream loading state) and confirm the timer starts at 0 and ticks up normally.
- [ ] With two panes streaming concurrently, each pane's indicator shows its own stream's elapsed time independently.