### PR TITLE
refactor: centralize worktree CWD resolution

### DIFF
--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -98,6 +98,15 @@ class AgentService:
         await self._save_worktree_cwd(chat.id, worktree_cwd)
         return worktree_cwd
 
+    async def resolve_cwd(self, chat: Chat, worktree: bool) -> str:
+        # A chat already bound to a worktree (e.g. a sub-thread inheriting the
+        # parent's) always runs in it, even when this turn didn't request one;
+        # otherwise only materialize one when the turn asks and a sandbox exists.
+        # "" is the canonical workspace root, resolved to an absolute cwd at the edge.
+        if chat.worktree_cwd or (worktree and chat.sandbox_id):
+            return await self.ensure_worktree_cwd(chat)
+        return ""
+
     async def build_session_config(
         self,
         *,
@@ -116,9 +125,6 @@ class AgentService:
         sandbox_provider = SandboxProviderType(chat.sandbox_provider)
         sandbox_id: str = chat.sandbox_id or ""
         workspace_path = chat.workspace_path
-        # "" is the canonical workspace-relative root cwd; providers resolve
-        # it to a runtime-absolute cwd at the edge.
-        cwd = ""
 
         agent_kind = MODELS[model_id].agent_kind
         stored_agent_kind = getattr(chat, "session_agent_kind", None)
@@ -128,8 +134,7 @@ class AgentService:
                 error_code=ErrorCode.VALIDATION_ERROR,
             )
 
-        if worktree and sandbox_id:
-            cwd = await self.ensure_worktree_cwd(chat)
+        cwd = await self.resolve_cwd(chat, worktree)
 
         is_custom_persona = selected_persona_name != DEFAULT_PERSONA_NAME
 

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -289,6 +289,7 @@ class ChatService(BaseDbService[Chat]):
     async def create_chat(self, user: User, chat_data: ChatCreate) -> Chat:
         async with self.session_factory() as db:
             workspace_id = chat_data.workspace_id
+            worktree_cwd: str | None = None
 
             if chat_data.parent_chat_id:
                 parent_result = await db.execute(
@@ -313,6 +314,9 @@ class ChatService(BaseDbService[Chat]):
                         status_code=400,
                     )
                 workspace_id = parent.workspace_id
+                # Sub-threads run in the parent's worktree so they see its
+                # uncommitted changes (e.g. /review-branch on the parent's diff).
+                worktree_cwd = parent.worktree_cwd
                 parent.updated_at = datetime.now(timezone.utc)
 
             ws_result = await db.execute(
@@ -336,6 +340,7 @@ class ChatService(BaseDbService[Chat]):
                 user_id=user.id,
                 workspace_id=workspace.id,
                 parent_chat_id=chat_data.parent_chat_id,
+                worktree_cwd=worktree_cwd,
             )
 
             db.add(chat)
@@ -680,11 +685,11 @@ class ChatService(BaseDbService[Chat]):
             return None
 
         try:
-            if worktree:
-                await AgentService(session_factory=session_factory).ensure_worktree_cwd(
-                    chat
-                )
-            cwd = chat.worktree_cwd if worktree else ""
+            # Resolve the same cwd the agent turn runs in, so the checkpoint's
+            # diff and restore target match where the agent actually edited.
+            cwd = await AgentService(session_factory=session_factory).resolve_cwd(
+                chat, worktree
+            )
             provider = SandboxProvider.create_provider(
                 chat.sandbox_provider, workspace_path=chat.workspace_path
             )


### PR DESCRIPTION
## Summary
- Extract `resolve_cwd()` method in AgentService to centralize worktree CWD resolution logic, removing duplication
- Sub-threads now inherit parent's `worktree_cwd` on creation, ensuring they see the same uncommitted changes
- Update checkpoint creation to use the new method for consistency with agent turn execution

This fixes the case where sub-threads wouldn't inherit the parent's worktree context (e.g., running /review-branch on the parent's diff).