### PR TITLE
Add skill search and filtering with extracted SkillListItem

### DIFF
--- a/frontend/src/components/settings/SkillListItem.tsx
+++ b/frontend/src/components/settings/SkillListItem.tsx
@@ -1,0 +1,55 @@
+import type { CustomSkill } from '@/types/user.types';
+import { Edit2 } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { formatBytes } from '@/utils/format';
+
+interface SkillListItemProps {
+  skill: CustomSkill;
+  onEdit: (skill: CustomSkill) => void;
+}
+
+export const SkillListItem: React.FC<SkillListItemProps> = ({ skill, onEdit }) => {
+  return (
+    <div className="rounded-lg border border-border/50 px-4 py-3 dark:border-border-dark/50">
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <h3 className="truncate text-xs font-medium text-text-primary dark:text-text-dark-primary">
+            {skill.name}
+          </h3>
+          {skill.read_only && (
+            <span className="shrink-0 rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
+              built-in
+            </span>
+          )}
+        </div>
+        {!skill.read_only && (
+          <Button
+            type="button"
+            onClick={() => onEdit(skill)}
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0 text-text-quaternary hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+            aria-label={`Edit ${skill.name}`}
+          >
+            <Edit2 className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+      {skill.description && (
+        <p className="mb-2 text-xs text-text-tertiary dark:text-text-dark-tertiary">
+          {skill.description}
+        </p>
+      )}
+      {/* Sources sit on the meta line with file/size so the title row stays clean. */}
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+        <span>{skill.sources.join(' · ')}</span>
+        <span className="text-border dark:text-border-dark">·</span>
+        <span>
+          {skill.file_count} file{skill.file_count !== 1 ? 's' : ''}
+        </span>
+        <span className="text-border dark:text-border-dark">·</span>
+        <span>{formatBytes(skill.size_bytes)}</span>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/SkillsSettingsTab.tsx
@@ -1,12 +1,27 @@
 import type { CustomSkill } from '@/types/user.types';
-import { Zap, Edit2 } from 'lucide-react';
+import { Zap, Search, Filter, type LucideIcon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { Button } from '@/components/ui/primitives/Button';
+import { Input } from '@/components/ui/primitives/Input';
 import { Select } from '@/components/ui/primitives/Select';
 import { SkillEditDialog } from '@/components/settings/dialogs/SkillEditDialog';
+import { SkillListItem } from '@/components/settings/SkillListItem';
 import { useWorkspacesList } from '@/hooks/queries/useWorkspaceQueries';
 import { useSkillsQuery } from '@/hooks/queries/useSkillsQueries';
-import { formatBytes } from '@/utils/format';
+import { useSkillsFilter } from '@/hooks/useSkillsFilter';
+import { cn } from '@/utils/cn';
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  message: string;
+}
+
+const EmptyState: React.FC<EmptyStateProps> = ({ icon: Icon, message }) => (
+  <div className="flex flex-col items-center justify-center rounded-lg border border-border/50 py-10 dark:border-border-dark/50">
+    <Icon className="mb-2 h-5 w-5 text-text-quaternary dark:text-text-dark-quaternary" />
+    <p className="text-xs text-text-tertiary dark:text-text-dark-tertiary">{message}</p>
+  </div>
+);
 
 export const SkillsSettingsTab: React.FC = () => {
   const workspaces = useWorkspacesList();
@@ -19,6 +34,15 @@ export const SkillsSettingsTab: React.FC = () => {
   const items = skills ?? [];
   const [editingSkill, setEditingSkill] = useState<CustomSkill | null>(null);
 
+  const {
+    searchQuery,
+    setSearchQuery,
+    activeSources,
+    toggleSource,
+    availableSources,
+    filteredItems,
+  } = useSkillsFilter(items, workspaceId);
+
   const handleCloseDialog = useCallback(() => {
     setEditingSkill(null);
   }, []);
@@ -30,9 +54,16 @@ export const SkillsSettingsTab: React.FC = () => {
   return (
     <div>
       <div className="mb-4">
-        <h2 className="text-sm font-medium text-text-primary dark:text-text-dark-primary">
-          Skills
-        </h2>
+        <div className="flex items-baseline justify-between gap-2">
+          <h2 className="text-sm font-medium text-text-primary dark:text-text-dark-primary">
+            Skills
+          </h2>
+          {items.length > 0 && (
+            <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+              {filteredItems.length} of {items.length}
+            </span>
+          )}
+        </div>
         <p className="mt-1 text-xs text-text-tertiary dark:text-text-dark-tertiary">
           Skills available in the selected workspace, from the Claude, Codex, Copilot, Cursor, or
           OpenCode CLI.
@@ -40,25 +71,63 @@ export const SkillsSettingsTab: React.FC = () => {
       </div>
 
       {workspaces.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-lg border border-border/50 py-10 dark:border-border-dark/50">
-          <Zap className="mb-2 h-5 w-5 text-text-quaternary dark:text-text-dark-quaternary" />
-          <p className="text-xs text-text-tertiary dark:text-text-dark-tertiary">No workspaces</p>
-        </div>
+        <EmptyState icon={Zap} message="No workspaces" />
       ) : (
         <>
-          <div className="mb-4">
-            <Select
-              value={workspaceId ?? ''}
-              onChange={(e) => setSelectedWorkspaceId(e.target.value)}
-              aria-label="Workspace"
-            >
-              {workspaces.map((ws) => (
-                <option key={ws.id} value={ws.id}>
-                  {ws.name}
-                </option>
-              ))}
-            </Select>
+          <div className="mb-3 flex flex-col gap-2 sm:flex-row">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-quaternary dark:text-text-dark-quaternary" />
+              <Input
+                variant="unstyled"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search skills…"
+                aria-label="Search skills"
+                className="h-10 w-full rounded-lg border border-border bg-surface-tertiary pl-9 pr-3 text-sm text-text-primary outline-none placeholder:text-text-quaternary hover:border-border-hover focus-visible:border-border-hover dark:border-border-dark dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:hover:border-border-dark-hover dark:focus-visible:border-border-dark-hover"
+              />
+            </div>
+            <div className="sm:w-52 sm:shrink-0">
+              <Select
+                value={workspaceId ?? ''}
+                onChange={(e) => setSelectedWorkspaceId(e.target.value)}
+                aria-label="Workspace"
+              >
+                {workspaces.map((ws) => (
+                  <option key={ws.id} value={ws.id}>
+                    {ws.name}
+                  </option>
+                ))}
+              </Select>
+            </div>
           </div>
+
+          {availableSources.length > 1 && (
+            <div className="mb-4 flex items-center gap-2">
+              <Filter className="h-3.5 w-3.5 shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+              <div className="flex flex-wrap gap-1.5">
+                {availableSources.map((source) => {
+                  const isActive = activeSources.has(source);
+                  return (
+                    <Button
+                      key={source}
+                      type="button"
+                      variant="unstyled"
+                      onClick={() => toggleSource(source)}
+                      aria-pressed={isActive}
+                      className={cn(
+                        'rounded-full border px-2.5 py-1 text-2xs transition-colors duration-200',
+                        isActive
+                          ? 'border-transparent bg-text-primary text-surface dark:bg-text-dark-primary dark:text-surface-dark'
+                          : 'border-border/50 bg-surface-secondary text-text-secondary hover:border-border-hover hover:text-text-primary dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-secondary dark:hover:border-border-dark-hover dark:hover:text-text-dark-primary',
+                      )}
+                    >
+                      {source}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
 
           {isLoading ? (
             <div className="flex items-center justify-center py-10">
@@ -67,66 +136,17 @@ export const SkillsSettingsTab: React.FC = () => {
               </p>
             </div>
           ) : items.length === 0 ? (
-            <div className="flex flex-col items-center justify-center rounded-lg border border-border/50 py-10 dark:border-border-dark/50">
-              <Zap className="mb-2 h-5 w-5 text-text-quaternary dark:text-text-dark-quaternary" />
-              <p className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
-                No skills installed
-              </p>
-            </div>
+            <EmptyState icon={Zap} message="No skills installed" />
+          ) : filteredItems.length === 0 ? (
+            <EmptyState icon={Search} message="No skills match your filters" />
           ) : (
             <div className="space-y-2">
-              {items.map((skill) => (
-                <div
+              {filteredItems.map((skill) => (
+                <SkillListItem
                   key={`${skill.name}/${skill.sources.join(',')}`}
-                  className="rounded-lg border border-border/50 px-4 py-3 dark:border-border-dark/50"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <div className="mb-1 flex flex-wrap items-center gap-2">
-                        <h3 className="min-w-0 max-w-full truncate text-xs font-medium text-text-primary dark:text-text-dark-primary sm:max-w-[250px]">
-                          {skill.name}
-                        </h3>
-                        {skill.sources.map((source) => (
-                          <span
-                            key={source}
-                            className="rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary"
-                          >
-                            {source}
-                          </span>
-                        ))}
-                        {skill.read_only && (
-                          <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
-                            built-in
-                          </span>
-                        )}
-                      </div>
-                      {skill.description && (
-                        <p className="mb-2 text-xs text-text-tertiary dark:text-text-dark-tertiary">
-                          {skill.description}
-                        </p>
-                      )}
-                      <div className="flex items-center gap-2 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-                        <span>
-                          {skill.file_count} file{skill.file_count !== 1 ? 's' : ''}
-                        </span>
-                        <span className="text-border dark:text-border-dark">/</span>
-                        <span>{formatBytes(skill.size_bytes)}</span>
-                      </div>
-                    </div>
-                    {!skill.read_only && (
-                      <Button
-                        type="button"
-                        onClick={() => setEditingSkill(skill)}
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7 text-text-quaternary hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
-                        aria-label={`Edit ${skill.name}`}
-                      >
-                        <Edit2 className="h-3.5 w-3.5" />
-                      </Button>
-                    )}
-                  </div>
-                </div>
+                  skill={skill}
+                  onEdit={setEditingSkill}
+                />
               ))}
             </div>
           )}

--- a/frontend/src/hooks/useSkillsFilter.ts
+++ b/frontend/src/hooks/useSkillsFilter.ts
@@ -1,0 +1,72 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { CustomSkill } from '@/types/user.types';
+import type { AgentKind } from '@/types/chat.types';
+import { fuzzySearch } from '@/utils/fuzzySearch';
+
+// Chip order for the source filter — typed against AgentKind so it can't drift
+// from the canonical provider set if a kind is added, removed, or renamed.
+const SOURCE_ORDER: AgentKind[] = ['claude', 'codex', 'copilot', 'cursor', 'opencode'];
+
+export function useSkillsFilter(items: CustomSkill[], workspaceId: string | undefined) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeSources, setActiveSources] = useState<Set<string>>(new Set());
+
+  // Clear the search when the workspace changes so a query from one workspace
+  // doesn't carry into the next.
+  const prevWorkspaceRef = useRef(workspaceId);
+  if (prevWorkspaceRef.current !== workspaceId) {
+    prevWorkspaceRef.current = workspaceId;
+    setSearchQuery('');
+  }
+
+  // Only offer chips for sources actually present in the current skills.
+  const availableSources = useMemo<string[]>(() => {
+    const present = new Set<string>();
+    for (const skill of items) {
+      for (const source of skill.sources) present.add(source);
+    }
+    return SOURCE_ORDER.filter((source) => present.has(source));
+  }, [items]);
+
+  // Drop active filters whose source no longer exists (workspace switch or refetch)
+  // so a stale chip can't hide every skill with no visible way to clear it.
+  const prevAvailableRef = useRef(availableSources);
+  if (prevAvailableRef.current !== availableSources) {
+    prevAvailableRef.current = availableSources;
+    setActiveSources((prev) => {
+      const next = new Set([...prev].filter((source) => availableSources.includes(source)));
+      return next.size === prev.size ? prev : next;
+    });
+  }
+
+  const filteredItems = useMemo(() => {
+    const bySource =
+      activeSources.size === 0
+        ? items
+        : items.filter((skill) => skill.sources.some((source) => activeSources.has(source)));
+    // Reuse the app-wide fuzzy search so skills match the same way as the command menu
+    // and mention suggestions; limit stays at the full set since this isn't a dropdown.
+    return fuzzySearch(searchQuery, bySource, {
+      keys: ['name', 'description'],
+      limit: bySource.length,
+    });
+  }, [items, searchQuery, activeSources]);
+
+  const toggleSource = useCallback((source: string) => {
+    setActiveSources((prev) => {
+      const next = new Set(prev);
+      if (next.has(source)) next.delete(source);
+      else next.add(source);
+      return next;
+    });
+  }, []);
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    activeSources,
+    toggleSource,
+    availableSources,
+    filteredItems,
+  };
+}


### PR DESCRIPTION
## Summary
- Add search bar to filter skills by name in real-time
- Add toggleable source filter buttons (Claude, Codex, Copilot, Cursor, OpenCode)
- Extract skill list item rendering into reusable `SkillListItem` component
- Introduce `useSkillsFilter` hook to centralize filter state management
- Display count of filtered items relative to total
- Show contextual empty state when no skills match current filters

## Changes
- **SkillsSettingsTab.tsx**: Refactored to integrate search/filter UI and use new components
- **SkillListItem.tsx**: New component extracted from the inline item rendering
- **useSkillsFilter.ts**: New hook managing search query and source filtering logic