### PR TITLE
Add keyboard shortcuts and split functionality to view switcher

### DIFF
--- a/frontend/src/components/layout/ViewSwitcher.tsx
+++ b/frontend/src/components/layout/ViewSwitcher.tsx
@@ -1,6 +1,9 @@
 import { useMemo } from 'react';
 import { Button } from '@/components/ui/primitives/Button';
+import { Tooltip } from '@/components/ui/Tooltip';
+import { ALL_COMMANDS, formatShortcut } from '@/components/ui/commandRegistry';
 import { useUIStore } from '@/store/uiStore';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { cn } from '@/utils/cn';
 import {
   isSecondaryPaneActive,
@@ -14,10 +17,25 @@ import type { ViewType } from '@/types/ui.types';
 // editor (file), terminal, secrets.
 const SWITCHABLE_VIEWS: Exclude<ViewType, 'agent'>[] = ['diff', 'editor', 'terminal', 'secrets'];
 
+// Reuse the command palette's shortcut bindings so the tooltips can't drift from
+// the real keys (⌘⇧E etc.).
+const VIEW_SHORTCUTS = new Map<ViewType, string>(
+  ALL_COMMANDS.flatMap((cmd) =>
+    cmd.type === 'view' ? [[cmd.id, formatShortcut(cmd.shortcut)] as const] : [],
+  ),
+);
+
+function viewTooltip(view: Exclude<ViewType, 'agent'>): string {
+  const shortcut = VIEW_SHORTCUTS.get(view);
+  const label = shortcut ? `${VIEW_LABELS[view]} · ${shortcut}` : VIEW_LABELS[view];
+  return `${label} · Right-click to split`;
+}
+
 export function ViewSwitcher() {
   const activeAgentTile = useUIStore((s) => s.activeAgentTile);
   const secondaryChatId = useUIStore((s) => s.secondaryChatId);
   const openTabs = useUIStore((s) => s.openTabs);
+  const isMobile = useIsMobile();
 
   // Resolve active state against the exact tile toggleView() will act on, so the
   // highlight (and the close-on-click) tracks the focused pane in split-chat mode.
@@ -30,23 +48,32 @@ export function ViewSwitcher() {
         const Icon = VIEW_ICONS[view];
         const isActive = openSet.has(viewTypeToTileId(view, secondary));
         return (
-          <Button
-            key={view}
-            variant="unstyled"
-            // Toggle: open the view as a full tab, or close it if already open.
-            onClick={() => useUIStore.getState().toggleView(view, true)}
-            className={cn(
-              'rounded-md p-1.5 transition-colors duration-200',
-              isActive
-                ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
-                : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-quaternary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary',
-            )}
-            aria-label={`Toggle ${VIEW_LABELS[view]} view`}
-            aria-pressed={isActive}
-            title={VIEW_LABELS[view]}
-          >
-            <Icon className="h-4 w-4" />
-          </Button>
+          <Tooltip key={view} content={viewTooltip(view)} position="bottom-end">
+            <Button
+              variant="unstyled"
+              // Left-click toggles the view full; right-click opens it beside the
+              // active pane (the split is the hero gesture, otherwise buried in the
+              // tab context menu).
+              onClick={() => useUIStore.getState().toggleView(view, true)}
+              onContextMenu={(e) => {
+                // Splitting is a desktop layout; leave the native long-press menu
+                // alone on mobile, where the workspace is single-pane anyway.
+                if (isMobile) return;
+                e.preventDefault();
+                useUIStore.getState().addViewToSplit(view, 'row');
+              }}
+              className={cn(
+                'rounded-md p-1.5 transition-colors duration-200',
+                isActive
+                  ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
+                  : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-quaternary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary',
+              )}
+              aria-label={`Toggle ${VIEW_LABELS[view]} view`}
+              aria-pressed={isActive}
+            >
+              <Icon className="h-4 w-4" />
+            </Button>
+          </Tooltip>
         );
       })}
     </div>

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -4,7 +4,9 @@ import { cn } from '@/utils/cn';
 interface TooltipProps {
   content: string;
   children: ReactNode;
-  position?: 'top' | 'right' | 'bottom' | 'left';
+  // 'bottom-end' drops below the trigger but right-aligns the bubble, so tooltips
+  // on right-edge controls (e.g. the view switcher) grow leftward and never clip.
+  position?: 'top' | 'right' | 'bottom' | 'bottom-end' | 'left';
   className?: string;
 }
 
@@ -12,6 +14,7 @@ const positionClasses = {
   top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
   right: 'left-full top-1/2 -translate-y-1/2 ml-2',
   bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+  'bottom-end': 'top-full right-0 mt-2',
   left: 'right-full top-1/2 -translate-y-1/2 mr-2',
 };
 
@@ -21,6 +24,8 @@ const arrowClasses = {
     'right-full top-1/2 -translate-y-1/2 border-r-surface-tertiary dark:border-r-surface-dark-tertiary border-y-transparent border-l-transparent',
   bottom:
     'bottom-full left-1/2 -translate-x-1/2 border-b-surface-tertiary dark:border-b-surface-dark-tertiary border-x-transparent border-t-transparent',
+  'bottom-end':
+    'bottom-full right-2 border-b-surface-tertiary dark:border-b-surface-dark-tertiary border-x-transparent border-t-transparent',
   left: 'left-full top-1/2 -translate-y-1/2 border-l-surface-tertiary dark:border-l-surface-dark-tertiary border-y-transparent border-r-transparent',
 };
 


### PR DESCRIPTION
## Summary
- Add tooltips showing keyboard shortcuts for view switcher buttons
- Enable right-click to split views (desktop only, mobile-aware)
- Extend Tooltip component with `bottom-end` positioning to prevent clipping on right-edge controls

## Details
View switcher buttons now display tooltips with the keyboard shortcut from the command registry and a hint to right-click for split. Right-click triggers the split action on desktop layouts; mobile is excluded to preserve the native long-press menu behavior.

The Tooltip component gained a `bottom-end` position variant that right-aligns the tooltip bubble, ensuring tooltips on right-edge controls grow leftward and never clip off-screen.