### PR TITLE
Add editor tabs and per-file draft management

### DIFF
--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -15,6 +15,8 @@ export interface CodeViewProps {
   files: FileStructure[];
   selectedFile: FileStructure | null;
   onFileSelect: (file: FileStructure | null) => void;
+  openFiles: FileStructure[];
+  onCloseFile: (path: string) => void;
   theme: string;
   sandboxId?: string;
   cwd?: string;
@@ -30,6 +32,8 @@ export const CodeView = memo(function CodeView({
   files,
   selectedFile,
   onFileSelect,
+  openFiles,
+  onCloseFile,
   theme,
   sandboxId,
   cwd,
@@ -205,6 +209,9 @@ export const CodeView = memo(function CodeView({
             sandboxId={sandboxId}
             onToggleFileTree={() => setShowMobileTree(true)}
             targetLine={targetLine}
+            openFiles={openFiles}
+            onFileSelect={onFileSelect}
+            onCloseFile={onCloseFile}
           />
         </div>
       </div>
@@ -252,6 +259,9 @@ export const CodeView = memo(function CodeView({
               onToggleFileTree={handleToggleFileTree}
               isFileTreeCollapsed={isFileTreeCollapsed}
               targetLine={targetLine}
+              openFiles={openFiles}
+              onFileSelect={onFileSelect}
+              onCloseFile={onCloseFile}
             />
           </div>
         </Panel>

--- a/frontend/src/components/editor/editor-core/Editor.tsx
+++ b/frontend/src/components/editor/editor-core/Editor.tsx
@@ -9,6 +9,8 @@ export interface EditorProps {
   files: FileStructure[];
   selectedFile: FileStructure | null;
   onFileSelect: (file: FileStructure | null) => void;
+  openFiles: FileStructure[];
+  onCloseFile: (path: string) => void;
   sandboxId?: string;
   worktreeCwd?: string;
   isSandboxSyncing?: boolean;
@@ -23,6 +25,8 @@ export const Editor = memo(function Editor({
   files,
   onFileSelect,
   selectedFile,
+  openFiles,
+  onCloseFile,
   sandboxId,
   worktreeCwd,
   isSandboxSyncing = false,
@@ -69,6 +73,8 @@ export const Editor = memo(function Editor({
         files={files}
         selectedFile={selectedFile}
         onFileSelect={onFileSelect}
+        openFiles={openFiles}
+        onCloseFile={onCloseFile}
         theme={theme}
         sandboxId={sandboxId}
         cwd={worktreeCwd}

--- a/frontend/src/components/editor/editor-core/EditorPane.tsx
+++ b/frontend/src/components/editor/editor-core/EditorPane.tsx
@@ -14,7 +14,7 @@ export const EditorPane = memo(function EditorPane({ chatId }: { chatId: string 
     currentChat,
     chatId,
   );
-  const { selectedFile, setSelectedFile, handleFileSelect, isRefreshing, handleRefresh } =
+  const { selectedFile, setSelectedFile, openFiles, closeFile, isRefreshing, handleRefresh } =
     useEditorState(refetchFilesMetadata, chatId, fileStructure);
   usePendingFileOpen(fileStructure, setSelectedFile, chatId);
 
@@ -22,7 +22,9 @@ export const EditorPane = memo(function EditorPane({ chatId }: { chatId: string 
     <Editor
       files={fileStructure}
       selectedFile={selectedFile}
-      onFileSelect={handleFileSelect}
+      onFileSelect={setSelectedFile}
+      openFiles={openFiles}
+      onCloseFile={closeFile}
       sandboxId={currentChat?.sandbox_id ?? undefined}
       worktreeCwd={currentChat?.worktree_cwd ?? undefined}
       isSandboxSyncing={isFileMetadataLoading}

--- a/frontend/src/components/editor/editor-view/EditorTabs.tsx
+++ b/frontend/src/components/editor/editor-view/EditorTabs.tsx
@@ -1,0 +1,85 @@
+import { memo } from 'react';
+import { X } from 'lucide-react';
+import type { FileStructure } from '@/types/file-system.types';
+import { Button } from '@/components/ui/primitives/Button';
+import { FileIcon } from '@/components/ui/shared/FileIcon';
+import { getFileName } from '@/utils/file';
+import { cn } from '@/utils/cn';
+
+export interface EditorTabsProps {
+  openFiles: FileStructure[];
+  selectedPath: string | null;
+  // Paths with unsaved edits — any open tab can be dirty, not just the active one,
+  // since View preserves a per-file draft buffer across tab switches.
+  dirtyPaths: ReadonlySet<string>;
+  onSelect: (file: FileStructure) => void;
+  onClose: (path: string) => void;
+}
+
+export const EditorTabs = memo(function EditorTabs({
+  openFiles,
+  selectedPath,
+  dirtyPaths,
+  onSelect,
+  onClose,
+}: EditorTabsProps) {
+  if (openFiles.length === 0) return null;
+
+  return (
+    <div
+      role="tablist"
+      className="flex h-9 shrink-0 items-stretch overflow-x-auto border-b border-border/50 dark:border-border-dark/50"
+    >
+      {openFiles.map((file) => {
+        const isActive = file.path === selectedPath;
+        const name = getFileName(file.path);
+        // A dirty tab shows the unsaved dot at rest, swapped for the close button on hover.
+        const showDot = dirtyPaths.has(file.path);
+        return (
+          <div
+            key={file.path}
+            className={cn(
+              'group flex shrink-0 items-stretch border-r border-border/30 transition-colors duration-200 dark:border-border-dark/30',
+              isActive
+                ? 'bg-surface-primary dark:bg-surface-dark-primary'
+                : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+            )}
+          >
+            {/* Select and close are sibling buttons (not nested) so both are keyboard-operable. */}
+            <Button
+              variant="unstyled"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => onSelect(file)}
+              className={cn(
+                'flex items-center gap-1.5 py-0 pl-3 pr-1 font-mono text-2xs transition-colors duration-200',
+                isActive
+                  ? 'text-text-primary dark:text-text-dark-primary'
+                  : 'text-text-tertiary hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-secondary',
+              )}
+            >
+              <FileIcon name={name} className="h-3.5 w-3.5 shrink-0" />
+              <span className="max-w-[12rem] truncate">{name}</span>
+            </Button>
+            <span className="relative flex w-6 items-center justify-center">
+              {showDot && (
+                <span className="absolute h-1.5 w-1.5 rounded-full bg-text-quaternary group-hover:hidden dark:bg-text-dark-quaternary" />
+              )}
+              <Button
+                variant="unstyled"
+                onClick={() => onClose(file.path)}
+                aria-label={`Close ${name}`}
+                className={cn(
+                  'rounded p-0.5 text-text-quaternary transition-colors duration-150 hover:text-text-primary focus-visible:opacity-100 group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
+                  isActive && !showDot ? 'opacity-100' : 'opacity-0',
+                )}
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+});

--- a/frontend/src/components/editor/editor-view/Header.tsx
+++ b/frontend/src/components/editor/editor-view/Header.tsx
@@ -62,9 +62,6 @@ export const Header = memo(function Header({
         <span className="truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-tertiary">
           {filePath}
         </span>
-        {hasUnsavedChanges && (
-          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-text-quaternary dark:bg-text-dark-quaternary" />
-        )}
       </div>
 
       <div className="flex items-center gap-1.5">

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -3,11 +3,14 @@ import type * as monaco from 'monaco-editor';
 import { Header } from './Header';
 import { Content } from './Content';
 import { EmptyState } from './EmptyState';
+import { EditorTabs } from './EditorTabs';
 import { FilePreview } from '../file-preview/FilePreview';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useEditorTheme } from '@/hooks/useEditorTheme';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
+import { useEditorDrafts } from '@/hooks/useEditorDrafts';
 import type { FileStructure } from '@/types/file-system.types';
-import { detectLanguage, findFileInStructure } from '@/utils/file';
+import { detectLanguage, findFileInStructure, getFileName } from '@/utils/file';
 import { useUpdateFileMutation, useFileContentQuery } from '@/hooks/queries/useSandboxQueries';
 import { isPreviewableFile, isHtmlFile } from '@/utils/fileTypes';
 import toast from 'react-hot-toast';
@@ -19,6 +22,9 @@ export interface ViewProps {
   onToggleFileTree?: () => void;
   isFileTreeCollapsed?: boolean;
   targetLine?: { path: string; line: number; nonce: number } | null;
+  openFiles: FileStructure[];
+  onFileSelect: (file: FileStructure) => void;
+  onCloseFile: (path: string) => void;
 }
 
 export const View = memo(function View({
@@ -28,15 +34,15 @@ export const View = memo(function View({
   onToggleFileTree,
   isFileTreeCollapsed,
   targetLine,
+  openFiles,
+  onFileSelect,
+  onCloseFile,
 }: ViewProps) {
   const theme = useResolvedTheme();
   const previousFileRef = useRef<FileStructure | null>(null);
   const [showPreview, setShowPreview] = useState(false);
-  const [currentContent, setCurrentContent] = useState('');
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<typeof monaco | null>(null);
-  const prevSelectedFileRef = useRef<FileStructure | null>(null);
   const selectedFilePath = selectedFile?.path ?? null;
   const mountedEditorPathRef = useRef(selectedFilePath);
   const [mountedEditorPath, setMountedEditorPath] = useState<string | null>(null);
@@ -66,30 +72,20 @@ export const View = memo(function View({
       ? fileContentData.content
       : undefined;
 
-  useEffect(() => {
-    if (!selectedFile) return;
-
-    const fileChanged =
-      !prevSelectedFileRef.current || prevSelectedFileRef.current.path !== selectedFile.path;
-
-    const queryContentChanged =
-      selectedFileContent !== undefined &&
-      prevSelectedFileRef.current?.path === selectedFile.path &&
-      prevSelectedFileRef.current?.content !== selectedFileContent;
-
-    if (fileChanged || queryContentChanged) {
-      const contentToUse = selectedFileContent ?? '';
-
-      prevSelectedFileRef.current = {
-        ...selectedFile,
-        content: contentToUse,
-        isLoaded: selectedFileContent !== undefined,
-      };
-
-      setCurrentContent(contentToUse);
-      setHasUnsavedChanges(false);
-    }
-  }, [selectedFile, selectedFileContent]);
+  // Per-file unsaved drafts, the dirty set, and the close-confirm flow live in this hook.
+  const {
+    currentContent,
+    displayContent,
+    hasUnsavedChanges,
+    hasLoadedSelectedFile,
+    dirtyPaths,
+    pendingClosePath,
+    handleEditorChange,
+    handleCloseTab,
+    confirmCloseTab,
+    cancelCloseTab,
+    commitSave,
+  } = useEditorDrafts({ selectedFile, selectedFileContent, sandboxId, onCloseFile });
 
   const error = fileContentError
     ? fileContentError instanceof Error
@@ -119,33 +115,24 @@ export const View = memo(function View({
   }, [selectedFile]);
 
   const language = selectedFile ? detectLanguage(selectedFile.path) : 'javascript';
-  const hasLoadedSelectedFile = prevSelectedFileRef.current?.path === selectedFile?.path;
-  // File selection updates before the content effect resets state; keep the
-  // previous file's text out of Monaco during that one render.
-  const displayContent = hasLoadedSelectedFile ? currentContent : (selectedFileContent ?? '');
   const displayHasUnsavedChanges = hasLoadedSelectedFile && hasUnsavedChanges;
-
-  const handleEditorChange = useCallback((value: string | undefined) => {
-    if (value === undefined) return;
-
-    setCurrentContent(value);
-
-    const originalContent = prevSelectedFileRef.current?.content || '';
-    setHasUnsavedChanges(value !== originalContent);
-  }, []);
 
   const handleUpdateFile = useCallback(async () => {
     if (!selectedFile || !sandboxId || !hasUnsavedChanges || !hasLoadedSelectedFile) return;
 
+    // Capture what we're saving; the active tab/content may change before this resolves.
+    const savedPath = selectedFile.path;
+    const submitted = currentContent;
+
     updateFileMutation.mutate(
       {
         sandboxId,
-        filePath: selectedFile.path,
-        content: currentContent,
+        filePath: savedPath,
+        content: submitted,
       },
       {
         onSuccess: () => {
-          setHasUnsavedChanges(false);
+          commitSave(savedPath, submitted);
           toast.success('File saved');
         },
         onError: (err) => {
@@ -160,6 +147,7 @@ export const View = memo(function View({
     hasUnsavedChanges,
     hasLoadedSelectedFile,
     updateFileMutation,
+    commitSave,
   ]);
 
   const handleEditorMount = useCallback(
@@ -268,11 +256,7 @@ export const View = memo(function View({
   const isValidFile =
     selectedFile && findFileInStructure(fileStructure, selectedFile.path) !== undefined;
 
-  if (!selectedFile || !isValidFile) {
-    return <EmptyState theme={theme} onToggleFileTree={onToggleFileTree} />;
-  }
-
-  const isPreviewable = isPreviewableFile(selectedFile);
+  const isPreviewable = selectedFile ? isPreviewableFile(selectedFile) : false;
 
   const handlePreviewToggle = (showPreviewState: boolean) => {
     setShowPreview(showPreviewState);
@@ -285,55 +269,84 @@ export const View = memo(function View({
       }
     : null;
 
+  // Tabs stay mounted above the content even when the active file is invalid
+  // (e.g. deleted from the tree), so the user can still switch to a sibling tab.
   return (
     <div className="relative flex h-full flex-col">
-      <Header
-        filePath={selectedFile.path}
-        error={error}
-        selectedFile={selectedFile}
-        showPreview={showPreview}
-        onTogglePreview={handlePreviewToggle}
-        hasUnsavedChanges={displayHasUnsavedChanges}
-        isSaving={updateFileMutation.isPending}
-        onSave={handleUpdateFile}
-        onToggleFileTree={onToggleFileTree}
-        isFileTreeCollapsed={isFileTreeCollapsed}
-        onToggleFullscreen={
-          isPreviewable && showPreview ? handleTogglePreviewFullscreen : undefined
-        }
+      <EditorTabs
+        openFiles={openFiles}
+        selectedPath={selectedFile?.path ?? null}
+        dirtyPaths={dirtyPaths}
+        onSelect={onFileSelect}
+        onClose={handleCloseTab}
       />
 
-      <div className="relative flex-1 overflow-hidden">
-        {isLoadingContent && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center bg-surface-secondary bg-opacity-75 dark:bg-surface-dark-secondary">
-            <div className="text-sm text-text-secondary dark:text-text-dark-secondary">
-              Loading file content...
-            </div>
-          </div>
-        )}
-
-        {!(isPreviewable && showPreview) && (
-          <Content
-            key={selectedFile.path}
-            content={displayContent}
-            language={language}
-            isReadOnly={false}
-            onChange={handleEditorChange}
-            onMount={handleEditorMount}
-            theme={currentTheme}
+      {!selectedFile || !isValidFile ? (
+        <EmptyState theme={theme} onToggleFileTree={onToggleFileTree} />
+      ) : (
+        <>
+          <Header
+            filePath={selectedFile.path}
+            error={error}
+            selectedFile={selectedFile}
+            showPreview={showPreview}
+            onTogglePreview={handlePreviewToggle}
+            hasUnsavedChanges={displayHasUnsavedChanges}
+            isSaving={updateFileMutation.isPending}
+            onSave={handleUpdateFile}
+            onToggleFileTree={onToggleFileTree}
+            isFileTreeCollapsed={isFileTreeCollapsed}
+            onToggleFullscreen={
+              isPreviewable && showPreview ? handleTogglePreviewFullscreen : undefined
+            }
           />
-        )}
 
-        {isPreviewable && showPreview && fileForPreview && (
-          <div className="h-full">
-            <FilePreview
-              file={fileForPreview}
-              isFullscreen={isPreviewFullscreen}
-              onToggleFullscreen={handleTogglePreviewFullscreen}
-            />
+          <div className="relative flex-1 overflow-hidden">
+            {isLoadingContent && (
+              <div className="absolute inset-0 z-10 flex items-center justify-center bg-surface-secondary bg-opacity-75 dark:bg-surface-dark-secondary">
+                <div className="text-sm text-text-secondary dark:text-text-dark-secondary">
+                  Loading file content...
+                </div>
+              </div>
+            )}
+
+            {!(isPreviewable && showPreview) && (
+              <Content
+                key={selectedFile.path}
+                content={displayContent}
+                language={language}
+                // Lock edits while a save is in flight so the in-flight buffer can't
+                // diverge from what was submitted — the success handler then clears the
+                // draft unconditionally without risking newer keystrokes.
+                isReadOnly={updateFileMutation.isPending}
+                onChange={handleEditorChange}
+                onMount={handleEditorMount}
+                theme={currentTheme}
+              />
+            )}
+
+            {isPreviewable && showPreview && fileForPreview && (
+              <div className="h-full">
+                <FilePreview
+                  file={fileForPreview}
+                  isFullscreen={isPreviewFullscreen}
+                  onToggleFullscreen={handleTogglePreviewFullscreen}
+                />
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </>
+      )}
+
+      <ConfirmDialog
+        isOpen={pendingClosePath !== null}
+        onClose={cancelCloseTab}
+        onConfirm={confirmCloseTab}
+        title="Discard unsaved changes?"
+        message={`"${getFileName(pendingClosePath ?? '')}" has unsaved edits that will be lost.`}
+        confirmLabel="Discard"
+        cancelLabel="Cancel"
+      />
     </div>
   );
 });

--- a/frontend/src/hooks/useEditorDrafts.ts
+++ b/frontend/src/hooks/useEditorDrafts.ts
@@ -1,0 +1,184 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import type { FileStructure } from '@/types/file-system.types';
+
+interface UseEditorDraftsArgs {
+  selectedFile: FileStructure | null;
+  // Loaded server content for the active file, or undefined until it resolves.
+  selectedFileContent: string | undefined;
+  sandboxId: string | undefined;
+  onCloseFile: (path: string) => void;
+}
+
+// Owns the editor's per-file unsaved buffers: the live content of the active file,
+// a draft per open path, the dirty set that drives the tab dots, and the close
+// confirmation flow. Drafts are session-scoped to one sandbox (see the reset) and are
+// NOT persisted — switching tabs preserves them, but a chat/sandbox switch drops them.
+export function useEditorDrafts({
+  selectedFile,
+  selectedFileContent,
+  sandboxId,
+  onCloseFile,
+}: UseEditorDraftsArgs) {
+  const [currentContent, setCurrentContent] = useState('');
+  // path -> baseline + loaded flag for the active file; the baseline is the saved
+  // content the live buffer diffs against.
+  const prevSelectedFileRef = useRef<FileStructure | null>(null);
+  // Per-file unsaved buffers (path -> content).
+  const draftsRef = useRef<Map<string, string>>(new Map());
+  // The paths of those dirty buffers, mirrored in state so each tab renders its own
+  // unsaved dot (any open tab can be dirty, not just the active one).
+  const [dirtyPaths, setDirtyPaths] = useState<Set<string>>(() => new Set());
+  // The dirty tab awaiting a discard confirmation before it closes (null = no prompt).
+  const [pendingClosePath, setPendingClosePath] = useState<string | null>(null);
+  const prevSandboxIdRef = useRef(sandboxId);
+  const selectedFilePath = selectedFile?.path ?? null;
+
+  if (prevSandboxIdRef.current !== sandboxId) {
+    // The editor pane is reused across chats/sandboxes without remounting (the split
+    // and landing editors aren't keyed by chat), and drafts are keyed by path only —
+    // so drop the previous sandbox's buffers to avoid bleeding edits into another
+    // sandbox's same-path file. Null prevSelectedFileRef so the content effect re-inits.
+    prevSandboxIdRef.current = sandboxId;
+    draftsRef.current.clear();
+    prevSelectedFileRef.current = null;
+    if (dirtyPaths.size > 0) setDirtyPaths(new Set());
+    if (pendingClosePath !== null) setPendingClosePath(null);
+  }
+
+  // Active file's dirty flag, derived from the per-file dirty set (single source of truth).
+  const hasUnsavedChanges = !!selectedFilePath && dirtyPaths.has(selectedFilePath);
+  const hasLoadedSelectedFile = prevSelectedFileRef.current?.path === selectedFile?.path;
+
+  // Single writer for a file's draft buffer — keeps draftsRef and the dirtyPaths render
+  // mirror in lockstep so no call site has to update both. `null` content clears the
+  // draft (and drives the per-tab unsaved dot off).
+  const setDraft = useCallback((path: string, content: string | null) => {
+    const isDirty = content !== null;
+    if (isDirty) draftsRef.current.set(path, content);
+    else draftsRef.current.delete(path);
+    setDirtyPaths((prev) => {
+      if (prev.has(path) === isDirty) return prev;
+      const next = new Set(prev);
+      if (isDirty) next.add(path);
+      else next.delete(path);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!selectedFile) {
+      // No active file (e.g. the last tab was closed/discarded): drop the stale buffer and
+      // baseline so reopening the same path reloads from the server instead of resurrecting
+      // the old content as if it were clean.
+      prevSelectedFileRef.current = null;
+      setCurrentContent('');
+      return;
+    }
+
+    const prev = prevSelectedFileRef.current;
+    const fileChanged = !prev || prev.path !== selectedFile.path;
+
+    const queryContentChanged =
+      selectedFileContent !== undefined &&
+      prev?.path === selectedFile.path &&
+      prev?.content !== selectedFileContent;
+
+    if (fileChanged || queryContentChanged) {
+      const baseline = selectedFileContent ?? '';
+      // An external update (the file was already loaded and its server content changed,
+      // e.g. an agent edited it) refreshes to the new content and discards any draft.
+      const externalUpdate = queryContentChanged && !fileChanged && (prev?.isLoaded ?? false);
+      if (externalUpdate && selectedFileContent !== undefined) {
+        setDraft(selectedFile.path, null);
+      }
+
+      // Otherwise restore an unsaved draft once content has loaded — covers both a tab
+      // switch and a deferred load (content evicted from cache then refetched), so edits
+      // survive either path. Guarded on loaded content to not race the async fetch.
+      const draft =
+        !externalUpdate && selectedFileContent !== undefined
+          ? draftsRef.current.get(selectedFile.path)
+          : undefined;
+      const contentToUse = draft ?? baseline;
+
+      prevSelectedFileRef.current = {
+        ...selectedFile,
+        content: baseline,
+        isLoaded: selectedFileContent !== undefined,
+      };
+
+      // dirtyPaths already reflects this file's draft (kept in sync by handleEditorChange),
+      // so the derived hasUnsavedChanges is correct without a separate write here.
+      setCurrentContent(contentToUse);
+    }
+  }, [selectedFile, selectedFileContent, setDraft]);
+
+  // File selection updates before the content effect resets state; keep the previous
+  // file's text out of Monaco during that one render.
+  const displayContent = hasLoadedSelectedFile ? currentContent : (selectedFileContent ?? '');
+
+  const handleEditorChange = useCallback(
+    (value: string | undefined) => {
+      if (value === undefined) return;
+
+      setCurrentContent(value);
+
+      const baseline = prevSelectedFileRef.current?.content ?? '';
+      const path = prevSelectedFileRef.current?.path;
+      // Persist the draft (or clear it once it matches the saved baseline) so the buffer
+      // survives a tab switch and the tab's unsaved dot stays accurate.
+      if (path) setDraft(path, value !== baseline ? value : null);
+    },
+    [setDraft],
+  );
+
+  // Closing a clean tab is immediate; closing a dirty one prompts first, since its
+  // draft lives only in this session and would be discarded with no further warning.
+  const handleCloseTab = useCallback(
+    (path: string) => {
+      if (dirtyPaths.has(path)) setPendingClosePath(path);
+      else onCloseFile(path);
+    },
+    [dirtyPaths, onCloseFile],
+  );
+
+  const confirmCloseTab = useCallback(() => {
+    if (pendingClosePath === null) return;
+    setDraft(pendingClosePath, null);
+    onCloseFile(pendingClosePath);
+    setPendingClosePath(null);
+  }, [pendingClosePath, setDraft, onCloseFile]);
+
+  const cancelCloseTab = useCallback(() => setPendingClosePath(null), []);
+
+  // After a save succeeds: rebaseline the saved file (if still active) so further edits
+  // diff against disk, and clear its draft. Scoped to the saved path captured at submit
+  // time, not the now-active tab.
+  const commitSave = useCallback(
+    (savedPath: string, submitted: string) => {
+      if (prevSelectedFileRef.current?.path === savedPath) {
+        prevSelectedFileRef.current = {
+          ...prevSelectedFileRef.current,
+          content: submitted,
+          isLoaded: true,
+        };
+      }
+      setDraft(savedPath, null);
+    },
+    [setDraft],
+  );
+
+  return {
+    currentContent,
+    displayContent,
+    hasUnsavedChanges,
+    hasLoadedSelectedFile,
+    dirtyPaths,
+    pendingClosePath,
+    handleEditorChange,
+    handleCloseTab,
+    confirmCloseTab,
+    cancelCloseTab,
+    commitSave,
+  };
+}

--- a/frontend/src/hooks/useEditorState.ts
+++ b/frontend/src/hooks/useEditorState.ts
@@ -2,6 +2,27 @@ import { useState, useCallback, useMemo } from 'react';
 import { useUIStore } from '@/store/uiStore';
 import { findFileByToolPath } from '@/utils/file';
 import type { FileStructure } from '@/types/file-system.types';
+import type { EditorPaneState } from '@/types/ui.types';
+
+const EMPTY_PATHS: string[] = [];
+
+// Sentinel key for the chat-less landing editor, so its selection/tabs ride the
+// same store map as real chats (cleared on landing mount — see LandingPage).
+const LANDING_KEY = '__landing_editor__';
+
+// Append a path to the open-tab list, preserving order and de-duping.
+function openPath(open: string[], path: string): string[] {
+  return open.includes(path) ? open : [...open, path];
+}
+
+// Remove a tab. When the active tab closes, selection falls back to its right
+// neighbor, then its left, then nothing; otherwise selection is unchanged.
+function closeTab(open: string[], closed: string, selected: string | null): EditorPaneState {
+  const idx = open.indexOf(closed);
+  const next = open.filter((p) => p !== closed);
+  const nextSelected = selected !== closed ? selected : (next[idx] ?? next[idx - 1] ?? null);
+  return { open: next, selected: nextSelected };
+}
 
 export function useEditorState(
   refetchFilesMetadata: () => Promise<unknown>,
@@ -9,50 +30,75 @@ export function useEditorState(
   fileStructure: FileStructure[],
 ) {
   const [isRefreshing, setIsRefreshing] = useState(false);
-  // Landing page (no chat) uses local state — nothing to persist across chat
-  // switches since there's no chat to switch back to.
-  const [localSelectedFile, setLocalSelectedFile] = useState<FileStructure | null>(null);
-  const selectedFilePath = useUIStore((s) => (chatId ? s.selectedFileByChat[chatId] : undefined));
+  // Both the chat editor and the landing editor stash their selection/tabs in the
+  // store keyed by chat id (or LANDING_KEY) — selection survives EditorPane unmount,
+  // and switching chatId reads a different entry so files can't bleed across chats.
+  const key = chatId ?? LANDING_KEY;
+  const entry = useUIStore((s) => s.editorByChat[key]);
+  const selectedFilePath = entry?.selected ?? null;
+  const openFilePaths = entry?.open ?? EMPTY_PATHS;
 
-  // Store-backed when chatId is set (persists across chat switches); local
-  // state for the chat-less landing page. Derived from the stashed path +
-  // fileStructure so the selection survives EditorPane unmount — switching
-  // chatId reads a different store entry, so the old chat's file can't bleed
-  // through. No re-seed effect needed: the derivation recomputes when the tree
-  // loads, and usePendingFileOpen writes the path directly via setSelectedFile.
+  // Resolve a stored path to a tree file, falling back to a stub so a file opened
+  // before the tree loads (e.g. a tool's "open in editor") still renders.
+  const resolveFile = useCallback(
+    (path: string): FileStructure =>
+      findFileByToolPath(fileStructure, path) ?? { path, type: 'file', content: '' },
+    [fileStructure],
+  );
+
+  // Derived from the stashed path + fileStructure (no re-seed effect needed): the
+  // derivation recomputes when the tree loads, and usePendingFileOpen writes the
+  // path directly via setSelectedFile.
   const selectedFile = useMemo(() => {
-    if (!chatId) return localSelectedFile;
     if (!selectedFilePath || fileStructure.length === 0) return null;
-    return (
-      findFileByToolPath(fileStructure, selectedFilePath) ?? {
-        path: selectedFilePath,
-        type: 'file',
-        content: '',
-      }
-    );
-  }, [chatId, localSelectedFile, selectedFilePath, fileStructure]);
+    return resolveFile(selectedFilePath);
+  }, [selectedFilePath, fileStructure, resolveFile]);
+
+  // The open tabs, resolved in stored order. Empty until the tree loads. Tabs only
+  // track which files are open; View holds the active buffer and preserves per-file
+  // unsaved drafts across tab switches/closes within the session.
+  const openFiles = useMemo(() => {
+    if (fileStructure.length === 0) return [];
+    return openFilePaths.map(resolveFile);
+  }, [openFilePaths, fileStructure, resolveFile]);
 
   const setSelectedFile = useCallback(
     (file: FileStructure | null) => {
-      if (!chatId) {
-        setLocalSelectedFile(file);
-        return;
-      }
       useUIStore.setState((s) => {
         if (!file) {
-          const next = { ...s.selectedFileByChat };
-          delete next[chatId];
-          return { selectedFileByChat: next };
+          // Deselect drops the whole entry — active file and tabs (landing's reset/switch).
+          // No-op when the key was never present (the common case for the mount reset).
+          if (!(key in s.editorByChat)) return {};
+          const next = { ...s.editorByChat };
+          delete next[key];
+          return { editorByChat: next };
         }
-        return { selectedFileByChat: { ...s.selectedFileByChat, [chatId]: file.path } };
+        const cur = s.editorByChat[key] ?? { open: [], selected: null };
+        return {
+          editorByChat: {
+            ...s.editorByChat,
+            [key]: { open: openPath(cur.open, file.path), selected: file.path },
+          },
+        };
       });
     },
-    [chatId],
+    [key],
   );
 
-  const handleFileSelect = useCallback(
-    (file: FileStructure | null) => setSelectedFile(file),
-    [setSelectedFile],
+  // Closing a tab drops it and, if it was active, re-aims selection at a neighbor.
+  // (A dirty tab is confirmed in View before this runs, and its draft discarded there.)
+  const closeFile = useCallback(
+    (path: string) => {
+      useUIStore.setState((s) => {
+        const cur = s.editorByChat[key];
+        if (!cur || !cur.open.includes(path)) return {};
+        // Selection and tabs update atomically — no chance of the two drifting apart.
+        return {
+          editorByChat: { ...s.editorByChat, [key]: closeTab(cur.open, path, cur.selected) },
+        };
+      });
+    },
+    [key],
   );
 
   const handleRefresh = useCallback(async () => {
@@ -67,7 +113,8 @@ export function useEditorState(
   return {
     selectedFile,
     setSelectedFile,
-    handleFileSelect,
+    openFiles,
+    closeFile,
     isRefreshing,
     handleRefresh,
   };

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -179,14 +179,16 @@ export function LandingPage() {
     [filesMetadata],
   );
 
-  const { selectedFile, setSelectedFile, isRefreshing, handleRefresh, handleFileSelect } =
+  const { selectedFile, setSelectedFile, isRefreshing, handleRefresh, openFiles, closeFile } =
     useEditorState(refetchFilesMetadata, undefined, fileStructure);
 
-  const prevSandboxIdRef = useRef(selectedSandboxId);
-  if (prevSandboxIdRef.current !== selectedSandboxId) {
-    prevSandboxIdRef.current = selectedSandboxId;
+  // The landing editor's selection/tabs live under a shared store key (not component
+  // state), so reset them when the chosen sandbox changes and on mount — otherwise a
+  // prior session's tabs would linger. An effect (not a render-phase store write) keeps
+  // the external-store mutation off the render path.
+  useEffect(() => {
     setSelectedFile(null);
-  }
+  }, [selectedSandboxId, setSelectedFile]);
 
   // No chat exists on the landing page, so there are no chat-bound file jumps.
   usePendingFileOpen(fileStructure, setSelectedFile, undefined);
@@ -412,7 +414,9 @@ export function LandingPage() {
               <Editor
                 files={fileStructure}
                 selectedFile={selectedFile}
-                onFileSelect={handleFileSelect}
+                onFileSelect={setSelectedFile}
+                openFiles={openFiles}
+                onCloseFile={closeFile}
                 sandboxId={selectedSandboxId}
                 isSandboxSyncing={false}
                 onRefresh={handleRefresh}
@@ -445,7 +449,9 @@ export function LandingPage() {
       selectedCloudWorkspaceId,
       fileStructure,
       selectedFile,
-      handleFileSelect,
+      setSelectedFile,
+      openFiles,
+      closeFile,
       selectedSandboxId,
       handleRefresh,
       isRefreshing,

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -210,7 +210,7 @@ export const useUIStore = create<UIStoreState>()(
       activeAgentTile: 'agent:primary',
       focusedTile: null,
       layoutsByChat: {},
-      selectedFileByChat: {},
+      editorByChat: {},
       currentWorkspaceChatId: null,
 
       activateTab: (tileId) => {

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -68,6 +68,12 @@ export interface WorkspaceLayout {
   visibleLayout: TileId[][];
 }
 
+// Per-chat editor pane state: the open file tabs (in strip order) and the active one.
+export interface EditorPaneState {
+  open: string[];
+  selected: string | null;
+}
+
 export interface SplitViewState {
   // Every open tab, in strip order. Always holds at least 'agent:primary'.
   openTabs: TileId[];
@@ -88,9 +94,10 @@ export interface SplitViewState {
   // Saved tabs per chat, so each chat restores its own workspace when revisited.
   // Excludes split-chat (:secondary) tiles, which the split effects rebuild.
   layoutsByChat: Record<string, WorkspaceLayout>;
-  // The file the user had open in each chat's editor — restored when revisiting
-  // a chat, since EditorPane's local selectedFile is lost on unmount.
-  selectedFileByChat: Record<string, string>;
+  // The open file tabs + active file in each chat's editor — restored when revisiting
+  // a chat, since EditorPane's selection is lost on unmount. Keyed by chat id (or a
+  // landing-editor sentinel for the chat-less landing page).
+  editorByChat: Record<string, EditorPaneState>;
   // Which chat the live openTabs/visibleLayout belong to — drives save-on-switch.
   currentWorkspaceChatId: string | null;
 }


### PR DESCRIPTION
## Summary
- Add `EditorTabs` component to display open files with visual indicators for unsaved changes
- Add `useEditorDrafts` hook to manage per-file draft buffers across tab switches
- Implement unsaved-change tracking with dirty dot indicators on tabs
- Add close-confirmation flow for dirty tabs to prevent accidental data loss
- Drafts are automatically reset when switching between sandboxes/chats to prevent cross-file contamination

## Key Features
- **Multi-file editing**: Keep multiple files open simultaneously in tabs
- **Draft persistence**: Unsaved changes survive tab switches but reset on sandbox change
- **Visual feedback**: Dirty tabs show an unsaved dot; close button appears on hover
- **Safe closing**: Dirty tabs prompt for confirmation before discarding drafts
- **Server sync**: External file updates (e.g., agent edits) refresh content and discard local drafts

## Testing
- Open multiple files and verify tabs render correctly
- Edit multiple files and switch between them; verify drafts are preserved
- Close dirty tabs and confirm the prompt appears
- Switch to a different chat/sandbox and verify drafts are cleared
- Save a file and verify the draft is cleared and content is rebaselined