### PR TITLE
chore: show 10 chats per workspace before "Show more"

### DIFF
--- a/frontend/src/components/layout/SidebarChatGroup.tsx
+++ b/frontend/src/components/layout/SidebarChatGroup.tsx
@@ -12,7 +12,7 @@ import { useStreamRestoration } from '@/hooks/useStreamRestoration';
 import { SidebarChatItem } from './SidebarChatItem';
 import { SubThreadList } from './SubThreadList';
 
-const CHATS_PER_WORKSPACE = 5;
+const CHATS_PER_WORKSPACE = 10;
 
 function flattenChatPages(data: InfiniteData<PaginatedChats> | undefined): Chat[] {
   return data?.pages.flatMap((page) => page.items) ?? [];


### PR DESCRIPTION
## Summary
- Raise `CHATS_PER_WORKSPACE` from 5 to 10 in `SidebarChatGroup`, so each workspace shows 10 recent chats before the "Show more" toggle appears.