### PR TITLE
Deduplicate skills by resolved path and handle symlinks

### DIFF
--- a/backend/app/models/schemas/workspace.py
+++ b/backend/app/models/schemas/workspace.py
@@ -12,7 +12,7 @@ class CustomSkill(BaseModel):
     description: str
     size_bytes: int
     file_count: int
-    source: str
+    sources: list[str]
     read_only: bool
 
 

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -25,7 +25,9 @@ class CustomSkillDict(TypedDict):
     description: str
     size_bytes: int
     file_count: int
-    source: str
+    # Agent kinds whose scan dirs resolve to this skill's directory; overlapping
+    # namespaces mean one on-disk skill can belong to several kinds.
+    sources: list[str]
     read_only: bool
 
 

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -127,7 +127,10 @@ class SkillService:
         return None
 
     def list_all(self) -> list[CustomSkillDict]:
-        skills: list[CustomSkillDict] = []
+        # Group by resolved directory so a skill scanned under several agent kinds
+        # (overlapping namespaces) surfaces once with all its sources, while
+        # same-named skills in distinct dirs stay separate.
+        by_path: dict[Path, CustomSkillDict] = {}
         for source, paths in self.paths_by_source.items():
             seen_names: set[str] = set()
             for base_path in paths:
@@ -140,6 +143,12 @@ class SkillService:
                     skill_md = entry / SKILL_MD_FILENAME
                     if not skill_md.exists():
                         continue
+                    resolved = entry.resolve()
+                    existing = by_path.get(resolved)
+                    if existing is not None:
+                        existing["sources"].append(source)
+                        seen_names.add(entry.name)
+                        continue
                     try:
                         content = skill_md.read_text(encoding="utf-8")
                     except (OSError, UnicodeDecodeError):
@@ -149,18 +158,16 @@ class SkillService:
                     except ValueError:
                         metadata = {}
                     file_count, total_size = self._compute_dir_stats(entry)
-                    skills.append(
-                        {
-                            "name": entry.name,
-                            "description": str(metadata.get("description", "")),
-                            "size_bytes": total_size,
-                            "file_count": file_count,
-                            "source": source,
-                            "read_only": is_readonly,
-                        }
-                    )
+                    by_path[resolved] = {
+                        "name": entry.name,
+                        "description": str(metadata.get("description", "")),
+                        "size_bytes": total_size,
+                        "file_count": file_count,
+                        "sources": [source],
+                        "read_only": is_readonly,
+                    }
                     seen_names.add(entry.name)
-        return skills
+        return list(by_path.values())
 
     def get_files(self, source: str, skill_name: str) -> list[SkillFileEntry]:
         # Text files are returned as-is, binary files as base64-encoded strings.
@@ -222,14 +229,18 @@ class SkillService:
             )
             file_count, total_size = self._compute_dir_stats(tmp_dir)
 
-            shutil.rmtree(skill_dir)
-            shutil.copytree(tmp_dir, skill_dir)
+            # Skills are often symlinked across agent namespaces to one canonical
+            # dir; rmtree refuses to run on a symlink, so replace the resolved
+            # target — the symlink keeps pointing at it.
+            target_dir = skill_dir.resolve()
+            shutil.rmtree(target_dir)
+            shutil.copytree(tmp_dir, target_dir)
 
         return {
             "name": skill_name,
             "description": str(metadata.get("description", "")),
             "size_bytes": total_size,
             "file_count": file_count,
-            "source": source,
+            "sources": [source],
             "read_only": skill_dir.parent in self.readonly_paths,
         }

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -26,7 +26,7 @@ class FakeSkillService:
                 "description": "Review code changes",
                 "size_bytes": 128,
                 "file_count": 2,
-                "source": "codex",
+                "sources": ["codex"],
                 "read_only": False,
             }
         ]
@@ -61,7 +61,7 @@ class FakeSkillService:
             "description": "Updated skill",
             "size_bytes": sum(len(file.content) for file in files),
             "file_count": len(files),
