### PR TITLE
Improve stream cancellation lifecycle

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -32,7 +32,6 @@ from app.core.deps import (
 )
 from app.core.security import get_current_user
 from app.models.db_models.chat import Chat
-from app.models.db_models.enums import MessageStreamStatus
 from app.models.db_models.user import User
 from app.models.types import MessageAttachmentDict, PermissionMode
 from app.models.schemas.chat import (
@@ -418,21 +417,20 @@ async def get_stream_status(
         )
 
     try:
-        latest_assistant_message = (
-            await chat_service.message_service.get_latest_assistant_message(chat_id)
+        active_assistant_message = (
+            await chat_service.message_service.get_in_progress_assistant_message(
+                chat_id
+            )
         )
 
-        if (
-            not latest_assistant_message
-            or latest_assistant_message.stream_status != MessageStreamStatus.IN_PROGRESS
-        ):
+        if not active_assistant_message:
             return INACTIVE_TASK_RESPONSE.copy()
 
         return {
             "has_active_task": True,
-            "message_id": latest_assistant_message.id,
-            "stream_id": latest_assistant_message.active_stream_id,
-            "last_seq": latest_assistant_message.last_seq,
+            "message_id": active_assistant_message.id,
+            "stream_id": active_assistant_message.active_stream_id,
+            "last_seq": active_assistant_message.last_seq,
         }
     except SQLAlchemyError as e:
         logger.error("Database error checking chat status: %s", e, exc_info=True)
@@ -535,10 +533,15 @@ async def get_message_file_diff(
 async def cancel_stream(
     chat_id: UUID,
     _chat: Chat = Depends(ensure_chat_access),
+    chat_service: ChatService = Depends(get_chat_service),
 ) -> None:
-    if not ChatStreamRuntime.has_active_chat(str(chat_id)):
+    if not ChatStreamRuntime.has_active_chat(
+        str(chat_id)
+    ) and not await chat_service.has_cancelable_pending_start(chat_id):
         return
 
+    # Stop can arrive after the assistant row exists but before the runtime task
+    # starts; the registry carries that pending cancel into the task.
     await session_registry.cancel_generation(str(chat_id))
 
 

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -974,22 +974,22 @@ class ChatService(BaseDbService[Chat]):
             if envelope.get("kind") in TERMINAL_STREAM_EVENT_TYPES:
                 return
 
+    async def has_cancelable_pending_start(self, chat_id: UUID) -> bool:
+        message = await self.message_service.get_in_progress_assistant_message(chat_id)
+        return bool(message and message.active_stream_id is None)
+
     async def _get_active_stream_targets(
         self, chat_id: UUID
     ) -> tuple[UUID | None, UUID | None]:
         # Look up the in-progress assistant message so create_event_stream has
         # real IDs for error reporting if the stream fails unexpectedly.
-        latest_assistant_message = (
-            await self.message_service.get_latest_assistant_message(chat_id)
+        active_assistant_message = (
+            await self.message_service.get_in_progress_assistant_message(chat_id)
         )
-        if (
-            latest_assistant_message
-            and latest_assistant_message.stream_status
-            == MessageStreamStatus.IN_PROGRESS
-        ):
+        if active_assistant_message:
             return (
-                latest_assistant_message.id,
-                latest_assistant_message.active_stream_id,
+                active_assistant_message.id,
+                active_assistant_message.active_stream_id,
             )
         return None, None
 

--- a/backend/app/services/message.py
+++ b/backend/app/services/message.py
@@ -119,6 +119,12 @@ class MessageService(BaseDbService[Message]):
             result = await db.execute(query)
             return cast(Message | None, result.scalar_one_or_none())
 
+    async def get_in_progress_assistant_message(self, chat_id: UUID) -> Message | None:
+        message = await self.get_latest_assistant_message(chat_id)
+        if message and message.stream_status == MessageStreamStatus.IN_PROGRESS:
+            return message
+        return None
+
     async def update_message_snapshot(
         self,
         message_id: UUID,

--- a/backend/app/services/session_registry.py
+++ b/backend/app/services/session_registry.py
@@ -16,6 +16,8 @@ TASK_CANCEL_TIMEOUT_SECONDS = 5.0
 
 IDLE_CHECK_INTERVAL_SECONDS = 60.0
 
+PENDING_CANCEL_TTL_SECONDS = 30.0
+
 
 @dataclass
 class ChatSession:
@@ -40,7 +42,7 @@ class SessionRegistry:
         # Pending cancels are tracked separately so a cancel request that
         # arrives between generations (no active task to cancel) is still
         # honoured when the next generation starts.
-        self._pending_cancels: set[str] = set()
+        self._pending_cancels: dict[str, float] = {}
 
     async def get_or_create(
         self,
@@ -78,7 +80,7 @@ class SessionRegistry:
         return session, created
 
     async def cancel_generation(self, chat_id: str) -> None:
-        self._pending_cancels.add(chat_id)
+        self._pending_cancels[chat_id] = time.monotonic()
         session = self._sessions.get(chat_id)
         if session is None:
             return
@@ -101,8 +103,10 @@ class SessionRegistry:
         )
 
     def consume_pending_cancel(self, chat_id: str) -> bool:
-        if chat_id in self._pending_cancels:
-            self._pending_cancels.discard(chat_id)
+        created_at = self._pending_cancels.pop(chat_id, None)
+        if created_at is None:
+            return False
+        if (time.monotonic() - created_at) <= PENDING_CANCEL_TTL_SECONDS:
             return True
         return False
 

--- a/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
@@ -82,36 +82,31 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
       tailSegments: segments.slice(traceEnd + 1),
     };
   }, [segments, isStreaming]);
+  // If a turn is cut off before an answer, the trace is the only visible content.
+  const rollUpTrace = traceSegments.length > 0 && tailSegments.length > 0;
+  const segmentViewProps = {
+    chatId,
+    agentKind,
+    activeThinkingIndex,
+    isLastBotMessage,
+    onSuggestionSelect,
+  };
+  const traceNodes = traceSegments.map((segment) => (
+    <SegmentView key={segment.id} segment={segment} {...segmentViewProps} />
+  ));
+  const tailNodes = tailSegments.map((segment) => (
+    <SegmentView key={segment.id} segment={segment} {...segmentViewProps} />
+  ));
 
   return (
     <AgentToolsContext value={agentTools}>
       <div className={className}>
-        {traceSegments.length > 0 && (
-          <WorkedRollup durationMs={durationMs}>
-            {traceSegments.map((segment) => (
-              <SegmentView
-                key={segment.id}
-                segment={segment}
-                chatId={chatId}
-                agentKind={agentKind}
-                activeThinkingIndex={activeThinkingIndex}
-                isLastBotMessage={isLastBotMessage}
-                onSuggestionSelect={onSuggestionSelect}
-              />
-            ))}
-          </WorkedRollup>
+        {rollUpTrace ? (
+          <WorkedRollup durationMs={durationMs}>{traceNodes}</WorkedRollup>
+        ) : (
+          traceNodes
         )}
-        {tailSegments.map((segment) => (
-          <SegmentView
-            key={segment.id}
-            segment={segment}
-            chatId={chatId}
-            agentKind={agentKind}
-            activeThinkingIndex={activeThinkingIndex}
-            isLastBotMessage={isLastBotMessage}
-            onSuggestionSelect={onSuggestionSelect}
-          />
-        ))}
+        {tailNodes}
       </div>
     </AgentToolsContext>
   );

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -14,6 +14,7 @@ import { useInputState } from '@/hooks/useInputState';
 import { useClipboard } from '@/hooks/useClipboard';
 import { useStreamCallbacks } from '@/hooks/useStreamCallbacks';
 import { useStreamReconnect } from '@/hooks/useStreamReconnect';
+import { chatService } from '@/services/chatService';
 
 interface UseChatStreamingParams {
   chatId: string | undefined;
@@ -172,40 +173,42 @@ export function useChatStreaming({
     setMessages([]);
   }
 
+  const reconcileStreamState = useCallback(() => {
+    if (!chatId) return;
+
+    const activeStreamForChat = useStreamStore.getState().getStreamByChat(chatId);
+
+    if (activeStreamForChat) {
+      const isPendingStop = pendingStopRef.current.has(activeStreamForChat.messageId);
+
+      if (!isPendingStop) {
+        setStreamState('streaming');
+        setCurrentMessageId(activeStreamForChat.messageId);
+        setWasAborted(false);
+      }
+    } else {
+      setStreamState((prev) => {
+        if (prev === 'streaming') {
+          setCurrentMessageId(null);
+          pendingStopRef.current.clear();
+          return 'idle';
+        }
+        return prev;
+      });
+    }
+  }, [chatId]);
+
   // Subscribes to the stream store and mirrors active-stream presence into
   // local React state (streamState, currentMessageId). This is the bridge
   // between the global EventSource lifecycle and the per-chat UI indicators.
   useEffect(() => {
     if (!chatId) return;
 
-    const reconcileStreamState = () => {
-      const activeStreamForChat = useStreamStore.getState().getStreamByChat(chatId);
-
-      if (activeStreamForChat) {
-        const isPendingStop = pendingStopRef.current.has(activeStreamForChat.messageId);
-
-        if (!isPendingStop) {
-          setStreamState('streaming');
-          setCurrentMessageId(activeStreamForChat.messageId);
-          setWasAborted(false);
-        }
-      } else {
-        setStreamState((prev) => {
-          if (prev === 'streaming') {
-            setCurrentMessageId(null);
-            pendingStopRef.current.clear();
-            return 'idle';
-          }
-          return prev;
-        });
-      }
-    };
-
     reconcileStreamState();
 
     const unsubscribe = useStreamStore.subscribe(reconcileStreamState);
     return () => unsubscribe();
-  }, [chatId]);
+  }, [chatId, reconcileStreamState]);
 
   const {
     sendMessage,
@@ -256,7 +259,8 @@ export function useChatStreaming({
 
   // Sends stop requests for one or all active streams in the current chat.
   // Immediately marks the UI as idle (optimistic) and tracks pending stops
-  // so incoming envelopes for the stopping stream are ignored.
+  // so active stream presence does not flip the UI back to streaming while
+  // the stop request is in flight.
   const stopActiveStreams = useCallback(
     async (messageId?: string) => {
       const pendingIds = new Set<string>();
@@ -285,9 +289,10 @@ export function useChatStreaming({
       }
       if (anyFailed) {
         pendingStopRef.current.clear();
+        reconcileStreamState();
       }
     },
-    [chatId, markStreamIdleAfterAbort, stopStream],
+    [chatId, markStreamIdleAfterAbort, reconcileStreamState, stopStream],
   );
 
   useEffect(() => {
@@ -298,12 +303,25 @@ export function useChatStreaming({
     if (streamState === 'loading') {
       cancelPendingStart();
       markStreamIdleAfterAbort();
+      if (chatId) {
+        void chatService.stopStream(chatId).catch((error) => {
+          logger.error('Pending stream stop request failed', 'useChatStreaming', error);
+          setWasAborted(false);
+        });
+      }
       clearInput();
       return;
     }
     void stopActiveStreams(currentMessageIdRef.current || undefined);
     clearInput();
-  }, [cancelPendingStart, clearInput, markStreamIdleAfterAbort, stopActiveStreams, streamState]);
+  }, [
+    cancelPendingStart,
+    chatId,
+    clearInput,
+    markStreamIdleAfterAbort,
+    stopActiveStreams,
+    streamState,
+  ]);
 
   useMountEffect(() => {
     cleanupExpiredPdfBlobs();

--- a/frontend/src/hooks/useGlobalStream.ts
+++ b/frontend/src/hooks/useGlobalStream.ts
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { logger } from '@/utils/logger';
 import { useStreamStore } from '@/store/streamStore';
-import { streamService } from '@/services/streamService';
 import { chatService } from '@/services/chatService';
 
 interface UseGlobalStreamOptions {
@@ -76,12 +75,4 @@ export function useGlobalStream(options?: UseGlobalStreamOptions) {
       clearInterval(intervalId);
     };
   }, [enabled, onPruneComplete]);
-
-  const stopAllStreams = useCallback(async () => {
-    await streamService.stopAllStreams();
-  }, []);
-
-  return {
-    stopAllStreams,
-  };
 }

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -249,6 +249,7 @@ export function useStreamCallbacks({
   const buffersRef = useRef<Map<string, StreamContentBuffer>>(new Map());
   const flushTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const streamSessionsRef = useRef<Map<string, StreamSessionState>>(new Map());
+  const pendingStopEnvelopesRef = useRef<Map<string, StreamEnvelope[]>>(new Map());
   const chatIdRef = useRef(chatId);
   chatIdRef.current = chatId;
 
@@ -281,6 +282,12 @@ export function useStreamCallbacks({
     }
 
     return undefined;
+  }, []);
+
+  const replayPendingStopEnvelopes = useCallback((messageId: string) => {
+    const envelopes = pendingStopEnvelopesRef.current.get(messageId);
+    pendingStopEnvelopesRef.current.delete(messageId);
+    return envelopes ?? [];
   }, []);
 
   // Writes the buffer's collected tokens to React state (live chat) and/or
@@ -381,6 +388,7 @@ export function useStreamCallbacks({
     const flushTimers = flushTimersRef.current;
     const buffers = buffersRef.current;
     const streamSessions = streamSessionsRef.current;
+    const pendingStopEnvelopes = pendingStopEnvelopesRef.current;
 
     return () => {
       timerIdsRef.current.forEach(clearTimeout);
@@ -401,6 +409,7 @@ export function useStreamCallbacks({
 
       buffers.clear();
       streamSessions.clear();
+      pendingStopEnvelopes.clear();
     };
   }, [queryClient]);
 
@@ -419,6 +428,9 @@ export function useStreamCallbacks({
   const onEnvelope = useCallback(
     (envelope: StreamEnvelope) => {
       if (pendingStopRef.current.has(envelope.messageId)) {
+        const envelopes = pendingStopEnvelopesRef.current.get(envelope.messageId) ?? [];
+        envelopes.push(envelope);
+        pendingStopEnvelopesRef.current.set(envelope.messageId, envelopes);
         return;
       }
 
@@ -577,6 +589,8 @@ export function useStreamCallbacks({
       // Cache finalization must run even for off-screen chats so returning
       // to the chat within the staleTime window doesn't show a stuck message.
       if (messageId) {
+        pendingStopRef.current.delete(messageId);
+        pendingStopEnvelopesRef.current.delete(messageId);
         const finalizeMessage = (message: Message): Message => ({
           ...message,
           active_stream_id: null,
@@ -866,9 +880,20 @@ export function useStreamCallbacks({
   const stopStream = useCallback(
     async (messageId: string) => {
       if (!chatId) return;
-      await streamService.stopStreamByMessage(chatId, messageId);
+      try {
+        const locallyFinalized = await streamService.stopStreamByMessage(chatId, messageId);
+        if (!locallyFinalized) {
+          onComplete(messageId, undefined, 'cancelled');
+        }
+      } catch (error) {
+        pendingStopRef.current.delete(messageId);
+        for (const envelope of replayPendingStopEnvelopes(messageId)) {
+          onEnvelope(envelope);
+        }
+        throw error;
+      }
     },
-    [chatId],
+    [chatId, onComplete, onEnvelope, pendingStopRef, replayPendingStopEnvelopes],
   );
 
   return {

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -224,6 +224,16 @@ class StreamService {
     this.cleanupStream(streamId, wrappedError, messageId);
   }
 
+  private finalizeStreamAsCancelled(stream: ActiveStream): void {
+    stream.callbacks?.onComplete?.(
+      stream.messageId,
+      undefined,
+      'cancelled',
+      Date.now() - stream.startTime,
+    );
+    useStreamStore.getState().abortStream(stream.id);
+  }
+
   private attachStreamHandlers(streamId: string, messageId: string): void {
     const activeStream = useStreamStore.getState().getStream(streamId);
     if (!activeStream) return;
@@ -281,46 +291,15 @@ class StreamService {
     }
   }
 
-  stopStream(streamId: string): void {
-    useStreamStore.getState().abortStream(streamId);
-  }
-
-  async stopStreamByMessage(chatId: string, messageId: string): Promise<void> {
+  async stopStreamByMessage(chatId: string, messageId: string): Promise<boolean> {
     const stream = useStreamStore.getState().getStreamByChatAndMessage(chatId, messageId);
+    await chatService.stopStream(chatId);
+
     if (stream) {
-      useStreamStore.getState().abortStream(stream.id);
-
-      try {
-        await chatService.stopStream(chatId);
-      } catch (error) {
-        logger.error('Stream stop failed', 'streamService', error);
-      }
+      this.finalizeStreamAsCancelled(stream);
+      return true;
     }
-  }
-
-  async stopAllStreams(): Promise<void> {
-    const { activeStreams, abortAllStreams } = useStreamStore.getState();
-
-    const chatIds = new Set<string>();
-    activeStreams.forEach((stream) => {
-      chatIds.add(stream.chatId);
-    });
-
-    abortAllStreams();
-
-    const chatIdArr = Array.from(chatIds);
-    const results = await Promise.allSettled(
-      chatIdArr.map((chatId) => chatService.stopStream(chatId)),
-    );
-
-    results.forEach((result, index) => {
-      if (result.status === 'rejected') {
-        logger.error('Batch stream stop failed', 'streamService', {
-          chatId: chatIdArr[index],
-          error: result.reason,
-        });
-      }
-    });
+    return false;
   }
 
   async reconnectToStream(options: StreamReconnectOptions): Promise<string> {

--- a/frontend/src/store/streamStore.ts
+++ b/frontend/src/store/streamStore.ts
@@ -18,7 +18,6 @@ interface StreamState {
   ) => void;
   updateStreamMessageId: (chatId: string, oldMessageId: string, newMessageId: string) => void;
   abortStream: (streamId: string) => void;
-  abortAllStreams: () => void;
   removeStreamMetadata: (chatId: string) => void;
   addStreamMetadata: (metadata: StreamMetadata) => void;
 }
@@ -175,18 +174,6 @@ export const useStreamStore = create<StreamState>((set, get) => ({
 
   abortStream: (streamId: string) => {
     get().removeStream(streamId);
-  },
-
-  abortAllStreams: () => {
-    get().activeStreams.forEach((stream) => {
-      shutdownStream(stream);
-    });
-
-    set({
-      activeStreams: new Map<string, ActiveStream>(),
-      streamIdByChatMessage: new Map<string, string>(),
-      activeStreamMetadata: [],
-    });
   },
 
   removeStreamMetadata: (chatId: string) => {


### PR DESCRIPTION
## Summary
- Clearer message query semantics with `get_in_progress_assistant_message`
- TTL-based pending cancel tracking (30s) to prevent stale cancels
- Better handling of cancellation before stream starts
- Enhanced frontend state recovery on cancellation errors