### PR TITLE
Add message duration tracking and refactor message renderer

### DIFF
--- a/backend/app/models/db_models/chat.py
+++ b/backend/app/models/db_models/chat.py
@@ -160,6 +160,8 @@ class Message(Base):
     total_cost_usd: Mapped[float | None] = mapped_column(
         Float, nullable=True, default=0.0, server_default="0.0"
     )
+    # Total wall-clock run time, recorded once at the terminal snapshot.
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
     stream_status: Mapped[MessageStreamStatus] = mapped_column(
         SQLAlchemyEnum(
             MessageStreamStatus,

--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -54,6 +54,7 @@ class Message(MessageBase):
     created_at: datetime
     model_id: str | None = None
     stream_status: MessageStreamStatus | None = None
+    duration_ms: int | None = None
     attachments: list[MessageAttachment] = Field(default_factory=list)
     checkpoint_id: UUID | None = None
 

--- a/backend/app/services/message.py
+++ b/backend/app/services/message.py
@@ -148,6 +148,17 @@ class MessageService(BaseDbService[Message]):
             }
             if stream_status is not None:
                 values["stream_status"] = stream_status
+                # Record total run time once, at the terminal snapshot. created_at
+                # marks run start — the empty assistant row is inserted before
+                # streaming begins.
+                if stream_status != MessageStreamStatus.IN_PROGRESS:
+                    created_at = await db.scalar(
+                        select(Message.created_at).where(Message.id == message_id)
+                    )
+                    if created_at is not None:
+                        values["duration_ms"] = int(
+                            (now - created_at).total_seconds() * 1000
+                        )
             if total_cost_usd is not None:
                 values["total_cost_usd"] = total_cost_usd
 

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -380,11 +380,13 @@ class ChatStreamRuntime:
         self,
         stream_result: StreamResult,
         stream_status: MessageStreamStatus,
-    ) -> None:
+    ) -> int | None:
+        # Returns the persisted run duration so the terminal event can carry it
+        # to the live client without waiting for a refetch.
         if not self.assistant_message_id:
-            return
+            return None
         await self._flush_event_buffer()
