### PR TITLE
fix: reset thinking timer on new stream

### DIFF
--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -408,7 +408,9 @@ export const Chat = memo(function Chat() {
 
     return (
       <div className="w-full lg:mx-auto lg:max-w-3xl">
-        {showThinking && <ThinkingIndicator streamStartTime={streamStartTime} />}
+        {showThinking && (
+          <ThinkingIndicator key={streamStartTime} streamStartTime={streamStartTime} />
+        )}
         {showPermissionAtEnd && <MessageInlinePermission />}
         {showStreamActions && chatId && <StreamActionsBar chatId={chatId} />}
       </div>

--- a/frontend/src/components/chat/chat-window/ThinkingIndicator.tsx
+++ b/frontend/src/components/chat/chat-window/ThinkingIndicator.tsx
@@ -12,6 +12,7 @@ export const ThinkingIndicator = memo(function ThinkingIndicator({
   // Seed from the active stream's start so the timer survives chat switches —
   // the indicator sits inside the chat-keyed scroller and remounts on switch.
   // Fall back to mount time when loading begins before the stream exists yet.
+  // Callers key this on streamStartTime so a new stream remounts and resets.
   const startTime = useRef(streamStartTime ?? Date.now());
 
   useMountEffect(() => {


### PR DESCRIPTION
## Summary
- The `ThinkingIndicator` seeds its elapsed timer from `streamStartTime` via a `useRef`, so it only initializes on mount.
- Within a single chat, starting a new stream didn't remount the component, leaving the timer counting from the *previous* stream's start.
- Add `key={streamStartTime}` where `ThinkingIndicator` is rendered in `Chat.tsx` so each new stream remounts the component and resets the timer.

## Test plan
- [ ] Start a stream, let the thinking timer run, then trigger a second stream in the same chat — verify the timer resets to 0.
- [ ] Switch chats mid-stream — verify the timer still reflects the active stream's start (no regression).