### PR TITLE
Add cwd parameter to sandbox file metadata endpoints

### DIFF
--- a/backend/app/api/endpoints/sandbox.py
+++ b/backend/app/api/endpoints/sandbox.py
@@ -56,9 +56,22 @@ router = APIRouter()
 async def get_files_metadata(
     sandbox_id: str = Depends(validate_sandbox_ownership),
     sandbox_service: SandboxService = Depends(get_sandbox_service),
+    cwd: str | None = Query(None),
 ) -> SandboxFilesMetadataResponse:
-    files = await sandbox_service.get_files_metadata(sandbox_id)
-    return SandboxFilesMetadataResponse(files=[FileMetadata(**f) for f in files])
+    try:
+        normalized_cwd = normalize_relative_path(cwd)
+        files = await sandbox_service.get_files_metadata(sandbox_id, normalized_cwd)
+        return SandboxFilesMetadataResponse(files=[FileMetadata(**f) for f in files])
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    except SandboxException as e:
+        raise HTTPException(
+            status_code=e.status_code,
+            detail=str(e),
+        )
 
 
 @router.get(

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -150,11 +150,14 @@ class SandboxService:
                 exc_info=True,
             )
 
-    async def get_files_metadata(self, sandbox_id: str) -> list[dict[str, Any]]:
-        metadata = await self.provider.list_files(sandbox_id)
+    async def get_files_metadata(
+        self, sandbox_id: str, cwd: str | None = None
+    ) -> list[dict[str, Any]]:
+        metadata = await self.provider.list_files(sandbox_id, cwd or "")
+        path_prefix = f"{cwd}/" if cwd else ""
         return [
             {
-                "path": m.path,
+                "path": f"{path_prefix}{m.path}",
                 "type": m.type,
                 "is_binary": m.is_binary,
             }

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -37,6 +37,7 @@ class FakeSandboxProvider(SandboxProvider):
         }
         self.writes: list[tuple[str, str, str | bytes]] = []
         self.commands: list[tuple[str, str, dict[str, str] | None]] = []
+        self.list_paths: list[str] = []
 
     @property
     def workspace_root(self) -> str:
@@ -136,6 +137,7 @@ class FakeSandboxProvider(SandboxProvider):
         sandbox_id: str,
         path: str = "",
     ) -> list[FileMetadata]:
+        self.list_paths.append(path)
         return [
             FileMetadata(path="src", type="directory"),
             *[

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -44,6 +44,10 @@ async def test_file_endpoints_use_owned_sandbox_and_provider(
         f"/api/v1/sandbox/{workspace.sandbox_id}/files/metadata",
         headers=headers,
     )
+    worktree_metadata_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/metadata?cwd=.worktrees/wt-1",
+        headers=headers,
+    )
     content_response = await client.get(
         f"/api/v1/sandbox/{workspace.sandbox_id}/files/content/README.md",
         headers=headers,
@@ -68,6 +72,12 @@ async def test_file_endpoints_use_owned_sandbox_and_provider(
         {"path": "src", "type": "directory", "is_binary": False},
         {"path": "README.md", "type": "file", "is_binary": False},
     ]
+    assert worktree_metadata_response.status_code == 200
+    assert worktree_metadata_response.json()["files"] == [
+        {"path": ".worktrees/wt-1/src", "type": "directory", "is_binary": False},
+        {"path": ".worktrees/wt-1/README.md", "type": "file", "is_binary": False},
+    ]
+    assert fake_provider.list_paths == ["", ".worktrees/wt-1"]
     assert content_response.status_code == 200
     assert content_response.json()["content"] == "Initial readme"
     assert update_response.status_code == 200

--- a/frontend/src/components/ui/commandRegistry.ts
+++ b/frontend/src/components/ui/commandRegistry.ts
@@ -280,7 +280,7 @@ export function executeCommand(
             queryKey: queryKeys.sandbox.gitBranchesAll(sandboxId),
           }),
           queryClient.invalidateQueries({
-            queryKey: queryKeys.sandbox.filesMetadata(sandboxId),
+            queryKey: queryKeys.sandbox.filesMetadataAll(sandboxId),
           }),
           queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitDiffAll(sandboxId) }),
         ]);

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -23,7 +23,9 @@ export const queryKeys = {
     fileContent: (sandboxId?: string, filePath?: string) =>
       ['sandbox', sandboxId, 'file-content', filePath] as const,
     fileContentAll: (sandboxId?: string) => ['sandbox', sandboxId, 'file-content'] as const,
-    filesMetadata: (sandboxId?: string) => ['sandbox', sandboxId, 'files-metadata'] as const,
+    filesMetadata: (sandboxId?: string, cwd?: string) =>
+      ['sandbox', sandboxId, 'files-metadata', cwd] as const,
+    filesMetadataAll: (sandboxId?: string) => ['sandbox', sandboxId, 'files-metadata'] as const,
     secrets: (sandboxId?: string) => ['sandbox', sandboxId, 'secrets'] as const,
     gitDiff: (
       sandboxId: string | undefined,

--- a/frontend/src/hooks/queries/useSandboxQueries.ts
+++ b/frontend/src/hooks/queries/useSandboxQueries.ts
@@ -32,11 +32,12 @@ export const useFileContentQuery = (
 
 export const useFilesMetadataQuery = (
   sandboxId: string | undefined,
+  cwd?: string,
   options?: Partial<UseQueryOptions<FileMetadata[]>>,
 ) => {
   return useQuery({
-    queryKey: queryKeys.sandbox.filesMetadata(sandboxId),
-    queryFn: () => sandboxService.getSandboxFilesMetadata(sandboxId),
+    queryKey: queryKeys.sandbox.filesMetadata(sandboxId, cwd),
+    queryFn: () => sandboxService.getSandboxFilesMetadata(sandboxId, cwd),
     enabled: !!sandboxId,
     ...options,
   });
@@ -68,7 +69,7 @@ export const useUpdateFileMutation = createMutation<UpdateFileResult, Error, Upd
         queryKey: queryKeys.sandbox.fileContent(sandboxId, filePath),
       }),
       queryClient.invalidateQueries({
-        queryKey: queryKeys.sandbox.filesMetadata(sandboxId),
+        queryKey: queryKeys.sandbox.filesMetadataAll(sandboxId),
       }),
     ]);
   },
