### PR TITLE
fix: per-agent MCP permission mode + current-chat sub-threads

### DIFF
--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -139,6 +139,7 @@ class AgentService:
             permission_mode=permission_mode,
             model_id=model_id,
             session_id=session_id,
+            chat_id=str(chat.id),
             thinking_mode=thinking_mode,
             cwd=cwd,
             sandbox_provider=sandbox_provider,
@@ -400,13 +401,21 @@ class AgentService:
         return env
 
     @staticmethod
-    def _build_mcp_server_configs() -> list[dict[str, Any]]:
+    def _build_mcp_server_configs(chat_id: str | None) -> list[dict[str, Any]]:
         # Opt-in: hand the agent Agentrove's own chat tools over a stdio MCP server.
         # Skipped unless enabled with credentials — the server logs into this backend.
         if not settings.AGENTROVE_MCP_ENABLED:
             return []
         if not (settings.AGENTROVE_MCP_EMAIL and settings.AGENTROVE_MCP_PASSWORD):
             return []
+        env = {
+            "AGENTROVE_API_URL": f"{settings.BASE_URL}{settings.API_V1_STR}",
+            "AGENTROVE_EMAIL": settings.AGENTROVE_MCP_EMAIL,
+            "AGENTROVE_PASSWORD": settings.AGENTROVE_MCP_PASSWORD,
+        }
+        # The chat this session runs in — lets the agent create sub-threads under it
+        if chat_id:
+            env["AGENTROVE_CURRENT_CHAT_ID"] = chat_id
         return [
             {
                 "name": "agentrove",
@@ -414,11 +423,7 @@ class AgentService:
                 # Python, which ships mcp+httpx) — avoids PATH/version surprises
                 "command": sys.executable,
                 "args": [str(MCP_SERVER_PATH)],
-                "env": {
-                    "AGENTROVE_API_URL": f"{settings.BASE_URL}{settings.API_V1_STR}",
-                    "AGENTROVE_EMAIL": settings.AGENTROVE_MCP_EMAIL,
-                    "AGENTROVE_PASSWORD": settings.AGENTROVE_MCP_PASSWORD,
-                },
+                "env": env,
             }
         ]
 
@@ -430,6 +435,7 @@ class AgentService:
         permission_mode: PermissionMode,
         model_id: str,
         session_id: str | None,
+        chat_id: str | None = None,
         thinking_mode: str | None = None,
         cwd: str = "",
         sandbox_provider: SandboxProviderType,
@@ -474,7 +480,7 @@ class AgentService:
             cwd=cwd,
             agent_kind=agent_kind,
             env=env,
-            mcp_servers=self._build_mcp_server_configs(),
+            mcp_servers=self._build_mcp_server_configs(chat_id),
             model=model_id,
             permission_mode=session_config.permission.session_mode,
             launch_approval_policy=session_config.permission.launch_approval_policy,

--- a/mcp-server/client.py
+++ b/mcp-server/client.py
@@ -17,8 +17,8 @@ class AgentroveClient:
         self._http = httpx.AsyncClient(base_url=self._base_url, timeout=60.0)
         self._access_token: str | None = None
         self._refresh_token: str | None = None
-        # Resolved lazily and cached so create_chat/create_message don't re-list every call
-        self._default_model_id: str | None = None
+        # Cached model list so send_message doesn't re-fetch on every call
+        self._models_cache: list[dict[str, Any]] | None = None
 
     async def aclose(self) -> None:
         await self._http.aclose()
@@ -99,19 +99,23 @@ class AgentroveClient:
         resp = await self.request("GET", "/models/", params=params)
         return resp.json()
 
-    async def resolve_model_id(self, model_id: str | None) -> str:
-        if model_id:
-            return model_id
-        if self._default_model_id:
-            return self._default_model_id
-        resp = await self.request("GET", "/models/")
-        models = resp.json()
+    async def resolve_model(self, model_id: str | None) -> tuple[str, str]:
+        # Returns (model_id, agent_kind). agent_kind drives the per-agent permission
+        # mode, so it must come from the model registry, not be assumed.
+        if self._models_cache is None:
+            resp = await self.request("GET", "/models/")
+            self._models_cache = resp.json()
+        models = self._models_cache
         if not models:
             raise AgentroveError("No models available.")
