### PR TITLE
feat: add Dracula theme

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -155,6 +155,22 @@
   --text-dark-quaternary: 86 104 140;
 }
 
+/* Dracula — dark base; surfaces mirror CUSTOM_PALETTE_TOKENS.dracula (hex) */
+:root[data-palette='dracula'] {
+  --surface-dark: 33 34 44;
+  --surface-dark-secondary: 40 42 54;
+  --surface-dark-tertiary: 52 55 70;
+  --surface-dark-hover: 66 68 80;
+  --surface-dark-active: 68 71 90;
+  --border-dark: 52 55 70;
+  --border-dark-secondary: 66 68 80;
+  --border-dark-hover: 98 114 164;
+  --text-dark-primary: 248 248 242;
+  --text-dark-secondary: 200 202 220;
+  --text-dark-tertiary: 152 159 189;
+  --text-dark-quaternary: 98 114 164;
+}
+
 html,
 body,
 #root {

--- a/frontend/src/styles/pierre-diff-theme.css
+++ b/frontend/src/styles/pierre-diff-theme.css
@@ -26,7 +26,8 @@
 :root[data-palette='dim'],
 :root[data-palette='solarized-dark'],
 :root[data-palette='nord'],
-:root[data-palette='midnight'] {
+:root[data-palette='midnight'],
+:root[data-palette='dracula'] {
   --diffs-bg-context-override: rgb(var(--surface-dark-secondary) / 1);
   --diffs-bg-buffer-override: rgb(var(--surface-dark) / 1);
   --diffs-bg-context-gutter-override: rgb(var(--surface-dark) / 1);

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -13,7 +13,8 @@ export type Theme =
   | 'solarized-light'
   | 'solarized-dark'
   | 'nord'
-  | 'midnight';
+  | 'midnight'
+  | 'dracula';
 export type ResolvedTheme = 'light' | 'dark';
 // Active palette with `system` resolved away — used where concrete per-theme colors
 // are built outside CSS (Monaco/xterm can't read CSS vars). Theme = Palette | 'system'.

--- a/frontend/src/utils/theme.ts
+++ b/frontend/src/utils/theme.ts
@@ -1,6 +1,7 @@
 import type { LucideIcon } from 'lucide-react';
 import {
   BookOpen,
+  Ghost,
   Monitor,
   Moon,
   MoonStar,
@@ -43,6 +44,7 @@ export const THEMES: ThemeMeta[] = [
   { value: 'solarized-dark', label: 'Solarized Dark', icon: Sunset, base: 'dark', shortcut: 'r' },
   { value: 'nord', label: 'Nord', icon: Snowflake, base: 'dark', shortcut: 'v' },
   { value: 'midnight', label: 'Midnight', icon: Sparkles, base: 'dark', shortcut: 'x' },
+  { value: 'dracula', label: 'Dracula', icon: Ghost, base: 'dark', shortcut: 'z' },
   { value: 'system', label: 'System', icon: Monitor, base: null, shortcut: 'y' },
 ];
 
@@ -124,5 +126,13 @@ export const CUSTOM_PALETTE_TOKENS: Record<CustomPalette, PaletteTokens> = {
     textPrimary: '#e6ecff',
     textSecondary: '#aebbd8',
     textTertiary: '#7384a8',
+  },
+  dracula: {
+    surface: '#21222c',
+    surfaceSecondary: '#282a36',
+    surfaceTertiary: '#343746',
+    textPrimary: '#f8f8f2',
+    textSecondary: '#c8cadc',
+    textTertiary: '#989fbd',
   },
 };


### PR DESCRIPTION
## Summary
- Add Dracula as a dark-base palette following the existing custom-palette pattern
- `Theme` union entry + `THEMES` metadata (Ghost icon, Cmd/Ctrl+Shift+Z shortcut)
- `CUSTOM_PALETTE_TOKENS` hex mirror + `data-palette='dracula'` CSS block (RGB channels)
- Added Dracula to the pierre-diff dark-base group so diff surfaces match
- Monaco / xterm / VisualWidget themes derive automatically from `CUSTOM_PALETTE_TOKENS`
- Uses shortcut `Z` because `D` is already taken by the Diff view (would have rendered a dead shortcut)

Note: structural surfaces only — syntax highlighting still routes through the shared pierre-dark Shiki theme, not Dracula's accent hues.

## Test plan
- [ ] Select Dracula from the theme menu — verify surfaces, text, and borders apply
- [ ] Cmd/Ctrl+Shift+Z switches to Dracula (no Diff conflict)
- [ ] Editor (Monaco) and terminal (xterm) canvases match the Dracula background
- [ ] Diff view gutter/buffer/hover backgrounds match the rest of the UI
- [ ] Theme persists across reload