### PR TITLE
feat: add multi-palette theme system

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { Toaster } from 'react-hot-toast';
 import { useAuthStore } from '@/store/authStore';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
+import { useUIStore } from '@/store/uiStore';
 import { useCurrentUserQuery } from '@/hooks/queries/useAuthQueries';
 import { useInfiniteChatsQuery } from '@/hooks/queries/useChatQueries';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
@@ -160,6 +161,7 @@ function AppContent() {
 
 export default function App() {
   const resolvedTheme = useResolvedTheme();
+  const theme = useUIStore((state) => state.theme);
   const [desktopReady, setDesktopReady] = useState(!isTauri());
   const [desktopError, setDesktopError] = useState<string | null>(null);
   const [authHydrated, setAuthHydrated] = useState(false);
@@ -197,11 +199,13 @@ export default function App() {
     document.body.classList.remove('light', 'dark');
     document.body.classList.add(resolvedTheme);
     document.documentElement.setAttribute('data-theme', resolvedTheme);
+    // data-palette drives the per-theme CSS-var overrides (dim/sepia); base modes have no override block
+    document.documentElement.setAttribute('data-palette', theme);
     const metaThemeColor = document.querySelector('meta[name="theme-color"]');
     if (metaThemeColor) {
       metaThemeColor.setAttribute('content', resolvedTheme === 'dark' ? '#0a0a0a' : '#ffffff');
     }
-  }, [resolvedTheme]);
+  }, [resolvedTheme, theme]);
 
   useMountEffect(() => {
     if (!isTauri()) return;

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,30 +1,21 @@
-import { ArrowLeft, LogOut, Monitor, Moon, Sun } from 'lucide-react';
+import { ArrowLeft, LogOut } from 'lucide-react';
 import { useNavigate, useMatch } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
 import { useLogoutMutation } from '@/hooks/queries/useAuthQueries';
 import { Button } from '@/components/ui/primitives/Button';
+import { THEME_CYCLE, getThemeMeta } from '@/utils/theme';
+import type { Theme } from '@/types/ui.types';
 import { cn } from '@/utils/cn';
 
 export interface HeaderProps {
   isAuthPage?: boolean;
 }
 
-const THEME_ICON_MAP = {
-  dark: Sun,
-  light: Moon,
-  system: Monitor,
-} as const;
-
-const THEME_NEXT_LABEL = {
-  dark: 'light',
-  light: 'system',
-  system: 'dark',
-} as const;
-
-function ThemeToggleButton({ theme, onToggle }: { theme: string; onToggle: () => void }) {
-  const Icon = THEME_ICON_MAP[theme as keyof typeof THEME_ICON_MAP] ?? Monitor;
-  const nextLabel = THEME_NEXT_LABEL[theme as keyof typeof THEME_NEXT_LABEL] ?? 'dark';
+function ThemeToggleButton({ theme, onToggle }: { theme: Theme; onToggle: () => void }) {
+  // Show the current theme's icon (matches the profile menu); the title names what's next.
+  const Icon = getThemeMeta(theme).icon;
+  const next = THEME_CYCLE[(THEME_CYCLE.indexOf(theme) + 1) % THEME_CYCLE.length];
   return (
     <Button
       onClick={onToggle}
@@ -37,7 +28,7 @@ function ThemeToggleButton({ theme, onToggle }: { theme: string; onToggle: () =>
         'transition-colors duration-200',
       )}
       aria-label="Toggle theme"
-      title={`Switch to ${nextLabel} mode`}
+      title={`Switch to ${getThemeMeta(next).label}`}
     >
       <Icon className="h-3.5 w-3.5" />
     </Button>

--- a/frontend/src/components/layout/UserProfileMenu.tsx
+++ b/frontend/src/components/layout/UserProfileMenu.tsx
@@ -1,4 +1,4 @@
-import { Download, Loader2, AlertCircle, Settings, LogOut, Sun, Moon, Monitor } from 'lucide-react';
+import { Download, Loader2, AlertCircle, Settings, LogOut } from 'lucide-react';
 import { UserAvatarCircle } from '@/components/chat/message-bubble/MessageAvatars';
 import { Button } from '@/components/ui/primitives/Button';
 import { useDesktopUpdateStore } from '@/store/updateStore';
@@ -6,10 +6,8 @@ import { useUIStore } from '@/store/uiStore';
 import { useDropdown } from '@/hooks/useDropdown';
 import { formatBytes } from '@/utils/format';
 import { checkDesktopUpdate } from '@/services/desktopUpdateService';
+import { getThemeMeta } from '@/utils/theme';
 import { cn } from '@/utils/cn';
-
-const THEME_ICON_MAP = { dark: Moon, light: Sun, system: Monitor } as const;
-const THEME_LABEL_MAP = { dark: 'Dark', light: 'Light', system: 'System' } as const;
 
 const MENU_ITEM_CLASS =
   'flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left ' +
@@ -32,7 +30,8 @@ export function UserProfileMenu({ displayName, onOpenSettings, onSignOut }: User
   const errorMessage = useDesktopUpdateStore((s) => s.errorMessage);
 
   const theme = useUIStore((s) => s.theme);
-  const ThemeIcon = THEME_ICON_MAP[theme];
+  const themeMeta = getThemeMeta(theme);
+  const ThemeIcon = themeMeta.icon;
 
   const { isOpen, dropdownRef, setIsOpen } = useDropdown();
 
@@ -192,7 +191,7 @@ export function UserProfileMenu({ displayName, onOpenSettings, onSignOut }: User
               <ThemeIcon className="h-3.5 w-3.5 flex-shrink-0" />
               <span className="flex-1 text-xs">Theme</span>
               <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-                {THEME_LABEL_MAP[theme]}
+                {themeMeta.label}
               </span>
             </Button>
             <Button

--- a/frontend/src/components/sandbox/git/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView.tsx
@@ -34,6 +34,7 @@ import type { WorkerPoolOptions, WorkerInitializationRenderOptions } from '@pier
 import DiffsWorker from '@pierre/diffs/worker/worker.js?worker';
 import type { DiffMode } from '@/types/sandbox.types';
 import { cn } from '@/utils/cn';
+import '@/styles/pierre-diff-theme.css';
 
 const DIFF_THEMES = { dark: 'pierre-dark', light: 'pierre-light' } as const;
 

--- a/frontend/src/components/sandbox/terminal/TerminalTab.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab.tsx
@@ -5,11 +5,13 @@ import 'xterm/css/xterm.css';
 
 import { Button } from '@/components/ui/primitives/Button';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
+import { useUIStore } from '@/store/uiStore';
 import { resolveSandboxWs } from '@/lib/api';
 
 import { getTerminalBackgroundClass } from '@/utils/terminal';
 import { useXterm } from '@/hooks/useXterm';
 import type { TerminalSize } from '@/types/sandbox.types';
+import type { Palette } from '@/types/ui.types';
 
 export interface TerminalTabProps {
   isVisible: boolean;
@@ -34,7 +36,10 @@ export const TerminalTab: FC<TerminalTabProps> = ({
   shouldClose = false,
   onClosed,
 }) => {
-  const theme = useResolvedTheme();
+  const resolvedTheme = useResolvedTheme();
+  const rawTheme = useUIStore((s) => s.theme);
+  // Only `system` needs resolving; every other theme is itself a palette
+  const palette: Palette = rawTheme === 'system' ? resolvedTheme : rawTheme;
   const [sessionState, setSessionState] = useState<SessionState>('idle');
   const [closeReason, setCloseReason] = useState<string | null>(null);
   const [connectAttempt, setConnectAttempt] = useState(0);
@@ -45,7 +50,7 @@ export const TerminalTab: FC<TerminalTabProps> = ({
   const isClosingRef = useRef(false);
   const shouldCloseRef = useRef(shouldClose);
 
-  const backgroundClass = getTerminalBackgroundClass(theme);
+  const backgroundClass = getTerminalBackgroundClass(palette);
 
   const resetWsRefs = useCallback(() => {
     wsRef.current = null;
@@ -75,7 +80,7 @@ export const TerminalTab: FC<TerminalTabProps> = ({
 
   const { fitTerminal, isReady, terminalRef, wrapperRef } = useXterm({
     isVisible,
-    mode: theme,
+    mode: palette,
     onData: (data: string) => {
       const ws = wsRef.current;
       if (ws?.readyState === WebSocket.OPEN) {

--- a/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/GeneralSettingsTab.tsx
@@ -1,11 +1,12 @@
 import { Button } from '@/components/ui/primitives/Button';
+import { Select } from '@/components/ui/primitives/Select';
 import { Switch } from '@/components/ui/primitives/Switch';
-import { SegmentedControl } from '@/components/ui/primitives/SegmentedControl';
 import type { ApiFieldKey, GeneralSecretFieldConfig } from '@/types/settings.types';
 import type { UserSettings } from '@/types/user.types';
 import type { Theme } from '@/types/ui.types';
 import { useUIStore } from '@/store/uiStore';
 import { SecretInput } from '@/components/settings/inputs/SecretInput';
+import { THEMES } from '@/utils/theme';
 import { cn } from '@/utils/cn';
 
 interface GeneralSettingsTabProps {
@@ -37,20 +38,25 @@ function SectionCard({
   );
 }
 
-const THEME_OPTIONS = [
-  { value: 'light', label: 'Light', disabled: false },
-  { value: 'dark', label: 'Dark', disabled: false },
-  { value: 'system', label: 'System', disabled: false },
-];
-
+// Dropdown rather than a row of buttons — 9 themes is too many to lay out inline.
+// Width is bounded on the wrapper since Select itself is w-full.
 function ThemeControl() {
   const theme = useUIStore((state) => state.theme);
   return (
-    <SegmentedControl
-      value={theme}
-      onChange={(val) => useUIStore.getState().setTheme(val as Theme)}
-      options={THEME_OPTIONS}
-    />
+    <div className="w-48 shrink-0">
+      <Select
+        value={theme}
+        onChange={(e) => useUIStore.getState().setTheme(e.target.value as Theme)}
+        className="h-8 text-xs"
+        aria-label="Theme"
+      >
+        {THEMES.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </Select>
+    </div>
   );
 }
 

--- a/frontend/src/components/ui/VisualWidget.tsx
+++ b/frontend/src/components/ui/VisualWidget.tsx
@@ -1,5 +1,9 @@
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
+import { useUIStore } from '@/store/uiStore';
+import type { CustomPalette, PaletteTokens } from '@/utils/theme';
+import { CUSTOM_PALETTE_TOKENS } from '@/utils/theme';
+import type { Theme } from '@/types/ui.types';
 
 interface VisualWidgetProps {
   code: string;
@@ -56,6 +60,27 @@ const THEME_CSS_LIGHT = `:root {
   --color-border-tertiary: rgba(0,0,0,0.15);
   --color-border-info: #2563eb;${SHARED_VARS}
 }`;
+
+// Custom palettes only diverge in the structural surface/text tokens — they inherit
+// the base dark/light semantic colors, borders, and SVG ramps. Appended after the base
+// :root so these win. Built from the shared palette tokens (the iframe can't read CSS
+// vars); values are our own constants, safe to interpolate.
+const paletteOverrideCss = (t: PaletteTokens): string =>
+  `:root {
+  --color-text-primary: ${t.textPrimary};
+  --color-text-secondary: ${t.textSecondary};
+  --color-text-tertiary: ${t.textTertiary};
+  --color-background-primary: ${t.surface};
+  --color-background-secondary: ${t.surfaceSecondary};
+  --color-background-tertiary: ${t.surfaceTertiary};
+}`;
+
+const PALETTE_OVERRIDE: Partial<Record<Theme, string>> = Object.fromEntries(
+  (Object.keys(CUSTOM_PALETTE_TOKENS) as CustomPalette[]).map((p) => [
+    p,
+    paletteOverrideCss(CUSTOM_PALETTE_TOKENS[p]),
+  ]),
+);
 
 const BASE_CLASSES = `
   .t { font: 400 14px var(--font-sans); fill: var(--color-text-primary); }
@@ -126,11 +151,12 @@ const VISUALIZER_RESIZE_EVENT = 'visualizer-resize';
 const RESIZE_THROTTLE_MS = 60;
 const HEIGHT_REPORTER = `<script>(function(){var last=0,h=0,tid=0;function send(){tid=0;last=Date.now();parent.postMessage({type:'${VISUALIZER_RESIZE_EVENT}',height:h},'*')}new ResizeObserver(function(){var n=document.documentElement.scrollHeight;if(n!==h){h=n;var now=Date.now();if(now-last>=${RESIZE_THROTTLE_MS}){clearTimeout(tid);send()}else if(!tid){tid=setTimeout(send,${RESIZE_THROTTLE_MS}-(now-last))}}}).observe(document.body)})()</script>`;
 
-function buildFrameHtml(code: string, isDark: boolean): string {
+function buildFrameHtml(code: string, isDark: boolean, theme: Theme): string {
   const colorScheme = isDark ? 'dark' : 'light';
   const themeCSS = isDark ? THEME_CSS_DARK : THEME_CSS_LIGHT;
+  const override = PALETTE_OVERRIDE[theme] ?? '';
   const rampClasses = isDark ? SVG_RAMP_DARK : SVG_RAMP_LIGHT;
-  return `<html style="color-scheme:${colorScheme}"><head><style>${themeCSS}\n${BASE_CLASSES}\n${rampClasses}</style></head><body>${code}${HEIGHT_REPORTER}</body></html>`;
+  return `<html style="color-scheme:${colorScheme}"><head><style>${themeCSS}\n${override}\n${BASE_CLASSES}\n${rampClasses}</style></head><body>${code}${HEIGHT_REPORTER}</body></html>`;
 }
 
 function VisualWidgetInner({ code }: VisualWidgetProps) {
@@ -138,8 +164,10 @@ function VisualWidgetInner({ code }: VisualWidgetProps) {
   const [iframeHeight, setIframeHeight] = useState(INITIAL_IFRAME_HEIGHT);
   const [isFrameLoaded, setIsFrameLoaded] = useState(false);
   const resolvedTheme = useResolvedTheme();
+  const theme = useUIStore((state) => state.theme);
   const isDark = resolvedTheme === 'dark';
-  const iframeHtml = useMemo(() => buildFrameHtml(code, isDark), [code, isDark]);
+  // theme is a dep so dark↔dim and light↔sepia recompute (both share an isDark value)
+  const iframeHtml = useMemo(() => buildFrameHtml(code, isDark, theme), [code, isDark, theme]);
 
   useEffect(() => {
     if (!isFrameLoaded || !iframeRef.current?.contentWindow) {

--- a/frontend/src/components/ui/commandRegistry.ts
+++ b/frontend/src/components/ui/commandRegistry.ts
@@ -10,11 +10,8 @@ import {
   KeyRound,
   GitCompareArrows,
   GitBranch,
-  Monitor,
   Search,
   PanelLeftClose,
-  Moon,
-  Sun,
   FileSearch,
   GitPullRequest,
   GitCommitHorizontal,
@@ -29,7 +26,8 @@ import { queryKeys } from '@/hooks/queries/queryKeys';
 import { isSecondaryPaneActive } from '@/utils/mosaicHelpers';
 import { traverseFileStructure, getFileName } from '@/utils/file';
 import { IS_MAC_PLATFORM } from '@/utils/platform';
-import type { ViewType } from '@/types/ui.types';
+import { THEMES } from '@/utils/theme';
+import type { Theme, ViewType } from '@/types/ui.types';
 import type { Chat } from '@/types/chat.types';
 import type { FileStructure } from '@/types/file-system.types';
 import type { GitBranchesData } from '@/types/sandbox.types';
@@ -145,6 +143,14 @@ const ACTION_COMMANDS: ActionCommandItem[] = [
   },
 ];
 
+const THEME_COMMANDS: ActionCommandItem[] = THEMES.map((t) => ({
+  type: 'action',
+  id: `theme-${t.value}`,
+  label: `Theme: ${t.label}`,
+  icon: t.icon,
+  shortcut: t.shortcut,
+}));
+
 const SETTING_COMMANDS: ActionCommandItem[] = [
   {
     type: 'action',
@@ -153,9 +159,7 @@ const SETTING_COMMANDS: ActionCommandItem[] = [
     icon: PanelLeftClose,
     shortcut: '.',
   },
-  { type: 'action', id: 'theme-dark', label: 'Theme: Dark', icon: Moon, shortcut: 'm' },
-  { type: 'action', id: 'theme-light', label: 'Theme: Light', icon: Sun, shortcut: 'g' },
-  { type: 'action', id: 'theme-system', label: 'Theme: System', icon: Monitor, shortcut: 'y' },
+  ...THEME_COMMANDS,
   { type: 'action', id: 'search-in-files', label: 'Search in files', icon: Search, shortcut: 'f' },
   {
     type: 'action',
@@ -291,7 +295,7 @@ export function executeCommand(
   } else if (cmd.id === 'toggle-sidebar') {
     ui.setSidebarOpen(!ui.sidebarOpen);
   } else if (cmd.id.startsWith('theme-')) {
-    ui.setTheme(cmd.id.slice(6) as 'dark' | 'light' | 'system');
+    ui.setTheme(cmd.id.slice(6) as Theme);
   } else if (cmd.id === 'search-in-files') {
     ui.setPendingMenuMode('search');
     ui.setCommandMenuOpen(true);

--- a/frontend/src/config/toaster.ts
+++ b/frontend/src/config/toaster.ts
@@ -1,13 +1,13 @@
 import type { ToasterProps } from 'react-hot-toast';
 
 const baseStyle = {
-  background: 'white',
-  color: '#0f172a',
-  border: '1px solid #e2e8f0',
   boxShadow: '0 4px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)',
 };
 
-const baseDarkClass =
+// Colors via token classes (not inline style) so every palette re-themes them;
+// `!` overrides react-hot-toast's default inline background/color
+const toastSurfaceClass =
+  '!border !bg-surface-secondary !text-text-primary !border-border ' +
   'dark:!bg-surface-dark-secondary dark:!text-text-dark-primary dark:!border-border-dark';
 
 export const toasterConfig: ToasterProps = {
@@ -27,7 +27,7 @@ export const toasterConfig: ToasterProps = {
         primary: '#22c55e',
         secondary: '#f0fdf4',
       },
-      className: baseDarkClass,
+      className: toastSurfaceClass,
     },
     error: {
       style: baseStyle,
@@ -35,7 +35,7 @@ export const toasterConfig: ToasterProps = {
         primary: '#ef4444',
         secondary: '#fef2f2',
       },
-      className: baseDarkClass,
+      className: toastSurfaceClass,
     },
     loading: {
       style: baseStyle,
@@ -43,11 +43,11 @@ export const toasterConfig: ToasterProps = {
         primary: '#3b82f6',
         secondary: '#eff6ff',
       },
-      className: baseDarkClass,
+      className: toastSurfaceClass,
     },
     blank: {
       style: baseStyle,
-      className: baseDarkClass,
+      className: toastSurfaceClass,
     },
   },
 };

--- a/frontend/src/hooks/useEditorTheme.ts
+++ b/frontend/src/hooks/useEditorTheme.ts
@@ -1,5 +1,9 @@
 import { useCallback } from 'react';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
+import { useUIStore } from '@/store/uiStore';
+import type { CustomPalette } from '@/utils/theme';
+import { CUSTOM_PALETTE_TOKENS, DARK_PALETTES } from '@/utils/theme';
+import type { Palette } from '@/types/ui.types';
 import type * as monaco from 'monaco-editor';
 
 const LIGHT_THEME: monaco.editor.IStandaloneThemeData = {
@@ -76,15 +80,55 @@ const DARK_THEME: monaco.editor.IStandaloneThemeData = {
   },
 };
 
+// Custom palettes reuse the light/dark syntax rules and only re-skin the surfaces,
+// so the editor canvas matches the themed chrome instead of staying white/black.
+// surface = editor.background; widget = suggest/widget popup background.
+function skin(
+  base: monaco.editor.IStandaloneThemeData,
+  surface: string,
+  widget: string,
+): monaco.editor.IStandaloneThemeData {
+  return {
+    ...base,
+    rules: base.rules.map((r) => (r.token === '' ? { ...r, background: surface } : r)),
+    colors: {
+      ...base.colors,
+      'editor.background': surface,
+      'editorSuggestWidget.background': widget,
+      'editorWidget.background': widget,
+    },
+  };
+}
+
+// editor canvas = surfaceSecondary; suggest/widget popup = the deeper surface.
+const CUSTOM_THEMES = Object.fromEntries(
+  (Object.keys(CUSTOM_PALETTE_TOKENS) as CustomPalette[]).map((p) => {
+    const tokens = CUSTOM_PALETTE_TOKENS[p];
+    const base = DARK_PALETTES.has(p) ? DARK_THEME : LIGHT_THEME;
+    return [p, skin(base, tokens.surfaceSecondary, tokens.surface)];
+  }),
+) as Record<CustomPalette, monaco.editor.IStandaloneThemeData>;
+
+const THEME_DATA: Record<Palette, monaco.editor.IStandaloneThemeData> = {
+  light: LIGHT_THEME,
+  dark: DARK_THEME,
+  ...CUSTOM_THEMES,
+};
+
 export function useEditorTheme() {
-  const theme = useResolvedTheme();
+  const resolvedTheme = useResolvedTheme();
+  const rawTheme = useUIStore((s) => s.theme);
+  // Only `system` needs resolving; every other theme is itself a palette
+  const palette: Palette = rawTheme === 'system' ? resolvedTheme : rawTheme;
+  const themeName = `custom-${palette}`;
 
   const setupEditorTheme = useCallback(
     (monaco: typeof import('monaco-editor')) => {
       if (!monaco || !monaco.editor) return;
 
-      monaco.editor.defineTheme('custom-light', LIGHT_THEME);
-      monaco.editor.defineTheme('custom-dark', DARK_THEME);
+      for (const [name, data] of Object.entries(THEME_DATA)) {
+        monaco.editor.defineTheme(`custom-${name}`, data);
+      }
 
       monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
         target: monaco.languages.typescript.ScriptTarget.ES2020,
@@ -108,13 +152,13 @@ export function useEditorTheme() {
         allowSyntheticDefaultImports: true,
       });
 
-      monaco.editor.setTheme(theme === 'dark' ? 'custom-dark' : 'custom-light');
+      monaco.editor.setTheme(themeName);
     },
-    [theme],
+    [themeName],
   );
 
   return {
-    currentTheme: theme === 'light' ? 'custom-light' : 'custom-dark',
+    currentTheme: themeName,
     setupEditorTheme,
   };
 }

--- a/frontend/src/hooks/useResolvedTheme.ts
+++ b/frontend/src/hooks/useResolvedTheme.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from 'react';
 import { useUIStore } from '@/store/uiStore';
+import { DARK_PALETTES } from '@/utils/theme';
 import type { ResolvedTheme } from '@/types/ui.types';
 
 function getMediaQuery(): MediaQueryList | null {
@@ -39,5 +40,6 @@ export function useResolvedTheme(): ResolvedTheme {
   if (theme === 'system') {
     return prefersDark ? 'dark' : 'light';
   }
-  return theme;
+  // Custom palettes map to a light/dark base for editor/terminal/diff theming
+  return DARK_PALETTES.has(theme) ? 'dark' : 'light';
 }

--- a/frontend/src/hooks/useXterm.ts
+++ b/frontend/src/hooks/useXterm.ts
@@ -5,6 +5,7 @@ import type { FitAddon as FitAddonType } from 'xterm-addon-fit';
 
 import { buildTerminalTheme } from '@/utils/terminal';
 import type { TerminalSize } from '@/types/sandbox.types';
+import type { Palette } from '@/types/ui.types';
 
 type XTermCore = {
   _core?: {
@@ -20,7 +21,7 @@ function hasRenderer(terminal: XTerm): boolean {
 
 interface UseXtermOptions {
   isVisible: boolean;
-  mode: 'light' | 'dark';
+  mode: Palette;
   onData: (data: string) => void;
   onFit: (size: TerminalSize) => void;
 }

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -24,6 +24,7 @@ import {
   viewTypeToTileId,
 } from '@/utils/mosaicHelpers';
 import type { MenuMode } from '@/components/ui/commandRegistry';
+import { THEME_CYCLE } from '@/utils/theme';
 
 export const MIN_SIDEBAR_WIDTH = 220;
 export const MAX_SIDEBAR_WIDTH = 560;
@@ -142,9 +143,8 @@ export const useUIStore = create<UIStoreState>()(
       theme: 'dark',
       toggleTheme: () =>
         set((state) => {
-          const next =
-            state.theme === 'dark' ? 'light' : state.theme === 'light' ? 'system' : 'dark';
-          return { theme: next };
+          const i = THEME_CYCLE.indexOf(state.theme);
+          return { theme: THEME_CYCLE[(i + 1) % THEME_CYCLE.length] };
         }),
       setTheme: (theme) => set({ theme }),
       sidebarOpen: getInitialSidebarState(),

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -24,10 +24,135 @@
 
 :root {
   color-scheme: light;
+
+  /* Structural color tokens as RGB channels (consumed via rgb(var(--x) / alpha) in tailwind.config.js).
+     Light + dark sets both live here; `dark:` utilities read the *-dark vars regardless of mode.
+     data-palette overrides re-theme a subset without touching any component. */
+  --surface: 245 245 245;
+  --surface-secondary: 249 249 249;
+  --surface-tertiary: 243 243 243;
+  --surface-hover: 224 224 224;
+  --surface-active: 216 216 216;
+  --border: 226 226 226;
+  --border-secondary: 209 209 209;
+  --border-hover: 154 154 154;
+  --text-primary: 15 23 42;
+  --text-secondary: 71 85 105;
+  --text-tertiary: 100 116 139;
+  --text-quaternary: 148 163 184;
+
+  --surface-dark: 17 17 17;
+  --surface-dark-secondary: 20 20 20;
+  --surface-dark-tertiary: 30 30 30;
+  --surface-dark-hover: 40 40 40;
+  --surface-dark-active: 50 50 50;
+  --border-dark: 42 42 42;
+  --border-dark-secondary: 51 51 51;
+  --border-dark-hover: 64 64 64;
+  --text-dark-primary: 255 255 255;
+  --text-dark-secondary: 224 224 224;
+  --text-dark-tertiary: 192 192 192;
+  --text-dark-quaternary: 160 160 160;
 }
 
 :root[data-theme='dark'] {
   color-scheme: dark;
+}
+
+/* Dim — softer dark; rides the `dark` base class, overrides the *-dark vars */
+:root[data-palette='dim'] {
+  --surface-dark: 28 28 30;
+  --surface-dark-secondary: 36 36 38;
+  --surface-dark-tertiary: 47 47 49;
+  --surface-dark-hover: 56 56 58;
+  --surface-dark-active: 66 66 70;
+  --border-dark: 56 56 58;
+  --border-dark-secondary: 67 67 70;
+  --border-dark-hover: 82 82 87;
+  --text-dark-primary: 228 228 230;
+  --text-dark-secondary: 184 184 189;
+  --text-dark-tertiary: 138 138 144;
+  --text-dark-quaternary: 106 106 112;
+}
+
+/* Sepia — warm paper; rides the light base, overrides the light vars */
+:root[data-palette='sepia'] {
+  --surface: 244 236 216;
+  --surface-secondary: 250 243 224;
+  --surface-tertiary: 239 230 207;
+  --surface-hover: 230 217 186;
+  --surface-active: 220 205 166;
+  --border: 221 208 176;
+  --border-secondary: 208 192 152;
+  --border-hover: 184 164 114;
+  --text-primary: 75 58 42;
+  --text-secondary: 111 89 66;
+  --text-tertiary: 154 131 102;
+  --text-quaternary: 179 160 127;
+}
+
+/* Solarized Light — light base */
+:root[data-palette='solarized-light'] {
+  --surface: 244 237 218;
+  --surface-secondary: 253 246 227;
+  --surface-tertiary: 238 232 213;
+  --surface-hover: 231 224 200;
+  --surface-active: 221 214 189;
+  --border: 222 216 195;
+  --border-secondary: 204 196 168;
+  --border-hover: 184 174 140;
+  --text-primary: 7 54 66;
+  --text-secondary: 88 110 117;
+  --text-tertiary: 101 123 131;
+  --text-quaternary: 147 161 161;
+}
+
+/* Solarized Dark — dark base */
+:root[data-palette='solarized-dark'] {
+  --surface-dark: 0 43 54;
+  --surface-dark-secondary: 7 54 66;
+  --surface-dark-tertiary: 10 68 83;
+  --surface-dark-hover: 13 79 96;
+  --surface-dark-active: 16 90 110;
+  --border-dark: 13 77 94;
+  --border-dark-secondary: 19 95 115;
+  --border-dark-hover: 26 112 136;
+  --text-dark-primary: 238 232 213;
+  --text-dark-secondary: 147 161 161;
+  --text-dark-tertiary: 131 148 150;
+  --text-dark-quaternary: 101 123 131;
+}
+
+/* Nord — dark base */
+:root[data-palette='nord'] {
+  --surface-dark: 42 47 58;
+  --surface-dark-secondary: 46 52 64;
+  --surface-dark-tertiary: 59 66 82;
+  --surface-dark-hover: 67 76 94;
+  --surface-dark-active: 76 86 106;
+  --border-dark: 59 66 82;
+  --border-dark-secondary: 67 76 94;
+  --border-dark-hover: 76 86 106;
+  --text-dark-primary: 236 239 244;
+  --text-dark-secondary: 216 222 233;
+  --text-dark-tertiary: 163 172 189;
+  --text-dark-quaternary: 123 132 148;
+}
+
+/* Midnight — deep blue dark base */
+:root[data-palette='midnight'] {
+  --surface-dark: 11 16 32;
+  --surface-dark-secondary: 15 21 48;
+  --surface-dark-tertiary: 23 33 69;
+  --surface-dark-hover: 30 42 85;
+  --surface-dark-active: 36 50 102;
+  --border-dark: 30 42 74;
+  --border-dark-secondary: 42 58 100;
+  --border-dark-hover: 58 77 128;
+  --text-dark-primary: 230 236 255;
+  --text-dark-secondary: 174 187 216;
+  --text-dark-tertiary: 115 132 168;
+  --text-dark-quaternary: 86 104 140;
 }
 
 html,

--- a/frontend/src/styles/pierre-diff-theme.css
+++ b/frontend/src/styles/pierre-diff-theme.css
@@ -1,0 +1,38 @@
+/*
+ * Surface overrides for @pierre/diffs under the palettes that diverge from the
+ * base light/dark themes. Syntax token colors still come from the pierre-light /
+ * pierre-dark Shiki themes (selected via themeType); only the code/gutter/buffer/
+ * hover/selection backgrounds are re-skinned so the diff matches the editor.
+ *
+ * `--diffs-*-override` is pierre's supported theming surface (consumed via var()
+ * fallback, inherited from :root). Values map to the structural token vars
+ * (globals.css), which resolve to the active palette. Grouped by base: light-base
+ * palettes read the light tokens, dark-base palettes read the *-dark tokens.
+ * Addition/deletion backgrounds are left to the theme — they stay semantic.
+ */
+
+:root[data-palette='sepia'],
+:root[data-palette='solarized-light'] {
+  --diffs-bg-context-override: rgb(var(--surface-secondary) / 1);
+  --diffs-bg-buffer-override: rgb(var(--surface) / 1);
+  --diffs-bg-context-gutter-override: rgb(var(--surface) / 1);
+  --diffs-bg-separator-override: rgb(var(--surface-tertiary) / 1);
+  --diffs-fg-number-override: rgb(var(--text-quaternary) / 1);
+  --diffs-bg-hover-override: rgb(var(--surface-hover) / 1);
+  --diffs-bg-selection-override: rgb(var(--surface-active) / 1);
+  --diffs-bg-selection-number-override: rgb(var(--surface-active) / 1);
+}
+
+:root[data-palette='dim'],
+:root[data-palette='solarized-dark'],
+:root[data-palette='nord'],
+:root[data-palette='midnight'] {
+  --diffs-bg-context-override: rgb(var(--surface-dark-secondary) / 1);
+  --diffs-bg-buffer-override: rgb(var(--surface-dark) / 1);
+  --diffs-bg-context-gutter-override: rgb(var(--surface-dark) / 1);
+  --diffs-bg-separator-override: rgb(var(--surface-dark-tertiary) / 1);
+  --diffs-fg-number-override: rgb(var(--text-dark-quaternary) / 1);
+  --diffs-bg-hover-override: rgb(var(--surface-dark-hover) / 1);
+  --diffs-bg-selection-override: rgb(var(--surface-dark-active) / 1);
+  --diffs-bg-selection-number-override: rgb(var(--surface-dark-active) / 1);
+}

--- a/frontend/src/styles/pierre-tree-theme.css
+++ b/frontend/src/styles/pierre-tree-theme.css
@@ -5,29 +5,30 @@
  * boundary via inheritance, so setting them on the host element themes the
  * internal UI without needing `unsafeCSS` injection.
  *
- * Palette mirrors tailwind.config.js tokens so the tree stays aligned with
- * the rest of the app.
+ * Palette maps to the structural token CSS vars (globals.css) so the tree
+ * follows every theme — including data-palette overrides (dim/sepia) — for free.
+ * var() resolves on the host, which inherits the tokens from :root.
  */
 
 file-tree-container {
-  /* Light (default) */
-  --trees-fg-override: #475569;
-  --trees-fg-muted-override: #94a3b8;
+  /* Light base (light + sepia) */
+  --trees-fg-override: rgb(var(--text-secondary) / 1);
+  --trees-fg-muted-override: rgb(var(--text-quaternary) / 1);
   --trees-bg-override: transparent;
-  --trees-bg-muted-override: #e0e0e0;
-  --trees-accent-override: #0f172a;
-  --trees-border-color-override: #e2e2e2;
+  --trees-bg-muted-override: rgb(var(--surface-hover) / 1);
+  --trees-accent-override: rgb(var(--text-primary) / 1);
+  --trees-border-color-override: rgb(var(--border) / 1);
 
-  --trees-selected-bg-override: #d8d8d8;
-  --trees-selected-fg-override: #0f172a;
+  --trees-selected-bg-override: rgb(var(--surface-active) / 1);
+  --trees-selected-fg-override: rgb(var(--text-primary) / 1);
   --trees-selected-focused-border-color-override: transparent;
 
-  --trees-focus-ring-color-override: rgb(148 163 184 / 0.3);
+  --trees-focus-ring-color-override: rgb(var(--text-quaternary) / 0.3);
   --trees-focus-ring-width-override: 1px;
   --trees-focus-ring-offset-override: 0;
 
   --trees-search-bg-override: transparent;
-  --trees-search-fg-override: #0f172a;
+  --trees-search-fg-override: rgb(var(--text-primary) / 1);
   --trees-search-font-weight-override: 500;
 
   --trees-input-bg-override: transparent;
@@ -35,60 +36,61 @@ file-tree-container {
   --trees-item-padding-x-override: 6px;
   /* Tighter than the 8px default so deep paths stay readable in the narrow panel. */
   --trees-level-gap-override: 6px;
-  --trees-indent-guide-bg-override: rgb(226 226 226 / 0.5);
-  --trees-scrollbar-thumb-override: #94a3b8;
+  --trees-indent-guide-bg-override: rgb(var(--border) / 0.5);
+  --trees-scrollbar-thumb-override: rgb(var(--text-quaternary) / 1);
 
   /* Monochrome git status — all modified/renamed/added collapse to the same
-     muted tone; only "deleted" uses a subtle semantic accent. */
-  --trees-status-modified-override: #94a3b8;
-  --trees-status-added-override: #94a3b8;
-  --trees-status-renamed-override: #94a3b8;
-  --trees-status-untracked-override: #94a3b8;
-  --trees-status-ignored-override: #cbd5e1;
-  --trees-status-deleted-override: #94a3b8;
+     muted tone; "ignored" is dimmer via opacity so it tracks the palette too. */
+  --trees-status-modified-override: rgb(var(--text-quaternary) / 1);
+  --trees-status-added-override: rgb(var(--text-quaternary) / 1);
+  --trees-status-renamed-override: rgb(var(--text-quaternary) / 1);
+  --trees-status-untracked-override: rgb(var(--text-quaternary) / 1);
+  --trees-status-ignored-override: rgb(var(--text-quaternary) / 0.6);
+  --trees-status-deleted-override: rgb(var(--text-quaternary) / 1);
 
-  --trees-git-modified-color-override: #94a3b8;
-  --trees-git-added-color-override: #94a3b8;
-  --trees-git-renamed-color-override: #94a3b8;
-  --trees-git-untracked-color-override: #94a3b8;
-  --trees-git-ignored-color-override: #cbd5e1;
-  --trees-git-deleted-color-override: #94a3b8;
+  --trees-git-modified-color-override: rgb(var(--text-quaternary) / 1);
+  --trees-git-added-color-override: rgb(var(--text-quaternary) / 1);
+  --trees-git-renamed-color-override: rgb(var(--text-quaternary) / 1);
+  --trees-git-untracked-color-override: rgb(var(--text-quaternary) / 1);
+  --trees-git-ignored-color-override: rgb(var(--text-quaternary) / 0.6);
+  --trees-git-deleted-color-override: rgb(var(--text-quaternary) / 1);
 
   --trees-font-size-override: 12px;
 }
 
 .dark file-tree-container {
-  --trees-fg-override: #e0e0e0;
-  --trees-fg-muted-override: #a0a0a0;
+  /* Dark base (dark + dim) */
+  --trees-fg-override: rgb(var(--text-dark-secondary) / 1);
+  --trees-fg-muted-override: rgb(var(--text-dark-quaternary) / 1);
   --trees-bg-override: transparent;
-  --trees-bg-muted-override: #282828;
-  --trees-accent-override: #ffffff;
-  --trees-border-color-override: #2a2a2a;
+  --trees-bg-muted-override: rgb(var(--surface-dark-hover) / 1);
+  --trees-accent-override: rgb(var(--text-dark-primary) / 1);
+  --trees-border-color-override: rgb(var(--border-dark) / 1);
 
-  --trees-selected-bg-override: #323232;
-  --trees-selected-fg-override: #ffffff;
+  --trees-selected-bg-override: rgb(var(--surface-dark-active) / 1);
+  --trees-selected-fg-override: rgb(var(--text-dark-primary) / 1);
   --trees-selected-focused-border-color-override: transparent;
 
-  --trees-focus-ring-color-override: rgb(160 160 160 / 0.3);
+  --trees-focus-ring-color-override: rgb(var(--text-dark-quaternary) / 0.3);
 
   --trees-search-bg-override: transparent;
-  --trees-search-fg-override: #ffffff;
+  --trees-search-fg-override: rgb(var(--text-dark-primary) / 1);
 
   --trees-input-bg-override: transparent;
-  --trees-indent-guide-bg-override: rgb(42 42 42 / 0.5);
-  --trees-scrollbar-thumb-override: #a0a0a0;
+  --trees-indent-guide-bg-override: rgb(var(--border-dark) / 0.5);
+  --trees-scrollbar-thumb-override: rgb(var(--text-dark-quaternary) / 1);
 
-  --trees-status-modified-override: #a0a0a0;
-  --trees-status-added-override: #a0a0a0;
-  --trees-status-renamed-override: #a0a0a0;
-  --trees-status-untracked-override: #a0a0a0;
-  --trees-status-ignored-override: #6b7280;
-  --trees-status-deleted-override: #a0a0a0;
+  --trees-status-modified-override: rgb(var(--text-dark-quaternary) / 1);
+  --trees-status-added-override: rgb(var(--text-dark-quaternary) / 1);
+  --trees-status-renamed-override: rgb(var(--text-dark-quaternary) / 1);
+  --trees-status-untracked-override: rgb(var(--text-dark-quaternary) / 1);
+  --trees-status-ignored-override: rgb(var(--text-dark-quaternary) / 0.6);
+  --trees-status-deleted-override: rgb(var(--text-dark-quaternary) / 1);
 
-  --trees-git-modified-color-override: #a0a0a0;
-  --trees-git-added-color-override: #a0a0a0;
-  --trees-git-renamed-color-override: #a0a0a0;
-  --trees-git-untracked-color-override: #a0a0a0;
-  --trees-git-ignored-color-override: #6b7280;
-  --trees-git-deleted-color-override: #a0a0a0;
+  --trees-git-modified-color-override: rgb(var(--text-dark-quaternary) / 1);
+  --trees-git-added-color-override: rgb(var(--text-dark-quaternary) / 1);
+  --trees-git-renamed-color-override: rgb(var(--text-dark-quaternary) / 1);
+  --trees-git-untracked-color-override: rgb(var(--text-dark-quaternary) / 1);
+  --trees-git-ignored-color-override: rgb(var(--text-dark-quaternary) / 0.6);
+  --trees-git-deleted-color-override: rgb(var(--text-dark-quaternary) / 1);
 }

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -3,8 +3,21 @@ import type { ToolAggregate } from './tools.types';
 
 export type ToolComponent = React.FC<{ tool: ToolAggregate; chatId?: string }>;
 
-export type Theme = 'light' | 'dark' | 'system';
+// Each theme rides a light or dark base (see DARK_PALETTES / useResolvedTheme)
+export type Theme =
+  | 'light'
+  | 'dark'
+  | 'system'
+  | 'dim'
+  | 'sepia'
+  | 'solarized-light'
+  | 'solarized-dark'
+  | 'nord'
+  | 'midnight';
 export type ResolvedTheme = 'light' | 'dark';
+// Active palette with `system` resolved away — used where concrete per-theme colors
+// are built outside CSS (Monaco/xterm can't read CSS vars). Theme = Palette | 'system'.
+export type Palette = Exclude<Theme, 'system'>;
 
 type MentionType = 'file';
 

--- a/frontend/src/utils/terminal.ts
+++ b/frontend/src/utils/terminal.ts
@@ -1,13 +1,33 @@
 import type { ITerminalOptions } from 'xterm';
+import type { Palette } from '@/types/ui.types';
+import { CUSTOM_PALETTE_TOKENS, DARK_PALETTES } from '@/utils/theme';
 
-export const buildTerminalTheme = (mode: 'light' | 'dark'): ITerminalOptions['theme'] => ({
-  background: mode === 'dark' ? '#141414' : '#f9f9f9',
-  foreground: mode === 'dark' ? '#e4e4e7' : '#27272a',
-  cursor: mode === 'dark' ? '#e4e4e7' : '#27272a',
-  cursorAccent: mode === 'dark' ? '#0a0a0a' : '#ffffff',
-  selectionBackground: mode === 'dark' ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.15)',
-  selectionInactiveBackground: mode === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.08)',
-});
+// xterm paints its own canvas background, so it can't read the surface-secondary CSS
+// var. Custom palettes derive bg/fg from the shared tokens; light/dark are the base
+// shades (mirrored from globals.css).
+const BASE_SURFACE = {
+  light: { background: '#f9f9f9', foreground: '#27272a' },
+  dark: { background: '#141414', foreground: '#e4e4e7' },
+} as const;
 
-export const getTerminalBackgroundClass = (mode: 'light' | 'dark'): string =>
-  mode === 'dark' ? 'bg-surface-dark-secondary' : 'bg-surface-secondary';
+function paletteSurface(palette: Palette): { background: string; foreground: string } {
+  if (palette === 'light' || palette === 'dark') return BASE_SURFACE[palette];
+  const t = CUSTOM_PALETTE_TOKENS[palette];
+  return { background: t.surfaceSecondary, foreground: t.textPrimary };
+}
+
+export const buildTerminalTheme = (palette: Palette): ITerminalOptions['theme'] => {
+  const isDark = DARK_PALETTES.has(palette);
+  const { background, foreground } = paletteSurface(palette);
+  return {
+    background,
+    foreground,
+    cursor: foreground,
+    cursorAccent: isDark ? '#0a0a0a' : '#ffffff',
+    selectionBackground: isDark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.15)',
+    selectionInactiveBackground: isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.08)',
+  };
+};
+
+export const getTerminalBackgroundClass = (palette: Palette): string =>
+  DARK_PALETTES.has(palette) ? 'bg-surface-dark-secondary' : 'bg-surface-secondary';

--- a/frontend/src/utils/theme.ts
+++ b/frontend/src/utils/theme.ts
@@ -1,0 +1,128 @@
+import type { LucideIcon } from 'lucide-react';
+import {
+  BookOpen,
+  Monitor,
+  Moon,
+  MoonStar,
+  Snowflake,
+  Sparkles,
+  Sun,
+  Sunrise,
+  Sunset,
+} from 'lucide-react';
+import type { Palette, Theme } from '@/types/ui.types';
+
+// Palettes that aren't the plain light/dark base — each re-skins the base surfaces.
+export type CustomPalette = Exclude<Palette, 'light' | 'dark'>;
+
+export interface ThemeMeta {
+  value: Theme;
+  label: string;
+  icon: LucideIcon;
+  // Base the palette rides; null for `system`, which follows the OS.
+  base: 'dark' | 'light' | null;
+  // Command-menu shortcut letter (Cmd/Ctrl+Shift+<key>).
+  shortcut: string;
+}
+
+// Single source for theme presentation, cycle order, and command shortcut. Adding a
+// custom palette also needs: a `CUSTOM_PALETTE_TOKENS` entry (hex, below) AND a
+// `data-palette` block in globals.css (RGB channels — the copy that does the theming).
+export const THEMES: ThemeMeta[] = [
+  { value: 'dark', label: 'Dark', icon: Moon, base: 'dark', shortcut: 'm' },
+  { value: 'light', label: 'Light', icon: Sun, base: 'light', shortcut: 'g' },
+  { value: 'dim', label: 'Dim', icon: MoonStar, base: 'dark', shortcut: 'i' },
+  { value: 'sepia', label: 'Sepia', icon: BookOpen, base: 'light', shortcut: 'p' },
+  {
+    value: 'solarized-light',
+    label: 'Solarized Light',
+    icon: Sunrise,
+    base: 'light',
+    shortcut: 'q',
+  },
+  { value: 'solarized-dark', label: 'Solarized Dark', icon: Sunset, base: 'dark', shortcut: 'r' },
+  { value: 'nord', label: 'Nord', icon: Snowflake, base: 'dark', shortcut: 'v' },
+  { value: 'midnight', label: 'Midnight', icon: Sparkles, base: 'dark', shortcut: 'x' },
+  { value: 'system', label: 'System', icon: Monitor, base: null, shortcut: 'y' },
+];
+
+const THEME_BY_VALUE = Object.fromEntries(THEMES.map((t) => [t.value, t])) as Record<
+  Theme,
+  ThemeMeta
+>;
+
+export const getThemeMeta = (theme: Theme): ThemeMeta => THEME_BY_VALUE[theme];
+
+// Order the quick-toggle (header / profile menu) steps through.
+export const THEME_CYCLE: Theme[] = THEMES.map((t) => t.value);
+
+// Palettes that ride the dark base (body `dark` class + the *-dark token vars).
+// Single source for dark/light classification.
+export const DARK_PALETTES: ReadonlySet<Palette> = new Set<Palette>(
+  THEMES.filter((t) => t.base === 'dark').map((t) => t.value as Palette),
+);
+
+export interface PaletteTokens {
+  surface: string; // deepest/page background
+  surfaceSecondary: string; // raised surface (editor + terminal canvas)
+  surfaceTertiary: string;
+  textPrimary: string;
+  textSecondary: string;
+  textTertiary: string;
+}
+
+// Structural colors for the custom palettes — a hex mirror of the data-palette blocks
+// in globals.css (the CSS-native copy, in RGB channels). Monaco, xterm, and the
+// VisualWidget iframe can't read CSS vars, so they project these instead. Trap: the two
+// copies are different formats (#1c1c1e here vs `28 28 30` there) with no check that
+// they agree — change a shade in both, and convert correctly.
+export const CUSTOM_PALETTE_TOKENS: Record<CustomPalette, PaletteTokens> = {
+  dim: {
+    surface: '#1c1c1e',
+    surfaceSecondary: '#242426',
+    surfaceTertiary: '#2f2f31',
+    textPrimary: '#e4e4e6',
+    textSecondary: '#b8b8bd',
+    textTertiary: '#8a8a90',
+  },
+  sepia: {
+    surface: '#f4ecd8',
+    surfaceSecondary: '#faf3e0',
+    surfaceTertiary: '#efe6cf',
+    textPrimary: '#4b3a2a',
+    textSecondary: '#6f5942',
+    textTertiary: '#9a8366',
+  },
+  'solarized-light': {
+    surface: '#f4edda',
+    surfaceSecondary: '#fdf6e3',
+    surfaceTertiary: '#eee8d5',
+    textPrimary: '#073642',
+    textSecondary: '#586e75',
+    textTertiary: '#657b83',
+  },
+  'solarized-dark': {
+    surface: '#002b36',
+    surfaceSecondary: '#073642',
+    surfaceTertiary: '#0a4453',
+    textPrimary: '#eee8d5',
+    textSecondary: '#93a1a1',
+    textTertiary: '#839496',
+  },
+  nord: {
+    surface: '#2a2f3a',
+    surfaceSecondary: '#2e3440',
+    surfaceTertiary: '#3b4252',
+    textPrimary: '#eceff4',
+    textSecondary: '#d8dee9',
+    textTertiary: '#a3acbd',
+  },
+  midnight: {
+    surface: '#0b1020',
+    surfaceSecondary: '#0f1530',
+    surfaceTertiary: '#172145',
+    textPrimary: '#e6ecff',
+    textSecondary: '#aebbd8',
+    textTertiary: '#7384a8',
+  },
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -79,31 +79,31 @@ export default {
           950: '#172554',
         },
 
-        // Surface colors
+        // Surface colors — CSS-variable channels so data-palette can re-theme them
         surface: {
-          DEFAULT: '#f5f5f5',
-          secondary: '#f9f9f9',
-          tertiary: '#f3f3f3',
-          hover: '#e0e0e0',
-          active: '#d8d8d8',
+          DEFAULT: 'rgb(var(--surface) / <alpha-value>)',
+          secondary: 'rgb(var(--surface-secondary) / <alpha-value>)',
+          tertiary: 'rgb(var(--surface-tertiary) / <alpha-value>)',
+          hover: 'rgb(var(--surface-hover) / <alpha-value>)',
+          active: 'rgb(var(--surface-active) / <alpha-value>)',
           dark: {
-            DEFAULT: '#111111',
-            secondary: '#141414',
-            tertiary: '#1e1e1e',
-            hover: '#282828',
-            active: '#323232',
+            DEFAULT: 'rgb(var(--surface-dark) / <alpha-value>)',
+            secondary: 'rgb(var(--surface-dark-secondary) / <alpha-value>)',
+            tertiary: 'rgb(var(--surface-dark-tertiary) / <alpha-value>)',
+            hover: 'rgb(var(--surface-dark-hover) / <alpha-value>)',
+            active: 'rgb(var(--surface-dark-active) / <alpha-value>)',
           },
         },
 
         // Border colors
         border: {
-          DEFAULT: '#e2e2e2',
-          secondary: '#d1d1d1',
-          hover: '#9a9a9a',
+          DEFAULT: 'rgb(var(--border) / <alpha-value>)',
+          secondary: 'rgb(var(--border-secondary) / <alpha-value>)',
+          hover: 'rgb(var(--border-hover) / <alpha-value>)',
           dark: {
-            DEFAULT: '#2a2a2a',
-            secondary: '#333333',
-            hover: '#404040',
+            DEFAULT: 'rgb(var(--border-dark) / <alpha-value>)',
+            secondary: 'rgb(var(--border-dark-secondary) / <alpha-value>)',
+            hover: 'rgb(var(--border-dark-hover) / <alpha-value>)',
           },
         },
 
@@ -114,15 +114,15 @@ export default {
 
         // Text colors
         text: {
-          primary: '#0f172a',
-          secondary: '#475569',
-          tertiary: '#64748b',
-          quaternary: '#94a3b8',
+          primary: 'rgb(var(--text-primary) / <alpha-value>)',
+          secondary: 'rgb(var(--text-secondary) / <alpha-value>)',
+          tertiary: 'rgb(var(--text-tertiary) / <alpha-value>)',
+          quaternary: 'rgb(var(--text-quaternary) / <alpha-value>)',
           dark: {
-            primary: '#ffffff',
-            secondary: '#e0e0e0',
-            tertiary: '#c0c0c0',
-            quaternary: '#a0a0a0',
+            primary: 'rgb(var(--text-dark-primary) / <alpha-value>)',
+            secondary: 'rgb(var(--text-dark-secondary) / <alpha-value>)',
+            tertiary: 'rgb(var(--text-dark-tertiary) / <alpha-value>)',
+            quaternary: 'rgb(var(--text-dark-quaternary) / <alpha-value>)',
           },
         },
       },


### PR DESCRIPTION
## Summary
- Expands theming from `light`/`dark`/`system` to **nine palettes** — adds Dim, Sepia, Solarized Light, Solarized Dark, Nord, and Midnight.
- Routes structural Tailwind tokens through CSS variables (`rgb(var(--x) / <alpha-value>)`), so a `data-palette` attribute on the document re-themes every token-based surface with **zero per-component changes** (opacity modifiers like `/50` still work).
- Adds a single `THEMES` registry (`utils/theme.ts`) as the source of truth for theme presentation (label/icon), cycle order, dark/light classification (`DARK_PALETTES`), and command-menu shortcuts. Collapses the previously-scattered icon/label/cycle maps in Header, UserProfileMenu, commandRegistry, settings, and uiStore.
- Themes the surfaces that **can't read CSS vars** by projecting a shared hex token map (`CUSTOM_PALETTE_TOKENS`): Monaco editor, xterm terminal, and the sandboxed VisualWidget iframe. Git diff/tree get dedicated palette CSS (`pierre-diff-theme.css`, `pierre-tree-theme.css`).
- Settings theme picker is a compact dropdown (`Select`) — 9 options don't fit an inline row.

## Notes
- `globals.css` (RGB channels) and `CUSTOM_PALETTE_TOKENS` (hex) are two hand-synced copies for the same custom-palette colors, in different formats, by necessity (Monaco/xterm/iframe can't read CSS vars). The trap is documented at the token map; they currently agree exactly.
- The header/profile quick-toggle cycles through all 9 themes (pre-existing `THEME_CYCLE` behavior, now derived from `THEMES`). Settings is the "pick any" surface. Open to shortening the quick-toggle to light/dark/system if preferred.

## Test plan
- [ ] Switch through all 9 themes via Settings → Preferences → Theme; confirm chrome, file tree, toasts, and git diff re-theme.
- [ ] Open the code editor and terminal under each custom palette (esp. Sepia, Nord, Midnight) — canvas matches the chrome, not white/black.
- [ ] Render a VisualWidget under a custom palette; confirm surfaces/text follow the palette.
- [ ] Command menu (Cmd/Ctrl+K) theme entries + shortcuts work; profile menu + header toggle show the current theme's icon.
- [ ] `system` follows OS light/dark; reload persists the selected theme.