### PR TITLE
Increase Sonnet context window to 1M tokens

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -128,7 +128,7 @@ SANDBOX_BASHRC_PATH: Final[str] = "/home/user/.bashrc"
 
 
 MODELS: dict[str, ModelInfo] = {
-    "sonnet": ModelInfo("Sonnet", AgentKind.CLAUDE, 200_000),
+    "sonnet": ModelInfo("Sonnet", AgentKind.CLAUDE, 1_000_000),
     "opus": ModelInfo("Opus", AgentKind.CLAUDE, 1_000_000),
     "haiku": ModelInfo("Haiku", AgentKind.CLAUDE, 200_000),
     "claude-fable-5": ModelInfo("Fable 5", AgentKind.CLAUDE, 1_000_000),


### PR DESCRIPTION
## Summary
- Increase Sonnet model context window limit from 200k to 1M tokens
- Aligns with the latest Claude 5 model capabilities