### PR TITLE
fix: scope Settings Skills tab to a workspace

### DIFF
--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import AsyncIterator
+from pathlib import Path
 from uuid import UUID
 
 from fastapi import Depends, HTTPException, Request, status
@@ -39,10 +40,6 @@ def get_user_service() -> UserService:
 
 def get_refresh_token_service() -> RefreshTokenService:
     return RefreshTokenService(session_factory=SessionLocal)
-
-
-def get_skill_service() -> SkillService:
-    return SkillService()
 
 
 async def get_github_token(
@@ -170,6 +167,18 @@ async def get_workspace_service(
         user_service,
         session_factory=SessionLocal,
     )
+
+
+async def get_skill_service(
+    workspace_id: UUID,
+    current_user: User = Depends(get_current_user),
+    workspace_service: WorkspaceService = Depends(get_workspace_service),
+) -> SkillService:
+    # Skills live under each workspace's .{agent}/skills dir, so scope discovery
+    # to the selected workspace rather than a single global root that, in cloud
+    # mode, holds no skills.
+    workspace = await workspace_service.get_workspace(workspace_id, current_user)
+    return SkillService(workspace_path=Path(workspace.workspace_path))
 
 
 def get_attachment_service() -> AttachmentService:

--- a/frontend/src/components/settings/dialogs/SkillEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/SkillEditDialog.tsx
@@ -34,6 +34,7 @@ const EDITOR_OPTIONS = {
 
 interface SkillEditDialogProps {
   isOpen: boolean;
+  workspaceId: string;
   skill: CustomSkill | null;
   onClose: () => void;
   onSaved: () => Promise<void>;
@@ -41,6 +42,7 @@ interface SkillEditDialogProps {
 
 export const SkillEditDialog: React.FC<SkillEditDialogProps> = ({
   isOpen,
+  workspaceId,
   skill,
   onClose,
   onSaved,
@@ -73,7 +75,7 @@ export const SkillEditDialog: React.FC<SkillEditDialogProps> = ({
 
     let cancelled = false;
     void skillService
-      .getSkillFiles(skill.source, skill.name)
+      .getSkillFiles(workspaceId, skill.source, skill.name)
       .then((loaded) => {
         if (cancelled) return;
         setFiles(loaded);
@@ -98,7 +100,7 @@ export const SkillEditDialog: React.FC<SkillEditDialogProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, skill]);
+  }, [isOpen, skill, workspaceId]);
 
   const selectedSkillFile = useMemo(
     () => files.find((file) => file.path === selectedFile?.path) ?? null,
@@ -142,7 +144,7 @@ export const SkillEditDialog: React.FC<SkillEditDialogProps> = ({
         const modified = modifiedFiles.get(file.path);
         return modified === undefined ? file : { ...file, content: modified };
       });
-      await skillService.updateSkill(skill.source, skill.name, merged);
+      await skillService.updateSkill(workspaceId, skill.source, skill.name, merged);
       await onSaved();
       onClose();
       toast.success('Skill updated');
@@ -151,7 +153,7 @@ export const SkillEditDialog: React.FC<SkillEditDialogProps> = ({
     } finally {
       setSaving(false);
     }
-  }, [files, modifiedFiles, onClose, onSaved, skill]);
+  }, [files, modifiedFiles, onClose, onSaved, skill, workspaceId]);
 
   if (!isOpen || !skill) return null;
 

--- a/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
@@ -2,24 +2,30 @@ import type { CustomSkill } from '@/types/user.types';
 import { Zap, Edit2 } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { Button } from '@/components/ui/primitives/Button';
+import { Select } from '@/components/ui/primitives/Select';
 import { SkillEditDialog } from '@/components/settings/dialogs/SkillEditDialog';
+import { useWorkspacesList } from '@/hooks/queries/useWorkspaceQueries';
+import { useSkillsQuery } from '@/hooks/queries/useSkillsQueries';
 import { formatBytes } from '@/utils/format';
 
-interface SkillsSettingsTabProps {
-  skills: CustomSkill[] | undefined;
-  onSkillsChanged: () => Promise<void>;
-}
+export const SkillsSettingsTab: React.FC = () => {
+  const workspaces = useWorkspacesList();
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>();
+  // Skills are per-workspace, so default to the first workspace until the user
+  // picks another instead of tracking selection in a sync effect.
+  const workspaceId = selectedWorkspaceId ?? workspaces[0]?.id;
 
-export const SkillsSettingsTab: React.FC<SkillsSettingsTabProps> = ({
-  skills,
-  onSkillsChanged,
-}) => {
+  const { data: skills, isLoading, refetch } = useSkillsQuery(workspaceId);
   const items = skills ?? [];
   const [editingSkill, setEditingSkill] = useState<CustomSkill | null>(null);
 
   const handleCloseDialog = useCallback(() => {
     setEditingSkill(null);
   }, []);
+
+  const handleSaved = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
 
   return (
     <div>
@@ -28,76 +34,109 @@ export const SkillsSettingsTab: React.FC<SkillsSettingsTabProps> = ({
           Skills
         </h2>
         <p className="mt-1 text-xs text-text-tertiary dark:text-text-dark-tertiary">
-          Skills installed via the Claude, Codex, Copilot, Cursor, or OpenCode CLI are shown here.
+          Skills available in the selected workspace, from the Claude, Codex, Copilot, Cursor, or
+          OpenCode CLI.
         </p>
       </div>
 
-      {items.length === 0 ? (
+      {workspaces.length === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-lg border border-border/50 py-10 dark:border-border-dark/50">
           <Zap className="mb-2 h-5 w-5 text-text-quaternary dark:text-text-dark-quaternary" />
-          <p className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
-            No skills installed
-          </p>
+          <p className="text-xs text-text-tertiary dark:text-text-dark-tertiary">No workspaces</p>
         </div>
       ) : (
-        <div className="space-y-2">
-          {items.map((skill) => (
-            <div
-              key={`${skill.source}/${skill.name}`}
-              className="rounded-lg border border-border/50 px-4 py-3 dark:border-border-dark/50"
+        <>
+          <div className="mb-4">
+            <Select
+              value={workspaceId ?? ''}
+              onChange={(e) => setSelectedWorkspaceId(e.target.value)}
+              aria-label="Workspace"
             >
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0 flex-1">
-                  <div className="mb-1 flex items-center gap-2">
-                    <h3 className="min-w-0 max-w-full truncate text-xs font-medium text-text-primary dark:text-text-dark-primary sm:max-w-[250px]">
-                      {skill.name}
-                    </h3>
-                    <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
-                      {skill.source}
-                    </span>
-                    {skill.read_only && (
-                      <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
-                        built-in
-                      </span>
+              {workspaces.map((ws) => (
+                <option key={ws.id} value={ws.id}>
+                  {ws.name}
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-10">
+              <p className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
+                Loading skills…
+              </p>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="flex flex-col items-center justify-center rounded-lg border border-border/50 py-10 dark:border-border-dark/50">
+              <Zap className="mb-2 h-5 w-5 text-text-quaternary dark:text-text-dark-quaternary" />
+              <p className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
+                No skills installed
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {items.map((skill) => (
+                <div
+                  key={`${skill.source}/${skill.name}`}
+                  className="rounded-lg border border-border/50 px-4 py-3 dark:border-border-dark/50"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="mb-1 flex items-center gap-2">
+                        <h3 className="min-w-0 max-w-full truncate text-xs font-medium text-text-primary dark:text-text-dark-primary sm:max-w-[250px]">
+                          {skill.name}
+                        </h3>
+                        <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
+                          {skill.source}
+                        </span>
+                        {skill.read_only && (
+                          <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
+                            built-in
+                          </span>
+                        )}
+                      </div>
+                      {skill.description && (
+                        <p className="mb-2 text-xs text-text-tertiary dark:text-text-dark-tertiary">
+                          {skill.description}
+                        </p>
+                      )}
+                      <div className="flex items-center gap-2 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                        <span>
+                          {skill.file_count} file{skill.file_count !== 1 ? 's' : ''}
+                        </span>
+                        <span className="text-border dark:text-border-dark">/</span>
+                        <span>{formatBytes(skill.size_bytes)}</span>
+                      </div>
+                    </div>
+                    {!skill.read_only && (
+                      <Button
+                        type="button"
+                        onClick={() => setEditingSkill(skill)}
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 text-text-quaternary hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+                        aria-label={`Edit ${skill.name}`}
+                      >
+                        <Edit2 className="h-3.5 w-3.5" />
+                      </Button>
                     )}
                   </div>
-                  {skill.description && (
-                    <p className="mb-2 text-xs text-text-tertiary dark:text-text-dark-tertiary">
-                      {skill.description}
-                    </p>
-                  )}
-                  <div className="flex items-center gap-2 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-                    <span>
-                      {skill.file_count} file{skill.file_count !== 1 ? 's' : ''}
-                    </span>
-                    <span className="text-border dark:text-border-dark">/</span>
-                    <span>{formatBytes(skill.size_bytes)}</span>
-                  </div>
                 </div>
-                {!skill.read_only && (
-                  <Button
-                    type="button"
-                    onClick={() => setEditingSkill(skill)}
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 text-text-quaternary hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
-                    aria-label={`Edit ${skill.name}`}
-                  >
-                    <Edit2 className="h-3.5 w-3.5" />
-                  </Button>
-                )}
-              </div>
+              ))}
             </div>
-          ))}
-        </div>
+          )}
+        </>
       )}
 
-      <SkillEditDialog
-        isOpen={editingSkill !== null}
-        skill={editingSkill}
-        onClose={handleCloseDialog}
-        onSaved={onSkillsChanged}
-      />
+      {workspaceId && (
+        <SkillEditDialog
+          isOpen={editingSkill !== null}
+          workspaceId={workspaceId}
+          skill={editingSkill}
+          onClose={handleCloseDialog}
+          onSaved={handleSaved}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/hooks/queries/useSkillsQueries.ts
+++ b/frontend/src/hooks/queries/useSkillsQueries.ts
@@ -4,10 +4,14 @@ import { skillService } from '@/services/skillService';
 import type { CustomSkill } from '@/types/user.types';
 import { queryKeys } from './queryKeys';
 
-export const useSkillsQuery = (options?: Partial<UseQueryOptions<CustomSkill[]>>) => {
+export const useSkillsQuery = (
+  workspaceId: string | undefined,
+  options?: Partial<UseQueryOptions<CustomSkill[]>>,
+) => {
   return useQuery({
-    queryKey: [queryKeys.skills],
-    queryFn: () => skillService.listSkills(),
+    queryKey: [queryKeys.skills, workspaceId],
+    queryFn: () => skillService.listSkills(workspaceId!),
+    enabled: !!workspaceId,
     ...options,
   });
 };

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -17,7 +17,6 @@ import type { UserSettings, UserSettingsUpdate } from '@/types/user.types';
 import type { ApiFieldKey } from '@/types/settings.types';
 import { useDeleteAllChatsMutation } from '@/hooks/queries/useChatQueries';
 import { useSettingsQuery, useUpdateSettingsMutation } from '@/hooks/queries/useSettingsQueries';
-import { useSkillsQuery } from '@/hooks/queries/useSkillsQueries';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Button } from '@/components/ui/primitives/Button';
 import { Spinner } from '@/components/ui/primitives/Spinner';
@@ -111,7 +110,6 @@ const SettingsPage: React.FC = () => {
   const generalSecretFields = getGeneralSecretFields();
 
   const { data: settings, error: fetchError } = useSettingsQuery();
-  const { data: skills, refetch: refetchSkills } = useSkillsQuery();
   const deleteAllChats = useDeleteAllChatsMutation();
 
   const [localSettings, setLocalSettings] = useState<UserSettings | null>(settings ?? null);
@@ -490,7 +488,7 @@ const SettingsPage: React.FC = () => {
 
                   {activeTab === 'skills' && (
                     <div role="tabpanel" id="skills-panel" aria-labelledby="skills-tab">
-                      <SkillsSettingsTab skills={skills} onSkillsChanged={refetchSkills} />
+                      <SkillsSettingsTab />
                     </div>
                   )}
 

--- a/frontend/src/services/skillService.ts
+++ b/frontend/src/services/skillService.ts
@@ -3,9 +3,13 @@ import { ensureResponse, withAuth } from '@/services/base/BaseService';
 import type { CustomSkill } from '@/types/user.types';
 import { validateRequired } from '@/utils/validation';
 
-async function listSkills(): Promise<CustomSkill[]> {
+async function listSkills(workspaceId: string): Promise<CustomSkill[]> {
+  validateRequired(workspaceId, 'Workspace');
+
   return withAuth(async () => {
-    const response = await apiClient.get<CustomSkill[]>('/skills');
+    const response = await apiClient.get<CustomSkill[]>(
+      `/skills?workspace_id=${encodeURIComponent(workspaceId)}`,
+    );
     return ensureResponse(response, 'Failed to fetch skills');
   });
 }
@@ -21,13 +25,18 @@ interface SkillFilesResponse {
   files: SkillFileEntry[];
 }
 
-async function getSkillFiles(source: string, skillName: string): Promise<SkillFileEntry[]> {
+async function getSkillFiles(
+  workspaceId: string,
+  source: string,
+  skillName: string,
+): Promise<SkillFileEntry[]> {
+  validateRequired(workspaceId, 'Workspace');
   validateRequired(source, 'Source');
   validateRequired(skillName, 'Skill name');
 
   return withAuth(async () => {
     const response = await apiClient.get<SkillFilesResponse>(
-      `/skills/${source}/${skillName}/files`,
+      `/skills/${source}/${skillName}/files?workspace_id=${encodeURIComponent(workspaceId)}`,
     );
     const data = ensureResponse(response, 'Failed to fetch skill files');
     return data.files;
@@ -35,15 +44,20 @@ async function getSkillFiles(source: string, skillName: string): Promise<SkillFi
 }
 
 async function updateSkill(
+  workspaceId: string,
   source: string,
   skillName: string,
   files: SkillFileEntry[],
 ): Promise<CustomSkill> {
+  validateRequired(workspaceId, 'Workspace');
   validateRequired(source, 'Source');
   validateRequired(skillName, 'Skill name');
 
   return withAuth(async () => {
-    const response = await apiClient.put<CustomSkill>(`/skills/${source}/${skillName}`, { files });
+    const response = await apiClient.put<CustomSkill>(
+      `/skills/${source}/${skillName}?workspace_id=${encodeURIComponent(workspaceId)}`,
+      { files },
+    );
     return ensureResponse(response, 'Failed to update skill');
   });
 }


### PR DESCRIPTION
## Summary

The **Settings → Skills** tab showed nothing in cloud/server mode. `get_skill_service()` built `SkillService()` with no workspace context, so it only scanned the `STORAGE_PATH` root (`/data/.../.claude/skills`, which holds no skills). The user's skills actually live under each workspace's `.{agent}/skills` dir — reachable only when a `workspace_path` is passed.

This makes the Skills tab **workspace-scoped**: a workspace picker drives discovery, edits, and saves against the selected workspace.

## Changes

- **`deps.py`** — `get_skill_service` now takes `workspace_id`, resolves the owned workspace (404 via the global `ServiceException` handler on a bad/foreign id), and scopes `SkillService` to its path. All three `/skills` endpoints (list, files, update) inherit the required `workspace_id` query param through the dependency. Moved below `get_workspace_service` so the `Depends(...)` default resolves.
- **`skillService.ts`** — `listSkills` / `getSkillFiles` / `updateSkill` take `workspaceId` and send `?workspace_id=`.
- **`useSkillsQueries.ts`** — `useSkillsQuery(workspaceId)`, keyed `['skills', workspaceId]`, gated on presence (prefix-invalidation on `['skills']` still matches).
- **`SkillsSettingsTab.tsx`** — self-contained: workspace `Select` (defaults to first workspace via derived state, no effect), loading/empty states, owns its query, passes `workspaceId` to the edit dialog.
- **`SkillEditDialog.tsx`** — takes `workspaceId`, threaded into the file-load effect and save.
- **`SettingsPage.tsx`** — dropped the global `useSkillsQuery` call, import, and props.

## Not changed

**Stream actions** are intentionally left as-is. Skills are excluded there by design (documented in `StreamActionEditDialog.tsx`) because an action defined globally runs in whatever workspace it's later triggered in, where a suggested skill may not exist.

## Test notes

- Verified empirically before the change: `SkillService(workspace_path=<workspace>)` returns the workspace's 18 `.claude/skills` (plus codex/opencode mirrors), while `SkillService()` returns 0 — confirming the root cause and the fix path.
- All callers of the changed backend dependency, service methods, query hook, and dialog were swept for consistency; no dead references remain.
- Per project conventions, type-check/tests were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)