### PR TITLE
feat: add desktop system tray with menu and hide-to-tray

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 tauri-build = { version = "2.5.5", features = [] }
 
 [dependencies]
-tauri = { version = "2.10.2", features = ["devtools"] }
+tauri = { version = "2.10.2", features = ["devtools", "tray-icon"] }
 tauri-plugin-updater = "2.10.0"
 tauri-plugin-process = "2.3.0"
 tauri-plugin-notification = "2.3.0"

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -10,6 +10,8 @@ use libc;
 #[cfg(target_os = "macos")]
 use objc2_app_kit::{NSWindow, NSWindowButton};
 use rand::Rng;
+use tauri::menu::{Menu, MenuItem};
+use tauri::tray::TrayIconBuilder;
 use tauri::Manager;
 
 #[tauri::command]
@@ -183,6 +185,34 @@ fn spawn_backend(
     child
 }
 
+fn show_main_window(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+fn build_tray(app: &tauri::App) -> tauri::Result<()> {
+    let show = MenuItem::with_id(app, "show", "Show Agentrove", true, None::<&str>)?;
+    let quit = MenuItem::with_id(app, "quit", "Quit Agentrove", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&show, &quit])?;
+
+    TrayIconBuilder::new()
+        .icon(app.default_window_icon().unwrap().clone())
+        .tooltip("Agentrove")
+        .menu(&menu)
+        // Click the tray to open the menu (standard macOS menu-bar behavior);
+        // "Show Agentrove" brings the window back.
+        .on_menu_event(|app, event| match event.id.as_ref() {
+            "show" => show_main_window(app),
+            "quit" => app.exit(0),
+            _ => {}
+        })
+        .build(app)?;
+
+    Ok(())
+}
+
 fn main() {
     let data_dir = data_dir();
     let secret_key = ensure_secret_key(&data_dir);
@@ -200,6 +230,14 @@ fn main() {
         .plugin(tauri_plugin_opener::init())
         .manage(backend_port.clone())
         .invoke_handler(tauri::generate_handler![get_backend_port])
+        .on_window_event(|window, event| {
+            // Closing the window hides it to the tray; the app keeps running.
+            // Real exit goes through the tray "Quit" item (app.exit), which bypasses this.
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                api.prevent_close();
+                let _ = window.hide();
+            }
+        })
         .setup(move |app| {
             // The window stays titled (overlay title bar in tauri.conf.json) so minimize works —
             // borderless windows can't miniaturize on macOS. Hide the native traffic lights here
@@ -221,6 +259,8 @@ fn main() {
                     }
                 }
             }
+
+            build_tray(app)?;
 
             let child = spawn_backend(app.handle(), &data_dir, &secret_key, port);
             *backend_process.lock().unwrap() = Some(child);


### PR DESCRIPTION
## Summary
- Add a system tray icon to the Tauri desktop app (enables the `tray-icon` feature on `tauri`).
- Tray menu with **Show Agentrove** and **Quit Agentrove**; clicking the tray opens the menu (standard macOS menu-bar behavior).
- Closing the window now hides it to the tray instead of quitting, so the backend sidecar keeps running. Real exit goes through the tray **Quit** item (`app.exit`), which triggers the existing backend teardown in `RunEvent::Exit`.

## Test plan
- [ ] Build the desktop app (`cargo build` in `frontend/src-tauri/`).
- [ ] Tray icon appears in the menu bar.
- [ ] Clicking the tray opens the menu; **Show Agentrove** focuses the window.
- [ ] Closing the window hides it (app stays running, backend alive); reopen via the tray.
- [ ] **Quit Agentrove** exits the app and terminates the backend process.