-        # Default to a Claude model when present, otherwise the first listed
-        claude = next((m for m in models if m["agent_kind"] == "claude"), None)
-        self._default_model_id = (claude or models[0])["model_id"]
-        return self._default_model_id
+        if model_id is None:
+            # Default to a Claude model when present, otherwise the first listed
+            chosen = next((m for m in models if m["agent_kind"] == "claude"), models[0])
+        else:
+            chosen = next((m for m in models if m["model_id"] == model_id), None)
+            if chosen is None:
+                raise AgentroveError(f"Unknown model_id: {model_id}")
+        return chosen["model_id"], chosen["agent_kind"]
 
     async def create_chat(
         self,

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -7,6 +7,19 @@ from client import DEFAULT_API_URL, AgentroveClient, AgentroveError
 
 mcp = FastMCP("agentrove")
 
+# Each agent's unattended (no-prompt, full-execution) session mode. The backend
+# rejects modes that don't belong to the target agent (e.g. Codex only accepts
+# auto/read-only/full-access), so the mode must match the model's agent kind.
+# Canonical valid modes live in backend adapters.py (*_SESSION_MODES); this thin
+# HTTP client can't import them, so the unattended tier is mirrored here.
+PERMISSION_MODE_BY_AGENT = {
+    "claude": "bypassPermissions",
+    "codex": "full-access",
+    "copilot": "autopilot",
+    "cursor": "agent",
+    "opencode": "build",
+}
+
 
 def _build_client() -> AgentroveClient:
     email = os.environ.get("AGENTROVE_EMAIL")
@@ -49,6 +62,17 @@ async def list_models(
             for m in models
         ]
     }
+
+
+@mcp.tool()
+async def get_current_chat() -> dict[str, Any]:
+    """Return the chat this MCP server is running inside, when known.
+
+    Use its chat_id as send_message's parent_chat_id to create sub-threads under the
+    current chat. Returns {"chat_id": null} if unknown (e.g. the server was launched
+    standalone rather than for an AgentRove chat session).
+    """
+    return {"chat_id": os.environ.get("AGENTROVE_CURRENT_CHAT_ID")}
 
 
 @mcp.tool()
@@ -123,9 +147,11 @@ async def send_message(
 
     Returns immediately with chat_id and the streaming message_id. To get the reply, poll
     get_messages and watch that message's stream_status flip from "in_progress" to
-    "completed". Permissions are bypassed so the turn runs unattended.
+    "completed". The turn runs unattended — it uses the model's full-execution permission
+    mode (e.g. bypassPermissions for Claude, full-access for Codex).
     """
-    resolved_model = await client.resolve_model_id(model_id)
+    resolved_model, agent_kind = await client.resolve_model(model_id)
+    permission_mode = PERMISSION_MODE_BY_AGENT[agent_kind]
     if chat_id is None:
         resolved_workspace = await client.resolve_workspace_id(workspace_id)
         chat_title = (title or prompt[:60]).strip() or "New chat"
@@ -137,7 +163,7 @@ async def send_message(
         chat_id,
         prompt,
         resolved_model,
-        permission_mode="bypassPermissions",
+        permission_mode=permission_mode,
         thinking_mode=thinking_mode,
         worktree=worktree,
         plan_mode=plan_mode,


### PR DESCRIPTION
## Summary
- Fix `send_message` failing for non-Claude agents with `Invalid Codex session mode: bypassPermissions`. The MCP hardcoded Claude's `bypassPermissions`, which the backend's per-agent session-mode guards reject for Codex/Cursor/Copilot/OpenCode. Now the unattended mode is derived from the model's `agent_kind` via `PERMISSION_MODE_BY_AGENT` (`codex→full-access`, `copilot→autopilot`, `cursor→agent`, `opencode→build`, `claude→bypassPermissions`).
- `client.resolve_model_id` → `resolve_model`, returning `(model_id, agent_kind)` (needed for the mode lookup) and now raising on an unknown `model_id` instead of passing it through unvalidated.
- Let agents create sub-threads under the chat they run in: the backend threads `chat_id` through `_build_acp_config` → `_build_mcp_server_configs` and passes `AGENTROVE_CURRENT_CHAT_ID` to the spawned MCP server. A new `get_current_chat` MCP tool surfaces it so the agent can pass it as `parent_chat_id`.

## Notes
- The canonical valid session modes live in `backend/app/services/acp/adapters.py` (`*_SESSION_MODES`); the thin stdio MCP client mirrors the unattended tier since it can't import backend constants (noted in a code comment).
- Both fixes verified end-to-end via the AgentRove review loop (Codex + Opus sub-thread reviews ran clean).