### PR TITLE
fix: mobile toast position and agent-view switching

### DIFF
--- a/frontend/src/config/toaster.ts
+++ b/frontend/src/config/toaster.ts
@@ -12,6 +12,12 @@ const toastSurfaceClass =
 
 export const toasterConfig: ToasterProps = {
   position: 'top-right',
+  // Push toasts below the iOS status-bar/notch inset (env() is 0 on web/desktop).
+  // The +1rem is just the gap below that inset — it does NOT account for the
+  // TitleBar height, so on chat screens toasts still sit partly over the bar.
+  containerStyle: {
+    top: 'calc(env(safe-area-inset-top) + 1rem)',
+  },
   toastOptions: {
     className: '',
     style: {

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -218,6 +218,13 @@ export const useUIStore = create<UIStoreState>()(
           }
           return;
         }
+        // Mobile shows one view at a time and the switcher has no agent icon, so
+        // re-tapping the active view returns to agent (removeTileFromMosaic can't
+        // collapse a single-string layout).
+        if (!isDesktop()) {
+          get().handleViewClick(toggle && state.currentView === view ? 'agent' : view, false);
+          return;
+        }
         // Target the tile of the pane the user is in — falls back to the primary
         // tile when there's no secondary chat to scope to.
         const secondary = isSecondaryPaneActive(state.activeAgentTile, state.secondaryChatId);


### PR DESCRIPTION
## Summary
- **Toast position:** offset the `react-hot-toast` container by `env(safe-area-inset-top) + 1rem` so toasts no longer render under the iOS notch/status bar (`env()` is `0` on web/desktop, so no change there).
- **Return to agent view on mobile:** the mobile view switcher has no Agent icon, and `removeTileFromMosaic` bails on a single-tile (string) layout — so re-tapping the active view did nothing and left the user stuck. `toggleView` now returns to the agent view when the current view is re-tapped on mobile, and switches views otherwise.

## Notes
- Uses the store-local `isDesktop()` helper (not the `useIsMobile` hook) because `toggleView` runs in the Zustand store, outside React — consistent with `ensureTileVisible`/`handleViewClick`/`openChatInSplit`.
- The `+1rem` toast gap clears the notch but not the full TitleBar height; on chat screens a toast can still sit partly over the bar. Comment documents this; can bump to `+2.5rem` if we want it fully clear.

## Test plan
- [ ] iOS: trigger a toast — it sits below the status bar/notch, not under it
- [ ] Web/desktop: toast position unchanged
- [ ] Mobile: open editor/terminal/secrets/diff from the TitleBar, tap the same icon again → returns to the agent view
- [ ] Mobile: tapping a different view icon switches to it
- [ ] Desktop: split-view toggling behavior unchanged