### PR TITLE
fix: bubble cloud project to top on new chat

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -253,12 +253,19 @@ export function LandingPage() {
           useChatStore.getState().setAttachedFilesForChat(PENDING_NEW_CHAT_KEY, []);
 
           // Register the chat as cloud-owned and refresh the sidebar's Cloud list
-          // so it appears immediately and routes to the VPS when opened.
+          // so it appears immediately and routes to the VPS when opened. Also
+          // refresh the cloud workspace list so the project bubbles to the top by
+          // last_chat_at — mirrors the local create mutation invalidating workspaces.
           markCloudChats([newChat.id]);
           const cloud = useCloudSettingsStore.getState();
-          void queryClient.invalidateQueries({
-            queryKey: queryKeys.cloudChats(cloud.cloudUrl, cloud.connectedEmail),
-          });
+          void Promise.all([
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.cloudChats(cloud.cloudUrl, cloud.connectedEmail),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.cloudWorkspaces(cloud.cloudUrl, cloud.connectedEmail),
+            }),
+          ]).catch((err) => console.error('Failed to refresh cloud sidebar', err));
 
           useModelStore.getState().selectModel(newChat.id, selectedModelId);
           useChatSettingsStore.getState().initChatFromDefaults(newChat.id);


### PR DESCRIPTION
## Summary
- When a new cloud-owned chat is created from the landing page, invalidate the cloud **workspaces** query in addition to the cloud **chats** query.
- This re-sorts the project to the top of the Cloud list by `last_chat_at`, mirroring how the local create mutation already invalidates workspaces.
- Both invalidations now run in parallel via `Promise.all`, with a single error handler.

## Test plan
- [ ] Create a new chat that routes to the cloud/VPS from the landing page
- [ ] Confirm the project bubbles to the top of the Cloud workspaces list immediately
- [ ] Confirm the new chat still appears in the Cloud chats list