### PR TITLE
Add MCP server support to backend and Docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -49,6 +49,12 @@ RUN /root/.local/bin/uv pip install --system --no-cache -r requirements.lock
 
 COPY backend/ /app/
 
+# Agentrove chat MCP server (mcp-server/server.py) lives at the repo root, not
+# under backend/. The backend spawns it from /app/mcp-server/ (see MCP_SERVER_PATH
+# in services/agent.py), so it must ship in the image — the desktop sidecar bundles
+# it separately via run_build.mjs, but the cloud/VPS image needs it copied here.
+COPY mcp-server/ /app/mcp-server/
+
 RUN chown -R appuser:appuser /app && \
     chmod -R 755 /app && \
     chmod +x /app/entrypoint.sh

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -110,4 +110,7 @@ DEP002 = [
     "python-multipart",
     "bcrypt",
     "email-validator",
+    # Imported by the bundled mcp-server/ (outside backend/), which the backend
+    # spawns at runtime — not imported by backend source, so deptry can't see it.
+    "mcp",
 ]

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -23,6 +23,7 @@ annotated-types==0.7.0
 anyio==4.12.1
     # via
     #   httpx
+    #   mcp
     #   sse-starlette
     #   starlette
     #   watchfiles
@@ -31,7 +32,10 @@ argon2-cffi==23.1.0
 argon2-cffi-bindings==25.1.0
     # via argon2-cffi
 attrs==25.4.0
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   jsonschema
+    #   referencing
 bcrypt==4.1.2
     # via
     #   -r backend/requirements.txt
@@ -86,7 +90,11 @@ httpcore==1.0.9
 httptools==0.7.1
     # via uvicorn
 httpx==0.28.1
-    # via -r backend/requirements.txt
+    # via
+    #   -r backend/requirements.txt
+    #   mcp
+httpx-sse==0.4.3
+    # via mcp
 idna==3.11
     # via
     #   anyio
@@ -99,6 +107,10 @@ jinja2==3.1.6
     # via
     #   -r backend/requirements.txt
     #   sqladmin
+jsonschema==4.26.0
+    # via mcp
+jsonschema-specifications==2025.9.1
+    # via jsonschema
 limits==5.8.0
     # via slowapi
 makefun==1.16.0
@@ -111,6 +123,8 @@ markupsafe==3.0.3
     #   jinja2
     #   mako
     #   wtforms
+mcp==1.19.0
+    # via -r backend/requirements.txt
 multidict==6.7.1
     # via
     #   aiohttp
@@ -138,11 +152,14 @@ pydantic==2.12.5
     #   -r backend/requirements.txt
     #   agent-client-protocol
     #   fastapi
+    #   mcp
     #   pydantic-settings
 pydantic-core==2.41.5
     # via pydantic
 pydantic-settings==2.12.0
-    # via -r backend/requirements.txt
+    # via
+    #   -r backend/requirements.txt
+    #   mcp
 pyjwt==2.8.0
     # via fastapi-users
 python-dotenv==1.2.1
@@ -157,6 +174,7 @@ python-multipart==0.0.9
     # via
     #   -r backend/requirements.txt
     #   fastapi-users
+    #   mcp
     #   sqladmin
 pyyaml==6.0.3
     # via
@@ -164,6 +182,14 @@ pyyaml==6.0.3
     #   uvicorn
 redis==6.4.0
     # via -r backend/requirements.txt
+referencing==0.37.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+rpds-py==2026.5.1
+    # via
+    #   jsonschema
+    #   referencing
 rsa==4.9.1
     # via python-jose
 six==1.17.0
@@ -179,11 +205,14 @@ sqlalchemy==2.0.46
     #   fastapi-users-db-sqlalchemy
     #   sqladmin
 sse-starlette==3.2.0
-    # via -r backend/requirements.txt
+    # via
+    #   -r backend/requirements.txt
+    #   mcp
 starlette==0.52.1
     # via
     #   -r backend/requirements.txt
     #   fastapi
+    #   mcp
     #   prometheus-fastapi-instrumentator
     #   sqladmin
     #   sse-starlette
@@ -196,6 +225,7 @@ typing-extensions==4.15.0
     #   limits
     #   pydantic
     #   pydantic-core
+    #   referencing
     #   sqlalchemy
     #   starlette
     #   typing-inspection
@@ -205,7 +235,9 @@ typing-inspection==0.4.2
     #   pydantic
     #   pydantic-settings
 uvicorn==0.40.0
-    # via -r backend/requirements.txt
+    # via
+    #   -r backend/requirements.txt
+    #   mcp
 uvloop==0.22.1
     # via uvicorn
 watchfiles==1.1.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,6 +18,7 @@ aiodocker>=0.22.0
 agent-client-protocol==0.9.0
 sqladmin[full]
 httpx
+mcp>=1.19.0
 aiosmtplib
 prometheus-fastapi-instrumentator
 slowapi


### PR DESCRIPTION
## Summary
- Add `mcp>=1.19.0` dependency to backend requirements
- Copy `mcp-server/` directory into Docker image for cloud/VPS deployments
- Desktop sidecar bundles MCP server separately via build process

This enables the backend to spawn and communicate with the Agentrove MCP server, supporting the Model Context Protocol integration for agents and tools.