### PR TITLE
fix: update lucide-react icons to current API

### DIFF
--- a/frontend/src/components/layout/ViewSwitcher.tsx
+++ b/frontend/src/components/layout/ViewSwitcher.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Code, GitCompareArrows, KeyRound, SquareTerminal } from 'lucide-react';
+import { CodeXml, GitBranch, Lock, Terminal } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { useUIStore } from '@/store/uiStore';
 import { cn } from '@/utils/cn';
@@ -8,11 +8,11 @@ import type { ViewType } from '@/types/ui.types';
 
 // Non-agent secondary views, in the order Cursor lays them out: diff (git),
 // editor (file), terminal, secrets. Icons mirror the command registry.
-const SWITCHABLE_VIEWS: { view: Exclude<ViewType, 'agent'>; icon: typeof Code }[] = [
-  { view: 'diff', icon: GitCompareArrows },
-  { view: 'editor', icon: Code },
-  { view: 'terminal', icon: SquareTerminal },
-  { view: 'secrets', icon: KeyRound },
+const SWITCHABLE_VIEWS: { view: Exclude<ViewType, 'agent'>; icon: typeof GitBranch }[] = [
+  { view: 'diff', icon: GitBranch },
+  { view: 'editor', icon: CodeXml },
+  { view: 'terminal', icon: Terminal },
+  { view: 'secrets', icon: Lock },
 ];
 
 export function ViewSwitcher() {
@@ -45,7 +45,7 @@ export function ViewSwitcher() {
             aria-pressed={isActive}
             title={VIEW_LABELS[view]}
           >
-            <Icon className="h-3.5 w-3.5" />
+            <Icon className="h-4 w-4" />
           </Button>
         );
       })}

--- a/frontend/src/components/ui/commandRegistry.ts
+++ b/frontend/src/components/ui/commandRegistry.ts
@@ -5,10 +5,9 @@ import type { QueryClient } from '@tanstack/react-query';
 import {
   MessagesSquare,
   MessageSquarePlus,
-  Code,
-  SquareTerminal,
-  KeyRound,
-  GitCompareArrows,
+  CodeXml,
+  Terminal,
+  Lock,
   GitBranch,
   Search,
   PanelLeftClose,
@@ -63,12 +62,12 @@ export interface FlatFileItem {
 
 const VIEW_COMMANDS: ViewCommandItem[] = [
   { type: 'view', id: 'agent', label: 'Agent', icon: MessagesSquare, shortcut: 'a' },
-  { type: 'view', id: 'editor', label: 'Editor', icon: Code, shortcut: 'e' },
+  { type: 'view', id: 'editor', label: 'Editor', icon: CodeXml, shortcut: 'e' },
   {
     type: 'view',
     id: 'terminal',
     label: 'Terminal',
-    icon: SquareTerminal,
+    icon: Terminal,
     shortcut: 't',
     requiresChat: true,
   },
@@ -76,11 +75,11 @@ const VIEW_COMMANDS: ViewCommandItem[] = [
     type: 'view',
     id: 'diff',
     label: 'Diff',
-    icon: GitCompareArrows,
+    icon: GitBranch,
     shortcut: 'd',
     requiresChat: true,
   },
-  { type: 'view', id: 'secrets', label: 'Secrets', icon: KeyRound, shortcut: 's' },
+  { type: 'view', id: 'secrets', label: 'Secrets', icon: Lock, shortcut: 's' },
 ];
 
 const ACTION_COMMANDS: ActionCommandItem[] = [


### PR DESCRIPTION
## Summary
- Replace deprecated lucide-react icons (Code, SquareTerminal, KeyRound, GitCompareArrows) with current API equivalents (CodeXml, Terminal, Lock, GitBranch)
- Update ViewSwitcher icon size from h-3.5 to h-4 for consistency
- Update all icon references in commandRegistry to use new names