@@ -124,7 +125,7 @@ export const useCheckoutBranchMutation = () => {
           queryKey: queryKeys.sandbox.gitBranchesAll(variables.sandboxId),
         }),
         queryClient.invalidateQueries({
-          queryKey: queryKeys.sandbox.filesMetadata(variables.sandboxId),
+          queryKey: queryKeys.sandbox.filesMetadataAll(variables.sandboxId),
         }),
         queryClient.invalidateQueries({
           queryKey: queryKeys.sandbox.gitDiffAll(variables.sandboxId),
@@ -198,7 +199,7 @@ export const useGitPullMutation = createMutation<
         queryKey: queryKeys.sandbox.gitBranchesAll(variables.sandboxId),
       }),
       queryClient.invalidateQueries({
-        queryKey: queryKeys.sandbox.filesMetadata(variables.sandboxId),
+        queryKey: queryKeys.sandbox.filesMetadataAll(variables.sandboxId),
       }),
       queryClient.invalidateQueries({
         queryKey: queryKeys.sandbox.gitDiffAll(variables.sandboxId),
@@ -239,7 +240,7 @@ export const useSearchInFilesQuery = (
 export const invalidateAfterGitRestore = (queryClient: QueryClient, sandboxId: string) =>
   Promise.all([
     queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitDiffAll(sandboxId) }),
-    queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.filesMetadata(sandboxId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.filesMetadataAll(sandboxId) }),
     queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.fileContentAll(sandboxId) }),
   ]);
 
@@ -279,7 +280,7 @@ export const useGitCreateBranchMutation = createMutation<
         queryKey: queryKeys.sandbox.gitBranchesAll(variables.sandboxId),
       }),
       queryClient.invalidateQueries({
-        queryKey: queryKeys.sandbox.filesMetadata(variables.sandboxId),
+        queryKey: queryKeys.sandbox.filesMetadataAll(variables.sandboxId),
       }),
       queryClient.invalidateQueries({
         queryKey: queryKeys.sandbox.gitDiffAll(variables.sandboxId),

--- a/frontend/src/hooks/useSandboxFiles.ts
+++ b/frontend/src/hooks/useSandboxFiles.ts
@@ -21,7 +21,7 @@ export function useSandboxFiles(
     data: filesMetadata = [],
     isLoading,
     refetch,
-  } = useFilesMetadataQuery(sandboxId, {
+  } = useFilesMetadataQuery(sandboxId, currentChat?.worktree_cwd ?? undefined, {
     enabled: !!sandboxId && !!chatId,
   });
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -169,6 +169,7 @@ export function LandingPage() {
 
   const { data: filesMetadata = [], refetch: refetchFilesMetadata } = useFilesMetadataQuery(
     selectedSandboxId,
+    undefined,
     {
       enabled: isAuthenticated && !!selectedSandboxId,
     },

--- a/frontend/src/services/sandboxService.ts
+++ b/frontend/src/services/sandboxService.ts
@@ -19,11 +19,12 @@ import type {
 } from '@/types/sandbox.types';
 import { validateRequired } from '@/utils/validation';
 
-async function getSandboxFilesMetadata(sandboxId: string): Promise<FileMetadata[]> {
+async function getSandboxFilesMetadata(sandboxId: string, cwd?: string): Promise<FileMetadata[]> {
   validateRequired(sandboxId, 'Sandbox ID');
 
   return serviceCall(async () => {
-    const url = `/sandbox/${sandboxId}/files/metadata`;
+    const qs = buildQueryString({ cwd });
+    const url = `/sandbox/${sandboxId}/files/metadata${qs}`;
     const response = await resolveSandboxClient(sandboxId).get<{ files: FileMetadata[] }>(url);
 
     if (!response || !response.files) {


### PR DESCRIPTION
## Summary
- Add `cwd` query parameter to `/sandbox/{id}/files/metadata` endpoint
- Update frontend query keys and hooks to support directory-scoped file listing
- Normalize and prefix returned file paths when `cwd` is specified
- Add test coverage for worktree directory listing

## Test plan
- Verify files listing works without `cwd` parameter
- Verify files listing with `cwd=.worktrees/wt-1` returns prefixed paths
- Confirm query invalidation uses `filesMetadataAll` for mutations