### PR TITLE
fix: reveal file in tree when opening from write/edit tool button

### DIFF
--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -147,11 +147,14 @@ export const CodeView = memo(function CodeView({
     const path = pendingFilePath.path;
     const panel = fileTreePanelRef.current;
     if (panel && panel.isCollapsed()) panel.expand();
+    const file = findFileByToolPath(filesRef.current, path);
+    const treePath = file?.path ?? path;
+    // Two frames before scrolling: the just-expanded panel lays out first, then
+    // pierre's virtualized viewport picks up its new size (a single frame no-ops).
+    // No cleanup: pendingFilePath clears right after, and a cancel would kill the scroll.
+    treeRef.current?.expandAncestors(treePath);
     requestAnimationFrame(() => {
-      const file = findFileByToolPath(filesRef.current, path);
-      const treePath = file?.path ?? path;
-      treeRef.current?.expandAncestors(treePath);
-      treeRef.current?.focusPath(treePath);
+      requestAnimationFrame(() => treeRef.current?.focusPath(treePath));
     });
   }, [pendingFilePath, chatId]);
 


### PR DESCRIPTION
## Problem

Clicking the **Open in editor** button next to a write/edit tool result opens the file in the editor, but the file tree doesn't scroll to or highlight that file — the user has to find it manually.

## Root cause

The file-tree panel defaults to **collapsed** (`defaultSize={0}`). `CodeView`'s `pendingFilePath` effect expanded the panel and then, in a **single** `requestAnimationFrame`, expanded ancestor folders **and** scrolled to the file in the same tick. Two timing problems compounded:

- The newly-revealed rows hadn't laid out yet, so `focusPath` couldn't find the target row.
- The panel had just expanded from zero width, so pierre's virtualized viewport hadn't picked up its real size (its `ResizeObserver` fires after the rAF) — scrolling against a stale/zero viewport is a no-op. The selection highlight applied, but to an off-screen row.

## Fix

In `CodeView`'s `pendingFilePath` effect:

- Expand ancestor folders **synchronously** so the target row is registered immediately.
- Defer the scroll across **two** frames — the first lets the just-expanded panel and revealed rows lay out, the second lets pierre's virtualized viewport pick up its new size before computing the scroll.
- Kept it fire-and-forget (no cleanup): `usePendingFileOpen` clears `pendingFilePath` right after, which re-runs this effect — a cancelling cleanup would kill the queued scroll.

Scoped to a single file (`CodeView.tsx`), no behavior change for any other reveal path.

## Test plan

- Collapse the file tree, run a write/edit tool, click **Open in editor** → tree expands, scrolls to, and highlights the file.
- Re-click on an already-open file after scrolling away → re-reveals it.
- Deeply-nested file with collapsed ancestors → ancestors expand and the file is revealed.