### PR TITLE
Add Agentrove MCP server integration for desktop

### DIFF
--- a/.env.desktop.example
+++ b/.env.desktop.example
@@ -1,0 +1,13 @@
+# Optional env vars for the desktop backend sidecar.
+#
+# Copy to `.env.desktop` in the app data dir and fill in — on macOS that's:
+#   ~/Library/Application Support/com.agentrove.app/.env.desktop
+# Loaded at sidecar startup (desktop/entry.py), so a normal launch picks it up.
+
+# --- Agentrove chat MCP server (opt-in) ---
+# Lets spawned agents (Claude Code, Codex, …) create/list/message chats via the
+# stdio MCP server in mcp-server/. The server logs into this backend, so it needs
+# a user's credentials.
+AGENTROVE_MCP_ENABLED=true
+AGENTROVE_MCP_EMAIL=you@example.com
+AGENTROVE_MCP_PASSWORD=your-password

--- a/.gitignore
+++ b/.gitignore
@@ -55,12 +55,14 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.venv/
 
 # Database files
 *.db
 
 # Env
 .env
+.env.desktop
 
 .agents/
 **/.claude/settings.local.json

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -156,6 +156,14 @@ class Settings(BaseSettings):
     GIT_CONFIG_GLOBAL: str = str(Path.home() / ".gitconfig")
     GNUPGHOME: str = str(Path.home() / ".gnupg")
 
+    # Agentrove chat MCP server — exposes its chat tools to spawned agents via a
+    # stdio MCP server (mcp-server/server.py, bundled next to the backend). Opt-in
+    # and only wired with credentials. The server logs into this same backend
+    # (reached at BASE_URL), so it needs a user's email/password.
+    AGENTROVE_MCP_ENABLED: bool = False
+    AGENTROVE_MCP_EMAIL: str | None = None
+    AGENTROVE_MCP_PASSWORD: str | None = None
+
     # Docker Sandbox configuration
     DOCKER_IMAGE: str = "ghcr.io/mng-dev-ai/agentrove-sandbox:latest"
     DOCKER_NETWORK: str = "agentrove-sandbox-net"

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
+import sys
 from collections.abc import AsyncIterator
+from pathlib import Path
 from typing import Any, cast
 from uuid import UUID
 
@@ -37,6 +39,10 @@ from app.services.user import UserService
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
+
+# MCP server ships next to the backend (bundled into the sidecar by run_build.mjs),
+# so its path derives from this file: app/services/agent.py -> ../../mcp-server/server.py
+MCP_SERVER_PATH = Path(__file__).resolve().parents[2] / "mcp-server" / "server.py"
 
 
 class StreamResult:
@@ -393,6 +399,29 @@ class AgentService:
                 env[env_var["key"]] = env_var["value"]
         return env
 
+    @staticmethod
+    def _build_mcp_server_configs() -> list[dict[str, Any]]:
+        # Opt-in: hand the agent Agentrove's own chat tools over a stdio MCP server.
+        # Skipped unless enabled with credentials — the server logs into this backend.
+        if not settings.AGENTROVE_MCP_ENABLED:
+            return []
+        if not (settings.AGENTROVE_MCP_EMAIL and settings.AGENTROVE_MCP_PASSWORD):
+            return []
+        return [
+            {
+                "name": "agentrove",
+                # Spawn with the backend's own interpreter (the bundled sidecar
+                # Python, which ships mcp+httpx) — avoids PATH/version surprises
+                "command": sys.executable,
+                "args": [str(MCP_SERVER_PATH)],
+                "env": {
+                    "AGENTROVE_API_URL": f"{settings.BASE_URL}{settings.API_V1_STR}",
+                    "AGENTROVE_EMAIL": settings.AGENTROVE_MCP_EMAIL,
+                    "AGENTROVE_PASSWORD": settings.AGENTROVE_MCP_PASSWORD,
+                },
+            }
+        ]
+
     async def _build_acp_config(
         self,
         *,
@@ -445,6 +474,7 @@ class AgentService:
             cwd=cwd,
             agent_kind=agent_kind,
             env=env,
+            mcp_servers=self._build_mcp_server_configs(),
             model=model_id,
             permission_mode=session_config.permission.session_mode,
             launch_approval_policy=session_config.permission.launch_approval_policy,

--- a/desktop/entry.py
+++ b/desktop/entry.py
@@ -6,8 +6,26 @@ import uvicorn
 from migrate import check_and_run_migrations
 
 
+def _load_desktop_env() -> None:
+    # Load <data_dir>/.env.desktop into the environment before the app reads settings.
+    # data_dir is the parent of STORAGE_PATH (set by desktop.rs); inline env still wins.
+    storage = os.environ.get("STORAGE_PATH")
+    if not storage:
+        return
+    env_file = Path(storage).parent / ".env.desktop"
+    if not env_file.is_file():
+        return
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip())
+
+
 def main() -> None:
     os.environ.setdefault("DESKTOP_MODE", "true")
