### PR TITLE
feat: cloud project rename, delete, and new-thread sidebar actions

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -19,7 +19,11 @@ import {
   useDeleteWorkspaceMutation,
   useUpdateWorkspaceMutation,
 } from '@/hooks/queries/useWorkspaceQueries';
-import { useCloudWorkspacesQuery } from '@/hooks/queries/useCloudQueries';
+import {
+  useCloudWorkspacesQuery,
+  useCloudUpdateWorkspaceMutation,
+  useCloudDeleteWorkspaceMutation,
+} from '@/hooks/queries/useCloudQueries';
 import { useToggleSet } from '@/hooks/useToggleSet';
 import { cn } from '@/utils/cn';
 import { useUIStore } from '@/store/uiStore';
@@ -128,14 +132,21 @@ export function Sidebar({
   const [pinnedHoveredId, setPinnedHoveredId] = useState<string | null>(null);
   const [chatToDelete, setChatToDelete] = useState<string | null>(null);
   const [chatToRename, setChatToRename] = useState<Chat | null>(null);
-  const [workspaceToDelete, setWorkspaceToDelete] = useState<string | null>(null);
-  const [workspaceToRename, setWorkspaceToRename] = useState<Workspace | null>(null);
+  const [workspaceToDelete, setWorkspaceToDelete] = useState<{
+    id: string;
+    isCloud: boolean;
+  } | null>(null);
+  const [workspaceToRename, setWorkspaceToRename] = useState<{
+    workspace: Workspace;
+    isCloud: boolean;
+  } | null>(null);
   const [dropdown, setDropdown] = useState<{
     chat: Chat;
     position: { top: number; left: number };
   } | null>(null);
   const [workspaceDropdown, setWorkspaceDropdown] = useState<{
     workspaceId: string;
+    isCloud: boolean;
     position: { top: number; left: number };
   } | null>(null);
   // Tracks which parent chats have their sub-threads expanded — collapsed by default to keep the sidebar compact
@@ -150,6 +161,8 @@ export function Sidebar({
   const pinChat = usePinChatMutation();
   const deleteWorkspace = useDeleteWorkspaceMutation();
   const updateWorkspace = useUpdateWorkspaceMutation();
+  const cloudUpdateWorkspace = useCloudUpdateWorkspaceMutation();
+  const cloudDeleteWorkspace = useCloudDeleteWorkspaceMutation();
 
   const { data: pinnedChatsData } = useInfiniteChatsQuery({ pinned: true });
   const pinnedChats = useMemo(() => {
@@ -173,6 +186,13 @@ export function Sidebar({
         return bTime - aTime;
       }),
     [workspaces, cloudWorkspaces],
+  );
+
+  // Distinguishes cloud vs local when the context menu opens, so rename/delete
+  // route to the right backend. Workspace IDs are UUIDs from separate DBs — no collisions.
+  const cloudWorkspaceIdSet = useMemo(
+    () => new Set((cloudWorkspaces ?? []).map((ws) => ws.id)),
+    [cloudWorkspaces],
   );
 
   const hasAnyContent =
@@ -401,34 +421,45 @@ export function Sidebar({
     [navigate, isMobile],
   );
 
+  const handleNewCloudThread = useCallback(
+    (e: React.MouseEvent, workspaceId: string) => {
+      e.stopPropagation();
+      // Landing composer flips to cloud and preselects this VPS workspace.
+      navigate('/', { state: { cloudWorkspaceId: workspaceId } });
+      if (isMobile) {
+        useUIStore.getState().setSidebarOpen(false);
+      }
+    },
+    [navigate, isMobile],
+  );
+
   const handleWorkspaceContextMenu = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>, workspaceId: string) => {
       e.stopPropagation();
       const rect = e.currentTarget.getBoundingClientRect();
+      const isCloud = cloudWorkspaceIdSet.has(workspaceId);
       setWorkspaceDropdown((prev) => {
         if (prev?.workspaceId === workspaceId) return null;
         const position = calculateDropdownPosition(rect);
-        return { workspaceId, position };
+        return { workspaceId, isCloud, position };
       });
     },
-    [],
+    [cloudWorkspaceIdSet],
   );
 
-  const handleRenameWorkspace = useCallback((workspace: Workspace) => {
-    setWorkspaceToRename(workspace);
+  const handleRenameWorkspace = useCallback((workspace: Workspace, isCloud: boolean) => {
+    setWorkspaceToRename({ workspace, isCloud });
     setWorkspaceDropdown(null);
   }, []);
 
   const handleSaveWorkspaceRename = useCallback(
     async (newName: string) => {
       if (!workspaceToRename) return;
+      const { workspace, isCloud } = workspaceToRename;
+      const mutation = isCloud ? cloudUpdateWorkspace : updateWorkspace;
       try {
         await mutateWithToast(
-          () =>
-            updateWorkspace.mutateAsync({
-              workspaceId: workspaceToRename.id,
-              data: { name: newName },
-            }),
+          () => mutation.mutateAsync({ workspaceId: workspace.id, data: { name: newName } }),
           'Workspace renamed',
           'Failed to rename workspace',
         );
@@ -438,23 +469,25 @@ export function Sidebar({
         setWorkspaceToRename(null);
       }
     },
-    [workspaceToRename, updateWorkspace],
+    [workspaceToRename, updateWorkspace, cloudUpdateWorkspace],
   );
 
-  const handleDeleteWorkspace = useCallback((workspaceId: string) => {
-    setWorkspaceToDelete(workspaceId);
+  const handleDeleteWorkspace = useCallback((workspaceId: string, isCloud: boolean) => {
+    setWorkspaceToDelete({ id: workspaceId, isCloud });
     setWorkspaceDropdown(null);
   }, []);
 
   const confirmDeleteWorkspace = useCallback(async () => {
     if (!workspaceToDelete) return;
+    const { id, isCloud } = workspaceToDelete;
+    const mutation = isCloud ? cloudDeleteWorkspace : deleteWorkspace;
     try {
       await mutateWithToast(
-        () => deleteWorkspace.mutateAsync(workspaceToDelete),
+        () => mutation.mutateAsync(id),
         'Workspace deleted',
         'Failed to delete workspace',
       );
-      if (selectedChatId && selectedChatWorkspaceId === workspaceToDelete) {
+      if (selectedChatId && selectedChatWorkspaceId === id) {
         navigate('/');
       }
     } catch {
@@ -462,7 +495,14 @@ export function Sidebar({
     } finally {
       setWorkspaceToDelete(null);
     }
-  }, [workspaceToDelete, deleteWorkspace, selectedChatId, selectedChatWorkspaceId, navigate]);
+  }, [
+    workspaceToDelete,
+    deleteWorkspace,
+    cloudDeleteWorkspace,
+    selectedChatId,
+    selectedChatWorkspaceId,
+    navigate,
+  ]);
 
   // Props every workspace group needs identically — local and cloud differ only in
   // the namespaced key and the local-only header actions (new thread, context menu).
@@ -559,6 +599,8 @@ export function Sidebar({
                     key={`cloud:${workspace.id}`}
                     workspace={workspace}
                     isCollapsed={collapsedWorkspaces.has(workspace.id)}
+                    onNewThread={handleNewCloudThread}
+                    onWorkspaceContextMenu={handleWorkspaceContextMenu}
                     {...sharedGroupProps}
                   />
                 ) : (
@@ -613,8 +655,9 @@ export function Sidebar({
             variant="unstyled"
             type="button"
             onClick={() => {
-              const ws = workspaces.find((w) => w.id === workspaceDropdown.workspaceId);
-              if (ws) handleRenameWorkspace(ws);
+              const list = workspaceDropdown.isCloud ? (cloudWorkspaces ?? []) : workspaces;
+              const ws = list.find((w) => w.id === workspaceDropdown.workspaceId);
+              if (ws) handleRenameWorkspace(ws, workspaceDropdown.isCloud);
             }}
             className="w-full rounded-md px-2.5 py-1.5 text-left text-xs text-text-secondary transition-colors duration-200 hover:bg-surface-hover dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover"
           >
@@ -623,7 +666,9 @@ export function Sidebar({
           <Button
             variant="unstyled"
             type="button"
-            onClick={() => handleDeleteWorkspace(workspaceDropdown.workspaceId)}
+            onClick={() =>
+              handleDeleteWorkspace(workspaceDropdown.workspaceId, workspaceDropdown.isCloud)
+            }
             className="w-full rounded-md px-2.5 py-1.5 text-left text-xs text-error-500 transition-colors duration-200 hover:bg-surface-hover dark:text-error-400 dark:hover:bg-surface-dark-hover"
           >
             Delete
@@ -665,8 +710,8 @@ export function Sidebar({
         isOpen={!!workspaceToRename}
         onClose={() => setWorkspaceToRename(null)}
         onSave={handleSaveWorkspaceRename}
-        currentTitle={workspaceToRename?.name || ''}
-        isLoading={updateWorkspace.isPending}
+        currentTitle={workspaceToRename?.workspace.name || ''}
+        isLoading={updateWorkspace.isPending || cloudUpdateWorkspace.isPending}
       />
     </>
   );

--- a/frontend/src/components/layout/SidebarChatGroup.tsx
+++ b/frontend/src/components/layout/SidebarChatGroup.tsx
@@ -105,8 +105,11 @@ interface ChatGroupProps {
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   onLoadMore: () => void;
-  // Local groups supply new-thread + context-menu buttons; cloud groups none.
-  headerActions?: React.ReactNode;
+  // Workspace identity for the header-action buttons. Both local and cloud groups
+  // render the same new-thread + context-menu actions, so the shell owns them.
+  workspaceId: string;
+  onNewThread: (e: React.MouseEvent, workspaceId: string) => void;
+  onWorkspaceContextMenu: (e: React.MouseEvent<HTMLButtonElement>, workspaceId: string) => void;
   rowProps: ChatRowProps;
 }
 
@@ -124,7 +127,9 @@ const SidebarChatGroup = memo(function SidebarChatGroup({
   hasNextPage,
   isFetchingNextPage,
   onLoadMore,
-  headerActions,
+  workspaceId,
+  onNewThread,
+  onWorkspaceContextMenu,
   rowProps,
 }: ChatGroupProps) {
   const [isChatsExpanded, setIsChatsExpanded] = useState(false);
@@ -154,7 +159,24 @@ const SidebarChatGroup = memo(function SidebarChatGroup({
             </span>
           )}
         </Button>
-        {headerActions}
+        <Button
+          variant="unstyled"
+          type="button"
+          title="New thread"
+          onClick={(e) => onNewThread(e, workspaceId)}
+          className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+        >
+          <SquarePen className="h-3 w-3" />
+        </Button>
+        <Button
+          variant="unstyled"
+          type="button"
+          data-ws-dropdown-trigger
+          onClick={(e) => onWorkspaceContextMenu(e, workspaceId)}
+          className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+        >
+          <MoreHorizontal className="h-3 w-3" />
+        </Button>
       </div>
       {!isCollapsed && (
         <div>
@@ -263,28 +285,9 @@ export const SidebarWorkspaceGroup = memo(function SidebarWorkspaceGroup({
       hasNextPage={!!hasNextPage}
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={() => void fetchNextPage()}
-      headerActions={
-        <>
-          <Button
-            variant="unstyled"
-            type="button"
-            title="New thread"
-            onClick={(e) => onNewThread(e, workspace.id)}
-            className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-          >
-            <SquarePen className="h-3 w-3" />
-          </Button>
-          <Button
-            variant="unstyled"
-            type="button"
-            data-ws-dropdown-trigger
-            onClick={(e) => onWorkspaceContextMenu(e, workspace.id)}
-            className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-          >
-            <MoreHorizontal className="h-3 w-3" />
-          </Button>
-        </>
-      }
+      workspaceId={workspace.id}
+      onNewThread={onNewThread}
+      onWorkspaceContextMenu={onWorkspaceContextMenu}
       rowProps={rowProps}
     />
   );
@@ -294,14 +297,19 @@ interface CloudGroupProps extends ChatRowProps {
   workspace: Workspace;
   isCollapsed: boolean;
   onToggleCollapse: (workspaceId: string) => void;
+  onNewThread: (e: React.MouseEvent, workspaceId: string) => void;
+  onWorkspaceContextMenu: (e: React.MouseEvent<HTMLButtonElement>, workspaceId: string) => void;
 }
 
-// A cloud project's chats — same shell as local, minus local-only affordances
-// (new thread, workspace context menu, which aren't wired for cloud).
+// A cloud project's chats — same shell and header affordances as local. New-thread
+// routes to the landing composer with the cloud target preselected; the context
+// menu (rename/delete) proxies to the VPS via the cloud workspace mutations.
 export const SidebarCloudGroup = memo(function SidebarCloudGroup({
   workspace,
   isCollapsed,
   onToggleCollapse,
+  onNewThread,
+  onWorkspaceContextMenu,
   ...rowProps
 }: CloudGroupProps) {
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } =
@@ -326,6 +334,9 @@ export const SidebarCloudGroup = memo(function SidebarCloudGroup({
       hasNextPage={!!hasNextPage}
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={() => void fetchNextPage()}
+      workspaceId={workspace.id}
+      onNewThread={onNewThread}
+      onWorkspaceContextMenu={onWorkspaceContextMenu}
       rowProps={rowProps}
     />
   );

--- a/frontend/src/hooks/queries/useCloudQueries.ts
+++ b/frontend/src/hooks/queries/useCloudQueries.ts
@@ -1,8 +1,13 @@
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { cloudChatService } from '@/services/cloudChatService';
 import { queryKeys } from '@/hooks/queries/queryKeys';
+import { createMutation } from '@/hooks/queries/createMutation';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
-import type { Workspace, WorkspaceResources } from '@/types/workspace.types';
+import type {
+  Workspace,
+  WorkspaceResources,
+  UpdateWorkspaceRequest,
+} from '@/types/workspace.types';
 import type { UserSettings } from '@/types/user.types';
 
 const CLOUD_CHATS_PER_PAGE = 25;
@@ -19,6 +24,37 @@ export const useCloudWorkspacesQuery = (enabled: boolean) => {
     staleTime: 30_000,
   });
 };
+
+// Rename/delete a VPS workspace. cloudUrl + connectedEmail are read at cache-update
+// time so the invalidation targets the same instance/account the query is keyed by.
+export const useCloudUpdateWorkspaceMutation = createMutation<
+  Workspace,
+  Error,
+  { workspaceId: string; data: UpdateWorkspaceRequest }
+>(
+  ({ workspaceId, data }) => cloudChatService.updateWorkspace(workspaceId, data),
+  (queryClient) => {
+    const { cloudUrl, connectedEmail } = useCloudSettingsStore.getState();
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.cloudWorkspaces(cloudUrl, connectedEmail),
+    });
+  },
+);
+
+export const useCloudDeleteWorkspaceMutation = createMutation<void, Error, string>(
+  (workspaceId) => cloudChatService.deleteWorkspace(workspaceId),
+  async (queryClient) => {
+    const { cloudUrl, connectedEmail } = useCloudSettingsStore.getState();
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.cloudWorkspaces(cloudUrl, connectedEmail),
+      }),
+      // Prefix-invalidate every project's cloud chats — the deleted workspace's
+      // chats are gone server-side and the sidebar list must drop them.
+      queryClient.invalidateQueries({ queryKey: queryKeys.cloudChatsAll }),
+    ]);
+  },
+);
 
 // VPS workspace skills and builtin slash-commands for the landing composer
 // before a chat exists. Keyed by cloudUrl + connectedEmail + workspaceId so

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -92,30 +92,45 @@ export function LandingPage() {
   const [message, setMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const consumedInitialMessageRef = useRef(false);
-  const routeState = location.state as { workspaceId?: string; initialMessage?: string } | null;
+  const routeState = location.state as {
+    workspaceId?: string;
+    cloudWorkspaceId?: string;
+    initialMessage?: string;
+  } | null;
   const initialWorkspaceId = routeState?.workspaceId ?? null;
+  const initialCloudWorkspaceId = routeState?.cloudWorkspaceId ?? null;
   const initialMessage = routeState?.initialMessage ?? null;
-  const consumedWorkspaceRef = useRef<string | null>(null);
+  // Keyed on location.key, not the target ID: React Router mints a fresh key on
+  // every navigation, so re-clicking the same workspace's "new thread" re-consumes
+  // the target and re-applies its run location even after a manual toggle.
+  const consumedNavKeyRef = useRef<string | null>(null);
 
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
 
   const isCloud = useChatSettingsStore((state) => state.runOnCloud);
   const [selectedCloudWorkspaceId, setSelectedCloudWorkspaceId] = useState<string | null>(null);
 
+  // Default the local workspace once the list loads or the current pick goes stale.
   useEffect(() => {
     if (!workspaces.length) return;
-    if (
-      initialWorkspaceId &&
-      initialWorkspaceId !== consumedWorkspaceRef.current &&
-      workspaces.some((ws) => ws.id === initialWorkspaceId)
-    ) {
-      consumedWorkspaceRef.current = initialWorkspaceId;
-      setSelectedWorkspaceId(initialWorkspaceId);
-      return;
-    }
     if (selectedWorkspaceId && workspaces.some((ws) => ws.id === selectedWorkspaceId)) return;
     setSelectedWorkspaceId(workspaces[0].id);
-  }, [initialWorkspaceId, workspaces, selectedWorkspaceId]);
+  }, [workspaces, selectedWorkspaceId]);
+
+  // Consume the sidebar "new thread" target once per navigation: preselect its
+  // workspace and flip the run location to match (cloud target → cloud, local →
+  // local). Keyed on location.key so re-clicking the same workspace re-applies it.
+  useEffect(() => {
+    if (location.key === consumedNavKeyRef.current) return;
+    consumedNavKeyRef.current = location.key;
+    if (initialCloudWorkspaceId) {
+      setSelectedCloudWorkspaceId(initialCloudWorkspaceId);
+      useChatSettingsStore.getState().setRunOnCloud(true);
+    } else if (initialWorkspaceId) {
+      setSelectedWorkspaceId(initialWorkspaceId);
+      useChatSettingsStore.getState().setRunOnCloud(false);
+    }
+  }, [location.key, initialWorkspaceId, initialCloudWorkspaceId]);
 
   if (initialMessage && !consumedInitialMessageRef.current) {
     consumedInitialMessageRef.current = true;

--- a/frontend/src/services/cloudChatService.ts
+++ b/frontend/src/services/cloudChatService.ts
@@ -5,7 +5,11 @@ import { cloudAuthStorage } from '@/utils/storage';
 import { markCloudChats, markCloudSandboxes, clearCloudOrigins } from '@/utils/chatOrigin';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import type { AuthResponse, UserSettings } from '@/types/user.types';
-import type { Workspace, WorkspaceResources } from '@/types/workspace.types';
+import type {
+  Workspace,
+  WorkspaceResources,
+  UpdateWorkspaceRequest,
+} from '@/types/workspace.types';
 import type { Chat, ChatRequest, CreateChatRequest } from '@/types/chat.types';
 import type { PaginatedChats, PaginatedResponse } from '@/types/api.types';
 
@@ -71,6 +75,22 @@ async function createChat(data: CreateChatRequest): Promise<Chat> {
   });
 }
 
+async function updateWorkspace(
+  workspaceId: string,
+  data: UpdateWorkspaceRequest,
+): Promise<Workspace> {
+  return serviceCall(async () => {
+    const response = await remoteApiClient.patch<Workspace>(`/workspaces/${workspaceId}`, data);
+    return ensureResponse(response, 'Failed to rename cloud workspace');
+  });
+}
+
+async function deleteWorkspace(workspaceId: string): Promise<void> {
+  await serviceCall(async () => {
+    await remoteApiClient.delete(`/workspaces/${workspaceId}`);
+  });
+}
+
 // Fetch a VPS workspace's skills and builtin slash-commands. The landing
 // composer needs these before a chat exists, so there's no chatId to route by —
 // call the VPS directly instead of going through resolveChatClient.
@@ -105,6 +125,8 @@ export const cloudChatService = {
   connect,
   disconnect,
   listWorkspaces,
+  updateWorkspace,
+  deleteWorkspace,
   listChats,
   createChat,
   getWorkspaceResources,


### PR DESCRIPTION
## Summary
- Cloud workspaces in the sidebar now render the same header actions as local ones: new thread, rename, and delete (previously read-only).
- Rename/delete proxy to the VPS via new `useCloudUpdateWorkspaceMutation` / `useCloudDeleteWorkspaceMutation` hooks and `cloudChatService.updateWorkspace` / `deleteWorkspace`.
- The workspace context menu and dropdown now track `isCloud` so rename/delete route to the correct backend; cloud and local IDs are UUIDs from separate DBs (no collisions).
- New-thread on a cloud project routes to the landing composer with the cloud target preselected and the run location flipped to cloud.
- `LandingPage` now consumes the sidebar new-thread target keyed on `location.key` (not the target ID), so re-clicking the same workspace re-applies its run location even after a manual toggle.
- `SidebarChatGroup` shell now owns the new-thread + context-menu header buttons for both local and cloud groups instead of taking them as a `headerActions` node.

## Test plan
- [ ] Cloud project shows new thread, rename, and delete actions on hover
- [ ] Renaming a cloud project updates the VPS and refreshes the sidebar
- [ ] Deleting a cloud project removes it and its chats from the sidebar
- [ ] Clicking "new thread" on a cloud project opens the landing composer with that workspace preselected and run location set to cloud
- [ ] Local project rename/delete/new-thread still work unchanged
- [ ] Re-clicking the same cloud project's new thread after toggling run location re-applies cloud