### PR TITLE
feat: move split-view pane controls into title-bar tabs

### DIFF
--- a/frontend/src/components/layout/SplitTabs.tsx
+++ b/frontend/src/components/layout/SplitTabs.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { X, Maximize2, Minimize2 } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { useUIStore } from '@/store/uiStore';
+import { useChatStore } from '@/store/chatStore';
+import { useChatQuery } from '@/hooks/queries/useChatQueries';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { cn } from '@/utils/cn';
+import {
+  getLeaves,
+  isMosaicSplitNode,
+  tileIdToViewType,
+  VIEW_LABELS,
+  VIEW_TYPES,
+} from '@/utils/mosaicHelpers';
+import type { MosaicTileId } from '@/types/ui.types';
+
+const TAB_BUTTON_CLASS = cn(
+  'flex items-center justify-center',
+  'h-5 w-4 rounded-md',
+  'text-text-tertiary dark:text-text-dark-tertiary',
+  'hover:text-text-primary dark:hover:text-text-dark-primary',
+  'transition-colors duration-200',
+);
+
+function getTileLabel(
+  tileId: MosaicTileId,
+  agentTitles: Partial<Record<MosaicTileId, string>>,
+): string {
+  return agentTitles[tileId] ?? VIEW_LABELS[tileIdToViewType(tileId)] ?? tileId;
+}
+
+// Pane tabs rendered inside the title bar. One segment per split pane, with
+// focus / maximize / close — replaces the per-pane window chrome. Self-sourcing:
+// everything it shows is globally reachable, so no props are threaded from the page.
+export function SplitTabs() {
+  const { chatId } = useParams();
+  const navigate = useNavigate();
+  const isMobile = useIsMobile();
+  const mosaicLayout = useUIStore((s) => s.mosaicLayout);
+  const focusedTile = useUIStore((s) => s.focusedTile);
+  const rawMaximized = useUIStore((s) => s.maximizedTile);
+  const secondaryChatId = useUIStore((s) => s.secondaryChatId);
+  const currentChat = useChatStore((s) => s.currentChat);
+  // Shares the chat-query cache with AgentPane / the page; used only for the
+  // secondary pane's tab label.
+  const secondaryTitle = useChatQuery(secondaryChatId ?? undefined).data?.title;
+
+  const agentTitles = useMemo<Partial<Record<MosaicTileId, string>>>(() => {
+    const titles: Partial<Record<MosaicTileId, string>> = {};
+    // Only the routed chat owns a title; on the landing split currentChat may be
+    // stale, so fall back to the generic view label there.
+    const primaryTitle = chatId ? currentChat?.title : undefined;
+    if (primaryTitle) titles['agent:primary'] = primaryTitle;
+    if (secondaryChatId && secondaryTitle) {
+      titles['agent:secondary'] = secondaryTitle;
+      // Each non-agent view's two tiles can coexist in split-chat view — name
+      // them by chat so the two copies (primary/secondary) are distinguishable.
+      for (const view of VIEW_TYPES) {
+        if (view === 'agent') continue;
+        if (primaryTitle) titles[view] = `${primaryTitle} · ${VIEW_LABELS[view]}`;
+        titles[`${view}:secondary`] = `${secondaryTitle} · ${VIEW_LABELS[view]}`;
+      }
+    }
+    return titles;
+  }, [chatId, currentChat?.title, secondaryChatId, secondaryTitle]);
+
+  const handleCloseTile = useCallback(
+    (tileId: MosaicTileId) => {
+      const ui = useUIStore.getState();
+      if (tileId === 'agent:secondary') {
+        ui.closeSplitChat();
+        return;
+      }
+      if (tileId === 'agent:primary' && ui.secondaryChatId && chatId) {
+        const newPrimary = ui.swapChatPanes(chatId);
+        if (newPrimary) {
+          navigate(`/chat/${newPrimary}`);
+          ui.closeSplitChat();
+          return;
+        }
+      }
+      ui.removeTileFromMosaic(tileId);
+    },
+    [chatId, navigate],
+  );
+
+  // Mirror the condition that mounts MosaicSplitView, so tabs only show when a
+  // real split is on screen (single-view and mobile render no split chrome).
+  const leaves = useMemo(
+    () => (mosaicLayout && isMosaicSplitNode(mosaicLayout) ? getLeaves(mosaicLayout) : []),
+    [mosaicLayout],
+  );
+
+  if (isMobile || leaves.length <= 1) return null;
+
+  // Both ephemeral tile pointers are derived on read: a value that's no longer a
+  // leaf is treated as absent, so the store never has to chase layout changes.
+  // Before the user touches a pane, highlight the first so one tab always reads active.
+  const activeTile = focusedTile && leaves.includes(focusedTile) ? focusedTile : leaves[0];
+  const maximizedTile = rawMaximized && leaves.includes(rawMaximized) ? rawMaximized : null;
+
+  return (
+    <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
+      {leaves.map((tileId) => {
+        const isFocused = tileId === activeTile;
+        const isMaximized = maximizedTile === tileId;
+        return (
+          <div
+            key={tileId}
+            className={cn(
+              'flex min-w-0 max-w-[220px] items-center gap-1.5 rounded-md py-1 pl-2.5 pr-1',
+              'transition-colors duration-200',
+              isFocused
+                ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
+                : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary',
+            )}
+          >
+            <Button
+              variant="unstyled"
+              onClick={() => useUIStore.getState().focusTile(tileId)}
+              className="min-w-0 flex-1 truncate text-left text-2xs font-medium"
+              title={getTileLabel(tileId, agentTitles)}
+            >
+              {getTileLabel(tileId, agentTitles)}
+            </Button>
+            <div className="flex items-center">
+              <Button
+                variant="unstyled"
+                onClick={() => useUIStore.getState().setMaximizedTile(isMaximized ? null : tileId)}
+                className={TAB_BUTTON_CLASS}
+                title={isMaximized ? 'Restore split' : 'Maximize'}
+              >
+                {isMaximized ? (
+                  <Minimize2 className="h-3 w-3" />
+                ) : (
+                  <Maximize2 className="h-3 w-3" />
+                )}
+              </Button>
+              {!maximizedTile && (
+                <Button
+                  variant="unstyled"
+                  onClick={() => handleCloseTile(tileId)}
+                  className={TAB_BUTTON_CLASS}
+                  title="Close tile"
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar.tsx
@@ -6,6 +6,7 @@ import { useUIStore } from '@/store/uiStore';
 import { Button } from '@/components/ui/primitives/Button';
 import { ToggleButton } from '@/components/ui/ToggleButton';
 import { ViewSwitcher } from './ViewSwitcher';
+import { SplitTabs } from './SplitTabs';
 import { cn } from '@/utils/cn';
 import { IS_MAC_PLATFORM, isDesktopApp } from '@/utils/platform';
 
@@ -199,8 +200,14 @@ export function TitleBar() {
         {IS_MACOS_DESKTOP && !(isAuthenticated && showSidebar) && <div className="w-1" />}
       </div>
 
-      {/* Main content area — matches main bg */}
-      <div className="flex h-full flex-1 items-center justify-end bg-surface px-3 pt-[env(safe-area-inset-top)] dark:bg-surface-dark">
+      {/* Main content area — matches main bg. Pane tabs (split view only) sit on
+          the left; the view switcher stays pinned right. */}
+      <div className="flex h-full flex-1 items-center justify-between gap-2 bg-surface px-3 pt-[env(safe-area-inset-top)] dark:bg-surface-dark">
+        {/* Landing can also split (opening a workspace file adds an editor pane),
+            so its panes need the same tab controls. */}
+        <div className="flex min-w-0 flex-1 items-center">
+          {(isChatPage || isLandingPage) && <SplitTabs />}
+        </div>
         {isChatPage && <ViewSwitcher />}
       </div>
     </div>

--- a/frontend/src/components/ui/MosaicSplitView.tsx
+++ b/frontend/src/components/ui/MosaicSplitView.tsx
@@ -1,74 +1,32 @@
-import { useCallback, useMemo, useState, ReactNode } from 'react';
-import { Button } from '@/components/ui/primitives/Button';
+import { useCallback, useMemo, ReactNode } from 'react';
 import { Mosaic, MosaicWindow } from 'react-mosaic-component';
-import { X, SplitSquareHorizontal, Maximize2, Minimize2 } from 'lucide-react';
 import { useUIStore } from '@/store/uiStore';
 import { cn } from '@/utils/cn';
-import {
-  mosaicLayoutToLibrary,
-  libraryToMosaicLayout,
-  getLeaves,
-  tileIdToViewType,
-  VIEW_LABELS,
-} from '@/utils/mosaicHelpers';
+import { getLeaves, mosaicLayoutToLibrary, libraryToMosaicLayout } from '@/utils/mosaicHelpers';
 import type { MosaicLayoutNode, MosaicTileId } from '@/types/ui.types';
 
 import 'react-mosaic-component/react-mosaic-component.css';
 import '@/styles/mosaic-theme.css';
 
-const TOOLBAR_BUTTON_CLASS = cn(
-  'flex items-center justify-center',
-  'h-5 w-5 rounded-md',
-  'text-text-tertiary dark:text-text-dark-tertiary',
-  'hover:text-text-primary dark:hover:text-text-dark-primary',
-  'transition-colors duration-200',
-);
-
-function getTileLabel(
-  tileId: MosaicTileId,
-  agentTitles: Partial<Record<MosaicTileId, string>>,
-): string {
-  return agentTitles[tileId] ?? VIEW_LABELS[tileIdToViewType(tileId)] ?? tileId;
-}
-
 interface MosaicSplitViewProps {
   mosaicLayout: MosaicLayoutNode;
   renderView: (tileId: MosaicTileId, slot: string) => ReactNode;
-  agentTitles?: Partial<Record<MosaicTileId, string>>;
-  onCloseTile?: (tileId: MosaicTileId) => void;
 }
 
-export function MosaicSplitView({
-  mosaicLayout,
-  renderView,
-  agentTitles,
-  onCloseTile,
-}: MosaicSplitViewProps) {
-  // Ephemeral: the tile expanded over the split via CSS (see `.has-maximized`).
-  // The store layout and every pane stay mounted, so minimizing just clears this
-  // and the split reappears with all panes' local state intact.
-  const [maximizedTile, setMaximizedTile] = useState<MosaicTileId | null>(null);
+export function MosaicSplitView({ mosaicLayout, renderView }: MosaicSplitViewProps) {
+  // Pane titles/controls live in the title bar's SplitTabs; the maximize state is
+  // shared via the store so the tab toggle and this CSS expansion stay in sync.
+  // Derived on read: a maximizedTile that's no longer a leaf (after any single-tile
+  // transition) is treated as cleared, so the store never needs to chase it.
+  const rawMaximized = useUIStore((s) => s.maximizedTile);
 
   const handleMosaicChange = useCallback((newNode: Parameters<typeof libraryToMosaicLayout>[0]) => {
     const layout = libraryToMosaicLayout(newNode);
     useUIStore.getState().setMosaicLayout(layout);
   }, []);
 
-  const handleCloseTile = useCallback(
-    (tileId: MosaicTileId) => {
-      if (onCloseTile) onCloseTile(tileId);
-      else useUIStore.getState().removeTileFromMosaic(tileId);
-    },
-    [onCloseTile],
-  );
-
   const leaves = useMemo(() => getLeaves(mosaicLayout), [mosaicLayout]);
-
-  // Drop the maximized tile once its pane is gone (closed/collapsed) so the
-  // split renders normally again.
-  if (maximizedTile && !leaves.includes(maximizedTile)) {
-    setMaximizedTile(null);
-  }
+  const maximizedTile = rawMaximized && leaves.includes(rawMaximized) ? rawMaximized : null;
 
   const libraryValue = useMemo(() => mosaicLayoutToLibrary(mosaicLayout), [mosaicLayout]);
 
@@ -91,59 +49,14 @@ export function MosaicSplitView({
             <MosaicWindow<string>
               path={path}
               className={maximizedTile === tileId ? 'mosaic-window--maximized' : undefined}
-              title={getTileLabel(tileId, agentTitles ?? {})}
-              toolbarControls={
-                <div className="flex items-center gap-0.5 pr-0.5">
-                  {leaves.length > 1 && (
-                    <>
-                      <Button
-                        variant="unstyled"
-                        onClick={() =>
-                          setMaximizedTile((current) => (current === tileId ? null : tileId))
-                        }
-                        className={TOOLBAR_BUTTON_CLASS}
-                        title={maximizedTile === tileId ? 'Restore split' : 'Maximize'}
-                      >
-                        {maximizedTile === tileId ? (
-                          <Minimize2 className="h-3 w-3" />
-                        ) : (
-                          <Maximize2 className="h-3 w-3" />
-                        )}
-                      </Button>
-                      {!maximizedTile && (
-                        <Button
-                          variant="unstyled"
-                          onClick={() => handleCloseTile(tileId)}
-                          className={TOOLBAR_BUTTON_CLASS}
-                          title="Close tile"
-                        >
-                          <X className="h-3 w-3" />
-                        </Button>
-                      )}
-                    </>
-                  )}
-                </div>
-              }
-              renderToolbar={(props) => (
-                <div
-                  className={cn(
-                    // w-full so it fills the wrapping .mosaic-window-toolbar —
-                    // otherwise the div shrinks to content and justify-between
-                    // can't push the controls to the right edge.
-                    'flex h-7 w-full items-center justify-between px-2',
-                    'bg-surface-secondary dark:bg-surface-dark-secondary',
-                    'border-b border-border/50 dark:border-border-dark/50',
-                  )}
-                >
-                  <div className="flex items-center gap-1.5">
-                    <SplitSquareHorizontal className="h-3 w-3 text-text-quaternary dark:text-text-dark-quaternary" />
-                    <span className="text-2xs font-medium text-text-secondary dark:text-text-dark-secondary">
-                      {props.title}
-                    </span>
-                  </div>
-                  <div className="flex items-center">{props.toolbarControls}</div>
-                </div>
-              )}
+              // title is a required prop but never renders — labels/controls live
+              // in the title-bar SplitTabs and the per-pane toolbar renders empty.
+              title={tileId}
+              // draggable=false skips react-dnd's connectDragSource on the empty
+              // toolbar — passing a Fragment to the connector throws in react-dnd 16,
+              // and there's no grab target anyway since the toolbar renders empty.
+              draggable={false}
+              renderToolbar={() => <></>}
             >
               <div className="flex h-full w-full overflow-hidden">
                 {renderView(tileId, `tile-${tileId}`)}

--- a/frontend/src/components/ui/SplitViewContainer.tsx
+++ b/frontend/src/components/ui/SplitViewContainer.tsx
@@ -11,14 +11,10 @@ const MosaicSplitView = lazy(() =>
 
 interface SplitViewContainerProps {
   renderView: (tileId: MosaicTileId, slot: string) => ReactNode;
-  agentTitles?: Partial<Record<MosaicTileId, string>>;
-  onCloseTile?: (tileId: MosaicTileId) => void;
 }
 
 export const SplitViewContainer = memo(function SplitViewContainer({
   renderView,
-  agentTitles,
-  onCloseTile,
 }: SplitViewContainerProps) {
   const currentView = useUIStore((state) => state.currentView);
   const mosaicLayout = useUIStore((state) => state.mosaicLayout);
@@ -34,12 +30,7 @@ export const SplitViewContainer = memo(function SplitViewContainer({
 
   return (
     <Suspense fallback={viewLoadingFallback}>
-      <MosaicSplitView
-        mosaicLayout={mosaicLayout}
-        renderView={renderView}
-        agentTitles={agentTitles}
-        onCloseTile={onCloseTile}
-      />
+      <MosaicSplitView mosaicLayout={mosaicLayout} renderView={renderView} />
     </Suspense>
   );
 });

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -9,8 +9,8 @@ import { CommandMenu } from '@/components/ui/CommandMenu';
 import { useCommandMenu } from '@/hooks/useCommandMenu';
 import { useActiveViews } from '@/hooks/useActiveViews';
 import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback';
-import type { AgentTileId, MosaicTileId, ViewType } from '@/types/ui.types';
-import { isSecondaryTile, tileIdToViewType, VIEW_LABELS, VIEW_TYPES } from '@/utils/mosaicHelpers';
+import type { MosaicTileId, ViewType } from '@/types/ui.types';
+import { isSecondaryTile, tileIdToViewType } from '@/utils/mosaicHelpers';
 import { Chat as ChatComponent } from '@/components/chat/chat-window/Chat';
 import { ChatSessionOrchestrator } from '@/components/chat/chat-window/ChatSessionOrchestrator';
 import { AgentPane } from '@/components/chat/chat-window/AgentPane';
@@ -164,6 +164,12 @@ export function ChatPage() {
       createCommitDialogOpen: false,
       createPRDialogOpen: false,
       createBranchDialogOpen: false,
+      // Ephemeral pane pointers don't belong to the new chat — a same-id tile in
+      // its split must not inherit chat A's maximize/focus. activeAgentTile (the
+      // coarse pointer) resets with them so the three stay consistent.
+      maximizedTile: null,
+      focusedTile: null,
+      activeAgentTile: 'agent:primary',
     });
   }
 
@@ -247,9 +253,6 @@ export function ChatPage() {
     (tileId: MosaicTileId, slot: string): ReactNode => {
       const isSecondary = isSecondaryTile(tileId);
       const isTerminal = tileId === 'terminal' || tileId === 'terminal:secondary';
-      // Every tile maps to the chat it shows; recording it on any interaction
-      // keeps pane-scoped shortcuts aimed at the chat the user is actually in.
-      const activePane: AgentTileId = isSecondary ? 'agent:secondary' : 'agent:primary';
       // The secondary terminal runs in the second chat's sandbox; the hidden
       // terminals kept alive in other slots stay on the primary chat.
       const terminalSandboxId = isSecondary
@@ -259,7 +262,9 @@ export function ChatPage() {
       return (
         <div
           className="relative flex h-full w-full"
-          onPointerDownCapture={() => useUIStore.getState().setActiveAgentTile(activePane)}
+          // Record focus on any interaction so shortcuts and the active tab both
+          // track the pane in use (focusTile derives the chat from the tile).
+          onPointerDownCapture={() => useUIStore.getState().focusTile(tileId)}
         >
           <div className={isTerminal ? 'flex h-full w-full' : 'hidden'}>
             <Suspense fallback={viewLoadingFallback}>
@@ -279,44 +284,6 @@ export function ChatPage() {
     },
     [currentChat, renderNonTerminalView, secondaryChatId, secondaryQuery.data?.sandbox_id],
   );
-
-  const handleCloseTile = useCallback(
-    (tileId: MosaicTileId) => {
-      const ui = useUIStore.getState();
-      if (tileId === 'agent:secondary') {
-        ui.closeSplitChat();
-        return;
-      }
-      if (tileId === 'agent:primary' && ui.secondaryChatId && chatId) {
-        const newPrimary = ui.swapChatPanes(chatId);
-        if (newPrimary) {
-          navigate(`/chat/${newPrimary}`);
-          ui.closeSplitChat();
-          return;
-        }
-      }
-      ui.removeTileFromMosaic(tileId);
-    },
-    [chatId, navigate],
-  );
-
-  const agentTitles = useMemo<Partial<Record<MosaicTileId, string>>>(() => {
-    const titles: Partial<Record<MosaicTileId, string>> = {};
-    const primaryTitle = currentChat?.title;
-    const secondaryTitle = secondaryQuery.data?.title;
-    if (primaryTitle) titles['agent:primary'] = primaryTitle;
-    if (secondaryChatId && secondaryTitle) {
-      titles['agent:secondary'] = secondaryTitle;
-      // Each non-agent view's two tiles can coexist in split-chat view — name
-      // them by chat so the two copies (primary/secondary) are distinguishable.
-      for (const view of VIEW_TYPES) {
-        if (view === 'agent') continue;
-        if (primaryTitle) titles[view] = `${primaryTitle} · ${VIEW_LABELS[view]}`;
-        titles[`${view}:secondary`] = `${secondaryTitle} · ${VIEW_LABELS[view]}`;
-      }
-    }
-    return titles;
-  }, [currentChat?.title, secondaryChatId, secondaryQuery.data?.title]);
 
   if (!chatId) return <Navigate to="/" />;
 
@@ -341,11 +308,7 @@ export function ChatPage() {
       >
         <div className="relative flex h-full">
           <div className="flex h-full flex-1 overflow-hidden bg-surface text-text-primary dark:bg-surface-dark dark:text-text-dark-primary">
-            <SplitViewContainer
-              renderView={renderView}
-              agentTitles={agentTitles}
-              onCloseTile={handleCloseTile}
-            />
+            <SplitViewContainer renderView={renderView} />
           </div>
           <CommandMenu />
           {subThreadDialogOpen && <SubThreadDialog />}

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -199,9 +199,24 @@ export const useUIStore = create<UIStoreState>()(
       mosaicLayout: null,
       secondaryChatId: null,
       activeAgentTile: 'agent:primary',
+      maximizedTile: null,
+      focusedTile: null,
 
-      setActiveAgentTile: (tile) => {
-        if (get().activeAgentTile !== tile) set({ activeAgentTile: tile });
+      setMaximizedTile: (tileId) => {
+        if (get().maximizedTile !== tileId) set({ maximizedTile: tileId });
+      },
+
+      focusTile: (tileId) => {
+        if (get().focusedTile === tileId) return;
+        // Single focus path for both tab and pane clicks. activeAgentTile is the
+        // coarsening of focusedTile (primary vs secondary chat). It stays a separate
+        // field because focusedTile is nullable (no interaction yet) while the ~6
+        // imperative coarse readers need an always-defined value — collapsing would
+        // scatter `?? 'agent:primary'` fallbacks across all of them.
+        set({
+          focusedTile: tileId,
+          activeAgentTile: isSecondaryTile(tileId) ? 'agent:secondary' : 'agent:primary',
+        });
       },
 
       toggleView: (view, toggle) => {
@@ -299,6 +314,10 @@ export const useUIStore = create<UIStoreState>()(
         if (!layout || typeof layout === 'string') return;
         const leaves = getLeaves(layout);
         if (!leaves.includes(tileId)) return;
+        // Clear maximize at the canonical "tile went away" event. Derive-on-read
+        // hides a stale pointer while the tile is absent, but only clearing here
+        // stops it resurrecting if the same tile id is re-added later.
+        if (state.maximizedTile === tileId) set({ maximizedTile: null });
         const clearedJumps = clearJumpsForTile(state, tileId);
         if (Object.keys(clearedJumps).length > 0) set(clearedJumps);
         const remaining = leaves.filter((v) => v !== tileId);
@@ -342,7 +361,11 @@ export const useUIStore = create<UIStoreState>()(
         const secondaryChanged = state.secondaryChatId !== chatId;
         const resetForNewSecondary: Partial<UIStoreState> = secondaryChanged
           ? {
+              // Reset all three pane pointers together — activeAgentTile alone
+              // would leave the tab highlight/maximize aimed at the old secondary.
               activeAgentTile: 'agent:primary',
+              focusedTile: null,
+              maximizedTile: null,
               ...clearJumpsForChat(state, state.secondaryChatId),
             }
           : {};
@@ -367,7 +390,11 @@ export const useUIStore = create<UIStoreState>()(
         // secondary chat.
         const reset: Partial<UIStoreState> = {
           secondaryChatId: null,
+          // All three pane pointers reset together so the tab highlight, command
+          // targeting, and maximize don't keep aiming at the closed secondary.
           activeAgentTile: 'agent:primary',
+          focusedTile: null,
+          maximizedTile: null,
           ...clearJumpsForChat(state, state.secondaryChatId),
         };
         if (layout && isMosaicSplitNode(layout)) {

--- a/frontend/src/styles/mosaic-theme.css
+++ b/frontend/src/styles/mosaic-theme.css
@@ -95,15 +95,8 @@
   overflow: hidden;
 }
 
-.mosaic-agentrove .mosaic-window .mosaic-window-toolbar.draggable {
-  cursor: grab;
-}
-
-.mosaic-agentrove .mosaic-window .mosaic-window-toolbar.draggable:active {
-  cursor: grabbing;
-}
-
-/* Hide the default title and controls — we render our own via renderToolbar */
+/* Defensive: hide any default toolbar chrome. Titles/controls live in the
+   title-bar SplitTabs; the per-pane toolbar renders empty. */
 .mosaic-agentrove .mosaic-window .mosaic-window-title,
 .mosaic-agentrove .mosaic-window .mosaic-window-controls {
   display: none;

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -78,6 +78,13 @@ export interface SplitViewState {
   // The agent pane the user last interacted with — targets pane-scoped actions
   // (e.g. the diff shortcut) at the chat the user is actually in.
   activeAgentTile: AgentTileId;
+  // Ephemeral (not persisted): the tile expanded over the split. The whole tree
+  // stays mounted; CSS expands this one, so clearing it restores every pane's state.
+  maximizedTile: MosaicTileId | null;
+  // The exact pane the user last touched — drives the active tab highlight.
+  // Distinct from activeAgentTile, which only tracks the active chat (primary vs
+  // secondary), not the specific tile.
+  focusedTile: MosaicTileId | null;
 }
 
 export interface SplitViewActions {
@@ -92,7 +99,10 @@ export interface SplitViewActions {
   closeSplitChat: () => void;
   // Returns the chatId that should become the new route primary (caller navigates).
   swapChatPanes: (currentPrimaryChatId: string) => string | null;
-  setActiveAgentTile: (tile: AgentTileId) => void;
+  setMaximizedTile: (tileId: MosaicTileId | null) => void;
+  // Single focus path: records the exact pane (highlights its tab) and scopes the
+  // active chat (primary/secondary) from the tile, so tab and pane clicks agree.
+  focusTile: (tileId: MosaicTileId) => void;
   // Opens or (when toggling) closes a view's tile for the active agent pane,
   // so the shortcut targets the chat the user is currently in.
   toggleView: (view: ViewType, toggle: boolean) => void;


### PR DESCRIPTION
## Summary
- Move per-pane mosaic chrome (title, maximize, close) into a new `SplitTabs` component pinned in the title bar; the mosaic toolbar now renders empty.
- Lift maximize/focus state into `uiStore` as `maximizedTile` / `focusedTile`, with a single `focusTile` action that also coarsens to `activeAgentTile` (primary vs secondary chat).
- Derive both ephemeral pointers on read — a tile id that's no longer a leaf is treated as absent — and clear `maximizedTile` at the canonical `removeTileFromMosaic` event so a re-added tile id can't resurrect a stale maximize.
- Reset all three pane pointers together on new chat, new secondary, and split close so the tab highlight, command targeting, and maximize never aim at a stale pane.
- Show tabs on both chat and landing splits; `SplitTabs` is self-sourcing, so `agentTitles`/`onCloseTile` props are dropped from `SplitViewContainer` and `MosaicSplitView`.

## Test plan
- [ ] Split a chat into two panes — confirm both tabs render with correct titles in the title bar.
- [ ] Click a tab and click into a pane — focus highlight follows the active pane in both cases.
- [ ] Maximize a pane from its tab, then restore — split reappears with all panes' state intact.
- [ ] Close a pane (secondary, primary-with-secondary swap, and a non-agent tile) — correct pane closes and routing updates.
- [ ] Open a new chat / open and close a split — tab highlight and maximize reset, never pointing at the old chat.
- [ ] Open a workspace file on the landing page to create an editor pane — tabs appear there too.
- [ ] Verify tabs are hidden on mobile and for single-pane views.