### PR TITLE
feat: shift-click view icon to stack split panes vertically

### DIFF
--- a/frontend/src/components/layout/ViewSwitcher.tsx
+++ b/frontend/src/components/layout/ViewSwitcher.tsx
@@ -39,8 +39,11 @@ export function ViewSwitcher() {
           <Button
             key={view}
             variant="unstyled"
-            // Toggle: open the view as a tile, or close it if already visible
-            onClick={() => useUIStore.getState().toggleView(view, true)}
+            // Toggle: open the view as a tile, or close it if already visible.
+            // Shift-click opens the new pane stacked (column) instead of side by side.
+            onClick={(e) =>
+              useUIStore.getState().toggleView(view, true, e.shiftKey ? 'column' : 'row')
+            }
             className={cn(
               'rounded-md p-1.5 transition-colors duration-200',
               isActive
@@ -49,7 +52,9 @@ export function ViewSwitcher() {
             )}
             aria-label={`Toggle ${VIEW_LABELS[view]} view`}
             aria-pressed={isActive}
-            title={VIEW_LABELS[view]}
+            // Hint shift-to-stack only while opening — shift has no effect on the
+            // close (active) click.
+            title={isActive ? VIEW_LABELS[view] : `${VIEW_LABELS[view]} · ⇧ to stack`}
           >
             <Icon className="h-3.5 w-3.5" />
           </Button>

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -8,6 +8,7 @@ import type {
   SplitViewActions,
   MosaicTileId,
   MosaicLayoutNode,
+  MosaicDirection,
 } from '@/types/ui.types';
 import { MOBILE_BREAKPOINT } from '@/config/constants';
 import {
@@ -90,6 +91,9 @@ function ensureTileVisible(
   set: (partial: Partial<UIStoreState>) => void,
   get: () => UIStoreState,
   tileId: MosaicTileId,
+  // row = side by side (default), column = stacked. Shift-clicking a view icon
+  // opens the new pane stacked instead.
+  direction: MosaicDirection = 'row',
 ): void {
   if (!isDesktop()) {
     set({ currentView: tileIdToViewType(tileId), mosaicLayout: tileId });
@@ -99,13 +103,13 @@ function ensureTileVisible(
   const layout = state.mosaicLayout;
   if (layout && isMosaicSplitNode(layout)) {
     if (!getLeaves(layout).includes(tileId)) {
-      set({ mosaicLayout: { direction: 'row', first: layout, second: tileId } });
+      set({ mosaicLayout: { direction, first: layout, second: tileId } });
     }
     return;
   }
   const currentTile = getEffectiveLayout(layout, state.currentView);
   if (currentTile !== tileId) {
-    set({ mosaicLayout: { direction: 'row', first: currentTile, second: tileId } });
+    set({ mosaicLayout: { direction, first: currentTile, second: tileId } });
   }
 }
 
@@ -219,7 +223,7 @@ export const useUIStore = create<UIStoreState>()(
         });
       },
 
-      toggleView: (view, toggle) => {
+      toggleView: (view, toggle, direction) => {
         const state = get();
         const layout = getEffectiveLayout(state.mosaicLayout, state.currentView);
         // Agent has no per-pane toggle: closing it tears down the split (or the
@@ -247,7 +251,7 @@ export const useUIStore = create<UIStoreState>()(
         if (toggle && getLeaves(layout).includes(tileId)) {
           get().removeTileFromMosaic(tileId);
         } else {
-          ensureTileVisible(set, get, tileId);
+          ensureTileVisible(set, get, tileId, direction);
         }
       },
 

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -104,8 +104,9 @@ export interface SplitViewActions {
   // active chat (primary/secondary) from the tile, so tab and pane clicks agree.
   focusTile: (tileId: MosaicTileId) => void;
   // Opens or (when toggling) closes a view's tile for the active agent pane,
-  // so the shortcut targets the chat the user is currently in.
-  toggleView: (view: ViewType, toggle: boolean) => void;
+  // so the shortcut targets the chat the user is currently in. `direction` sets
+  // how a newly opened pane splits (row = side by side, column = stacked).
+  toggleView: (view: ViewType, toggle: boolean, direction?: MosaicDirection) => void;
 }
 
 export interface UIState {


### PR DESCRIPTION
## Summary
- Shift-clicking a view icon in the `ViewSwitcher` now opens the new split-view pane stacked (column) instead of side by side (row).
- Threads an optional `direction` arg through `toggleView` → `ensureTileVisible`, defaulting to `'row'` so existing click behavior is unchanged.
- Updates the tooltip to hint `⇧ to stack` only while opening (shift has no effect on the close click).

## Test plan
- [ ] Click a view icon — pane opens side by side (row) as before.
- [ ] Shift-click a view icon — new pane opens stacked (column).
- [ ] Hover an inactive view icon — tooltip shows `… · ⇧ to stack`; active icon shows plain label.
- [ ] On mobile/non-desktop, view still replaces full layout (no split).