### PR TITLE
Improve iOS install script robustness

### DIFF
--- a/scripts/ios-install.sh
+++ b/scripts/ios-install.sh
@@ -5,7 +5,17 @@
 # the committed config and each dev signs as themselves.
 set -euo pipefail
 
-: "${APPLE_DEVELOPMENT_TEAM:?Set APPLE_DEVELOPMENT_TEAM (your Apple Team ID) before running}"
+# cargo lives under ~/.cargo/bin but isn't always on a non-interactive PATH (npm scripts).
+command -v cargo >/dev/null 2>&1 || export PATH="$HOME/.cargo/bin:$PATH"
+
+# Default the team to this dev's own signing identity (the cert's OU is the Team ID), so a
+# plain `npm run ios:install` works without exporting anything. Override via the env var.
+if [ -z "${APPLE_DEVELOPMENT_TEAM:-}" ]; then
+  APPLE_DEVELOPMENT_TEAM="$(security find-certificate -a -c 'Apple Development' -p 2>/dev/null \
+    | openssl x509 -noout -subject 2>/dev/null \
+    | tr ',/' '\n\n' | sed -nE 's/^[[:space:]]*OU[[:space:]]*=[[:space:]]*([A-Z0-9]+).*/\1/p' | head -1)"
+fi
+[ -n "$APPLE_DEVELOPMENT_TEAM" ] || { echo "error: no Apple Development signing identity found; set APPLE_DEVELOPMENT_TEAM" >&2; exit 1; }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FRONTEND_DIR="$SCRIPT_DIR/../frontend"
@@ -25,5 +35,7 @@ DEVICE_ID="$(xcrun xctrace list devices 2>/dev/null \
 [ -n "$DEVICE_ID" ] || { echo "error: no iPhone/iPad connected" >&2; exit 1; }
 
 echo "Installing $(basename "$IPA") on device $DEVICE_ID ..."
-xcrun devicectl device install app --device "$DEVICE_ID" "$IPA"
+# The first contact can hit a transient connection reset when the device is locked/asleep — retry once.
+xcrun devicectl device install app --device "$DEVICE_ID" "$IPA" \
+  || { sleep 3; xcrun devicectl device install app --device "$DEVICE_ID" "$IPA"; }
 echo "Done — launch Agentrove on the device."


### PR DESCRIPTION
## Summary
- Auto-detect Apple Development Team from dev's signing identity (remove manual env var requirement)
- Ensure cargo is available on PATH for npm script environments
- Add retry logic for transient device connection resets during install

## Test plan
- [ ] Run `npm run ios:install` without setting APPLE_DEVELOPMENT_TEAM
- [ ] Verify device install succeeds on first try (normal case)
- [ ] Manually trigger a connection reset and verify retry succeeds