### PR TITLE
Surface Codex .system and Claude marketplace plugin skills in cloud mode

### DIFF
--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -73,11 +73,16 @@ class SkillService:
 
         # Cursor CLI ships built-in skills at ~/.cursor/skills-cursor/ and manages
         # that directory automatically (updates overwrite user edits), so we
-        # surface those skills but flag them read-only.
+        # surface those skills but flag them read-only. Codex does the same for
+        # its preinstalled skills under .codex/skills/.system/ (user-installed
+        # ones stay flat in .codex/skills/ and are found via the namespace path).
         for base in bases:
             cursor_builtin = base / ".cursor" / "skills-cursor"
             result[AgentKind.CURSOR.value].append(cursor_builtin)
             readonly_paths.add(cursor_builtin)
+            codex_builtin = base / ".codex" / "skills" / ".system"
+            result[AgentKind.CODEX.value].append(codex_builtin)
+            readonly_paths.add(codex_builtin)
 
         # Claude plugins can also bundle skills.
         result[AgentKind.CLAUDE.value].extend(

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -84,47 +84,43 @@ class SkillService:
             result[AgentKind.CODEX.value].append(codex_builtin)
             readonly_paths.add(codex_builtin)
 
-        # Claude plugins can also bundle skills.
-        result[AgentKind.CLAUDE.value].extend(
-            SkillService._get_claude_plugin_skill_paths(bases)
-        )
+        # Claude marketplace plugins bundle skills; surface them read-only since
+        # the marketplace manages those dirs (updates overwrite edits).
+        plugin_skill_paths = SkillService._get_claude_plugin_skill_paths(bases)
+        result[AgentKind.CLAUDE.value].extend(plugin_skill_paths)
+        readonly_paths.update(plugin_skill_paths)
 
         return result, readonly_paths
 
     @staticmethod
     def _get_claude_plugin_skill_paths(bases: list[Path]) -> list[Path]:
-        # Claude-specific: cross-reference each home's .claude/settings.json
-        # (enabled flags) with installed_plugins.json (install paths) to discover
-        # plugin-bundled skills.
+        # Claude plugins bundle skills under each installed marketplace. Read
+        # known_marketplaces.json for the marketplace install location, then
+        # collect the skills/ dir of every downloaded plugin and external plugin.
         paths: list[Path] = []
         for base in bases:
-            claude_dir = base / ".claude"
-            settings_path = claude_dir / "settings.json"
-            installed_path = claude_dir / "plugins" / "installed_plugins.json"
-            if not settings_path.is_file() or not installed_path.is_file():
+            known_path = base / ".claude" / "plugins" / "known_marketplaces.json"
+            if not known_path.is_file():
                 continue
             try:
-                claude_settings = json.loads(settings_path.read_text(encoding="utf-8"))
-                installed = json.loads(installed_path.read_text(encoding="utf-8"))
+                marketplaces = json.loads(known_path.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError, UnicodeDecodeError):
                 continue
-            enabled_plugins = claude_settings.get("enabledPlugins", {})
-            # Plugin IDs use the format "plugin-name@marketplace"
-            enabled_ids = {
-                pid for pid, enabled in enabled_plugins.items() if enabled is True
-            }
-            if not enabled_ids:
-                continue
-            for plugin_id, installs in installed.get("plugins", {}).items():
-                if plugin_id not in enabled_ids:
+            for entry in marketplaces.values():
+                install_location = entry.get("installLocation")
+                if not install_location:
                     continue
-                for entry in installs:
-                    install_path = entry.get("installPath")
-                    if not install_path:
+                mp_root = Path(install_location)
+                # Plugins from this marketplace repo live under plugins/; remote
+                # ones it references are mirrored under external_plugins/.
+                for group in ("plugins", "external_plugins"):
+                    group_dir = mp_root / group
+                    if not group_dir.is_dir():
                         continue
-                    skills_dir = Path(install_path) / "skills"
-                    if skills_dir.is_dir():
-                        paths.append(skills_dir)
+                    for plugin_dir in group_dir.iterdir():
+                        skills_dir = plugin_dir / "skills"
+                        if skills_dir.is_dir():
+                            paths.append(skills_dir)
         return paths
 
     @staticmethod


### PR DESCRIPTION
## Summary

Follow-up to #657. After moving skill discovery to per-sandbox HOMEs, the skills list was still empty/near-empty in cloud mode. Two distinct gaps, both fixed here:

### 1. Codex preinstalled (`.system`) skills
Codex stores **preinstalled** skills under `.codex/skills/.system/<name>/`, while **user-installed** ones go flat in `.codex/skills/<name>/`. The scan only walked the flat path, so the `.system` dir (no `SKILL.md` of its own) was skipped. Added `.codex/skills/.system` as a read-only base per home, mirroring the existing Cursor `skills-cursor` built-in handling.

### 2. Claude marketplace plugin skills
`_get_claude_plugin_skill_paths` read `.claude/plugins/installed_plugins.json` and `enabledPlugins` from `settings.json` — neither exists in the current Claude layout, so **no** plugin skills surfaced. Rewrote it against the real layout: `known_marketplaces.json` gives each marketplace's `installLocation`, and bundled skills live under `<installLocation>/{plugins,external_plugins}/*/skills/`. Surfaced read-only (the marketplace manages those dirs; updates overwrite edits). Only physically-present plugins are scanned (the official marketplace installs ~52 of 234 catalog entries), so this reflects what's installed, not the full catalog.

## Result (verified against real on-disk sandbox homes)

Running the real `SkillService.list_all()` across all sandbox homes: **0 → 30 skills** (25 Claude plugin skills + 5 Codex `.system`), all `read_only=True`, deduped across homes. Confirmed `get_files` still serves them (viewable) and `update` is rejected for read-only skills.

## Known limitation (pre-existing)

Skill identity is `{source, name}`, so two plugins exposing a same-named skill (e.g. `access`/`configure` in `discord`/`imessage`/`telegram`) collapse to one entry. Disambiguating needs a plugin/location qualifier in the API + UI — tracked separately.

## Test notes

No automated test suite run (repo policy). Verified by executing the actual service against the real per-sandbox homes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
