### PR TITLE
feat: awaiting-approval pill for blocked sidebar chats

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -29,6 +29,7 @@ import { cn } from '@/utils/cn';
 import { useUIStore } from '@/store/uiStore';
 import { useChatStore } from '@/store/chatStore';
 import { useStreamStore } from '@/store/streamStore';
+import { usePermissionStore } from '@/store/permissionStore';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useCurrentUserQuery, useLogoutMutation } from '@/hooks/queries/useAuthQueries';
 import { useAuthStore } from '@/store/authStore';
@@ -127,6 +128,11 @@ export function Sidebar({
     () => new Set(activeStreamMetadata.map((meta) => meta.chatId)),
     [activeStreamMetadata],
   );
+  // Chats with a pending plan/question/permission request — the agent is
+  // blocked on the user. Empty queues are deleted from the store, so every
+  // remaining key has an outstanding request.
+  const pendingRequests = usePermissionStore((state) => state.pendingRequests);
+  const blockedChatIdSet = useMemo(() => new Set(pendingRequests.keys()), [pendingRequests]);
   const [collapsedWorkspaces, toggleWorkspaceCollapse, setCollapsedWorkspaces] =
     useToggleSet<string>();
   const [pinnedHoveredId, setPinnedHoveredId] = useState<string | null>(null);
@@ -511,6 +517,7 @@ export function Sidebar({
     secondaryChatId,
     dropdownChatId: dropdown?.chat.id ?? null,
     streamingChatIdSet,
+    blockedChatIdSet,
     onToggleCollapse: toggleWorkspaceCollapse,
     onChatSelect: handleChatSelect,
     onOpenInSplit: canOpenInSplit ? handleOpenInSplit : undefined,
@@ -565,6 +572,7 @@ export function Sidebar({
                           isHovered={pinnedHoveredId === chat.id}
                           isDropdownOpen={dropdown?.chat.id === chat.id}
                           isChatStreaming={streamingChatIdSet.has(chat.id)}
+                          isChatBlocked={blockedChatIdSet.has(chat.id)}
                           onSelect={handleChatSelect}
                           onOpenInSplit={canOpenInSplit ? handleOpenInSplit : undefined}
                           onDropdownClick={handleDropdownClick}
@@ -585,6 +593,7 @@ export function Sidebar({
                             onSelect={handleChatSelect}
                             onDropdownClick={handleDropdownClick}
                             streamingChatIdSet={streamingChatIdSet}
+                            blockedChatIdSet={blockedChatIdSet}
                           />
                         )}
                       </div>

--- a/frontend/src/components/layout/SidebarChatGroup.tsx
+++ b/frontend/src/components/layout/SidebarChatGroup.tsx
@@ -31,6 +31,7 @@ interface ChatRowProps {
   secondaryChatId: string | null;
   dropdownChatId: string | null;
   streamingChatIdSet: Set<string>;
+  blockedChatIdSet: Set<string>;
   onChatSelect: (chatId: string) => void;
   onOpenInSplit?: (chatId: string) => void;
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
@@ -54,6 +55,7 @@ function SidebarChatRow({
     secondaryChatId,
     dropdownChatId,
     streamingChatIdSet,
+    blockedChatIdSet,
     onChatSelect,
     onOpenInSplit,
     onDropdownClick,
@@ -71,6 +73,7 @@ function SidebarChatRow({
         isHovered={hover.isHovered}
         isDropdownOpen={dropdownChatId === chat.id}
         isChatStreaming={streamingChatIdSet.has(chat.id)}
+        isChatBlocked={blockedChatIdSet.has(chat.id)}
         onSelect={onChatSelect}
         onOpenInSplit={onOpenInSplit}
         onDropdownClick={onDropdownClick}
@@ -87,6 +90,7 @@ function SidebarChatRow({
           onSelect={onChatSelect}
           onDropdownClick={onDropdownClick}
           streamingChatIdSet={streamingChatIdSet}
+          blockedChatIdSet={blockedChatIdSet}
         />
       )}
     </div>

--- a/frontend/src/components/layout/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/SidebarChatItem.tsx
@@ -14,6 +14,7 @@ interface SidebarChatItemProps {
   isHovered: boolean;
   isDropdownOpen: boolean;
   isChatStreaming: boolean;
+  isChatBlocked: boolean;
   onSelect: (chatId: string) => void;
   onOpenInSplit?: (chatId: string) => void;
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
@@ -30,6 +31,7 @@ export const SidebarChatItem = memo(function SidebarChatItem({
   isHovered,
   isDropdownOpen,
   isChatStreaming,
+  isChatBlocked,
   onSelect,
   onOpenInSplit,
   onDropdownClick,
@@ -72,8 +74,17 @@ export const SidebarChatItem = memo(function SidebarChatItem({
         <div className="h-3 w-3 flex-shrink-0" />
       )}
 
-      <div className="flex min-w-0 flex-1 items-center gap-1.5 pr-10">
-        {isChatStreaming && (
+      {/* Wider right padding when blocked reserves room for the "Awaiting approval"
+          pill so long titles truncate before reaching it. */}
+      <div
+        className={cn(
+          'flex min-w-0 flex-1 items-center gap-1.5',
+          isChatBlocked ? 'pr-[104px]' : 'pr-10',
+        )}
+      >
+        {/* A pending plan/question/permission request blocks the agent; show the
+            approval pill instead of the running pulse. */}
+        {isChatStreaming && !isChatBlocked && (
           <div className="h-1.5 w-1.5 flex-shrink-0 animate-pulse rounded-full bg-warning-500" />
         )}
         <Button
@@ -111,12 +122,14 @@ export const SidebarChatItem = memo(function SidebarChatItem({
 
       <span
         className={cn(
-          'absolute right-2 text-[10px] tabular-nums text-text-quaternary dark:text-text-dark-quaternary',
-          'transition-opacity duration-200',
+          'absolute right-2 text-[10px] transition-opacity duration-200',
+          isChatBlocked
+            ? 'rounded-md bg-text-primary px-1.5 py-0.5 font-medium text-surface dark:bg-text-dark-primary dark:text-surface-dark'
+            : 'tabular-nums text-text-quaternary dark:text-text-dark-quaternary',
           isHovered || isActive || isDropdownOpen ? 'opacity-0' : 'opacity-100',
         )}
       >
-        {getRelativeTime(chat.updated_at)}
+        {isChatBlocked ? 'Awaiting approval' : getRelativeTime(chat.updated_at)}
       </span>
 
       <Button

--- a/frontend/src/components/layout/SubThreadList.tsx
+++ b/frontend/src/components/layout/SubThreadList.tsx
@@ -15,6 +15,7 @@ interface SubThreadListProps {
   onSelect: (chatId: string) => void;
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
   streamingChatIdSet: Set<string>;
+  blockedChatIdSet: Set<string>;
 }
 
 export const SubThreadList = memo(function SubThreadList({
@@ -24,6 +25,7 @@ export const SubThreadList = memo(function SubThreadList({
   onSelect,
   onDropdownClick,
   streamingChatIdSet,
+  blockedChatIdSet,
 }: SubThreadListProps) {
   const { data: subThreads, isLoading, isError, refetch } = useSubThreadsQuery(parentChatId);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
@@ -59,6 +61,7 @@ export const SubThreadList = memo(function SubThreadList({
         const isSelected = thread.id === selectedChatId;
         const isActive = isSelected || thread.id === secondaryChatId;
         const isStreaming = streamingChatIdSet.has(thread.id);
+        const isBlocked = blockedChatIdSet.has(thread.id);
         const isHovered = hoveredId === thread.id;
 
         return (
@@ -81,13 +84,14 @@ export const SubThreadList = memo(function SubThreadList({
               onClick={() => onSelect(thread.id)}
               title={thread.title}
               className={cn(
-                'flex w-full items-center gap-2 px-2 py-1.5 pr-10 transition-colors duration-200',
+                'flex w-full items-center gap-2 px-2 py-1.5 transition-colors duration-200',
+                isBlocked ? 'pr-[104px]' : 'pr-10',
                 isActive
                   ? 'text-text-primary dark:text-text-dark-primary'
                   : 'text-text-tertiary hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-secondary',
               )}
             >
-              {isStreaming && (
+              {isStreaming && !isBlocked && (
                 <div className="h-[5px] w-[5px] flex-shrink-0 animate-pulse rounded-full bg-warning-500" />
               )}
               {thread.session_agent_kind && (
@@ -103,12 +107,14 @@ export const SubThreadList = memo(function SubThreadList({
 
             <span
               className={cn(
-                'absolute right-2 text-[10px] tabular-nums text-text-quaternary dark:text-text-dark-quaternary',
-                'transition-opacity duration-200',
+                'absolute right-2 text-[10px] transition-opacity duration-200',
+                isBlocked
+                  ? 'rounded-md bg-text-primary px-1.5 py-0.5 font-medium text-surface dark:bg-text-dark-primary dark:text-surface-dark'
+                  : 'tabular-nums text-text-quaternary dark:text-text-dark-quaternary',
                 isHovered || isActive ? 'opacity-0' : 'opacity-100',
               )}
             >
-              {getRelativeTime(thread.updated_at)}
+              {isBlocked ? 'Awaiting approval' : getRelativeTime(thread.updated_at)}
             </span>
 
             <Button


### PR DESCRIPTION
## Summary
- Add an "Awaiting approval" pill to sidebar chat rows and sub-threads when a chat has a pending plan/question/permission request (the agent is blocked on the user).
- Derive blocked state from `usePermissionStore`'s `pendingRequests` keys; empty queues are deleted from the store, so every remaining key has an outstanding request.
- The pill replaces the running pulse and relative timestamp for that chat; right padding widens so long titles truncate before reaching it.
- Thread the `blockedChatIdSet` through `Sidebar` → `SidebarChatGroup` → `SubThreadList` → `SidebarChatItem`, mirroring the existing `streamingChatIdSet` plumbing.

## Test plan
- [ ] Trigger a permission/plan/question prompt in a chat and confirm the sidebar row shows the "Awaiting approval" pill instead of the pulse/timestamp.
- [ ] Confirm the pill clears once the request is approved/denied.
- [ ] Verify sub-threads show the pill correctly and long titles truncate without overlapping it.
- [ ] Check light and dark mode rendering.