### PR TITLE
Scan per-sandbox HOMEs for skill discovery in cloud mode

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -184,6 +184,10 @@ class Settings(BaseSettings):
             return self.HOST_SANDBOX_BASE_DIR
         return f"{self.STORAGE_PATH.rstrip('/')}/host-sandboxes"
 
+    def get_host_sandbox_home(self, sandbox_id: str) -> Path:
+        # The real host HOME directory backing a sandbox's virtual /home/user.
+        return Path(self.get_host_sandbox_base_dir()) / sandbox_id
+
     # Security Headers Configuration
     ENABLE_SECURITY_HEADERS: bool = True
     HSTS_MAX_AGE: int = 31536000

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -6,6 +6,7 @@ from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import get_settings
 from app.core.security import get_current_user
 from app.core.user_manager import optional_current_active_user
 from app.db.session import SessionLocal, get_db
@@ -31,6 +32,7 @@ from app.services.user import UserService
 from app.utils.cache import CacheError, cache_connection
 
 logger = logging.getLogger(__name__)
+settings = get_settings()
 
 
 def get_user_service() -> UserService:
@@ -41,8 +43,29 @@ def get_refresh_token_service() -> RefreshTokenService:
     return RefreshTokenService(session_factory=SessionLocal)
 
 
-def get_skill_service() -> SkillService:
-    return SkillService()
+async def get_skill_service(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SkillService:
+    # Desktop reads the single real home; cloud aggregates each workspace's
+    # per-sandbox HOME, where CLI-installed skills actually land.
+    if settings.DESKTOP_MODE:
+        return SkillService()
+    # Stable ordering so duplicate skill names across workspaces resolve to the
+    # same sandbox home on every request — list and edit must agree, otherwise a
+    # PUT can target a different workspace's skill than the one shown.
+    result = await db.execute(
+        select(Workspace.sandbox_id)
+        .where(
+            Workspace.user_id == current_user.id,
+            Workspace.deleted_at.is_(None),
+        )
+        .order_by(Workspace.id)
+    )
+    home_bases = [
+        settings.get_host_sandbox_home(sid) for sid in result.scalars().all()
+    ]
+    return SkillService(home_bases=home_bases)
 
 
 async def get_github_token(

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -505,8 +505,7 @@ class AcpSession:
         # TLS settings, and tool paths are available to the agent process.
         env = dict(os.environ)
         if config.sandbox_id:
-            host_base = settings.get_host_sandbox_base_dir()
-            host_home = f"{host_base}/{config.sandbox_id}"
+            host_home = str(settings.get_host_sandbox_home(config.sandbox_id))
             # Rewrite virtual sandbox paths (/home/user/...) to the real
             # host sandbox directory so helpers like GIT_ASKPASS resolve.
             for key, val in config.env.items():

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -216,7 +216,7 @@ class LocalHostProvider(SandboxProvider):
 
         env = os.environ.copy()
         if sandbox_id and not settings.DESKTOP_MODE:
-            host_home = Path(settings.get_host_sandbox_base_dir()) / sandbox_id
+            host_home = settings.get_host_sandbox_home(sandbox_id)
             host_home.mkdir(parents=True, exist_ok=True)
             env["HOME"] = str(host_home)
         env["TERM"] = TERMINAL_TYPE

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -19,40 +19,54 @@ SKILL_MD_FILENAME = "SKILL.md"
 
 
 class SkillService:
-    def __init__(self, workspace_path: Path | None = None) -> None:
+    def __init__(
+        self,
+        workspace_path: Path | None = None,
+        home_bases: list[Path] | None = None,
+    ) -> None:
+        # home_bases are the global skill roots to scan. Desktop has one real
+        # home; cloud passes one per workspace sandbox HOME (where the CLIs
+        # actually install skills). Defaults preserve single-base behavior.
+        bases = home_bases if home_bases is not None else self._default_home_bases()
         self.paths_by_source, self.readonly_paths = self._build_paths_by_source(
-            workspace_path
+            workspace_path, bases
         )
 
     @staticmethod
+    def _default_home_bases() -> list[Path]:
+        # Only desktop has a single global skill home. Server mode always passes
+        # explicit per-sandbox bases — there is no skills root at STORAGE_PATH.
+        return [Path.home()] if settings.DESKTOP_MODE else []
+
+    @staticmethod
     def _namespace_paths(
-        workspace_path: Path | None, base: Path, namespaces: list[str]
+        workspace_path: Path | None, bases: list[Path], namespaces: list[str]
     ) -> list[Path]:
         # Workspace paths come first (per-namespace) so they take priority over globals.
         paths: list[Path] = []
         if workspace_path:
             paths.extend(workspace_path / f".{ns}" / "skills" for ns in namespaces)
-        paths.extend(base / f".{ns}" / "skills" for ns in namespaces)
+        for base in bases:
+            paths.extend(base / f".{ns}" / "skills" for ns in namespaces)
         return paths
 
     @staticmethod
     def _build_paths_by_source(
         workspace_path: Path | None,
+        bases: list[Path],
     ) -> tuple[dict[str, list[Path]], set[Path]]:
-        # Desktop mode reads from the user's home dir, server mode from STORAGE_PATH.
-        base = Path.home() if settings.DESKTOP_MODE else Path(settings.STORAGE_PATH)
         ns = SkillService._namespace_paths
 
         # .{name}/skills namespaces each agent searches. Codex/Copilot/Cursor share
         # the Vercel .agents/skills ecosystem; OpenCode additionally cross-reads
         # Claude-compatible skills.
         result: dict[str, list[Path]] = {
-            AgentKind.CODEX.value: ns(workspace_path, base, ["codex", "agents"]),
-            AgentKind.COPILOT.value: ns(workspace_path, base, ["copilot", "agents"]),
-            AgentKind.CURSOR.value: ns(workspace_path, base, ["cursor", "agents"]),
-            AgentKind.CLAUDE.value: ns(workspace_path, base, ["claude"]),
+            AgentKind.CODEX.value: ns(workspace_path, bases, ["codex", "agents"]),
+            AgentKind.COPILOT.value: ns(workspace_path, bases, ["copilot", "agents"]),
+            AgentKind.CURSOR.value: ns(workspace_path, bases, ["cursor", "agents"]),
+            AgentKind.CLAUDE.value: ns(workspace_path, bases, ["claude"]),
             AgentKind.OPENCODE.value: ns(
-                workspace_path, base, ["opencode", "agents", "claude"]
+                workspace_path, bases, ["opencode", "agents", "claude"]
             ),
         }
         readonly_paths: set[Path] = set()
@@ -60,49 +74,52 @@ class SkillService:
         # Cursor CLI ships built-in skills at ~/.cursor/skills-cursor/ and manages
         # that directory automatically (updates overwrite user edits), so we
         # surface those skills but flag them read-only.
-        cursor_builtin = base / ".cursor" / "skills-cursor"
-        result[AgentKind.CURSOR.value].append(cursor_builtin)
-        readonly_paths.add(cursor_builtin)
+        for base in bases:
+            cursor_builtin = base / ".cursor" / "skills-cursor"
+            result[AgentKind.CURSOR.value].append(cursor_builtin)
+            readonly_paths.add(cursor_builtin)
 
         # Claude plugins can also bundle skills.
         result[AgentKind.CLAUDE.value].extend(
-            SkillService._get_claude_plugin_skill_paths()
+            SkillService._get_claude_plugin_skill_paths(bases)
         )
 
         return result, readonly_paths
 
     @staticmethod
-    def _get_claude_plugin_skill_paths() -> list[Path]:
-        # Claude-specific: cross-reference ~/.claude/settings.json (enabled flags)
-        # with installed_plugins.json (install paths) to discover plugin-bundled skills.
-        claude_dir = Path.home() / ".claude"
-        settings_path = claude_dir / "settings.json"
-        installed_path = claude_dir / "plugins" / "installed_plugins.json"
-        if not settings_path.is_file() or not installed_path.is_file():
-            return []
-        try:
-            settings = json.loads(settings_path.read_text(encoding="utf-8"))
-            installed = json.loads(installed_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-            return []
-        enabled_plugins = settings.get("enabledPlugins", {})
-        # Plugin IDs use the format "plugin-name@marketplace"
-        enabled_ids = {
-            pid for pid, enabled in enabled_plugins.items() if enabled is True
-        }
-        if not enabled_ids:
-            return []
+    def _get_claude_plugin_skill_paths(bases: list[Path]) -> list[Path]:
+        # Claude-specific: cross-reference each home's .claude/settings.json
+        # (enabled flags) with installed_plugins.json (install paths) to discover
+        # plugin-bundled skills.
         paths: list[Path] = []
-        for plugin_id, installs in installed.get("plugins", {}).items():
-            if plugin_id not in enabled_ids:
+        for base in bases:
+            claude_dir = base / ".claude"
+            settings_path = claude_dir / "settings.json"
+            installed_path = claude_dir / "plugins" / "installed_plugins.json"
+            if not settings_path.is_file() or not installed_path.is_file():
                 continue
-            for entry in installs:
-                install_path = entry.get("installPath")
-                if not install_path:
+            try:
+                claude_settings = json.loads(settings_path.read_text(encoding="utf-8"))
+                installed = json.loads(installed_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            enabled_plugins = claude_settings.get("enabledPlugins", {})
+            # Plugin IDs use the format "plugin-name@marketplace"
+            enabled_ids = {
+                pid for pid, enabled in enabled_plugins.items() if enabled is True
+            }
+            if not enabled_ids:
+                continue
+            for plugin_id, installs in installed.get("plugins", {}).items():
+                if plugin_id not in enabled_ids:
                     continue
-                skills_dir = Path(install_path) / "skills"
-                if skills_dir.is_dir():
-                    paths.append(skills_dir)
+                for entry in installs:
+                    install_path = entry.get("installPath")
+                    if not install_path:
+                        continue
+                    skills_dir = Path(install_path) / "skills"
+                    if skills_dir.is_dir():
+                        paths.append(skills_dir)
         return paths
 
     @staticmethod

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -271,7 +271,11 @@ class WorkspaceService(BaseDbService[Workspace]):
         # Thread-offloaded: SkillService walks the filesystem synchronously.
         workspace = await self.get_workspace(workspace_id, user)
         workspace_path = Path(workspace.workspace_path)
-        skill_service = SkillService(workspace_path=workspace_path)
+        # Cloud mode: skills live in per-sandbox HOME dirs, not STORAGE_PATH root.
+        home_bases = None
+        if not settings.DESKTOP_MODE:
+            home_bases = [settings.get_host_sandbox_home(workspace.sandbox_id)]
+        skill_service = SkillService(workspace_path=workspace_path, home_bases=home_bases)
 
         return await asyncio.to_thread(self._build_workspace_resources, skill_service)
 


### PR DESCRIPTION
## Summary

In cloud (server) mode, skill discovery scanned a single `STORAGE_PATH` root, but the host provider installs CLI skills into **per-sandbox HOME** dirs (`get_host_sandbox_base_dir()/sandbox_id`). The root scan therefore matched nothing, so `/skills` and `/workspaces/{id}/resources` returned no skills.

This generalizes `SkillService` to accept N `home_bases`:
- **`/skills` (global settings)** aggregates every workspace's sandbox HOME.
- **`/workspaces/{id}/resources`** scans that one workspace's sandbox HOME (plus its `workspace_path`).
- Desktop mode is unchanged (single real `~`).

### Changes
- Add `Settings.get_host_sandbox_home(sandbox_id)` and route the four duplicated `host_base / sandbox_id` call sites through it (`config`, `deps`, `workspace`, `host_provider`, `acp/session`).
- Order the workspace query by `id` so duplicate skill names across workspaces resolve to the **same** sandbox home on every request — list and edit agree, so a `PUT /skills/{source}/{name}` can't target a different workspace's skill than the one shown.
- Drop the now-dead `STORAGE_PATH` server default in `_default_home_bases` (server mode always passes explicit bases; desktop returns `~`).

### Known limitation (pre-existing, unchanged)
Host-side skill discovery requires the sandbox HOME to live on the host filesystem (host provider). **Docker** workspaces keep `HOME=/home/user` inside the container and bind-mount only the workspace, so CLI-installed skills there are not visible to the API — same as before this change. Exposing Docker skills would need a separate feature (exec-into-container listing or a home volume).

## Test notes
No automated tests run (repo policy: don't run verification unless asked). The existing skills API tests stub the `get_skill_service` dependency and assert workspace-resources returns a list, so they remain green; they don't exercise provider-specific discovery. Manual reasoning traced in the PR discussion confirms list/edit now resolve to a stable, identical sandbox home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
