### PR TITLE
Extract chat title and sub-thread counting into service methods

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -32,7 +32,7 @@ from app.core.deps import (
 )
 from app.core.security import get_current_user
 from app.models.db_models.chat import Chat
-from app.models.db_models.enums import MessageRole, MessageStreamStatus
+from app.models.db_models.enums import MessageStreamStatus
 from app.models.db_models.user import User
 from app.models.types import MessageAttachmentDict, PermissionMode
 from app.models.schemas.chat import (
@@ -179,27 +179,17 @@ async def generate_chat_title(
     chat: Chat = Depends(ensure_chat_access),
     current_user: User = Depends(get_current_user),
     ai_service: AgentService = Depends(get_agent_service),
+    chat_service: ChatService = Depends(get_chat_service),
 ) -> dict[str, str]:
     # Title from the first user message — same source the automatic
     # background titling uses when a chat starts.
-    user_messages = [
-        m
-        for m in chat.messages
-        if m.role == MessageRole.USER and m.content_text.strip()
-    ]
-    # model_id is only stored on assistant messages, so pick the most
-    # recent one — that's the model the chat is currently using.
-    model_ids = [
-        (m.created_at, m.model_id) for m in chat.messages if m.model_id is not None
-    ]
-    if not user_messages or not model_ids:
+    source = await chat_service.get_title_source(chat.id)
+    if source is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Chat has no messages to generate a title from",
         )
-
-    prompt = min(user_messages, key=lambda m: m.created_at).content_text
-    model_id = max(model_ids)[1]
+    prompt, model_id = source
 
     title = await ai_service.generate_title(prompt, model_id, current_user, chat=chat)
     if not title:
@@ -279,7 +269,11 @@ async def get_chat_detail(
     chat_service: ChatService = Depends(get_chat_service),
 ) -> ChatSchema:
     try:
-        return await chat_service.get_chat(chat_id, current_user)
+        chat = await chat_service.get_chat(chat_id, current_user)
+        chat.sub_thread_count = await chat_service.count_sub_threads(
+            chat_id, current_user
+        )
+        return chat
     except ChatException as e:
         raise HTTPException(status_code=e.status_code, detail=str(e)) from e
     except SQLAlchemyError as e:

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -421,9 +421,10 @@ class ChatService(BaseDbService[Chat]):
             return chat
 
     async def get_chat(self, chat_id: UUID, user: User) -> Chat:
-        # Fetch a single chat with its messages (non-deleted) and workspace eagerly loaded.
-        # Also computes sub_thread_count as a transient attribute on the ORM object
-        # so ChatSchema.model_validate() picks it up via from_attributes=True.
+        # Fetch a single chat with its workspace eagerly loaded (sandbox_id reads it).
+        # Messages aren't loaded here — the Chat schema has no message field; the
+        # paginated /messages endpoint serves the visible history. sub_thread_count
+        # is computed only by callers that serialize it (see count_sub_threads).
         async with self.session_factory() as db:
             query = (
                 select(Chat)
@@ -433,9 +434,6 @@ class ChatService(BaseDbService[Chat]):
                     Chat.deleted_at.is_(None),
                 )
                 .options(
-                    selectinload(
-                        Chat.messages.and_(Message.deleted_at.is_(None))
-                    ).selectinload(Message.attachments),
                     selectinload(Chat.workspace),
                 )
             )
@@ -450,16 +448,55 @@ class ChatService(BaseDbService[Chat]):
                     status_code=404,
                 )
 
-            sub_count_result = await db.execute(
+            return chat
+
+    async def count_sub_threads(self, chat_id: UUID, user: User) -> int:
+        async with self.session_factory() as db:
+            result = await db.execute(
                 select(func.count(Chat.id)).filter(
                     Chat.parent_chat_id == chat_id,
                     Chat.user_id == user.id,
                     Chat.deleted_at.is_(None),
                 )
             )
-            chat.sub_thread_count = sub_count_result.scalar()
+            return result.scalar() or 0
 
-            return chat
+    async def get_title_source(self, chat_id: UUID) -> tuple[str, str] | None:
+        # Title prompt is the first non-empty user message; model is the most
+        # recent one stored on a message (only assistant messages carry it).
+        # Returns None when either is missing. Queried directly so callers don't
+        # need the full message history loaded.
+        async with self.session_factory() as db:
+            prompt = (
+                await db.execute(
+                    select(Message.content_text)
+                    .filter(
+                        Message.chat_id == chat_id,
+                        Message.role == MessageRole.USER,
+                        Message.deleted_at.is_(None),
+                        func.trim(Message.content_text) != "",
+                    )
+                    .order_by(Message.created_at.asc())
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+
+            model_id = (
+                await db.execute(
+                    select(Message.model_id)
+                    .filter(
+                        Message.chat_id == chat_id,
+                        Message.deleted_at.is_(None),
+                        Message.model_id.is_not(None),
+                    )
+                    .order_by(Message.created_at.desc())
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+
+        if not prompt or not model_id:
+            return None
+        return prompt, model_id
 
     async def get_model_context_window(self, chat_id: UUID) -> int | None:
         last_msg = await self.message_service.get_latest_assistant_message(chat_id)


### PR DESCRIPTION
## Summary
- Extract `get_title_source()` service method for title generation logic
- Extract `count_sub_threads()` service method for sub-thread counting
- Remove eager-loading of messages in `get_chat()` (not used by Chat schema)
- Compute `sub_thread_count` only in endpoints that need it

## Test plan
- [ ] Chat title generation still works (`/chat/{id}/generate-title`)
- [ ] Chat detail endpoint returns correct sub-thread count
- [ ] Verify message history endpoint works independently