### PR TITLE
Persist selected file per chat

### DIFF
--- a/frontend/src/components/editor/editor-core/EditorPane.tsx
+++ b/frontend/src/components/editor/editor-core/EditorPane.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef } from 'react';
+import { memo } from 'react';
 import { Editor } from '@/components/editor/editor-core/Editor';
 import { useChatQuery } from '@/hooks/queries/useChatQueries';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
@@ -15,14 +15,7 @@ export const EditorPane = memo(function EditorPane({ chatId }: { chatId: string 
     chatId,
   );
   const { selectedFile, setSelectedFile, handleFileSelect, isRefreshing, handleRefresh } =
-    useEditorState(refetchFilesMetadata);
-  // Swapping the pane's chat reuses this same instance — drop the prior chat's
-  // selection so it doesn't show a file that belongs to the old chat.
-  const prevChatIdRef = useRef(chatId);
-  if (prevChatIdRef.current !== chatId) {
-    prevChatIdRef.current = chatId;
-    setSelectedFile(null);
-  }
+    useEditorState(refetchFilesMetadata, chatId, fileStructure);
   usePendingFileOpen(fileStructure, setSelectedFile, chatId);
 
   return (

--- a/frontend/src/hooks/useEditorState.ts
+++ b/frontend/src/hooks/useEditorState.ts
@@ -1,11 +1,59 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
+import { useUIStore } from '@/store/uiStore';
+import { findFileByToolPath } from '@/utils/file';
 import type { FileStructure } from '@/types/file-system.types';
 
-export function useEditorState(refetchFilesMetadata: () => Promise<unknown>) {
+export function useEditorState(
+  refetchFilesMetadata: () => Promise<unknown>,
+  chatId: string | undefined,
+  fileStructure: FileStructure[],
+) {
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [selectedFile, setSelectedFile] = useState<FileStructure | null>(null);
+  // Landing page (no chat) uses local state — nothing to persist across chat
+  // switches since there's no chat to switch back to.
+  const [localSelectedFile, setLocalSelectedFile] = useState<FileStructure | null>(null);
+  const selectedFilePath = useUIStore((s) => (chatId ? s.selectedFileByChat[chatId] : undefined));
 
-  const handleFileSelect = useCallback((file: FileStructure | null) => setSelectedFile(file), []);
+  // Store-backed when chatId is set (persists across chat switches); local
+  // state for the chat-less landing page. Derived from the stashed path +
+  // fileStructure so the selection survives EditorPane unmount — switching
+  // chatId reads a different store entry, so the old chat's file can't bleed
+  // through. No re-seed effect needed: the derivation recomputes when the tree
+  // loads, and usePendingFileOpen writes the path directly via setSelectedFile.
+  const selectedFile = useMemo(() => {
+    if (!chatId) return localSelectedFile;
+    if (!selectedFilePath || fileStructure.length === 0) return null;
+    return (
+      findFileByToolPath(fileStructure, selectedFilePath) ?? {
+        path: selectedFilePath,
+        type: 'file',
+        content: '',
+      }
+    );
+  }, [chatId, localSelectedFile, selectedFilePath, fileStructure]);
+
+  const setSelectedFile = useCallback(
+    (file: FileStructure | null) => {
+      if (!chatId) {
+        setLocalSelectedFile(file);
+        return;
+      }
+      useUIStore.setState((s) => {
+        if (!file) {
+          const next = { ...s.selectedFileByChat };
+          delete next[chatId];
+          return { selectedFileByChat: next };
+        }
+        return { selectedFileByChat: { ...s.selectedFileByChat, [chatId]: file.path } };
+      });
+    },
+    [chatId],
+  );
+
+  const handleFileSelect = useCallback(
+    (file: FileStructure | null) => setSelectedFile(file),
+    [setSelectedFile],
+  );
 
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -180,7 +180,7 @@ export function LandingPage() {
   );
 
   const { selectedFile, setSelectedFile, isRefreshing, handleRefresh, handleFileSelect } =
-    useEditorState(refetchFilesMetadata);
+    useEditorState(refetchFilesMetadata, undefined, fileStructure);
 
   const prevSandboxIdRef = useRef(selectedSandboxId);
   if (prevSandboxIdRef.current !== selectedSandboxId) {

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -210,6 +210,7 @@ export const useUIStore = create<UIStoreState>()(
       activeAgentTile: 'agent:primary',
       focusedTile: null,
       layoutsByChat: {},
+      selectedFileByChat: {},
       currentWorkspaceChatId: null,
 
       activateTab: (tileId) => {

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -88,6 +88,9 @@ export interface SplitViewState {
   // Saved tabs per chat, so each chat restores its own workspace when revisited.
   // Excludes split-chat (:secondary) tiles, which the split effects rebuild.
   layoutsByChat: Record<string, WorkspaceLayout>;
+  // The file the user had open in each chat's editor — restored when revisiting
+  // a chat, since EditorPane's local selectedFile is lost on unmount.
+  selectedFileByChat: Record<string, string>;
   // Which chat the live openTabs/visibleLayout belong to — drives save-on-switch.
   currentWorkspaceChatId: string | null;
 }


### PR DESCRIPTION
## Summary
- Move chat-specific file selection logic from EditorPane's ref-based reset into useEditorState
- Store selected file path per chat in Zustand (uiStore) instead of local component state
- EditorPane now passes chatId and fileStructure to useEditorState so it can manage persistence
- Landing page (no chat) uses local state; chats use store-backed persistence
- File selection survives chat switches and EditorPane unmount/remount

## Testing
- Verify file selection is restored when switching between chats
- Verify landing page file selection is local (not persisted across app sessions)
- Confirm no regressions in editor state when opening/closing files