### PR TITLE
Add one-step iOS install helper; fix mobile CodeView drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,24 +98,31 @@ Install on your own iPhone with a free Apple ID — no paid developer account ne
    after the first install trust the certificate under
    **Settings → General → VPN & Device Management**.
 
-Build a standalone `.ipa` and install it on the connected iPhone:
+Build a standalone `.ipa` and install it on the connected iPhone. The easiest path
+is the bundled helper, which builds, signs, exports, and installs in one step. It
+reads your team from `APPLE_DEVELOPMENT_TEAM` (so nothing is hardcoded to anyone
+else's team) and auto-detects the connected device:
 
 ```bash
-# from frontend/ — rebuild the bundled UI + native app any time the code changes.
-# Sign with your own Apple team (find the ID in Xcode → Signing & Capabilities);
-# nothing is hardcoded to anyone else's team. The -c flag injects it into both
-# the build signing and the IPA export, so it stays out of the committed config.
-npm run ios:build -- --debug --export-method debugging \
+export APPLE_DEVELOPMENT_TEAM=<YOUR_TEAM_ID>   # find it in Xcode → Signing & Capabilities
+cd frontend
+npm run ios:install
+```
+
+Or run the steps yourself. The `-c` flag injects the team into both the build
+signing and the IPA export, so it stays out of the committed config:
+
+```bash
+npm run ios:build -- --export-method debugging \
   -c '{"bundle":{"iOS":{"developmentTeam":"<YOUR_TEAM_ID>"}}}'
 # -> src-tauri/gen/apple/build/arm64/Agentrove.ipa
 
-# find your device id, then install the freshly built .ipa
-xcrun devicectl list devices
+xcrun devicectl list devices   # find your device id
 xcrun devicectl device install app --device <DEVICE_ID> \
   src-tauri/gen/apple/build/arm64/Agentrove.ipa
 ```
 
-To update the app later, re-run those two commands — the standalone build runs on
+To update the app later, re-run `npm run ios:install` — the standalone build runs on
 the phone without keeping a Mac connected.
 
 ## Production

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "build:mobile": "vite build --mode mobile",
     "ios:dev": "tauri ios dev",
     "ios:build": "tauri ios build",
+    "ios:install": "bash ../scripts/ios-install.sh",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -88,12 +88,15 @@ export const CodeView = memo(function CodeView({
 
   const handleMobileFileSelect = useCallback(
     (file: FileStructure | null) => {
-      onFileSelect(file);
-      if (file && file.type === 'file') {
+      const isSameFile = file?.path === selectedFile?.path;
+      // Pierre replays the current selection when the mobile tree mounts; keep that
+      // sync from immediately closing the just-opened drawer.
+      if (!isSameFile) onFileSelect(file);
+      if (file && file.type === 'file' && !isSameFile) {
         setShowMobileTree(false);
       }
     },
-    [onFileSelect],
+    [onFileSelect, selectedFile?.path],
   );
 
   // Read the latest file tree through a ref so handleOpenResult stays

--- a/scripts/ios-install.sh
+++ b/scripts/ios-install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Build, sign, and install the Tauri iOS app on a connected iPhone in one step.
+# The team is passed via tauri's -c config override (the APPLE_DEVELOPMENT_TEAM env
+# var alone doesn't reach tauri's generated ExportOptions.plist), so it stays out of
+# the committed config and each dev signs as themselves.
+set -euo pipefail
+
+: "${APPLE_DEVELOPMENT_TEAM:?Set APPLE_DEVELOPMENT_TEAM (your Apple Team ID) before running}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$SCRIPT_DIR/../frontend"
+
+# 1. Build + sign + export a standalone IPA.
+( cd "$FRONTEND_DIR" && npm run ios:build -- --export-method debugging \
+    -c "{\"bundle\":{\"iOS\":{\"developmentTeam\":\"$APPLE_DEVELOPMENT_TEAM\"}}}" )
+
+IPA="$(ls -t "$FRONTEND_DIR"/src-tauri/gen/apple/build/*/*.ipa 2>/dev/null | head -1 || true)"
+[ -n "$IPA" ] || { echo "error: no .ipa produced under src-tauri/gen/apple/build" >&2; exit 1; }
+
+# 2. Resolve the first connected physical device (skips the Mac and simulators) and install.
+DEVICE_ID="$(xcrun xctrace list devices 2>/dev/null \
+  | awk '/== Devices ==/{f=1;next} /== Simulators ==/{f=0} f' \
+  | grep -iE 'iphone|ipad' | head -1 \
+  | sed -E 's/.*\(([0-9A-Fa-f-]+)\)$/\1/')" || true
+[ -n "$DEVICE_ID" ] || { echo "error: no iPhone/iPad connected" >&2; exit 1; }
+
+echo "Installing $(basename "$IPA") on device $DEVICE_ID ..."
+xcrun devicectl device install app --device "$DEVICE_ID" "$IPA"
+echo "Done — launch Agentrove on the device."


### PR DESCRIPTION
## Summary
- Add `npm run ios:install` (`scripts/ios-install.sh`) to build, sign, export, and install the iOS app on a connected device in one step. Reads the signing team from `APPLE_DEVELOPMENT_TEAM` (nothing hardcoded to anyone's team) and auto-detects the first connected iPhone/iPad.
- Update the README iOS section to point at the one-step helper, while keeping the manual steps documented.
- Fix the mobile CodeView file-select handler: Pierre replays the current selection when the mobile tree mounts, which was immediately closing the just-opened drawer. Now guarded so a same-file re-select is a no-op.

## Test plan
- [ ] `export APPLE_DEVELOPMENT_TEAM=<team>` then `cd frontend && npm run ios:install` builds and installs on a connected device
- [ ] Helper errors clearly when `APPLE_DEVELOPMENT_TEAM` is unset or no device is connected
- [ ] On mobile, opening a file from the tree keeps the drawer closing as expected; re-selecting the current file no longer reopens/closes the drawer unexpectedly