+    _load_desktop_env()
     os.chdir(Path(__file__).resolve().parent)
     check_and_run_migrations()
 

--- a/desktop/run_build.mjs
+++ b/desktop/run_build.mjs
@@ -239,6 +239,14 @@ function copySource() {
   copyFileSync(join(backendDir, 'alembic.ini'), join(sidecarDir, 'alembic.ini'));
   copyFileSync(join(backendDir, 'migrate.py'), join(sidecarDir, 'migrate.py'));
   copyFileSync(join(dir, 'entry.py'), join(sidecarDir, 'entry.py'));
+  // Bundle the MCP server alongside the backend so agent.py can compute its path
+  // (sidecar/app/services/agent.py -> sidecar/mcp-server/server.py) without config
+  rmSync(join(sidecarDir, 'mcp-server'), { recursive: true, force: true });
+  cpSync(join(rootDir, 'mcp-server'), join(sidecarDir, 'mcp-server'), {
+    recursive: true,
+    filter: (src) =>
+      !src.includes('__pycache__') && !src.endsWith('.pyc') && !src.includes('.venv'),
+  });
 }
 
 function writeLauncher() {

--- a/frontend/.env.desktop
+++ b/frontend/.env.desktop
@@ -1,2 +1,0 @@
-VITE_API_BASE_URL=http://localhost:8081/api/v1
-VITE_WS_URL=ws://localhost:8081/api/v1/ws

--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -6,7 +6,7 @@ import type { TreeHandle } from '../file-tree/Tree';
 import { View } from '../editor-view/View';
 import type { FileStructure } from '@/types/file-system.types';
 import { cn } from '@/utils/cn';
-import { findFileInStructure } from '@/utils/file';
+import { findFileByToolPath, findFileInStructure } from '@/utils/file';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useUIStore } from '@/store/uiStore';
@@ -137,6 +137,23 @@ export const CodeView = memo(function CodeView({
     });
     useUIStore.getState().consumeFileJump();
   }, [pendingFileJump, chatId]);
+
+  // `openFileInEditor` (the write/edit tool buttons) only activates the editor tile;
+  // expand the collapsed tree panel here, then scroll on the next frame so pierre's
+  // scroll/highlight has a real viewport and doesn't race selectedFile's commit cycle.
+  const pendingFilePath = useUIStore((s) => s.pendingFilePath);
+  useEffect(() => {
+    if (!pendingFilePath || pendingFilePath.chatId !== chatId) return;
+    const path = pendingFilePath.path;
+    const panel = fileTreePanelRef.current;
+    if (panel && panel.isCollapsed()) panel.expand();
+    requestAnimationFrame(() => {
+      const file = findFileByToolPath(filesRef.current, path);
+      const treePath = file?.path ?? path;
+      treeRef.current?.expandAncestors(treePath);
+      treeRef.current?.focusPath(treePath);
+    });
+  }, [pendingFilePath, chatId]);
 
   const sharedSidebarProps = {
     files,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -287,8 +287,14 @@ class APIClient {
   }
 }
 
-let API_BASE_URL: string = resolveHttpBaseUrl(import.meta.env.VITE_API_BASE_URL);
-export let WS_BASE_URL: string = resolveWsBaseUrl(import.meta.env.VITE_WS_URL);
+// Desktop has no VITE_* env (the real backend port is injected at runtime via
+// setApiPort); fall back to the local default so the initial URL is well-formed.
+let API_BASE_URL: string = resolveHttpBaseUrl(
+  import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8081/api/v1',
+);
+export let WS_BASE_URL: string = resolveWsBaseUrl(
+  import.meta.env.VITE_WS_URL ?? 'ws://localhost:8081/api/v1/ws',
+);
 // Cloud WS origin, set alongside the cloud HTTP base so sandbox terminals on the
 // VPS connect to the right host. Empty until a VPS is connected.
 let CLOUD_WS_BASE_URL = '';

