### PR TITLE
fix: remount ChatSessionOrchestrator on chat ID change

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -301,6 +301,7 @@ export function ChatPage() {
       personas={settings?.personas}
     >
       <ChatSessionOrchestrator
+        key={chatId}
         chatId={chatId}
         currentChat={currentChat}
         fetchedMessages={fetchedMessages}


### PR DESCRIPTION
## Summary
- Adds `key={chatId}` to ChatSessionOrchestrator to force remounting when the chat ID changes
- Ensures component state resets properly when switching between chats