### PR TITLE
refactor: extract logout logic into useLogout hook

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,8 +1,7 @@
-import { ArrowLeft, LogOut } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { useNavigate, useMatch } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
-import { useLogoutMutation } from '@/hooks/queries/useAuthQueries';
 import { Button } from '@/components/ui/primitives/Button';
 import { THEME_CYCLE, getThemeMeta } from '@/utils/theme';
 import type { Theme } from '@/types/ui.types';
@@ -78,13 +77,6 @@ export function Header({ isAuthPage = false }: HeaderProps) {
   // Pages with their own nav + UserProfileMenu — no Header needed
   const isSidebarPage = isChatPage || isLandingPage || isSettingsPage;
 
-  const logoutMutation = useLogoutMutation({
-    onSuccess: () => {
-      useAuthStore.getState().setAuthenticated(false);
-      navigate('/login');
-    },
-  });
-
   // Sidebar pages have controls in TitleBar + Sidebar footer — no header needed
   if (!isAuthPage && isAuthenticated && isSidebarPage) return null;
 
@@ -114,23 +106,6 @@ export function Header({ isAuthPage = false }: HeaderProps) {
 
         <div className="flex items-center gap-1.5">
           <ThemeToggleButton theme={theme} onToggle={() => useUIStore.getState().toggleTheme()} />
-          {isAuthenticated && !isAuthPage && (
-            <Button
-              onClick={() => logoutMutation.mutate()}
-              variant="unstyled"
-              className={cn(
-                'rounded-full p-1.5',
-                'text-text-tertiary hover:text-text-primary',
-                'dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
-                'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-                'transition-colors duration-200',
-              )}
-              aria-label="Sign out"
-              title="Sign out"
-            >
-              <LogOut className="h-3.5 w-3.5" />
-            </Button>
-          )}
           {!isAuthPage && !isAuthenticated && (
             <AuthButtons onLogin={() => navigate('/login')} onSignup={() => navigate('/signup')} />
           )}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -31,8 +31,9 @@ import { useChatStore } from '@/store/chatStore';
 import { useStreamStore } from '@/store/streamStore';
 import { usePermissionStore } from '@/store/permissionStore';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { useCurrentUserQuery, useLogoutMutation } from '@/hooks/queries/useAuthQueries';
+import { useCurrentUserQuery } from '@/hooks/queries/useAuthQueries';
 import { useAuthStore } from '@/store/authStore';
+import { useLogout } from '@/hooks/useLogout';
 import { UserProfileMenu } from './UserProfileMenu';
 import { SidebarChatItem } from './SidebarChatItem';
 import { SidebarResizeHandle } from './SidebarResizeHandle';
@@ -116,12 +117,7 @@ export function Sidebar({
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { data: currentUser } = useCurrentUserQuery({ enabled: isAuthenticated });
   const userDisplayName = currentUser?.username || currentUser?.email || '';
-  const logoutMutation = useLogoutMutation({
-    onSuccess: () => {
-      useAuthStore.getState().setAuthenticated(false);
-      navigate('/login');
-    },
-  });
+  const logoutMutation = useLogout();
   const activeStreamMetadata = useStreamStore((state) => state.activeStreamMetadata);
   const secondaryChatId = useUIStore((state) => state.secondaryChatId);
   const streamingChatIdSet = useMemo(

--- a/frontend/src/hooks/useLogout.ts
+++ b/frontend/src/hooks/useLogout.ts
@@ -1,0 +1,14 @@
+import { useNavigate } from 'react-router-dom';
+import { useLogoutMutation } from '@/hooks/queries/useAuthQueries';
+import { useAuthStore } from '@/store/authStore';
+
+// Shared logout flow: tears down the session, drops the auth flag, and routes to /login.
+export function useLogout() {
+  const navigate = useNavigate();
+  return useLogoutMutation({
+    onSuccess: () => {
+      useAuthStore.getState().setAuthenticated(false);
+      navigate('/login');
+    },
+  });
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -26,8 +26,9 @@ import { SkillsSettingsTab } from '@/components/settings/tabs/SkillsSettingsTab'
 import { CloudSettingsTab } from '@/components/settings/tabs/CloudSettingsTab';
 import { SettingsProvider } from '@/contexts/SettingsContext';
 import { UserProfileMenu } from '@/components/layout/UserProfileMenu';
-import { useCurrentUserQuery, useLogoutMutation } from '@/hooks/queries/useAuthQueries';
+import { useCurrentUserQuery } from '@/hooks/queries/useAuthQueries';
 import { useAuthStore } from '@/store/authStore';
+import { useLogout } from '@/hooks/useLogout';
 import { getGeneralSecretFields } from '@/utils/settings';
 import { PersonasSection } from '@/components/settings/sections/PersonasSection';
 import { EnvVarsSection } from '@/components/settings/sections/EnvVarsSection';
@@ -82,12 +83,7 @@ const SettingsPage: React.FC = () => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { data: currentUser } = useCurrentUserQuery({ enabled: isAuthenticated });
   const userDisplayName = currentUser?.username || currentUser?.email || '';
-  const logoutMutation = useLogoutMutation({
-    onSuccess: () => {
-      useAuthStore.getState().setAuthenticated(false);
-      navigate('/login');
-    },
-  });
+  const logoutMutation = useLogout();
   // Honor a deep-link tab (e.g. the "Connect a cloud instance" CTA → Cloud tab).
   const [activeTab, setActiveTab] = useState<TabKey>(() => {
     const requested = (location.state as { tab?: TabKey } | null)?.tab;


### PR DESCRIPTION
## Summary
- Extract repeated logout mutation logic into a reusable `useLogout` hook
- Remove logout button from Header (sidebar already has it via UserProfileMenu)
- Update Sidebar and SettingsPage to use the new hook instead of inline mutation setup