-        await self.message_service.update_message_snapshot(
+        message = await self.message_service.update_message_snapshot(
             UUID(self.assistant_message_id),
             content_text=self.snapshot.content_text,
             content_render=self.snapshot.to_render(),
@@ -393,13 +395,14 @@ class ChatStreamRuntime:
             stream_status=stream_status,
             total_cost_usd=stream_result.total_cost_usd,
         )
+        return message.duration_ms if message else None
 
     async def _complete_stream(
         self,
         stream_result: StreamResult,
         status: MessageStreamStatus,
     ) -> str:
-        await self._save_final_snapshot(stream_result, status)
+        duration_ms = await self._save_final_snapshot(stream_result, status)
         final_content = self.snapshot.content_text
 
         if status == MessageStreamStatus.COMPLETED:
@@ -413,7 +416,7 @@ class ChatStreamRuntime:
                 await self._emit_context_usage(stream_result)
                 await self.emit_event(
                     "complete",
-                    {"status": "completed"},
+                    {"status": "completed", "duration_ms": duration_ms},
                     apply_snapshot=False,
                 )
         elif status == MessageStreamStatus.INTERRUPTED:
@@ -428,14 +431,14 @@ class ChatStreamRuntime:
             await self._emit_context_usage(stream_result)
             await self.emit_event(
                 "cancelled",
-                {"status": status.value},
+                {"status": status.value, "duration_ms": duration_ms},
                 apply_snapshot=False,
             )
         else:
             await self._emit_context_usage(stream_result)
             await self.emit_event(
                 "complete",
-                {"status": status.value},
+                {"status": status.value, "duration_ms": duration_ms},
                 apply_snapshot=False,
             )
 

--- a/backend/migrations/versions/d2e3f4a5b6c7_add_duration_ms_to_messages.py
+++ b/backend/migrations/versions/d2e3f4a5b6c7_add_duration_ms_to_messages.py
@@ -1,0 +1,25 @@
+# Revision ID: d2e3f4a5b6c7
+# Revises: c1a2b3d4e5f6
+# Create Date: 2026-06-29 00:00:00.000000
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "d2e3f4a5b6c7"
+down_revision: str | None = "c1a2b3d4e5f6"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "messages",
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("messages", "duration_ms")

--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -350,7 +350,7 @@ export const Chat = memo(function Chat() {
       const uploadingAttachmentIds = shouldShowUploadingOverlay ? localAttachmentIds : undefined;
 
       return (
-        <div className="w-full lg:mx-auto lg:max-w-3xl">
+        <div className="w-full lg:mx-auto lg:max-w-4xl">
           {isBotMessage ? (
             <AssistantMessage
               id={msg.id}
@@ -360,6 +360,7 @@ export const Chat = memo(function Chat() {
               isStreaming={messageIsStreaming}
               createdAt={msg.created_at}
               modelId={msg.model_id}
+              durationMs={msg.duration_ms}
               checkpointId={msg.checkpoint_id}
               isLastBotMessage={isLastBotMessage && !messageIsStreaming}
             />
@@ -386,7 +387,7 @@ export const Chat = memo(function Chat() {
     }
 
     return (
-      <div className="w-full lg:mx-auto lg:max-w-3xl">
+      <div className="w-full lg:mx-auto lg:max-w-4xl">
         <div className="flex h-4 items-center justify-center p-4">
           {isFetchingNextPage && (
             <div className="flex items-center gap-2 text-sm text-text-secondary dark:text-text-dark-secondary">
@@ -407,7 +408,7 @@ export const Chat = memo(function Chat() {
     }
 
     return (
-      <div className="w-full lg:mx-auto lg:max-w-3xl">
+      <div className="w-full lg:mx-auto lg:max-w-4xl">
         {showThinking && (
           <ThinkingIndicator key={streamStartTime} streamStartTime={streamStartTime} />
         )}
@@ -442,7 +443,7 @@ export const Chat = memo(function Chat() {
         {showScrollButton && <ScrollButton onClick={scrollToBottom} />}
 
         <div className="relative bg-surface pb-safe dark:bg-surface-dark">
-          <div className="relative w-full py-2 lg:mx-auto lg:max-w-3xl">
+          <div className="relative w-full py-2 lg:mx-auto lg:max-w-4xl">
             {pendingMessages.length > 0 && (
               <div className="relative z-0 -mb-4 px-10 sm:px-14">
                 <div className="flex flex-col overflow-hidden rounded-t-2xl border border-b-0 border-border/50 bg-surface-secondary pb-4 dark:border-border-dark/50 dark:bg-surface-dark-secondary">

--- a/frontend/src/components/chat/message-bubble/Message.tsx
+++ b/frontend/src/components/chat/message-bubble/Message.tsx
@@ -74,6 +74,7 @@ export interface AssistantMessageProps extends SharedContentProps {
   checkpointId: string | null;
   createdAt?: string;
   modelId?: string;
+  durationMs?: number | null;
   isLastBotMessage?: boolean;
 }
 
@@ -86,6 +87,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   isStreaming,
   createdAt,
   modelId,
+  durationMs,
   isLastBotMessage,
 }: AssistantMessageProps) {
   const { chatId, sandboxId } = useChatContext();
@@ -127,6 +129,7 @@ export const AssistantMessage = memo(function AssistantMessage({
               isStreaming={isStreaming}
               chatId={chatId}
               isLastBotMessage={isLastBotMessage}
+              durationMs={durationMs}
               onSuggestionSelect={onSuggestionSelect}
               agentKind={agentKind}
             />

--- a/frontend/src/components/chat/message-bubble/MessageContent.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageContent.tsx
@@ -37,6 +37,7 @@ export const UserMessageContent = memo(function UserMessageContent({
 
 interface AssistantMessageContentProps extends SharedContentProps {
   isLastBotMessage?: boolean;
+  durationMs?: number | null;
   onSuggestionSelect?: (suggestion: string) => void;
   agentKind?: AgentKind;
 }
@@ -47,6 +48,7 @@ export const AssistantMessageContent = memo(function AssistantMessageContent({
   isStreaming,
   chatId,
   isLastBotMessage,
+  durationMs,
   onSuggestionSelect,
   agentKind,
 }: AssistantMessageContentProps) {
@@ -57,6 +59,7 @@ export const AssistantMessageContent = memo(function AssistantMessageContent({
         isStreaming={isStreaming}
         chatId={chatId}
         isLastBotMessage={isLastBotMessage}
+        durationMs={durationMs}
         onSuggestionSelect={onSuggestionSelect}
         agentKind={agentKind}
       />

--- a/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
@@ -1,13 +1,10 @@
-import React, { memo, Suspense } from 'react';
-import { LazyMarkDown } from '@/components/ui/LazyMarkDown';
-import { ThinkingBlock } from './ThinkingBlock';
-import { PromptSuggestions } from './PromptSuggestions';
-import { getToolComponent } from '@/components/chat/tools/registry';
+import React, { memo } from 'react';
+import { SegmentView } from './SegmentView';
+import { WorkedRollup } from './WorkedRollup';
 import { buildSegments } from './segmentBuilder';
 import { AgentToolsContext } from '@/contexts/AgentToolsContext';
 import type { AgentKind, AssistantStreamEvent } from '@/types/chat.types';
 import type { ToolAggregate } from '@/types/tools.types';
-import { Spinner } from '@/components/ui/primitives/Spinner';
 
 interface MessageRendererProps {
   events: AssistantStreamEvent[];
@@ -15,6 +12,7 @@ interface MessageRendererProps {
   isStreaming?: boolean;
   chatId?: string;
   isLastBotMessage?: boolean;
+  durationMs?: number | null;
   onSuggestionSelect?: (suggestion: string) => void;
   agentKind?: AgentKind;
 }
@@ -25,6 +23,7 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
   isStreaming = false,
   chatId,
   isLastBotMessage = false,
+  durationMs = null,
   onSuggestionSelect,
   agentKind,
 }) => {
@@ -65,68 +64,54 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
     [segments],
   );
 
+  // Split a completed turn at its last tool/thinking segment: everything up to
+  // it is the collapsible work trace, everything after is the final answer.
+  // While streaming, the trace stays empty so the live work renders flat.
+  const { traceSegments, tailSegments } = React.useMemo(() => {
+    if (isStreaming) return { traceSegments: [], tailSegments: segments };
+    let traceEnd = -1;
+    for (let i = segments.length - 1; i >= 0; i--) {
+      if (segments[i].kind === 'tool' || segments[i].kind === 'thinking') {
+        traceEnd = i;
+        break;
+      }
+    }
+    if (traceEnd < 0) return { traceSegments: [], tailSegments: segments };
+    return {
+      traceSegments: segments.slice(0, traceEnd + 1),
+      tailSegments: segments.slice(traceEnd + 1),
+    };
+  }, [segments, isStreaming]);
+
   return (
     <AgentToolsContext value={agentTools}>
       <div className={className}>
-        {segments.map((segment) => {
-          switch (segment.kind) {
-            case 'text':
-              return (
-                <div
-                  key={segment.id}
-                  className="prose prose-sm dark:prose-invert max-w-none break-words"
-                >
-                  <LazyMarkDown content={segment.text} />
-                </div>
-              );
-            case 'thinking': {
-              return (
-                <div key={segment.id} className="mb-2 mt-0.5">
-                  <ThinkingBlock
-                    content={segment.text}
-                    isActiveThinking={segment.eventIndex === activeThinkingIndex}
-                  />
-                </div>
-              );
-            }
-            case 'tool': {
-              const Component = getToolComponent(segment.tool.name, agentKind);
-              return (
-                <div key={segment.id} className="mb-2 mt-1">
-                  <Suspense
-                    fallback={
-                      <div className="flex items-center gap-2 rounded-lg border border-border/50 px-3 py-2 dark:border-border-dark/50">
-                        <Spinner
-                          size="sm"
-                          className="text-text-quaternary dark:text-text-dark-quaternary"
-                        />
-                        <span className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
-                          Loading tool output...
-                        </span>
-                      </div>
-                    }
-                  >
-                    <Component tool={segment.tool} chatId={chatId} />
-                  </Suspense>
-                </div>
-              );
-            }
-            case 'suggestions': {
-              if (!isLastBotMessage || !onSuggestionSelect) {
-                return null;
-              }
-              return (
-                <PromptSuggestions
-                  key={segment.id}
-                  suggestions={segment.suggestions}
-                  onSelect={onSuggestionSelect}
-                />
-              );
-            }
-            default:
-              return null;
-          }
-        })}
+        {traceSegments.length > 0 && (
+          <WorkedRollup durationMs={durationMs}>
+            {traceSegments.map((segment) => (
+              <SegmentView
+                key={segment.id}
+                segment={segment}
+                chatId={chatId}
+                agentKind={agentKind}
+                activeThinkingIndex={activeThinkingIndex}
+                isLastBotMessage={isLastBotMessage}
+                onSuggestionSelect={onSuggestionSelect}
+              />
+            ))}
+          </WorkedRollup>
+        )}
+        {tailSegments.map((segment) => (
+          <SegmentView
+            key={segment.id}
+            segment={segment}
+            chatId={chatId}
+            agentKind={agentKind}
+            activeThinkingIndex={activeThinkingIndex}
+            isLastBotMessage={isLastBotMessage}
+            onSuggestionSelect={onSuggestionSelect}
+          />
+        ))}
       </div>
     </AgentToolsContext>
   );

--- a/frontend/src/components/chat/message-bubble/SegmentView.tsx
+++ b/frontend/src/components/chat/message-bubble/SegmentView.tsx
@@ -1,0 +1,71 @@
+import React, { Suspense } from 'react';
+import { LazyMarkDown } from '@/components/ui/LazyMarkDown';
+import { ThinkingBlock } from './ThinkingBlock';
+import { PromptSuggestions } from './PromptSuggestions';
+import { getToolComponent } from '@/components/chat/tools/registry';
+import type { MessageSegment } from './segmentBuilder';
+import type { AgentKind } from '@/types/chat.types';
+import { Spinner } from '@/components/ui/primitives/Spinner';
+
+interface SegmentViewProps {
+  segment: MessageSegment;
+  chatId?: string;
+  agentKind?: AgentKind;
+  activeThinkingIndex: number;
+  isLastBotMessage: boolean;
+  onSuggestionSelect?: (suggestion: string) => void;
+}
+
+export const SegmentView: React.FC<SegmentViewProps> = ({
+  segment,
+  chatId,
+  agentKind,
+  activeThinkingIndex,
+  isLastBotMessage,
+  onSuggestionSelect,
+}) => {
+  switch (segment.kind) {
+    case 'text':
+      return (
+        <div className="prose prose-sm dark:prose-invert max-w-none break-words">
+          <LazyMarkDown content={segment.text} />
+        </div>
+      );
+    case 'thinking':
+      return (
+        <div className="mb-2 mt-0.5">
+          <ThinkingBlock
+            content={segment.text}
+            isActiveThinking={segment.eventIndex === activeThinkingIndex}
+          />
+        </div>
+      );
+    case 'tool': {
+      const Component = getToolComponent(segment.tool.name, agentKind);
+      return (
+        <div className="mb-2 mt-1">
+          <Suspense
+            fallback={
+              <div className="flex items-center gap-2 rounded-lg border border-border/50 px-3 py-2 dark:border-border-dark/50">
+                <Spinner
+                  size="sm"
+                  className="text-text-quaternary dark:text-text-dark-quaternary"
+                />
+                <span className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
+                  Loading tool output...
+                </span>
+              </div>
+            }
+          >
+            <Component tool={segment.tool} chatId={chatId} />
+          </Suspense>
+        </div>
+      );
+    }
+    case 'suggestions':
+      if (!isLastBotMessage || !onSuggestionSelect) return null;
+      return <PromptSuggestions suggestions={segment.suggestions} onSelect={onSuggestionSelect} />;
+    default:
+      return null;
+  }
+};

--- a/frontend/src/components/chat/message-bubble/WorkedRollup.tsx
+++ b/frontend/src/components/chat/message-bubble/WorkedRollup.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { formatDuration } from '@/utils/date';
+
+interface WorkedRollupProps {
+  durationMs: number | null;
+  children: React.ReactNode;
+}
+
+// Collapses the tool/thinking trace of a completed turn behind a single header,
+// so the transcript leads with the final answer and the work expands on demand.
+export const WorkedRollup: React.FC<WorkedRollupProps> = ({ durationMs, children }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  // Older messages persisted before duration tracking have no duration_ms.
+  const label =
+    durationMs != null && durationMs > 0 ? `Worked for ${formatDuration(durationMs)}` : 'Worked';
+
+  return (
+    <div className="mb-2">
+      <Button
+        type="button"
+        variant="unstyled"
+        onClick={() => setIsExpanded((prev) => !prev)}
+        className="group/button flex items-center gap-1 px-0 py-0.5 text-xs font-medium text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+      >
+        <span>{label}</span>
+        {/* Disclosure chevron: points right when collapsed, rotates down when open. */}
+        <ChevronRight
+          className={`h-3.5 w-3.5 transition-transform duration-300 ease-out group-hover/button:text-text-primary dark:group-hover/button:text-text-dark-primary ${isExpanded ? 'rotate-90' : ''}`}
+        />
+      </Button>
+      {isExpanded && <div className="mt-1 animate-fade-in">{children}</div>}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useMessageActions.ts
+++ b/frontend/src/hooks/useMessageActions.ts
@@ -142,6 +142,7 @@ export function useMessageActions({
           attachments: [],
           created_at: new Date().toISOString(),
           model_id: selectedModelId ?? undefined,
+          duration_ms: null,
           checkpoint_id: checkpointId,
         };
 
@@ -233,6 +234,7 @@ export function useMessageActions({
         model_id: selectedModelId,
         created_at: new Date().toISOString(),
         attachments: createAttachmentsFromFiles(inputFiles, storeBlobUrl) ?? [],
+        duration_ms: null,
         checkpoint_id: null,
       };
 

--- a/frontend/src/hooks/useMessageInitialization.ts
+++ b/frontend/src/hooks/useMessageInitialization.ts
@@ -68,6 +68,7 @@ export function useMessageInitialization({
         attachments: processedAttachments,
         created_at: msg.created_at,
         model_id: msg.model_id,
+        duration_ms: msg.duration_ms,
         checkpoint_id: msg.checkpoint_id,
       };
     });

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -190,6 +190,7 @@ interface UseStreamCallbacksResult {
     messageId?: string,
     streamId?: string,
     terminalKind?: 'complete' | 'cancelled',
+    durationMs?: number | null,
   ) => void;
   onError: (error: Error, messageId?: string, streamId?: string) => void;
   onQueueProcess: (data: QueueProcessingData) => void;
@@ -236,6 +237,7 @@ export function useStreamCallbacks({
       messageId?: string,
       streamId?: string,
       terminalKind?: 'complete' | 'cancelled',
+      durationMs?: number | null,
     ) => void;
     onError?: (error: Error, messageId?: string, streamId?: string) => void;
     onQueueProcess?: (data: QueueProcessingData) => void;
@@ -553,6 +555,7 @@ export function useStreamCallbacks({
       messageId?: string,
       streamId?: string,
       terminalKind: 'complete' | 'cancelled' = 'complete',
+      durationMs?: number | null,
     ) => {
       const resolvedStreamId = streamId ?? findStreamIdByMessage(messageId);
       const isCancelled = terminalKind === 'cancelled';
@@ -578,6 +581,10 @@ export function useStreamCallbacks({
           ...message,
           active_stream_id: null,
           stream_status: isCancelled ? 'interrupted' : 'completed',
+          // Backend records the run duration at the terminal snapshot and ships
+          // it on the complete event, so the rollup shows the real time without
+          // waiting for a refetch. Older messages persisted before this carry null.
+          duration_ms: durationMs ?? message.duration_ms,
         });
         if (targetChatId) {
           updateMessageInCacheForChat(queryClient, targetChatId, messageId, finalizeMessage);
@@ -744,6 +751,7 @@ export function useStreamCallbacks({
         created_at: new Date().toISOString(),
         attachments: data.attachments || [],
         is_bot: false,
+        duration_ms: null,
         checkpoint_id: null,
       };
 
@@ -760,6 +768,7 @@ export function useStreamCallbacks({
         model_id: data.modelId,
         attachments: [],
         is_bot: true,
+        duration_ms: null,
         checkpoint_id: data.checkpointId,
       };
 

--- a/frontend/src/hooks/useStreamReconnect.ts
+++ b/frontend/src/hooks/useStreamReconnect.ts
@@ -131,6 +131,7 @@ export function useStreamReconnect({
             created_at: new Date().toISOString(),
             model_id: selectedModelIdRef.current || '',
             is_bot: true,
+            duration_ms: null,
             checkpoint_id: null,
           };
           addMessageToCache(placeholderMessage);

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -21,6 +21,7 @@ export interface StreamOptions {
     messageId?: string,
     streamId?: string,
     terminalKind?: 'complete' | 'cancelled',
+    durationMs?: number | null,
   ) => void;
   onError?: (error: Error, messageId?: string, streamId?: string) => void;
   onQueueProcess?: (data: QueueProcessingData) => void;
@@ -35,6 +36,7 @@ interface StreamReconnectOptions {
     messageId?: string,
     streamId?: string,
     terminalKind?: 'complete' | 'cancelled',
+    durationMs?: number | null,
   ) => void;
   onError?: (error: Error, messageId?: string, streamId?: string) => void;
   onQueueProcess?: (data: QueueProcessingData) => void;
@@ -184,8 +186,10 @@ class StreamService {
 
     if (parsed.kind === 'complete' || parsed.kind === 'cancelled') {
       const { callbacks } = currentStream;
+      const durationMs =
+        typeof parsed.payload?.duration_ms === 'number' ? parsed.payload.duration_ms : null;
       useStreamStore.getState().removeStream(streamId);
-      callbacks?.onComplete?.(parsed.messageId, parsed.streamId, parsed.kind);
+      callbacks?.onComplete?.(parsed.messageId, parsed.streamId, parsed.kind, durationMs);
       return;
     }
 

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -23,6 +23,7 @@ export interface Message {
   is_bot?: boolean;
   role: 'user' | 'assistant';
   model_id: string | null;
+  duration_ms: number | null;
   attachments: MessageAttachment[];
   created_at: string;
   checkpoint_id: string | null;

--- a/frontend/src/types/stream.types.ts
+++ b/frontend/src/types/stream.types.ts
@@ -56,6 +56,7 @@ export interface ActiveStream {
       messageId?: string,
       streamId?: string,
       terminalKind?: 'complete' | 'cancelled',
+      durationMs?: number | null,
     ) => void;
     onError?: (error: Error, messageId?: string, streamId?: string) => void;
     onQueueProcess?: (data: QueueProcessingData) => void;

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -51,6 +51,14 @@ export function getRelativeTime(dateStr: string): string {
   return `${months}mo`;
 }
 
+export const formatDuration = (ms: number): string => {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds}s`;
+};
+
 export const formatFullTimestamp = (date: string | Date): string => {
   const targetDate = typeof date === 'string' ? new Date(date) : date;
 

--- a/frontend/src/utils/message.ts
+++ b/frontend/src/utils/message.ts
@@ -35,6 +35,7 @@ export function createInitialMessage(
         : [],
     created_at: new Date().toISOString(),
     model_id: modelId,
+    duration_ms: null,
     checkpoint_id: null,
   };
 }


### PR DESCRIPTION
## Summary
- Add `duration_ms` field to Message model and track wall-clock execution time at terminal snapshot
- Refactor MessageRenderer to use new SegmentView and WorkedRollup components for better message display
- Update stream callbacks and message initialization to pass duration data through the pipeline
- Add duration utilities to format and display execution time on frontend

## Test Plan
- Verify messages display execution duration when available
- Confirm existing messages without duration still render correctly
- Test message streaming with duration tracking