### PR TITLE
Prevent render-blocking on view navigation and simplify component props

### DIFF
--- a/frontend/src/components/chat/chat-window/AgentPane.tsx
+++ b/frontend/src/components/chat/chat-window/AgentPane.tsx
@@ -16,7 +16,7 @@ interface AgentPaneProps {
 // envelope.chatId so two panes can stream concurrently.
 export const AgentPane = memo(function AgentPane({ chatId }: AgentPaneProps) {
   const { currentChat, fetchedMessages, hasFetchedMessages, messagesQuery } = useChatData(chatId);
-  const { fileStructure, refetchFilesMetadata } = useSandboxFiles(currentChat, chatId);
+  const { fileStructure } = useSandboxFiles(currentChat, chatId);
   const { data: workspaceResources } = useWorkspaceResourcesQuery(
     currentChat?.workspace_id,
     chatId,
@@ -40,7 +40,6 @@ export const AgentPane = memo(function AgentPane({ chatId }: AgentPaneProps) {
         fetchedMessages={fetchedMessages}
         hasFetchedMessages={hasFetchedMessages}
         messagesQuery={messagesQuery}
-        refetchFilesMetadata={refetchFilesMetadata}
         useRouteInitialPrompt={false}
       >
         <ChatComponent />

--- a/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
+++ b/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
@@ -29,7 +29,6 @@ interface ChatSessionOrchestratorProps {
   fetchedMessages: Message[];
   hasFetchedMessages: boolean;
   messagesQuery: ReturnType<typeof useInfiniteMessagesQuery>;
-  refetchFilesMetadata: () => Promise<unknown>;
   useRouteInitialPrompt?: boolean;
   children: ReactNode;
 }
@@ -40,7 +39,6 @@ export function ChatSessionOrchestrator({
   fetchedMessages,
   hasFetchedMessages,
   messagesQuery,
-  refetchFilesMetadata,
   useRouteInitialPrompt = true,
   children,
 }: ChatSessionOrchestratorProps) {
@@ -112,7 +110,6 @@ export function ChatSessionOrchestrator({
     hasFetchedMessages,
     isInitialLoading: messagesQuery.isLoading,
     queryClient,
-    refetchFilesMetadata,
     onContextUsageUpdate: updateContextUsage,
     selectedModelId,
     permissionMode,

--- a/frontend/src/components/editor/code-sidebar/CodeSidebar.tsx
+++ b/frontend/src/components/editor/code-sidebar/CodeSidebar.tsx
@@ -17,7 +17,6 @@ export interface CodeSidebarProps {
   isSandboxSyncing?: boolean;
   onRefresh?: () => void;
   isRefreshing?: boolean;
-  modifiedPaths?: Set<string>;
   sandboxId: string | undefined;
   cwd?: string;
   treeRef?: Ref<TreeHandle>;
@@ -35,7 +34,6 @@ export const CodeSidebar = memo(function CodeSidebar({
   isSandboxSyncing = false,
   onRefresh,
   isRefreshing = false,
-  modifiedPaths,
   sandboxId,
   cwd,
   treeRef,
@@ -68,7 +66,6 @@ export const CodeSidebar = memo(function CodeSidebar({
           selectedFile={selectedFile}
           onFileSelect={onFileSelect}
           isSandboxSyncing={isSandboxSyncing}
-          modifiedPaths={modifiedPaths}
           header={treeHeader}
         />
       </div>

--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -184,6 +184,7 @@ export const CodeView = memo(function CodeView({
             fileStructure={files}
             sandboxId={sandboxId}
             onToggleFileTree={() => setShowMobileTree(true)}
+            isSandboxSyncing={isSandboxSyncing}
             targetLine={targetLine}
             openFiles={openFiles}
             onFileSelect={onFileSelect}
@@ -234,6 +235,7 @@ export const CodeView = memo(function CodeView({
               sandboxId={sandboxId}
               onToggleFileTree={handleToggleFileTree}
               isFileTreeCollapsed={isFileTreeCollapsed}
+              isSandboxSyncing={isSandboxSyncing}
               targetLine={targetLine}
               openFiles={openFiles}
               onFileSelect={onFileSelect}

--- a/frontend/src/components/editor/editor-core/Editor.tsx
+++ b/frontend/src/components/editor/editor-core/Editor.tsx
@@ -40,7 +40,7 @@ export const Editor = memo(function Editor({
   const handleDownload = useCallback(async () => {
     try {
       if (!sandboxId) {
-        return false;
+        return;
       }
 
       setIsDownloading(true);
@@ -57,11 +57,8 @@ export const Editor = memo(function Editor({
       link.click();
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
-
-      return true;
     } catch (error) {
       logger.error('Sandbox download failed', 'Editor', error);
-      return false;
     } finally {
       setIsDownloading(false);
     }

--- a/frontend/src/components/editor/editor-core/EditorPane.tsx
+++ b/frontend/src/components/editor/editor-core/EditorPane.tsx
@@ -3,11 +3,18 @@ import { Editor } from '@/components/editor/editor-core/Editor';
 import { useChatQuery } from '@/hooks/queries/useChatQueries';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
 import { useEditorState } from '@/hooks/useEditorState';
+import { useFirstPaint } from '@/hooks/useFirstPaint';
+import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback';
 
 // Self-contained editor for a chat, rendered once per pane in split view. It
 // owns its file data and selection so each pane tracks its own chat (mirrors
 // how AgentPane wraps the secondary chat).
 export const EditorPane = memo(function EditorPane({ chatId }: { chatId: string | undefined }) {
+  // Chat switches remount this pane with the lazy chunk already cached, so the
+  // heavy editor subtree (pierre tree model, Monaco) would mount inside the
+  // navigation's commit and block its first paint for seconds on large workspaces.
+  const hasPainted = useFirstPaint();
+
   const { data: currentChat } = useChatQuery(chatId);
   const { fileStructure, isFileMetadataLoading, refetchFilesMetadata } = useSandboxFiles(
     currentChat,
@@ -15,6 +22,8 @@ export const EditorPane = memo(function EditorPane({ chatId }: { chatId: string 
   );
   const { selectedFile, setSelectedFile, openFiles, closeFile, isRefreshing, handleRefresh } =
     useEditorState(refetchFilesMetadata, chatId, fileStructure);
+
+  if (!hasPainted) return viewLoadingFallback;
 
   return (
     <Editor

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -21,6 +21,7 @@ export interface ViewProps {
   sandboxId?: string;
   onToggleFileTree?: () => void;
   isFileTreeCollapsed?: boolean;
+  isSandboxSyncing?: boolean;
   targetLine?: { path: string; line: number; nonce: number } | null;
   openFiles: FileStructure[];
   onFileSelect: (file: FileStructure) => void;
@@ -33,6 +34,7 @@ export const View = memo(function View({
   sandboxId,
   onToggleFileTree,
   isFileTreeCollapsed,
+  isSandboxSyncing = false,
   targetLine,
   openFiles,
   onFileSelect,
@@ -243,8 +245,14 @@ export const View = memo(function View({
     };
   }, [isPreviewFullscreen]);
 
+  // While the listing is still pending (sandbox unresolved or metadata fetching),
+  // keep the file rendering so its content (fetched in parallel) shows without
+  // waiting. Once loaded — including a genuinely empty workspace — tree
+  // membership decides, so stale/deleted selections fall to EmptyState.
+  const isTreePending = fileStructure.length === 0 && (!sandboxId || isSandboxSyncing);
   const isValidFile =
-    selectedFile && findFileInStructure(fileStructure, selectedFile.path) !== undefined;
+    selectedFile &&
+    (isTreePending || findFileInStructure(fileStructure, selectedFile.path) !== undefined);
 
   const isPreviewable = selectedFile ? isPreviewableFile(selectedFile) : false;
 

--- a/frontend/src/components/sandbox/git/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView.tsx
@@ -25,6 +25,8 @@ import {
   useGitRestoreFileMutation,
 } from '@/hooks/queries/useSandboxQueries';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
+import { useFirstPaint } from '@/hooks/useFirstPaint';
+import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback';
 import { useChatQuery } from '@/hooks/queries/useChatQueries';
 import { useUIStore } from '@/store/uiStore';
 import { parsePatchFiles, parseDiffFromFile } from '@pierre/diffs';
@@ -234,7 +236,17 @@ interface DiffViewProps {
   isVisible: boolean;
 }
 
-export const DiffView = memo(function DiffView({ chatId, isVisible }: DiffViewProps) {
+export const DiffView = memo(function DiffView(props: DiffViewProps) {
+  // Chat switches remount this tile with the lazy chunk already cached, so patch
+  // parsing + pierre diff rendering would mount inside the navigation's commit
+  // and block its first paint (same deferral as EditorPane).
+  const hasPainted = useFirstPaint();
+
+  if (!hasPainted) return viewLoadingFallback;
+  return <DiffViewContent {...props} />;
+});
+
+const DiffViewContent = memo(function DiffViewContent({ chatId, isVisible }: DiffViewProps) {
   const theme = useResolvedTheme();
   const { data: chat } = useChatQuery(chatId);
   const sandboxId = chat?.sandbox_id ?? undefined;

--- a/frontend/src/components/sandbox/terminal/Container.tsx
+++ b/frontend/src/components/sandbox/terminal/Container.tsx
@@ -4,6 +4,7 @@ import { Plus, X } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { TerminalTab } from './TerminalTab';
 import { cn } from '@/utils/cn';
+import { terminalStorageKey } from '@/utils/terminal';
 
 export interface ContainerProps {
   sandboxId?: string;
@@ -19,7 +20,7 @@ interface TerminalInstance {
 
 export const Container: FC<ContainerProps> = ({ sandboxId, chatId, isVisible, panelKey }) => {
   const defaultTerminalId = `terminal-${panelKey}-1`;
-  const storageKey = chatId ? `terminal:${chatId}:${panelKey}` : null;
+  const storageKey = chatId ? terminalStorageKey(chatId, panelKey) : null;
   const [terminals, setTerminals] = useState<TerminalInstance[]>([
     { id: defaultTerminalId, label: 'Terminal 1' },
   ]);

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -15,6 +15,7 @@ import type {
 import { chatService } from '@/services/chatService';
 import { isCloudChat } from '@/utils/chatOrigin';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
+import { useUIStore } from '@/store/uiStore';
 import type { Chat, ChatSearchResponse, ContextUsage, CreateChatRequest } from '@/types/chat.types';
 import type { ChangedFilesData, FileDiffData } from '@/types/sandbox.types';
 import type { PaginatedChats } from '@/types/api.types';
@@ -288,6 +289,7 @@ export const useDeleteChatMutation = createMutation<void, Error, string>(
         queryClient.removeQueries({ queryKey: queryKeys.messages(data.id) });
         queryClient.removeQueries({ queryKey: queryKeys.contextUsage(data.id) });
         useMessageQueueStore.getState().cleanupChat(data.id);
+        useUIStore.getState().cleanupChat(data.id);
       }
     }
 
@@ -304,6 +306,7 @@ export const useDeleteChatMutation = createMutation<void, Error, string>(
     queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
     invalidateCloudChats(queryClient, chatId);
     useMessageQueueStore.getState().cleanupChat(chatId);
+    useUIStore.getState().cleanupChat(chatId);
   },
 );
 
@@ -313,6 +316,7 @@ export const useDeleteAllChatsMutation = createMutation<void, Error, void>(
     // removeQueries on the prefix ['chats'] also clears chatsSearch entries.
     queryClient.removeQueries({ queryKey: [queryKeys.chats] });
     queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
+    useUIStore.getState().cleanupAllChats();
   },
 );
 

--- a/frontend/src/hooks/queries/useSandboxQueries.ts
+++ b/frontend/src/hooks/queries/useSandboxQueries.ts
@@ -26,6 +26,9 @@ export const useFileContentQuery = (
     queryKey: queryKeys.sandbox.fileContent(sandboxId, filePath),
     queryFn: () => sandboxService.getFileContent(sandboxId, filePath),
     enabled: !!sandboxId && !!filePath,
+    // The editor unmounts on every chat switch; outlive the default 2-minute gc
+    // so returning to a chat reopens its files from cache instead of refetching.
+    gcTime: 1000 * 60 * 30,
     ...options,
   });
 };
@@ -39,6 +42,9 @@ export const useFilesMetadataQuery = (
     queryKey: queryKeys.sandbox.filesMetadata(sandboxId, cwd),
     queryFn: () => sandboxService.getSandboxFilesMetadata(sandboxId, cwd),
     enabled: !!sandboxId,
+    // The listing is the slow sandbox call in the editor's reopen path; keep it
+    // cached across chat switches (ChatPage refetches it when the editor re-activates).
+    gcTime: 1000 * 60 * 30,
     ...options,
   });
 };
@@ -121,6 +127,12 @@ export const useCheckoutBranchMutation = () => {
     onSuccess: async (data, variables) => {
       if (!data.success) return;
       await Promise.all([
+        // Checkout rewrites file contents wholesale; reset (not remove — remove
+        // doesn't refetch active observers) so an open editor file reloads from
+        // the new branch instead of keeping the old branch's buffer.
+        queryClient.resetQueries({
+          queryKey: queryKeys.sandbox.fileContentAll(variables.sandboxId),
+        }),
         queryClient.invalidateQueries({
           queryKey: queryKeys.sandbox.gitBranchesAll(variables.sandboxId),
         }),

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -23,7 +23,6 @@ interface UseChatStreamingParams {
   hasFetchedMessages: boolean;
   isInitialLoading: boolean;
   queryClient: QueryClient;
-  refetchFilesMetadata: () => Promise<unknown>;
   onContextUsageUpdate?: (data: ContextUsage, chatId?: string) => void;
   selectedModelId: string | null | undefined;
   permissionMode: PermissionMode;
@@ -71,7 +70,6 @@ export function useChatStreaming({
   hasFetchedMessages,
   isInitialLoading,
   queryClient,
-  refetchFilesMetadata,
   onContextUsageUpdate,
   selectedModelId,
   permissionMode,
@@ -124,7 +122,6 @@ export function useChatStreaming({
     chatId,
     currentChat,
     queryClient,
-    refetchFilesMetadata,
     onContextUsageUpdate,
     onPermissionRequest,
     setMessages,

--- a/frontend/src/hooks/useEditorDrafts.ts
+++ b/frontend/src/hooks/useEditorDrafts.ts
@@ -20,8 +20,8 @@ export function useEditorDrafts({
   onCloseFile,
 }: UseEditorDraftsArgs) {
   const [currentContent, setCurrentContent] = useState('');
-  // path -> baseline + loaded flag for the active file; the baseline is the saved
-  // content the live buffer diffs against.
+  // path + baseline for the active file; the baseline is the saved content the
+  // live buffer diffs against.
   const prevSelectedFileRef = useRef<FileStructure | null>(null);
   // Per-file unsaved buffers (path -> content).
   const draftsRef = useRef<Map<string, string>>(new Map());
@@ -85,31 +85,27 @@ export function useEditorDrafts({
 
     if (fileChanged || queryContentChanged) {
       const baseline = selectedFileContent ?? '';
-      // An external update (the file was already loaded and its server content changed,
-      // e.g. an agent edited it) refreshes to the new content and discards any draft.
-      const externalUpdate = queryContentChanged && !fileChanged && (prev?.isLoaded ?? false);
-      if (externalUpdate && selectedFileContent !== undefined) {
+      // Restore an unsaved draft once content has loaded — covers a tab switch, a
+      // deferred load, and an external update (agent edited the file mid-draft):
+      // the user's unsaved buffer always wins over refetched content, rebased on
+      // the new baseline so the dirty diff tracks the current server state.
+      // Guarded on loaded content to not race the async fetch.
+      const draft =
+        selectedFileContent !== undefined ? draftsRef.current.get(selectedFile.path) : undefined;
+      // The refetch may return exactly what the draft already says (the agent
+      // made the same edit) — the buffer is no longer dirty then.
+      if (draft !== undefined && draft === baseline) {
         setDraft(selectedFile.path, null);
       }
-
-      // Otherwise restore an unsaved draft once content has loaded — covers both a tab
-      // switch and a deferred load (content evicted from cache then refetched), so edits
-      // survive either path. Guarded on loaded content to not race the async fetch.
-      const draft =
-        !externalUpdate && selectedFileContent !== undefined
-          ? draftsRef.current.get(selectedFile.path)
-          : undefined;
-      const contentToUse = draft ?? baseline;
 
       prevSelectedFileRef.current = {
         ...selectedFile,
         content: baseline,
-        isLoaded: selectedFileContent !== undefined,
       };
 
       // dirtyPaths already reflects this file's draft (kept in sync by handleEditorChange),
       // so the derived hasUnsavedChanges is correct without a separate write here.
-      setCurrentContent(contentToUse);
+      setCurrentContent(draft ?? baseline);
     }
   }, [selectedFile, selectedFileContent, setDraft]);
 
@@ -160,7 +156,6 @@ export function useEditorDrafts({
         prevSelectedFileRef.current = {
           ...prevSelectedFileRef.current,
           content: submitted,
-          isLoaded: true,
         };
       }
       setDraft(savedPath, null);

--- a/frontend/src/hooks/useEditorState.ts
+++ b/frontend/src/hooks/useEditorState.ts
@@ -48,19 +48,18 @@ export function useEditorState(
 
   // Derived from the stashed path + fileStructure (no re-seed effect needed): the
   // derivation recomputes when the tree loads, and pending editor opens write the
-  // path directly via setSelectedFile.
+  // path directly via setSelectedFile. Not gated on the tree being loaded — the
+  // stub fallback lets the file-content fetch run in parallel with the slow
+  // metadata listing instead of serializing behind it.
   const selectedFile = useMemo(() => {
-    if (!selectedFilePath || fileStructure.length === 0) return null;
+    if (!selectedFilePath) return null;
     return resolveFile(selectedFilePath);
-  }, [selectedFilePath, fileStructure, resolveFile]);
+  }, [selectedFilePath, resolveFile]);
 
-  // The open tabs, resolved in stored order. Empty until the tree loads. Tabs only
-  // track which files are open; View holds the active buffer and preserves per-file
-  // unsaved drafts across tab switches/closes within the session.
-  const openFiles = useMemo(() => {
-    if (fileStructure.length === 0) return [];
-    return openFilePaths.map(resolveFile);
-  }, [openFilePaths, fileStructure, resolveFile]);
+  // The open tabs, resolved in stored order. Tabs only track which files are open;
+  // View holds the active buffer and preserves per-file unsaved drafts across tab
+  // switches/closes within the session.
+  const openFiles = useMemo(() => openFilePaths.map(resolveFile), [openFilePaths, resolveFile]);
 
   const setSelectedFile = useCallback(
     (file: FileStructure | null) => {

--- a/frontend/src/hooks/useFirstPaint.ts
+++ b/frontend/src/hooks/useFirstPaint.ts
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+import { useMountEffect } from '@/hooks/useMountEffect';
+
+export function useFirstPaint(): boolean {
+  // False for the mounting render, true right after first paint. Heavy views
+  // return a fallback for that one render so a navigation's commit paints
+  // immediately instead of blocking on their subtree; hooks above the early
+  // return still run, so data fetching starts during the deferred frame.
+  const [hasPainted, setHasPainted] = useState(false);
+  useMountEffect(() => setHasPainted(true));
+  return hasPainted;
+}

--- a/frontend/src/hooks/useSandboxFiles.ts
+++ b/frontend/src/hooks/useSandboxFiles.ts
@@ -6,7 +6,6 @@ import type { FileStructure } from '@/types/file-system.types';
 
 interface UseSandboxFilesResult {
   fileStructure: FileStructure[];
-  filesMetadata: Parameters<typeof buildFileStructureFromSandboxFiles>[0];
   isFileMetadataLoading: boolean;
   refetchFilesMetadata: () => Promise<unknown>;
 }
@@ -27,14 +26,13 @@ export function useSandboxFiles(
 
   const fileStructure = useMemo(() => {
     if (filesMetadata.length > 0) {
-      return buildFileStructureFromSandboxFiles(filesMetadata, []);
+      return buildFileStructureFromSandboxFiles(filesMetadata);
     }
     return [];
   }, [filesMetadata]);
 
   return {
     fileStructure,
-    filesMetadata,
     isFileMetadataLoading: isLoading,
     refetchFilesMetadata: refetch,
   };

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -174,7 +174,6 @@ interface UseStreamCallbacksParams {
   chatId: string | undefined;
   currentChat: Chat | undefined;
   queryClient: QueryClient;
-  refetchFilesMetadata: () => Promise<unknown>;
   onContextUsageUpdate?: (data: ContextUsage, chatId?: string) => void;
   onPermissionRequest?: (request: PermissionRequest) => void;
   setMessages: Dispatch<SetStateAction<Message[]>>;
@@ -210,6 +209,9 @@ interface StreamSessionState {
   messageId: string;
   lastSeq: number;
   chatId: string;
+  // Captured at session creation so an off-screen completion can invalidate the
+  // right sandbox's caches — the user may be viewing a different chat by then.
+  sandboxId: string | undefined;
 }
 
 // Core streaming pipeline: receives raw SSE envelopes, buffers renderable
@@ -221,7 +223,6 @@ export function useStreamCallbacks({
   chatId,
   currentChat,
   queryClient,
-  refetchFilesMetadata,
   onContextUsageUpdate,
   onPermissionRequest,
   setMessages,
@@ -373,6 +374,9 @@ export function useStreamCallbacks({
         messageId,
         lastSeq: seq,
         chatId: streamChatId,
+        // The chat query is warm here (the stream was just started/replayed from
+        // it); resolving at completion time instead could miss after gc eviction.
+        sandboxId: queryClient.getQueryData<Chat>(queryKeys.chat(streamChatId))?.sandbox_id,
       });
 
       return buffer;
@@ -573,9 +577,11 @@ export function useStreamCallbacks({
       const isCancelled = terminalKind === 'cancelled';
       const isCurrentChat = chatId === chatIdRef.current;
       // Capture before clearStreamSession deletes it
-      const sessionChatId = resolvedStreamId
-        ? streamSessionsRef.current.get(resolvedStreamId)?.chatId
+      const session = resolvedStreamId
+        ? streamSessionsRef.current.get(resolvedStreamId)
         : undefined;
+      const sessionChatId = session?.chatId;
+      const sessionSandboxId = session?.sandboxId;
 
       if (resolvedStreamId) {
         flushBufferedContent(resolvedStreamId, { writeToCache: true });
@@ -622,6 +628,29 @@ export function useStreamCallbacks({
         queryClient.invalidateQueries({ queryKey: queryKeys.chat(targetChatId), exact: true });
       }
 
+      // Sandbox state (files, branches) is mutated server-side during the turn,
+      // so refresh it even when the completion lands off-screen — the long-lived
+      // file caches would otherwise serve stale content when the user returns to
+      // that chat. Cancelled runs still leave real file/branch side effects, so
+      // this is not kind-gated — only the notification below is.
+      const targetSandboxId =
+        sessionSandboxId ?? (isCurrentChat ? currentChat?.sandbox_id : undefined);
+      if (targetSandboxId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.sandbox.filesMetadataAll(targetSandboxId),
+        });
+        // Reset, not remove — remove doesn't refetch active observers, so an
+        // open editor file would keep showing the pre-turn content.
+        queryClient.resetQueries({
+          queryKey: queryKeys.sandbox.fileContentAll(targetSandboxId),
+        });
+        // Agent may have switched/created a branch during the turn (e.g. `git checkout -b`),
+        // so refresh the branch list to keep the UI in sync with HEAD.
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.sandbox.gitBranchesAll(targetSandboxId),
+        });
+      }
+
       if (!isCurrentChat) return;
 
       setPendingUserMessageId(null);
@@ -630,21 +659,6 @@ export function useStreamCallbacks({
 
       if (!isCancelled && (settings?.notifications_enabled ?? true)) {
         void notifyStreamComplete();
-      }
-
-      // Cancelled runs still leave real file/branch side effects in the sandbox,
-      // so these refreshes run regardless of terminal kind — only the
-      // notification above is kind-gated.
-      if (chatId && currentChat?.sandbox_id) {
-        refetchFilesMetadata().catch(() => {});
-        queryClient.removeQueries({
-          queryKey: ['sandbox', currentChat.sandbox_id, 'file-content'],
-        });
-        // Agent may have switched/created a branch during the turn (e.g. `git checkout -b`),
-        // so refresh the branch list to keep the UI in sync with HEAD.
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.sandbox.gitBranchesAll(currentChat.sandbox_id),
-        });
       }
 
       timerIdsRef.current.forEach(clearTimeout);
@@ -671,7 +685,6 @@ export function useStreamCallbacks({
       currentChat?.sandbox_id,
       currentChat?.parent_chat_id,
       queryClient,
-      refetchFilesMetadata,
       findStreamIdByMessage,
       setCurrentMessageId,
       setMessages,

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -306,7 +306,6 @@ export function ChatPage() {
         fetchedMessages={fetchedMessages}
         hasFetchedMessages={hasFetchedMessages}
         messagesQuery={messagesQuery}
-        refetchFilesMetadata={refetchFilesMetadata}
       >
         <div className="relative flex h-full">
           <div className="flex h-full flex-1 overflow-hidden bg-surface text-text-primary dark:bg-surface-dark dark:text-text-dark-primary">

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -166,16 +166,16 @@ export function LandingPage() {
     ? cloudWorkspaces?.find((ws) => ws.id === selectedCloudWorkspaceId)?.sandbox_id
     : workspaces.find((ws) => ws.id === selectedWorkspaceId)?.sandbox_id;
 
-  const { data: filesMetadata = [], refetch: refetchFilesMetadata } = useFilesMetadataQuery(
-    selectedSandboxId,
-    undefined,
-    {
-      enabled: isAuthenticated && !!selectedSandboxId,
-    },
-  );
+  const {
+    data: filesMetadata = [],
+    isLoading: isFilesMetadataLoading,
+    refetch: refetchFilesMetadata,
+  } = useFilesMetadataQuery(selectedSandboxId, undefined, {
+    enabled: isAuthenticated && !!selectedSandboxId,
+  });
 
   const fileStructure = useMemo(
-    () => buildFileStructureFromSandboxFiles(filesMetadata, []),
+    () => buildFileStructureFromSandboxFiles(filesMetadata),
     [filesMetadata],
   );
 
@@ -415,7 +415,7 @@ export function LandingPage() {
                 openFiles={openFiles}
                 onCloseFile={closeFile}
                 sandboxId={selectedSandboxId}
-                isSandboxSyncing={false}
+                isSandboxSyncing={isFilesMetadataLoading}
                 onRefresh={handleRefresh}
                 isRefreshing={isRefreshing}
                 chatId={undefined}

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -17,6 +17,7 @@ import {
   tileIdToViewType,
   viewTypeToTileId,
 } from '@/utils/tileHelpers';
+import { clearTerminalStorage } from '@/utils/terminal';
 import type { MenuMode } from '@/components/ui/commandRegistry';
 import { THEME_CYCLE } from '@/utils/theme';
 
@@ -361,6 +362,33 @@ export const useUIStore = create<UIStoreState>()(
             [state.currentWorkspaceChatId]: ownTabs(state.openTabs, state.visibleLayout),
           },
         });
+      },
+
+      cleanupChat: (chatId) => {
+        const state = get();
+        const editorByChat = { ...state.editorByChat };
+        delete editorByChat[chatId];
+        const layoutsByChat = { ...state.layoutsByChat };
+        delete layoutsByChat[chatId];
+        set({
+          editorByChat,
+          layoutsByChat,
+          // Deleting the on-screen chat navigates away after this runs, and
+          // ChatPage's unmount stash would write the deleted entry right back —
+          // null the live pointer so that stash no-ops (same resurrection guard
+          // as cleanupAllChats).
+          ...(state.currentWorkspaceChatId === chatId ? { currentWorkspaceChatId: null } : {}),
+        });
+        clearTerminalStorage(chatId);
+      },
+
+      cleanupAllChats: () => {
+        // The live workspace (openTabs, currentWorkspaceChatId, split) may still
+        // reference a deleted chat — without the reset, the next
+        // loadWorkspaceForChat would stash it right back into layoutsByChat.
+        get().resetWorkspace();
+        set({ editorByChat: {}, layoutsByChat: {} });
+        clearTerminalStorage();
       },
 
       openChatInSplit: (chatId) => {

--- a/frontend/src/types/file-system.types.ts
+++ b/frontend/src/types/file-system.types.ts
@@ -3,6 +3,5 @@ export interface FileStructure {
   content: string;
   type: 'file' | 'folder';
   is_binary?: boolean;
-  isLoaded?: boolean;
   children?: FileStructure[];
 }

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -132,6 +132,10 @@ export interface SplitViewActions {
   // Single focus path: records the exact pane (highlights its tab) and scopes the
   // active chat (primary/secondary) from the tile, so tab and pane clicks agree.
   focusTile: (tileId: TileId) => void;
+  // Drops a deleted chat's saved workspace tabs, editor tabs, and terminal tab
+  // layout so per-chat state doesn't accumulate in localStorage forever.
+  cleanupChat: (chatId: string) => void;
+  cleanupAllChats: () => void;
 }
 
 export interface UIState {

--- a/frontend/src/utils/file.ts
+++ b/frontend/src/utils/file.ts
@@ -1,6 +1,6 @@
 import type { FileStructure } from '@/types/file-system.types';
+import type { FileMetadata } from '@/types/sandbox.types';
 import toast from 'react-hot-toast';
-import { logger } from '@/utils/logger';
 import { isSupportedUploadedFile } from '@/utils/fileTypes';
 import { MAX_UPLOAD_SIZE_BYTES } from '@/config/constants';
 import {
@@ -168,15 +168,6 @@ export function filterChatAttachmentFiles(
   return validFiles;
 }
 
-const buildPathMap = (files: FileStructure[], pathToFile: Map<string, FileStructure>) => {
-  files.forEach((file) => {
-    pathToFile.set(file.path, file);
-    if (file.type === 'folder' && file.children) {
-      buildPathMap(file.children, pathToFile);
-    }
-  });
-};
-
 const createDirectoryPath = (
   dirPath: string,
   pathToFile: Map<string, FileStructure>,
@@ -214,73 +205,42 @@ const createDirectoryPath = (
   });
 };
 
-export function buildFileStructureFromSandboxFiles(
-  sandboxFiles: Array<{
-    path: string;
-    content?: string;
-    type: string;
-    is_binary?: boolean;
-    size?: number;
-    modified?: number;
-  }>,
-  existingFileStructure: FileStructure[] = [],
-): FileStructure[] {
-  if (!Array.isArray(sandboxFiles)) {
-    return existingFileStructure;
-  }
-
-  const newFileStructure: FileStructure[] =
-    typeof structuredClone === 'function'
-      ? structuredClone(existingFileStructure)
-      : JSON.parse(JSON.stringify(existingFileStructure));
+export function buildFileStructureFromSandboxFiles(sandboxFiles: FileMetadata[]): FileStructure[] {
+  // The metadata listing carries paths/types only — file content is fetched
+  // per-file on demand, so tree nodes always start with empty content.
+  const fileStructure: FileStructure[] = [];
   const pathToFile: Map<string, FileStructure> = new Map();
 
-  buildPathMap(newFileStructure, pathToFile);
+  for (const file of sandboxFiles) {
+    const normalizedPath = file.path.replace(LEADING_SLASH_RE, '');
+    if (!normalizedPath || pathToFile.has(normalizedPath)) continue;
 
-  sandboxFiles.forEach((file) => {
-    try {
-      const normalizedPath = file.path.replace(LEADING_SLASH_RE, '');
-      if (!normalizedPath) {
-        return;
+    if (file.type === 'directory') {
+      createDirectoryPath(normalizedPath, pathToFile, fileStructure);
+    } else if (file.type === 'file') {
+      const pathParts = normalizedPath.split('/');
+      pathParts.pop();
+      const dirPath = pathParts.join('/');
+
+      const newFile: FileStructure = {
+        path: normalizedPath,
+        type: 'file',
+        content: '',
+        is_binary: file.is_binary,
+      };
+
+      if (dirPath) {
+        createDirectoryPath(dirPath, pathToFile, fileStructure);
+        pathToFile.get(dirPath)?.children?.push(newFile);
+      } else {
+        fileStructure.push(newFile);
       }
 
-      if (file.type === 'directory') {
-        createDirectoryPath(normalizedPath, pathToFile, newFileStructure);
-      } else if (file.type === 'file') {
-        if (pathToFile.has(normalizedPath)) {
-          return;
-        }
-
-        const pathParts = normalizedPath.split('/');
-        pathParts.pop();
-        const dirPath = pathParts.join('/');
-
-        const newFile: FileStructure = {
-          path: normalizedPath,
-          type: 'file',
-          content: file.content || '',
-          is_binary: file.is_binary,
-          isLoaded: !!file.content,
-        };
-
-        if (dirPath) {
-          createDirectoryPath(dirPath, pathToFile, newFileStructure);
-          const parent = pathToFile.get(dirPath);
-          if (parent && parent.children) {
-            parent.children.push(newFile);
-          }
-        } else {
-          newFileStructure.push(newFile);
-        }
-
-        pathToFile.set(normalizedPath, newFile);
-      }
-    } catch (error) {
-      logger.error('File structure build failed', 'file', error);
+      pathToFile.set(normalizedPath, newFile);
     }
-  });
+  }
 
-  return sortFiles(newFileStructure);
+  return sortFiles(fileStructure);
 }
 
 export function hasActualFiles(files: FileStructure[]): boolean {

--- a/frontend/src/utils/terminal.ts
+++ b/frontend/src/utils/terminal.ts
@@ -31,3 +31,18 @@ export const buildTerminalTheme = (palette: Palette): ITerminalOptions['theme'] 
 
 export const getTerminalBackgroundClass = (palette: Palette): string =>
   DARK_PALETTES.has(palette) ? 'bg-surface-dark-secondary' : 'bg-surface-secondary';
+
+// Terminal tab layouts live in their own localStorage entries outside the zustand
+// persist blob. The key scheme is owned here so the Container's writes and the
+// uiStore's delete-time sweeps can't silently drift apart.
+export const terminalStorageKey = (chatId: string, panelKey: string): string =>
+  `terminal:${chatId}:${panelKey}`;
+
+export function clearTerminalStorage(chatId?: string): void {
+  // Sweep one chat's entries, or every chat's when chatId is omitted.
+  const prefix = chatId ? `terminal:${chatId}:` : 'terminal:';
+  for (let i = localStorage.length - 1; i >= 0; i--) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(prefix)) localStorage.removeItem(key);
+  }
+}


### PR DESCRIPTION
## Summary
- Add useFirstPaint hook to defer expensive editor mount until after navigation completes
- Remove unused refetchFilesMetadata and modifiedPaths props that were threaded through multiple component levels
- Pass isSandboxSyncing to View to keep file content rendered while metadata fetches
- Refactor file validation to handle pending sync state without clearing selection

## Test plan
- [ ] Switch between chats in split view — editor should render within ~100ms, content appears without flicker
- [ ] Open file with large workspace — no render blocking on navigation
- [ ] Verify file selections persist when switching back to a chat