-            "source": source,
+            "sources": [source],
             "read_only": False,
         }
 
@@ -96,7 +96,7 @@ async def test_list_skills_returns_available_skills(
             "description": "Review code changes",
             "size_bytes": 128,
             "file_count": 2,
-            "source": "codex",
+            "sources": ["codex"],
             "read_only": False,
         }
     ]
@@ -155,7 +155,7 @@ async def test_update_skill_passes_files_to_service(
         "description": "Updated skill",
         "size_bytes": 35,
         "file_count": 1,
-        "source": "codex",
+        "sources": ["codex"],
         "read_only": False,
     }
     assert len(fake_skill_service.updated) == 1

--- a/frontend/src/components/settings/dialogs/SkillEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/SkillEditDialog.tsx
@@ -75,7 +75,7 @@ export const SkillEditDialog: React.FC<SkillEditDialogProps> = ({
 
     let cancelled = false;
     void skillService
-      .getSkillFiles(workspaceId, skill.source, skill.name)
+      .getSkillFiles(workspaceId, skill.sources[0], skill.name)
       .then((loaded) => {
         if (cancelled) return;
         setFiles(loaded);
@@ -144,7 +144,7 @@ export const SkillEditDialog: React.FC<SkillEditDialogProps> = ({
         const modified = modifiedFiles.get(file.path);
         return modified === undefined ? file : { ...file, content: modified };
       });
-      await skillService.updateSkill(workspaceId, skill.source, skill.name, merged);
+      await skillService.updateSkill(workspaceId, skill.sources[0], skill.name, merged);
       await onSaved();
       onClose();
       toast.success('Skill updated');

--- a/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
@@ -77,18 +77,23 @@ export const SkillsSettingsTab: React.FC = () => {
             <div className="space-y-2">
               {items.map((skill) => (
                 <div
-                  key={`${skill.source}/${skill.name}`}
+                  key={`${skill.name}/${skill.sources.join(',')}`}
                   className="rounded-lg border border-border/50 px-4 py-3 dark:border-border-dark/50"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">
-                      <div className="mb-1 flex items-center gap-2">
+                      <div className="mb-1 flex flex-wrap items-center gap-2">
                         <h3 className="min-w-0 max-w-full truncate text-xs font-medium text-text-primary dark:text-text-dark-primary sm:max-w-[250px]">
                           {skill.name}
                         </h3>
-                        <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
-                          {skill.source}
-                        </span>
+                        {skill.sources.map((source) => (
+                          <span
+                            key={source}
+                            className="rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary"
+                          >
+                            {source}
+                          </span>
+                        ))}
                         {skill.read_only && (
                           <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
                             built-in

--- a/frontend/src/hooks/useSlashCommandSuggestions.ts
+++ b/frontend/src/hooks/useSlashCommandSuggestions.ts
@@ -24,7 +24,7 @@ export const useSlashCommandSuggestions = ({
 
     // Custom skills filtered to match the active agent kind
     const skillCommands: SlashCommand[] = customSkills
-      .filter((skill) => skill.source === agentKind)
+      .filter((skill) => skill.sources.includes(agentKind))
       .map((skill) => ({
         value: `/${skill.name}`,
         label: skill.name,

--- a/frontend/src/types/user.types.ts
+++ b/frontend/src/types/user.types.ts
@@ -25,7 +25,7 @@ export interface CustomSkill {
   description: string;
   size_bytes: number;
   file_count: number;
-  source: string;
+  sources: string[];
   read_only: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Refactor SkillService to deduplicate skills by their resolved directory path
- Change skill schema from `source` (string) to `sources` (list of strings)
- Skills symlinked across agent namespaces now surface once with all sources
- Handle symlink resolution when updating skill directories (rmtree + copytree)
- Update frontend types, components, and tests to match new schema

## Why
Skills can be symlinked across multiple agent namespaces to point to the same
canonical directory. Previously, the same skill would appear multiple times in
the list. Now, deduplication happens by resolved path, and we track which
namespaces source each skill.