### PR TITLE
refactor: centralize view icons and update tab indicator

### DIFF
--- a/frontend/src/components/layout/SplitTabs.tsx
+++ b/frontend/src/components/layout/SplitTabs.tsx
@@ -9,7 +9,7 @@ import { useChatQuery } from '@/hooks/queries/useChatQueries';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useDropdown } from '@/hooks/useDropdown';
 import { cn } from '@/utils/cn';
-import { isSecondaryTile, tileIdToViewType, VIEW_LABELS } from '@/utils/tileHelpers';
+import { isSecondaryTile, tileIdToViewType, VIEW_ICONS, VIEW_LABELS } from '@/utils/tileHelpers';
 import type { SplitDirection, TileId } from '@/types/ui.types';
 
 const TAB_BUTTON_CLASS = cn(
@@ -128,6 +128,7 @@ export function SplitTabs() {
       {openTabs.map((tileId) => {
         const isVisible = visibleSet.has(tileId);
         const { name, kind } = tabParts(tileId, primaryTitle, secondaryTitle);
+        const Icon = VIEW_ICONS[tileIdToViewType(tileId)];
         return (
           <div
             key={tileId}
@@ -136,25 +137,22 @@ export function SplitTabs() {
               openMenu(tileId, e.currentTarget);
             }}
             className={cn(
-              'flex min-w-0 max-w-[220px] items-center gap-1 rounded-md py-1 pl-2.5 pr-1',
+              'relative flex min-w-0 max-w-[220px] items-center gap-1 rounded-md py-1 pl-2 pr-1',
               'transition-colors duration-200',
               isVisible
-                ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
+                ? 'text-text-primary dark:text-text-dark-primary'
                 : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary',
             )}
           >
             <Button
               variant="unstyled"
               onClick={() => useUIStore.getState().activateTab(tileId)}
-              className="flex min-w-0 flex-1 items-center text-left text-2xs font-medium"
+              className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-2xs font-medium"
               title={kind ? `${name} · ${kind}` : name}
             >
+              {/* Icon inherits the tab's text color, so it tracks active/hover state */}
+              <Icon className="h-3 w-3 flex-shrink-0" />
               <span className="min-w-0 truncate">{name}</span>
-              {kind && (
-                <span className="ml-1 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary">
-                  · {kind}
-                </span>
-              )}
             </Button>
             <Button
               variant="unstyled"
@@ -164,6 +162,11 @@ export function SplitTabs() {
             >
               <MoreHorizontal className="h-3 w-3" />
             </Button>
+            {/* Underline active indicator — inset from the tab edges, pinned to the
+                tab's bottom (overflow-y is clipped, so it can't sit below the strip) */}
+            {isVisible && (
+              <span className="pointer-events-none absolute inset-x-2 bottom-0 h-0.5 rounded-full bg-text-primary dark:bg-text-dark-primary" />
+            )}
           </div>
         );
       })}

--- a/frontend/src/components/layout/ViewSwitcher.tsx
+++ b/frontend/src/components/layout/ViewSwitcher.tsx
@@ -1,19 +1,18 @@
 import { useMemo } from 'react';
-import { CodeXml, GitBranch, Lock, Terminal } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { useUIStore } from '@/store/uiStore';
 import { cn } from '@/utils/cn';
-import { isSecondaryPaneActive, VIEW_LABELS, viewTypeToTileId } from '@/utils/tileHelpers';
+import {
+  isSecondaryPaneActive,
+  VIEW_ICONS,
+  VIEW_LABELS,
+  viewTypeToTileId,
+} from '@/utils/tileHelpers';
 import type { ViewType } from '@/types/ui.types';
 
 // Non-agent secondary views, in the order Cursor lays them out: diff (git),
-// editor (file), terminal, secrets. Icons mirror the command registry.
-const SWITCHABLE_VIEWS: { view: Exclude<ViewType, 'agent'>; icon: typeof GitBranch }[] = [
-  { view: 'diff', icon: GitBranch },
-  { view: 'editor', icon: CodeXml },
-  { view: 'terminal', icon: Terminal },
-  { view: 'secrets', icon: Lock },
-];
+// editor (file), terminal, secrets.
+const SWITCHABLE_VIEWS: Exclude<ViewType, 'agent'>[] = ['diff', 'editor', 'terminal', 'secrets'];
 
 export function ViewSwitcher() {
   const activeAgentTile = useUIStore((s) => s.activeAgentTile);
@@ -27,7 +26,8 @@ export function ViewSwitcher() {
 
   return (
     <div className="flex items-center gap-0.5">
-      {SWITCHABLE_VIEWS.map(({ view, icon: Icon }) => {
+      {SWITCHABLE_VIEWS.map((view) => {
+        const Icon = VIEW_ICONS[view];
         const isActive = openSet.has(viewTypeToTileId(view, secondary));
         return (
           <Button

--- a/frontend/src/utils/tileHelpers.ts
+++ b/frontend/src/utils/tileHelpers.ts
@@ -1,3 +1,5 @@
+import type { LucideIcon } from 'lucide-react';
+import { Bot, CodeXml, GitBranch, Lock, Terminal } from 'lucide-react';
 import type { AgentTileId, TileId, SecondaryTileId, ViewType } from '@/types/ui.types';
 
 export const VIEW_LABELS: Record<ViewType, string> = {
@@ -6,6 +8,16 @@ export const VIEW_LABELS: Record<ViewType, string> = {
   editor: 'Editor',
   terminal: 'Terminal',
   secrets: 'Secrets',
+};
+
+// Canonical view → icon map; shared by the pane tabs and the view switcher so the
+// glyph for a kind (diff, terminal…) stays identical in both places.
+export const VIEW_ICONS: Record<ViewType, LucideIcon> = {
+  agent: Bot,
+  diff: GitBranch,
+  editor: CodeXml,
+  terminal: Terminal,
+  secrets: Lock,
 };
 
 // The secondary pane is the action target only when it's both focused and bound


### PR DESCRIPTION
## Summary
- Extract view icons to shared `VIEW_ICONS` mapping in `tileHelpers.ts`
- Use icons consistently across split pane tabs and the view switcher
- Update active tab indicator from background color to bottom underline
- Remove kind label from tab text for cleaner appearance

## Changes
- `tileHelpers.ts`: Add `VIEW_ICONS` record mapping view types to Lucide icons
- `SplitTabs.tsx`: Display icon for each tab, add underline indicator for active tab, remove kind label
- `ViewSwitcher.tsx`: Simplify to use centralized `VIEW_ICONS` instead of inline icon definitions