### PR TITLE
fix: stop SettingsPage crashing on cold load

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -110,7 +110,7 @@ const SettingsPage: React.FC = () => {
 
   const generalSecretFields = getGeneralSecretFields();
 
-  const { data: settings, isLoading: loading, error: fetchError } = useSettingsQuery();
+  const { data: settings, error: fetchError } = useSettingsQuery();
   const { data: skills, refetch: refetchSkills } = useSkillsQuery();
   const deleteAllChats = useDeleteAllChatsMutation();
 
@@ -195,7 +195,8 @@ const SettingsPage: React.FC = () => {
   });
 
   const hasUnsavedChanges = useMemo(() => {
-    if (!settings) return false;
+    // localSettings lags settings by one render on first load (synced via effect) — bail until it's populated.
+    if (!settings || !localSettings) return false;
     if (activeTab !== 'general' && activeTab !== 'instructions') return false;
 
     const changedPayload = buildChangedPayload(localSettings, settings);
@@ -269,14 +270,6 @@ const SettingsPage: React.FC = () => {
     setMobileNavOpen(false);
   }, []);
 
-  if (loading) {
-    return (
-      <div className="min-h-viewport flex items-center justify-center bg-surface dark:bg-surface-dark">
-        <Spinner size="lg" className="text-text-quaternary dark:text-text-dark-quaternary" />
-      </div>
-    );
-  }
-
   if (fetchError && !settings) {
     return (
       <div className="min-h-viewport flex items-center justify-center bg-surface dark:bg-surface-dark">
@@ -285,8 +278,14 @@ const SettingsPage: React.FC = () => {
     );
   }
 
+  // Covers both first load (no settings yet) and the one render where settings has resolved but the
+  // syncing effect hasn't populated localSettings yet.
   if (!settings || !localSettings) {
-    throw new Error('Settings data is required after the loading gate');
+    return (
+      <div className="min-h-viewport flex items-center justify-center bg-surface dark:bg-surface-dark">
+        <Spinner size="lg" className="text-text-quaternary dark:text-text-dark-quaternary" />
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- On a hard refresh of the Settings page, there's exactly one render where the query's `settings` have resolved (so `loading` is false) but the `useEffect` that syncs `localSettings` hasn't fired yet — leaving `localSettings === null`.
- That render crashed two ways: the post-gate invariant `throw`'d, and `hasUnsavedChanges` dereferenced the null `localSettings` via `buildChangedPayload` (`null is not an object`).
- Guard `hasUnsavedChanges` against null `localSettings`, and replace the post-gate `throw` with the loading spinner so the page waits one render for the sync effect.
- Consolidate the now-redundant `if (loading)` branch into the single `!settings || !localSettings` spinner gate (`isLoading` is only true when there's no data yet), dropping the unused `loading` binding.
- Kept the `useEffect` sync rather than a render-time ref check — `localSettings` is settings-form state (a copy of server data the user edits independently), which CLAUDE.md designates as the correct case for effect-based syncing.

## Test plan
- [ ] Hard-refresh on `/settings` (each tab) — page loads without crashing
- [ ] Navigate to `/settings` from a warm cache — no spinner flash, content renders immediately
- [ ] Edit a field, confirm the unsaved-changes banner appears and Save/Discard work
- [ ] Simulate a settings fetch failure — "Failed to load settings" still shows