--- a/mcp-server/client.py
+++ b/mcp-server/client.py
@@ -1,0 +1,169 @@
+from typing import Any
+
+import httpx
+
+DEFAULT_API_URL = "http://localhost:8080/api/v1"
+
+
+class AgentroveError(Exception):
+    pass
+
+
+class AgentroveClient:
+    def __init__(self, base_url: str, email: str, password: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._email = email
+        self._password = password
+        self._http = httpx.AsyncClient(base_url=self._base_url, timeout=60.0)
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        # Resolved lazily and cached so create_chat/create_message don't re-list every call
+        self._default_model_id: str | None = None
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
+
+    async def _login(self) -> None:
+        # fastapi-users JWT login expects OAuth2 form fields (username = email)
+        resp = await self._http.post(
+            "/auth/jwt/login",
+            data={"username": self._email, "password": self._password},
+        )
+        if resp.status_code != 200:
+            raise AgentroveError(f"Login failed ({resp.status_code}): {resp.text}")
+        body = resp.json()
+        self._access_token = body["access_token"]
+        self._refresh_token = body.get("refresh_token")
+
+    async def _refresh(self) -> bool:
+        if not self._refresh_token:
+            return False
+        resp = await self._http.post(
+            "/auth/jwt/refresh", json={"refresh_token": self._refresh_token}
+        )
+        if resp.status_code != 200:
+            return False
+        body = resp.json()
+        self._access_token = body["access_token"]
+        self._refresh_token = body.get("refresh_token", self._refresh_token)
+        return True
+
+    async def _send(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        headers = {"Authorization": f"Bearer {self._access_token}"}
+        headers.update(kwargs.pop("headers", {}))
+        return await self._http.request(method, path, headers=headers, **kwargs)
+
+    async def request(
+        self, method: str, path: str, *, expected: tuple[int, ...] = (200,), **kwargs: Any
+    ) -> httpx.Response:
+        if self._access_token is None:
+            await self._login()
+        resp = await self._send(method, path, **kwargs)
+        # Access tokens are short-lived (15 min) — on expiry, refresh or re-login and retry once
+        if resp.status_code == 401:
+            if not await self._refresh():
+                await self._login()
+            resp = await self._send(method, path, **kwargs)
+        if resp.status_code not in expected:
+            raise AgentroveError(f"{method} {path} -> {resp.status_code}: {resp.text}")
+        return resp
+
+    async def list_workspaces(self) -> list[dict[str, Any]]:
+        resp = await self.request("GET", "/workspaces", params={"per_page": 100})
+        return resp.json()["items"]
+
+    async def resolve_workspace_id(self, workspace_id: str | None) -> str:
+        if workspace_id:
+            return workspace_id
+        resp = await self.request("GET", "/workspaces", params={"per_page": 1})
+        items = resp.json()["items"]
+        if not items:
+            raise AgentroveError("No workspaces found — create one in AgentRove first.")
+        return items[0]["id"]
+
+    async def list_chats(
+        self, workspace_id: str | None, page: int, per_page: int
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"page": page, "per_page": per_page}
+        if workspace_id:
+            params["workspace_id"] = workspace_id
+        resp = await self.request("GET", "/chat/chats", params=params)
+        return resp.json()
+
+    async def list_personas(self) -> list[dict[str, Any]]:
+        resp = await self.request("GET", "/settings/")
+        return resp.json().get("personas") or []
+
+    async def list_models(self, agent_kind: str | None) -> list[dict[str, Any]]:
+        params = {"agent_kind": agent_kind} if agent_kind else None
+        resp = await self.request("GET", "/models/", params=params)
+        return resp.json()
+
+    async def resolve_model_id(self, model_id: str | None) -> str:
+        if model_id:
+            return model_id
+        if self._default_model_id:
+            return self._default_model_id
+        resp = await self.request("GET", "/models/")
+        models = resp.json()
+        if not models:
+            raise AgentroveError("No models available.")
+        # Default to a Claude model when present, otherwise the first listed
+        claude = next((m for m in models if m["agent_kind"] == "claude"), None)
+        self._default_model_id = (claude or models[0])["model_id"]
+        return self._default_model_id
+
+    async def create_chat(
+        self,
+        title: str,
+        workspace_id: str,
+        model_id: str,
+        parent_chat_id: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "title": title,
+            "model_id": model_id,
+            "workspace_id": workspace_id,
+        }
+        # Sub-thread: the backend overrides workspace_id with the parent's workspace
+        if parent_chat_id:
+            body["parent_chat_id"] = parent_chat_id
+        resp = await self.request("POST", "/chat/chats", json=body, expected=(201,))
+        return resp.json()
+
+    async def send_message(
+        self,
+        chat_id: str,
+        prompt: str,
+        model_id: str,
+        permission_mode: str,
+        thinking_mode: str | None = None,
+        worktree: bool = False,
+        plan_mode: bool = False,
+        persona: str | None = None,
+    ) -> dict[str, Any]:
+        # Endpoint reads Form fields; no file upload here so urlencoded form is fine
+        # (httpx serializes bools to "true"/"false", which FastAPI parses back)
+        data: dict[str, Any] = {
+            "prompt": prompt,
+            "chat_id": chat_id,
+            "model_id": model_id,
+            "permission_mode": permission_mode,
+            "worktree": worktree,
+            "plan_mode": plan_mode,
+        }
+        if thinking_mode:
+            data["thinking_mode"] = thinking_mode
+        if persona:
+            data["selected_persona_name"] = persona
+        resp = await self.request("POST", "/chat/chat", data=data)
+        return resp.json()
+
+    async def get_messages(
+        self, chat_id: str, limit: int, cursor: str | None
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"limit": limit}
+        if cursor:
+            params["cursor"] = cursor
+        resp = await self.request("GET", f"/chat/chats/{chat_id}/messages", params=params)
+        return resp.json()

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentrove-mcp"
+version = "0.1.0"
+description = "MCP server exposing AgentRove chat tools (create_chat, create_message, get_messages)"
+requires-python = ">=3.12"
+dependencies = [
+    "mcp>=1.19.0",
+    "httpx>=0.27",
+]
+
+[tool.setuptools]
+py-modules = ["server", "client"]

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -1,0 +1,184 @@
+import os
+from typing import Any, Literal
+
+from mcp.server.fastmcp import FastMCP
+
+from client import DEFAULT_API_URL, AgentroveClient, AgentroveError
+
+mcp = FastMCP("agentrove")
+
+
+def _build_client() -> AgentroveClient:
+    email = os.environ.get("AGENTROVE_EMAIL")
+    password = os.environ.get("AGENTROVE_PASSWORD")
+    if not email or not password:
+        raise AgentroveError("AGENTROVE_EMAIL and AGENTROVE_PASSWORD must be set")
+    base_url = os.environ.get("AGENTROVE_API_URL", DEFAULT_API_URL)
+    return AgentroveClient(base_url, email, password)
+
+
+client = _build_client()
+
+
+@mcp.tool()
+async def list_workspaces() -> dict[str, Any]:
+    """List the available AgentRove workspaces.
+
+    Returns each workspace's id and name. Pass a workspace id as `workspace_id` to
+    send_message to create a new chat in that workspace; otherwise the most recently
+    active workspace is used.
+    """
+    workspaces = await client.list_workspaces()
+    return {"workspaces": [{"id": w["id"], "name": w["name"]} for w in workspaces]}
+
+
+@mcp.tool()
+async def list_models(
+    agent_kind: Literal["claude", "codex", "copilot", "cursor", "opencode"] | None = None,
+) -> dict[str, Any]:
+    """List available AI models, optionally filtered by agent_kind.
+
+    Each entry has model_id, name and agent_kind. Pass a model_id as `model_id` to
+    send_message to use it; otherwise a Claude model is used. An instance can expose
+    many models, so filter by agent_kind to narrow the list.
+    """
+    models = await client.list_models(agent_kind)
+    return {
+        "models": [
+            {"model_id": m["model_id"], "name": m["name"], "agent_kind": m["agent_kind"]}
+            for m in models
+        ]
+    }
+
+
+@mcp.tool()
+async def list_chats(
+    workspace_id: str | None = None,
+    page: int = 1,
+    per_page: int = 20,
+) -> dict[str, Any]:
+    """List existing chats for discovery, most recent first.
+
+    Use a chat's id with send_message — as chat_id to continue it, or as parent_chat_id to
+    add a sub-thread (only top-level chats, where parent_chat_id is null, can be parents).
+    Filter by workspace_id to scope to one workspace. Returns id, title, workspace_id,
+    parent_chat_id, sub_thread_count and updated_at, plus pagination.
+    """
+    data = await client.list_chats(workspace_id, page=page, per_page=per_page)
+    chats = [
+        {
+            "id": c["id"],
+            "title": c["title"],
+            "workspace_id": c["workspace_id"],
+            "parent_chat_id": c["parent_chat_id"],
+            "sub_thread_count": c["sub_thread_count"],
+            "updated_at": c["updated_at"],
+        }
+        for c in data["items"]
+    ]
+    return {
+        "chats": chats,
+        "page": data["page"],
+        "pages": data["pages"],
+        "total": data["total"],
+    }
+
+
+@mcp.tool()
+async def list_personas() -> dict[str, Any]:
+    """List custom personas available for send_message's `persona` argument.
+
+    Returns each persona's name. Pass one as `persona` to send_message; if none are
+    defined or `persona` is omitted, the standard "Default" persona is used.
+    """
+    personas = await client.list_personas()
+    return {"personas": [{"name": p["name"]} for p in personas]}
+
+
+@mcp.tool()
+async def send_message(
+    prompt: str,
+    chat_id: str | None = None,
+    parent_chat_id: str | None = None,
+    title: str | None = None,
+    workspace_id: str | None = None,
+    model_id: str | None = None,
+    thinking_mode: Literal["low", "medium", "high", "xhigh", "max"] | None = None,
+    worktree: bool = False,
+    plan_mode: bool = False,
+    persona: str | None = None,
+) -> dict[str, Any]:
+    """Send a prompt to AgentRove and start the agent turn.
+
+    Omit chat_id to create a new chat first (auto-resolving the workspace and a Claude
+    model unless given, titled from `title` or the prompt) and send the prompt to it;
+    pass chat_id to continue an existing chat. Set parent_chat_id (when creating) to make
+    the new chat a sub-thread of that parent — it inherits the parent's workspace, and the
+    parent must be a top-level chat (sub-threads can't nest).
+
+    Per-turn options: thinking_mode sets reasoning effort (values not supported by the
+    chosen model fall back to medium); worktree=true runs the turn in an isolated git
+    worktree (its own branch); plan_mode=true runs a read-only planning turn; persona
+    selects a custom persona by name (defaults to the standard persona).
+
+    Returns immediately with chat_id and the streaming message_id. To get the reply, poll
+    get_messages and watch that message's stream_status flip from "in_progress" to
+    "completed". Permissions are bypassed so the turn runs unattended.
+    """
+    resolved_model = await client.resolve_model_id(model_id)
+    if chat_id is None:
+        resolved_workspace = await client.resolve_workspace_id(workspace_id)
+        chat_title = (title or prompt[:60]).strip() or "New chat"
+        chat = await client.create_chat(
+            chat_title, resolved_workspace, resolved_model, parent_chat_id=parent_chat_id
+        )
+        chat_id = chat["id"]
+    sent = await client.send_message(
+        chat_id,
+        prompt,
+        resolved_model,
+        permission_mode="bypassPermissions",
+        thinking_mode=thinking_mode,
+        worktree=worktree,
+        plan_mode=plan_mode,
+        persona=persona,
+    )
+    return {
+        "chat_id": chat_id,
+        "message_id": sent["message_id"],
+        "status": "in_progress",
+    }
+
+
+@mcp.tool()
+async def get_messages(
+    chat_id: str,
+    limit: int = 20,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """List messages in an AgentRove chat, oldest first.
+
+    Returns up to `limit` messages (1-100) with role, content_text and stream_status.
+    Use the returned next_cursor with a follow-up call to page through older messages.
+    """
+    page = await client.get_messages(chat_id, limit=limit, cursor=cursor)
+    # Backend returns newest-first; flip to chronological for readability
+    messages = [
+        {
+            "id": m["id"],
+            "role": m["role"],
+            "content": m["content_text"],
+            "stream_status": m.get("stream_status"),
+            "created_at": m["created_at"],
+        }
+        for m in reversed(page["items"])
+    ]
+    return {
+        "messages": messages,
+        "next_cursor": page["next_cursor"],
+        "has_more": page["has_more"],
+    }
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary
- Implement opt-in Agentrove MCP server to expose chat tools to spawned agents
- Load desktop environment configuration from `.env.desktop` in user data directory
- Bundle MCP server alongside backend in desktop sidecar
- Improve file tree expansion and focus when editor tools open files
- Add fallback API URLs for desktop mode without build-time environment variables

## Changes
- **Backend config**: Add `AGENTROVE_MCP_ENABLED`, `AGENTROVE_MCP_EMAIL`, `AGENTROVE_MCP_PASSWORD` settings
- **Agent service**: Build MCP server configurations and integrate into execution pipeline
- **Desktop entry**: Load `.env.desktop` from data directory before app startup
- **Build script**: Bundle mcp-server into sidecar; exclude cache/venv
- **Editor**: Expand file tree and focus selected file on `openFileInEditor` tool invocation
- **API client**: Add fallback URLs for localhost desktop mode
- **MCP server**: New stdio MCP server implementation with client authentication