### PR TITLE
fix: order sidebar local and cloud projects by activity

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -160,6 +160,20 @@ export function Sidebar({
   // Cloud projects (workspaces on the connected VPS, desktop only). Each renders
   // its own paginated group, mirroring the local per-workspace groups.
   const { data: cloudWorkspaces } = useCloudWorkspacesQuery(true);
+  const orderedWorkspaces = useMemo(
+    () =>
+      [
+        ...workspaces.map((workspace) => ({ workspace, isCloud: false })),
+        ...(cloudWorkspaces ?? []).map((workspace) => ({ workspace, isCloud: true })),
+      ].sort((a, b) => {
+        // Local and cloud lists are fetched separately; merge by activity so a
+        // fresh cloud chat can move its project above stale local projects.
+        const aTime = Date.parse(a.workspace.last_chat_at ?? a.workspace.updated_at);
+        const bTime = Date.parse(b.workspace.last_chat_at ?? b.workspace.updated_at);
+        return bTime - aTime;
+      }),
+    [workspaces, cloudWorkspaces],
+  );
 
   const hasAnyContent =
     pinnedChats.length > 0 || workspaces.length > 0 || (cloudWorkspaces?.length ?? 0) > 0;
@@ -450,6 +464,21 @@ export function Sidebar({
     }
   }, [workspaceToDelete, deleteWorkspace, selectedChatId, selectedChatWorkspaceId, navigate]);
 
+  // Props every workspace group needs identically — local and cloud differ only in
+  // the namespaced key and the local-only header actions (new thread, context menu).
+  const sharedGroupProps = {
+    selectedChatId,
+    secondaryChatId,
+    dropdownChatId: dropdown?.chat.id ?? null,
+    streamingChatIdSet,
+    onToggleCollapse: toggleWorkspaceCollapse,
+    onChatSelect: handleChatSelect,
+    onOpenInSplit: canOpenInSplit ? handleOpenInSplit : undefined,
+    onDropdownClick: handleDropdownClick,
+    expandedSubThreads,
+    onToggleSubThreads: handleToggleSubThreads,
+  };
+
   return (
     <>
       <aside
@@ -524,43 +553,25 @@ export function Sidebar({
                 </div>
               )}
 
-              {workspaces.map((workspace) => (
-                <SidebarWorkspaceGroup
-                  key={workspace.id}
-                  workspace={workspace}
-                  selectedChatId={selectedChatId}
-                  secondaryChatId={secondaryChatId}
-                  dropdownChatId={dropdown?.chat.id ?? null}
-                  streamingChatIdSet={streamingChatIdSet}
-                  isCollapsed={collapsedWorkspaces.has(workspace.id)}
-                  onToggleCollapse={toggleWorkspaceCollapse}
-                  onChatSelect={handleChatSelect}
-                  onOpenInSplit={canOpenInSplit ? handleOpenInSplit : undefined}
-                  onDropdownClick={handleDropdownClick}
-                  onNewThread={handleNewWorkspaceThread}
-                  onWorkspaceContextMenu={handleWorkspaceContextMenu}
-                  expandedSubThreads={expandedSubThreads}
-                  onToggleSubThreads={handleToggleSubThreads}
-                />
-              ))}
-
-              {cloudWorkspaces?.map((workspace) => (
-                <SidebarCloudGroup
-                  key={workspace.id}
-                  workspace={workspace}
-                  selectedChatId={selectedChatId}
-                  secondaryChatId={secondaryChatId}
-                  dropdownChatId={dropdown?.chat.id ?? null}
-                  streamingChatIdSet={streamingChatIdSet}
-                  isCollapsed={collapsedWorkspaces.has(workspace.id)}
-                  onToggleCollapse={toggleWorkspaceCollapse}
-                  onChatSelect={handleChatSelect}
-                  onOpenInSplit={canOpenInSplit ? handleOpenInSplit : undefined}
-                  onDropdownClick={handleDropdownClick}
-                  expandedSubThreads={expandedSubThreads}
-                  onToggleSubThreads={handleToggleSubThreads}
-                />
-              ))}
+              {orderedWorkspaces.map(({ workspace, isCloud }) =>
+                isCloud ? (
+                  <SidebarCloudGroup
+                    key={`cloud:${workspace.id}`}
+                    workspace={workspace}
+                    isCollapsed={collapsedWorkspaces.has(workspace.id)}
+                    {...sharedGroupProps}
+                  />
+                ) : (
+                  <SidebarWorkspaceGroup
+                    key={`local:${workspace.id}`}
+                    workspace={workspace}
+                    isCollapsed={collapsedWorkspaces.has(workspace.id)}
+                    onNewThread={handleNewWorkspaceThread}
+                    onWorkspaceContextMenu={handleWorkspaceContextMenu}
+                    {...sharedGroupProps}
+                  />
+                ),
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -252,13 +252,19 @@ export function LandingPage() {
           setMessage('');
           useChatStore.getState().setAttachedFilesForChat(PENDING_NEW_CHAT_KEY, []);
 
-          // Register the chat as cloud-owned and refresh the sidebar's Cloud list
-          // so it appears immediately and routes to the VPS when opened.
+          // Register the chat as cloud-owned and refresh the sidebar's cloud chats
+          // and workspaces so the new chat appears and its project re-sorts to the
+          // top by last_chat_at — the merged sidebar list orders local + cloud together.
           markCloudChats([newChat.id]);
           const cloud = useCloudSettingsStore.getState();
-          void queryClient.invalidateQueries({
-            queryKey: queryKeys.cloudChats(cloud.cloudUrl, cloud.connectedEmail),
-          });
+          void Promise.all([
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.cloudChats(cloud.cloudUrl, cloud.connectedEmail),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.cloudWorkspaces(cloud.cloudUrl, cloud.connectedEmail),
+            }),
+          ]).catch((err) => console.error('Failed to refresh cloud sidebar after new chat', err));
 
           useModelStore.getState().selectModel(newChat.id, selectedModelId);
           useChatSettingsStore.getState().initChatFromDefaults(newChat.id);


### PR DESCRIPTION
## Summary
- Merge local and cloud workspaces into one sidebar list sorted by activity (`last_chat_at`, falling back to `updated_at`), so a fresh cloud chat can move its project above stale local projects. Previously the two were rendered as fixed sections and could never interleave.
- Extract `sharedGroupProps` to remove duplication between the local and cloud group renders.
- On new cloud chat, invalidate cloud *workspaces* in addition to cloud chats so the project re-sorts to the top immediately.

This re-attempts the work reverted in #672 (revert of #671), now with local + cloud ordering unified so the re-sort is actually reflected.

## Test plan
- [ ] Start a new cloud chat and confirm its project bubbles to the top of the sidebar
- [ ] Confirm local and cloud projects interleave by activity rather than in fixed sections
- [ ] Confirm local-only header actions (new thread, context menu) still work on local groups