### PR TITLE
feat: add Ember theme

### DIFF
--- a/frontend/src/styles/palettes.ts
+++ b/frontend/src/styles/palettes.ts
@@ -18,7 +18,8 @@ export type PaletteKey =
   | 'midnight'
   | 'dracula'
   | 'tokyo-night'
-  | 'catppuccin-latte';
+  | 'catppuccin-latte'
+  | 'ember';
 
 export interface PaletteDef {
   base: 'light' | 'dark';
@@ -171,5 +172,20 @@ export const PALETTES: Record<PaletteKey, PaletteDef> = {
     textSecondary: '#5c5f77',
     textTertiary: '#8c8fa1',
     textQuaternary: '#9ca0b0',
+  },
+  ember: {
+    base: 'dark',
+    surface: '#1a1310',
+    surfaceSecondary: '#211813',
+    surfaceTertiary: '#2e211a',
+    surfaceHover: '#3a2a20',
+    surfaceActive: '#4a3528',
+    border: '#3a2a20',
+    borderSecondary: '#4a3528',
+    borderHover: '#6b4a32',
+    textPrimary: '#f5e6d8',
+    textSecondary: '#e0b894',
+    textTertiary: '#b3835f',
+    textQuaternary: '#856249',
   },
 };

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -16,7 +16,8 @@ export type Theme =
   | 'midnight'
   | 'dracula'
   | 'tokyo-night'
-  | 'catppuccin-latte';
+  | 'catppuccin-latte'
+  | 'ember';
 export type ResolvedTheme = 'light' | 'dark';
 // Active palette with `system` resolved away — used where concrete per-theme colors
 // are built outside CSS (Monaco/xterm can't read CSS vars). Theme = Palette | 'system'.

--- a/frontend/src/utils/theme.ts
+++ b/frontend/src/utils/theme.ts
@@ -3,6 +3,7 @@ import {
   BookOpen,
   Building2,
   Coffee,
+  Flame,
   Ghost,
   Monitor,
   Moon,
@@ -41,6 +42,7 @@ export const THEMES: ThemeMeta[] = [
   { value: 'dracula', label: 'Dracula', icon: Ghost },
   { value: 'tokyo-night', label: 'Tokyo Night', icon: Building2 },
   { value: 'catppuccin-latte', label: 'Catppuccin Latte', icon: Coffee },
+  { value: 'ember', label: 'Ember', icon: Flame },
   { value: 'system', label: 'System', icon: Monitor },
 ];
 


### PR DESCRIPTION
## Summary
- Add **Ember**, a warm dark theme (glowing-coal browns and ambers on near-black charcoal)
- Registered as pure data in `PALETTES`; CSS vars, `@pierre/diffs` overrides, Monaco/xterm hex tokens, and `DARK_PALETTES` membership all derive automatically
- Wired into the `Theme` union and the `THEMES` picker list (icon: `Flame`)

## Test plan
- [ ] Restart the dev server (palette CSS is generated once at Vite config load)
- [ ] Select **Ember** from the theme picker; verify app surfaces/text re-skin
- [ ] Confirm editor (Monaco), terminal (xterm), and diff view pick up the dark base
- [ ] Toggle through the theme cycle and back to confirm no crashes