### PR TITLE
Add smooth text reveal for streaming with optimized markdown block parsing

### DIFF
--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -258,20 +258,12 @@ export const Chat = memo(function Chat() {
     prevScrollHeightRef.current = null;
   }, [messages]);
 
-  // Follow output during streaming
-  useEffect(() => {
-    if (isStreaming && isAtBottomRef.current) {
-      const container = scrollerRef.current;
-      if (container) {
-        container.scrollTop = container.scrollHeight;
-      }
-    }
-  }, [messages, isStreaming]);
-
   const scrollToBottom = useCallback(() => {
     setShowScrollButton(false);
     scrollerRef.current?.scrollTo({ top: scrollerRef.current.scrollHeight, behavior: 'smooth' });
   }, []);
+
+  const contentResizeObserverRef = useRef<ResizeObserver | null>(null);
 
   const containerRefCallback = useCallback(
     (node: HTMLDivElement | null) => {
@@ -279,10 +271,27 @@ export const Chat = memo(function Chat() {
       if (prev) {
         prev.removeEventListener('scroll', handleScroll);
       }
+      contentResizeObserverRef.current?.disconnect();
+      contentResizeObserverRef.current = null;
       scrollerRef.current = node;
       if (node) {
         lastScrollTopRef.current = node.scrollTop;
         node.addEventListener('scroll', handleScroll, { passive: true });
+        // Stick to bottom whenever the content grows while the user is anchored
+        // there. Growth comes from stream flushes, the word-reveal animation
+        // ticking between flushes, and late layout (images, KaTeX) — a
+        // messages-keyed effect misses the latter two. ResizeObserver fires
+        // after layout and before paint, so the scroll never lags the growth.
+        const content = node.firstElementChild;
+        if (content) {
+          const observer = new ResizeObserver(() => {
+            if (isAtBottomRef.current) {
+              node.scrollTop = node.scrollHeight;
+            }
+          });
+          observer.observe(content);
+          contentResizeObserverRef.current = observer;
+        }
       }
     },
     [handleScroll],
@@ -429,13 +438,16 @@ export const Chat = memo(function Chat() {
             ref={containerRefCallback}
             className="scrollbar-thin scrollbar-thumb-border-secondary dark:scrollbar-thumb-border-dark hover:scrollbar-thumb-text-quaternary dark:hover:scrollbar-thumb-border-dark-hover scrollbar-track-transparent h-full overflow-y-auto overflow-x-hidden"
           >
-            {listHeader}
+            {/* Single wrapper so the stick-to-bottom ResizeObserver tracks all content */}
+            <div>
+              {listHeader}
 
-            {messages.map((msg) => (
-              <div key={msg.id}>{renderMessage(msg)}</div>
-            ))}
+              {messages.map((msg) => (
+                <div key={msg.id}>{renderMessage(msg)}</div>
+              ))}
 
-            {listFooter}
+              {listFooter}
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 import { SegmentView } from './SegmentView';
 import { WorkedRollup } from './WorkedRollup';
-import { buildSegments } from './segmentBuilder';
+import { buildSegments, segmentsEqual, type MessageSegment } from './segmentBuilder';
 import { AgentToolsContext } from '@/contexts/AgentToolsContext';
 import type { AgentKind, AssistantStreamEvent } from '@/types/chat.types';
 import type { ToolAggregate } from '@/types/tools.types';
@@ -27,26 +27,37 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
   onSuggestionSelect,
   agentKind,
 }) => {
-  const { segments, activeThinkingIndex } = React.useMemo(() => {
+  const prevSegmentsRef = React.useRef<Map<string, MessageSegment>>(new Map());
+
+  const { segments, activeThinkingId, activeTextId } = React.useMemo(() => {
     const builtSegments = buildSegments(events);
 
-    let thinkingIndex = -1;
-    if (isStreaming && events.length > 0) {
-      const lastEvent = events[events.length - 1];
-      if (lastEvent.type === 'assistant_thinking') {
-        for (let i = events.length - 1; i >= 0; i--) {
-          if (events[i].type === 'assistant_thinking') {
-            thinkingIndex = i;
-            break;
-          }
-        }
-      }
-    }
+    // Reuse the previous object for any segment whose content didn't change so
+    // memoized SegmentViews bail out — otherwise every stream flush re-renders
+    // every completed tool/thinking/text segment, not just the growing tail.
+    const previousById = prevSegmentsRef.current;
+    const stableSegments = builtSegments.map((segment) => {
+      const previous = previousById.get(segment.id);
+      return previous && segmentsEqual(previous, segment) ? previous : segment;
+    });
+    prevSegmentsRef.current = new Map(stableSegments.map((segment) => [segment.id, segment]));
 
-    return {
-      segments: builtSegments,
-      activeThinkingIndex: thinkingIndex,
-    };
+    // The live thinking indicator and the word-reveal animation apply only to
+    // the segment currently receiving stream output — always the last segment,
+    // gated on the last event's type so a late tool update on an earlier
+    // segment doesn't masquerade as active thinking/typing.
+    const lastEvent = events[events.length - 1];
+    const lastSegment = stableSegments[stableSegments.length - 1];
+    const thinkingId =
+      isStreaming && lastEvent?.type === 'assistant_thinking' && lastSegment?.kind === 'thinking'
+        ? lastSegment.id
+        : null;
+    const textId =
+      isStreaming && lastEvent?.type === 'assistant_text' && lastSegment?.kind === 'text'
+        ? lastSegment.id
+        : null;
+
+    return { segments: stableSegments, activeThinkingId: thinkingId, activeTextId: textId };
   }, [events, isStreaming]);
 
   const agentTools = React.useMemo(
@@ -87,15 +98,28 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
   const segmentViewProps = {
     chatId,
     agentKind,
-    activeThinkingIndex,
     isLastBotMessage,
     onSuggestionSelect,
   };
+  // Per-segment booleans instead of the active ids: when the active segment
+  // changes, only the segments whose flag flipped lose their memo bailout.
   const traceNodes = traceSegments.map((segment) => (
-    <SegmentView key={segment.id} segment={segment} {...segmentViewProps} />
+    <SegmentView
+      key={segment.id}
+      segment={segment}
+      isActiveThinking={segment.id === activeThinkingId}
+      isActiveText={segment.id === activeTextId}
+      {...segmentViewProps}
+    />
   ));
   const tailNodes = tailSegments.map((segment) => (
-    <SegmentView key={segment.id} segment={segment} {...segmentViewProps} />
+    <SegmentView
+      key={segment.id}
+      segment={segment}
+      isActiveThinking={segment.id === activeThinkingId}
+      isActiveText={segment.id === activeTextId}
+      {...segmentViewProps}
+    />
   ));
 
   return (

--- a/frontend/src/components/chat/message-bubble/SegmentView.tsx
+++ b/frontend/src/components/chat/message-bubble/SegmentView.tsx
@@ -1,5 +1,6 @@
-import React, { Suspense } from 'react';
+import { memo, Suspense } from 'react';
 import { LazyMarkDown } from '@/components/ui/LazyMarkDown';
+import { useSmoothText } from '@/hooks/useSmoothText';
 import { ThinkingBlock } from './ThinkingBlock';
 import { PromptSuggestions } from './PromptSuggestions';
 import { getToolComponent } from '@/components/chat/tools/registry';
@@ -11,33 +12,41 @@ interface SegmentViewProps {
   segment: MessageSegment;
   chatId?: string;
   agentKind?: AgentKind;
-  activeThinkingIndex: number;
+  isActiveThinking: boolean;
+  isActiveText: boolean;
   isLastBotMessage: boolean;
   onSuggestionSelect?: (suggestion: string) => void;
 }
 
-export const SegmentView: React.FC<SegmentViewProps> = ({
+const TextSegment = ({ text, isActive }: { text: string; isActive: boolean }) => {
+  // The segment receiving stream output reveals its text word-by-word instead
+  // of jumping a flush-sized chunk at a time.
+  const smoothText = useSmoothText(text, isActive);
+  return (
+    <div className="prose prose-sm dark:prose-invert max-w-none break-words">
+      <LazyMarkDown content={smoothText} streaming={isActive} />
+    </div>
+  );
+};
+
+export const SegmentView = memo(function SegmentView({
   segment,
   chatId,
   agentKind,
-  activeThinkingIndex,
+  isActiveThinking,
+  isActiveText,
   isLastBotMessage,
   onSuggestionSelect,
-}) => {
+}: SegmentViewProps) {
+  // Memoized so stream flushes only re-render segments whose object identity
+  // changed — MessageRenderer keeps unchanged segments referentially stable.
   switch (segment.kind) {
     case 'text':
-      return (
-        <div className="prose prose-sm dark:prose-invert max-w-none break-words">
-          <LazyMarkDown content={segment.text} />
-        </div>
-      );
+      return <TextSegment text={segment.text} isActive={isActiveText} />;
     case 'thinking':
       return (
         <div className="mb-2 mt-0.5">
-          <ThinkingBlock
-            content={segment.text}
-            isActiveThinking={segment.eventIndex === activeThinkingIndex}
-          />
+          <ThinkingBlock content={segment.text} isActiveThinking={isActiveThinking} />
         </div>
       );
     case 'tool': {
@@ -68,4 +77,4 @@ export const SegmentView: React.FC<SegmentViewProps> = ({
     default:
       return null;
   }
-};
+});

--- a/frontend/src/components/chat/message-bubble/segmentBuilder.ts
+++ b/frontend/src/components/chat/message-bubble/segmentBuilder.ts
@@ -14,7 +14,6 @@ export interface ThinkingSegment {
   kind: 'thinking';
   id: string;
   text: string;
-  eventIndex: number;
 }
 
 export interface ToolSegment {
@@ -30,6 +29,37 @@ export interface SuggestionsSegment {
 }
 
 export type MessageSegment = TextSegment | ThinkingSegment | ToolSegment | SuggestionsSegment;
+
+const toolsEqual = (a: ToolAggregate, b: ToolAggregate): boolean => {
+  // Aggregates are rebuilt from scratch on every stream flush, but input/result/
+  // error come straight off the underlying event payloads, which keep object
+  // identity across rebuilds — reference checks detect real changes.
+  if (
+    a.id !== b.id ||
+    a.name !== b.name ||
+    a.title !== b.title ||
+    a.status !== b.status ||
+    a.parentId !== b.parentId ||
+    a.input !== b.input ||
+    a.result !== b.result ||
+    a.error !== b.error ||
+    a.children.length !== b.children.length
+  ) {
+    return false;
+  }
+  return a.children.every((child, i) => toolsEqual(child, b.children[i]));
+};
+
+export const segmentsEqual = (a: MessageSegment, b: MessageSegment): boolean => {
+  // Lets MessageRenderer hand unchanged segments the same object identity across
+  // flushes so memoized SegmentViews bail out instead of re-rendering.
+  if (a.id !== b.id) return false;
+  if (a.kind === 'text' && b.kind === 'text') return a.text === b.text;
+  if (a.kind === 'thinking' && b.kind === 'thinking') return a.text === b.text;
+  if (a.kind === 'tool' && b.kind === 'tool') return toolsEqual(a.tool, b.tool);
+  if (a.kind === 'suggestions' && b.kind === 'suggestions') return a.suggestions === b.suggestions;
+  return false;
+};
 
 const statusMap: Record<'tool_started' | 'tool_completed' | 'tool_failed', ToolEventStatus> = {
   tool_started: 'started',
@@ -318,7 +348,6 @@ export const buildSegments = (events: AssistantStreamEvent[]): MessageSegment[] 
   const pendingChildren = new Map<string, ToolAggregate[]>();
   let pendingText = '';
   let pendingThinking = '';
-  let pendingThinkingIndex = -1;
   let textSegmentCount = 0;
   let thinkingSegmentCount = 0;
   let suggestionsSegmentCount = 0;
@@ -350,11 +379,9 @@ export const buildSegments = (events: AssistantStreamEvent[]): MessageSegment[] 
       kind: 'thinking',
       id: `thinking-${thinkingSegmentCount}`,
       text: pendingThinking,
-      eventIndex: pendingThinkingIndex,
     });
     thinkingSegmentCount++;
     pendingThinking = '';
-    pendingThinkingIndex = -1;
   };
 
   const context: ProcessToolEventContext = {
@@ -364,7 +391,7 @@ export const buildSegments = (events: AssistantStreamEvent[]): MessageSegment[] 
     segments,
   };
 
-  events.forEach((event, index) => {
+  events.forEach((event) => {
     switch (event.type) {
       case 'assistant_text':
         flushThinking();
@@ -372,7 +399,6 @@ export const buildSegments = (events: AssistantStreamEvent[]): MessageSegment[] 
         break;
       case 'assistant_thinking':
         flushText();
-        pendingThinkingIndex = index;
         pendingThinking += event.thinking;
         break;
       case 'prompt_suggestions':

--- a/frontend/src/components/ui/LazyMarkDown.tsx
+++ b/frontend/src/components/ui/LazyMarkDown.tsx
@@ -5,16 +5,17 @@ const MarkDown = lazy(() => import('./MarkDown'));
 interface LazyMarkDownProps {
   content: string;
   className?: string;
+  streaming?: boolean;
 }
 
-export function LazyMarkDown({ content, className }: LazyMarkDownProps) {
+export function LazyMarkDown({ content, className, streaming }: LazyMarkDownProps) {
   return (
     <Suspense
       fallback={
         <div className={`whitespace-pre-wrap text-sm ${className ?? ''}`.trim()}>{content}</div>
       }
     >
-      <MarkDown content={content} className={className} />
+      <MarkDown content={content} className={className} streaming={streaming} />
     </Suspense>
   );
 }

--- a/frontend/src/components/ui/MarkDown.tsx
+++ b/frontend/src/components/ui/MarkDown.tsx
@@ -1,7 +1,7 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { useMemo, useState, useCallback, memo, useEffect, lazy, Suspense } from 'react';
-import type { Components } from 'react-markdown';
+import { useMemo, useState, memo, useEffect, lazy, Suspense } from 'react';
+import type { Components, Options } from 'react-markdown';
 import type { AnchorHTMLAttributes, HTMLAttributes, ImgHTMLAttributes } from 'react';
 import { AttachmentViewer } from './AttachmentViewer';
 import { Button } from './primitives/Button';
@@ -38,6 +38,15 @@ const OPENING_VISUALIZER_RE = /```visualizer$/;
 
 // Matches a complete ```visualizer ... ``` block.
 const CLOSED_VISUALIZER_RE = /```visualizer\n([\s\S]*?)```/g;
+
+// Matches a line that can safely start a new markdown block. Indented lines,
+// list items, and blockquote lines must stay attached to the previous block —
+// splitting a loose list or nested content would change how it renders.
+const SAFE_BLOCK_START_RE = /^(?![ \t]|[-*+] |\d+[.)] |>)\S/;
+// Captures the fence marker and any trailing info string separately — closing
+// a fence requires matching the opening marker, not just any 3+ fence chars.
+const CODE_FENCE_LINE_RE = /^\s*(`{3,}|~{3,})(.*)$/;
+const MATH_FENCE_LINE_RE = /^\s*\$\$\s*$/;
 
 const createImageAttachment = (url: string, alt?: string): MessageAttachment => {
   return {
@@ -84,12 +93,379 @@ function splitVisualizerBlocks(raw: string): Array<{ type: 'md' | 'visualizer'; 
   return segments;
 }
 
-function MarkDownInner({ content, className = '' }: { content: string; className?: string }) {
-  const [copiedCode, setCopiedCode] = useState<string | null>(null);
+// Split markdown into block-level chunks at blank lines outside code/math
+// fences. Streaming only appends text, so completed chunks stay byte-identical
+// across flushes and their memoized renderers skip re-parsing entirely.
+// Blocks parse in isolation, breaking cross-block reference links/footnotes —
+// so this only runs on actively streaming content; static renders and the
+// final parse at stream end get full document semantics.
+function splitMarkdownBlocks(md: string): string[] {
+  const lines = md.split('\n');
+  const blocks: string[] = [];
+  let current: string[] = [];
+  let openFence: string | null = null;
+  let inMathFence = false;
+  let pendingBlanks = 0;
+
+  for (const line of lines) {
+    if (!openFence && !inMathFence && line.trim() === '') {
+      if (current.length > 0) pendingBlanks++;
+      continue;
+    }
+    if (pendingBlanks > 0) {
+      if (SAFE_BLOCK_START_RE.test(line)) {
+        blocks.push(current.join('\n'));
+        current = [];
+      } else {
+        // Blank lines inside a loose list / continuation must be preserved
+        for (let i = 0; i < pendingBlanks; i++) current.push('');
+      }
+      pendingBlanks = 0;
+    }
+    current.push(line);
+    const fence = inMathFence ? null : CODE_FENCE_LINE_RE.exec(line);
+    if (fence) {
+      if (!openFence) {
+        openFence = fence[1];
+      } else if (
+        // Per CommonMark, a closing fence uses the same character, is at least
+        // as long as the opener, and has no info string — so ``` examples
+        // inside a ```` fence don't end the block early.
+        fence[1][0] === openFence[0] &&
+        fence[1].length >= openFence.length &&
+        fence[2].trim() === ''
+      ) {
+        openFence = null;
+      }
+    } else if (!openFence && MATH_FENCE_LINE_RE.test(line)) {
+      inMathFence = !inMathFence;
+    }
+  }
+  if (current.length > 0) blocks.push(current.join('\n'));
+  return blocks;
+}
+
+interface CodeBlockProps extends HTMLAttributes<HTMLElement> {
+  language: string;
+  codeContent: string;
+}
+
+const CodeBlock = ({ language, codeContent, className, ...props }: CodeBlockProps) => {
+  // Copied state lives here, not in MarkDownInner, so a copy click doesn't
+  // change the components mapping identity and re-parse every memoized block.
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(codeContent);
+    setIsCopied(true);
+    setTimeout(() => setIsCopied(false), 2000);
+  };
+
+  return (
+    <div className="group relative my-4">
+      <div className="absolute right-0 top-0 z-10 flex overflow-hidden rounded-bl">
+        <div className="border-b border-l border-border bg-surface-secondary/50 px-1.5 py-0.5 text-xs font-medium text-text-tertiary dark:border-border-dark dark:bg-surface-dark-secondary dark:text-text-dark-tertiary">
+          {language}
+        </div>
+        <Button
+          onClick={handleCopy}
+          variant="unstyled"
+          className="border-b border-l border-border bg-surface-secondary/50 px-1.5 py-0.5 text-xs font-medium text-text-tertiary hover:text-text-primary dark:border-border-dark dark:bg-surface-dark-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+          aria-label="Copy code"
+        >
+          {isCopied ? 'Copied!' : 'Copy'}
+        </Button>
+      </div>
+      <pre className="overflow-x-auto rounded-lg border border-border bg-surface-secondary p-2 pt-5 dark:border-border-dark dark:bg-surface-dark-secondary">
+        <code
+          className={`${className || ''} font-mono text-xs text-text-primary dark:text-text-dark-primary`}
+          {...props}
+        >
+          {codeContent}
+        </code>
+      </pre>
+    </div>
+  );
+};
+
+// Module-level so every MarkdownBlock sees the same components identity forever
+// — the memo on completed blocks never busts after CodeBlock took copy state.
+const MARKDOWN_COMPONENTS: Components = {
+  table: ({ children, ...props }: CommonProps) => (
+    <div className="my-6 overflow-x-auto">
+      <table className="min-w-full divide-y divide-border dark:divide-border-dark" {...props}>
+        {children}
+      </table>
+    </div>
+  ),
+  thead: ({ children, ...props }: CommonProps) => (
+    <thead className="bg-surface-secondary dark:bg-surface-dark-secondary" {...props}>
+      {children}
+    </thead>
+  ),
+  tbody: ({ children, ...props }: CommonProps) => (
+    <tbody
+      className="divide-y divide-border bg-surface dark:divide-border-dark dark:bg-surface-dark"
+      {...props}
+    >
+      {children}
+    </tbody>
+  ),
+  tr: ({ children, ...props }: CommonProps) => (
+    <tr
+      className="transition-colors hover:bg-surface-hover dark:hover:bg-surface-dark-hover"
+      {...props}
+    >
+      {children}
+    </tr>
+  ),
+  th: ({ children, ...props }: CommonProps) => (
+    <th
+      className="px-3 py-2 text-left text-xs font-semibold text-text-primary dark:text-text-dark-primary"
+      {...props}
+    >
+      {children}
+    </th>
+  ),
+  td: ({ children, ...props }: CommonProps) => (
+    <td className="px-3 py-2 text-xs text-text-secondary dark:text-text-dark-secondary" {...props}>
+      {children}
+    </td>
+  ),
+
+  h1: ({ children, ...props }: CommonProps) => (
+    <h1
+      className="mb-3 mt-4 text-lg font-semibold text-text-primary first:mt-0 dark:text-text-dark-primary"
+      {...props}
+    >
+      {children}
+    </h1>
+  ),
+  h2: ({ children, ...props }: CommonProps) => (
+    <h2
+      className="mb-2 mt-4 text-base font-semibold text-text-primary dark:text-text-dark-primary"
+      {...props}
+    >
+      {children}
+    </h2>
+  ),
+  h3: ({ children, ...props }: CommonProps) => (
+    <h3
+      className="mb-1.5 mt-3 text-sm font-semibold text-text-primary dark:text-text-dark-primary"
+      {...props}
+    >
+      {children}
+    </h3>
+  ),
+
+  p: ({ children, ...props }: CommonProps) => {
+    if (typeof children === 'string' && isImageUrl(children.trim())) {
+      const url = children.trim();
+      return (
+        <div className="mb-3 last:mb-0">
+          <AttachmentViewer attachments={[createImageAttachment(url)]} />
+        </div>
+      );
+    }
+
+    return (
+      <p
+        className="mb-3 whitespace-pre-wrap leading-5 text-text-secondary [overflow-wrap:anywhere] last:mb-0 dark:text-text-dark-secondary"
+        {...props}
+      >
+        {children}
+      </p>
+    );
+  },
+  strong: ({ children, ...props }: CommonProps) => (
+    <strong className="font-semibold text-text-primary dark:text-text-dark-primary" {...props}>
+      {children}
+    </strong>
+  ),
+  em: ({ children, ...props }: CommonProps) => (
+    <em className="italic text-text-secondary dark:text-text-dark-secondary" {...props}>
+      {children}
+    </em>
+  ),
+
+  code: ({ inline, className, children, ...props }: CodeProps) => {
+    const match = /language-(\w+)/.exec(className || '');
+    const codeContent = String(children).replace(/\n$/, '');
+    const hasNewlines = codeContent.includes('\n');
+    const isInline = inline || (!match && !hasNewlines);
+
+    if (isInline) {
+      return (
+        <code
+          className={`rounded bg-surface-secondary px-1 py-0.5 font-mono text-xs text-text-primary dark:bg-surface-dark-secondary dark:text-text-dark-primary ${className || ''}`}
+          {...props}
+        >
+          {codeContent}
+        </code>
+      );
+    }
+
+    if (!match) {
+      return (
+        <div className="my-4">
+          <pre className="overflow-x-auto rounded-lg border border-border bg-surface-secondary p-2 dark:border-border-dark dark:bg-surface-dark-secondary">
+            <code
+              className="font-mono text-xs text-text-primary dark:text-text-dark-primary"
+              {...props}
+            >
+              {codeContent}
+            </code>
+          </pre>
+        </div>
+      );
+    }
+
+    const language = match[1];
+    if (language === 'mermaid') {
+      return (
+        <Suspense
+          fallback={
+            <pre className="overflow-x-auto rounded-lg border border-border bg-surface-secondary p-2 dark:border-border-dark dark:bg-surface-dark-secondary">
+              <code className="font-mono text-xs text-text-primary dark:text-text-dark-primary">
+                {codeContent}
+              </code>
+            </pre>
+          }
+        >
+          <Mermaid content={codeContent} />
+        </Suspense>
+      );
+    }
+
+    return (
+      <CodeBlock language={language} codeContent={codeContent} className={className} {...props} />
+    );
+  },
+
+  ul: ({ children, ...props }: CommonProps) => (
+    <ul
+      className="mb-3 list-disc space-y-1 pl-4 text-text-secondary dark:text-text-dark-secondary"
+      {...props}
+    >
+      {children}
+    </ul>
+  ),
+  ol: ({ children, ...props }: CommonProps) => (
+    <ol
+      className="mb-3 list-decimal space-y-1 pl-4 text-text-secondary dark:text-text-dark-secondary"
+      {...props}
+    >
+      {children}
+    </ol>
+  ),
+  li: ({ children, ...props }: CommonProps) => (
+    <li className="pl-1 text-text-secondary dark:text-text-dark-secondary" {...props}>
+      {children}
+    </li>
+  ),
+  blockquote: ({ children, ...props }: CommonProps) => (
+    <blockquote
+      className="my-3 border-l-2 border-border pl-3 italic text-text-secondary dark:border-border-dark dark:text-text-dark-secondary"
+      {...props}
+    >
+      {children}
+    </blockquote>
+  ),
+
+  a: ({ children, href, ...props }: LinkProps) => {
+    if (href && isImageUrl(href)) {
+      return <AttachmentViewer attachments={[createImageAttachment(href)]} />;
+    }
+
+    return (
+      <Link
+        href={href}
+        variant="unstyled"
+        className="text-text-primary underline transition-colors hover:text-text-secondary dark:text-text-dark-primary dark:hover:text-text-dark-secondary"
+        target="_blank"
+        rel="noopener noreferrer"
+        {...props}
+      >
+        {children}
+      </Link>
+    );
+  },
+
+  img: ({ src, alt, ...props }: ImageProps) => {
+    if (src) {
+      return <AttachmentViewer attachments={[createImageAttachment(src, alt)]} />;
+    }
+
+    return (
+      <img
+        className="my-4 h-auto max-w-full rounded-lg border border-border dark:border-border-dark"
+        alt={alt || ''}
+        loading="lazy"
+        {...props}
+      />
+    );
+  },
+
+  hr: (props: HTMLAttributes<HTMLHRElement>) => (
+    <hr className="my-6 border-border dark:border-border-dark" {...props} />
+  ),
+
+  pre: ({ children, ...props }: CommonProps) => (
+    <pre className="overflow-x-auto" {...props}>
+      {children}
+    </pre>
+  ),
+};
+
+interface MarkdownBlockProps {
+  content: string;
+  remarkPlugins: Options['remarkPlugins'];
+  rehypePlugins: Options['rehypePlugins'];
+}
+
+const MarkdownBlock = memo(function MarkdownBlock({
+  content,
+  remarkPlugins,
+  rehypePlugins,
+}: MarkdownBlockProps) {
+  // Memoized per block so a streaming message only re-parses its growing tail
+  // block each flush; completed blocks keep identical props and bail out.
+  return (
+    <ReactMarkdown
+      remarkPlugins={remarkPlugins}
+      rehypePlugins={rehypePlugins}
+      components={MARKDOWN_COMPONENTS}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+});
+
+interface MarkDownProps {
+  content: string;
+  className?: string;
+  // True only while this content is actively receiving stream output — block
+  // splitting trades cross-block references for cheap incremental re-parses,
+  // so static content parses as one document.
+  streaming?: boolean;
+}
+
+function MarkDownInner({ content, className = '', streaming = false }: MarkDownProps) {
   const [remarkMathPlugin, setRemarkMathPlugin] = useState<unknown>(null);
   const [rehypeKatexPlugin, setRehypeKatexPlugin] = useState<unknown>(null);
 
-  const segments = useMemo(() => splitVisualizerBlocks(content), [content]);
+  const blocks = useMemo(
+    () =>
+      splitVisualizerBlocks(content).flatMap((seg) =>
+        seg.type === 'md' && streaming
+          ? splitMarkdownBlocks(seg.content).map((chunk) => ({
+              type: 'md' as const,
+              content: chunk,
+            }))
+          : [seg],
+      ),
+    [content, streaming],
+  );
 
   const needsMath = useMemo(() => MATH_PATTERN.test(content), [content]);
 
@@ -117,269 +493,6 @@ function MarkDownInner({ content, className = '' }: { content: string; className
     };
   }, [needsMath, remarkMathPlugin, rehypeKatexPlugin]);
 
-  const handleCopyCode = useCallback((code: string) => {
-    navigator.clipboard.writeText(code);
-    setCopiedCode(code);
-    setTimeout(() => setCopiedCode(null), 2000);
-  }, []);
-
-  const components = useMemo<Components>(
-    () => ({
-      table: ({ children, ...props }: CommonProps) => (
-        <div className="my-6 overflow-x-auto">
-          <table className="min-w-full divide-y divide-border dark:divide-border-dark" {...props}>
-            {children}
-          </table>
-        </div>
-      ),
-      thead: ({ children, ...props }: CommonProps) => (
-        <thead className="bg-surface-secondary dark:bg-surface-dark-secondary" {...props}>
-          {children}
-        </thead>
-      ),
-      tbody: ({ children, ...props }: CommonProps) => (
-        <tbody
-          className="divide-y divide-border bg-surface dark:divide-border-dark dark:bg-surface-dark"
-          {...props}
-        >
-          {children}
-        </tbody>
-      ),
-      tr: ({ children, ...props }: CommonProps) => (
-        <tr
-          className="transition-colors hover:bg-surface-hover dark:hover:bg-surface-dark-hover"
-          {...props}
-        >
-          {children}
-        </tr>
-      ),
-      th: ({ children, ...props }: CommonProps) => (
-        <th
-          className="px-3 py-2 text-left text-xs font-semibold text-text-primary dark:text-text-dark-primary"
-          {...props}
-        >
-          {children}
-        </th>
-      ),
-      td: ({ children, ...props }: CommonProps) => (
-        <td
-          className="px-3 py-2 text-xs text-text-secondary dark:text-text-dark-secondary"
-          {...props}
-        >
-          {children}
-        </td>
-      ),
-
-      h1: ({ children, ...props }: CommonProps) => (
-        <h1
-          className="mb-3 mt-4 text-lg font-semibold text-text-primary first:mt-0 dark:text-text-dark-primary"
-          {...props}
-        >
-          {children}
-        </h1>
-      ),
-      h2: ({ children, ...props }: CommonProps) => (
-        <h2
-          className="mb-2 mt-4 text-base font-semibold text-text-primary dark:text-text-dark-primary"
-          {...props}
-        >
-          {children}
-        </h2>
-      ),
-      h3: ({ children, ...props }: CommonProps) => (
-        <h3
-          className="mb-1.5 mt-3 text-sm font-semibold text-text-primary dark:text-text-dark-primary"
-          {...props}
-        >
-          {children}
-        </h3>
-      ),
-
-      p: ({ children, ...props }: CommonProps) => {
-        if (typeof children === 'string' && isImageUrl(children.trim())) {
-          const url = children.trim();
-          return (
-            <div className="mb-3 last:mb-0">
-              <AttachmentViewer attachments={[createImageAttachment(url)]} />
-            </div>
-          );
-        }
-
-        return (
-          <p
-            className="mb-3 whitespace-pre-wrap leading-5 text-text-secondary [overflow-wrap:anywhere] last:mb-0 dark:text-text-dark-secondary"
-            {...props}
-          >
-            {children}
-          </p>
-        );
-      },
-      strong: ({ children, ...props }: CommonProps) => (
-        <strong className="font-semibold text-text-primary dark:text-text-dark-primary" {...props}>
-          {children}
-        </strong>
-      ),
-      em: ({ children, ...props }: CommonProps) => (
-        <em className="italic text-text-secondary dark:text-text-dark-secondary" {...props}>
-          {children}
-        </em>
-      ),
-
-      code: ({ inline, className, children, ...props }: CodeProps) => {
-        const match = /language-(\w+)/.exec(className || '');
-        const codeContent = String(children).replace(/\n$/, '');
-        const hasNewlines = codeContent.includes('\n');
-        const isInline = inline || (!match && !hasNewlines);
-
-        if (isInline) {
-          return (
-            <code
-              className={`rounded bg-surface-secondary px-1 py-0.5 font-mono text-xs text-text-primary dark:bg-surface-dark-secondary dark:text-text-dark-primary ${className || ''}`}
-              {...props}
-            >
-              {codeContent}
-            </code>
-          );
-        }
-
-        if (!match) {
-          return (
-            <div className="my-4">
-              <pre className="overflow-x-auto rounded-lg border border-border bg-surface-secondary p-2 dark:border-border-dark dark:bg-surface-dark-secondary">
-                <code
-                  className="font-mono text-xs text-text-primary dark:text-text-dark-primary"
-                  {...props}
-                >
-                  {codeContent}
-                </code>
-              </pre>
-            </div>
-          );
-        }
-
-        const language = match[1];
-        if (language === 'mermaid') {
-          return (
-            <Suspense
-              fallback={
-                <pre className="overflow-x-auto rounded-lg border border-border bg-surface-secondary p-2 dark:border-border-dark dark:bg-surface-dark-secondary">
-                  <code className="font-mono text-xs text-text-primary dark:text-text-dark-primary">
-                    {codeContent}
-                  </code>
-                </pre>
-              }
-            >
-              <Mermaid content={codeContent} />
-            </Suspense>
-          );
-        }
-
-        const isCopied = copiedCode === codeContent;
-
-        return (
-          <div className="group relative my-4">
-            <div className="absolute right-0 top-0 z-10 flex overflow-hidden rounded-bl">
-              <div className="border-b border-l border-border bg-surface-secondary/50 px-1.5 py-0.5 text-xs font-medium text-text-tertiary dark:border-border-dark dark:bg-surface-dark-secondary dark:text-text-dark-tertiary">
-                {language}
-              </div>
-              <Button
-                onClick={() => handleCopyCode(codeContent)}
-                variant="unstyled"
-                className="border-b border-l border-border bg-surface-secondary/50 px-1.5 py-0.5 text-xs font-medium text-text-tertiary hover:text-text-primary dark:border-border-dark dark:bg-surface-dark-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
-                aria-label="Copy code"
-              >
-                {isCopied ? 'Copied!' : 'Copy'}
-              </Button>
-            </div>
-            <pre className="overflow-x-auto rounded-lg border border-border bg-surface-secondary p-2 pt-5 dark:border-border-dark dark:bg-surface-dark-secondary">
-              <code
-                className={`${className || ''} font-mono text-xs text-text-primary dark:text-text-dark-primary`}
-                {...props}
-              >
-                {codeContent}
-              </code>
-            </pre>
-          </div>
-        );
-      },
-
-      ul: ({ children, ...props }: CommonProps) => (
-        <ul
-          className="mb-3 list-disc space-y-1 pl-4 text-text-secondary dark:text-text-dark-secondary"
-          {...props}
-        >
-          {children}
-        </ul>
-      ),
-      ol: ({ children, ...props }: CommonProps) => (
-        <ol
-          className="mb-3 list-decimal space-y-1 pl-4 text-text-secondary dark:text-text-dark-secondary"
-          {...props}
-        >
-          {children}
-        </ol>
-      ),
-      li: ({ children, ...props }: CommonProps) => (
-        <li className="pl-1 text-text-secondary dark:text-text-dark-secondary" {...props}>
-          {children}
-        </li>
-      ),
-      blockquote: ({ children, ...props }: CommonProps) => (
-        <blockquote
-          className="my-3 border-l-2 border-border pl-3 italic text-text-secondary dark:border-border-dark dark:text-text-dark-secondary"
-          {...props}
-        >
-          {children}
-        </blockquote>
-      ),
-
-      a: ({ children, href, ...props }: LinkProps) => {
-        if (href && isImageUrl(href)) {
-          return <AttachmentViewer attachments={[createImageAttachment(href)]} />;
-        }
-
-        return (
-          <Link
-            href={href}
-            variant="unstyled"
-            className="text-text-primary underline transition-colors hover:text-text-secondary dark:text-text-dark-primary dark:hover:text-text-dark-secondary"
-            target="_blank"
-            rel="noopener noreferrer"
-            {...props}
-          >
-            {children}
-          </Link>
-        );
-      },
-
-      img: ({ src, alt, ...props }: ImageProps) => {
-        if (src) {
-          return <AttachmentViewer attachments={[createImageAttachment(src, alt)]} />;
-        }
-
-        return (
-          <img
-            className="my-4 h-auto max-w-full rounded-lg border border-border dark:border-border-dark"
-            alt={alt || ''}
-            loading="lazy"
-            {...props}
-          />
-        );
-      },
-
-      hr: (props: HTMLAttributes<HTMLHRElement>) => (
-        <hr className="my-6 border-border dark:border-border-dark" {...props} />
-      ),
-
-      pre: ({ children, ...props }: CommonProps) => (
-        <pre className="overflow-x-auto" {...props}>
-          {children}
-        </pre>
-      ),
-    }),
-    [copiedCode, handleCopyCode],
-  );
-
   const remarkPlugins = useMemo(
     () => [remarkGfm, ...(remarkMathPlugin ? [remarkMathPlugin as never] : [])],
     [remarkMathPlugin],
@@ -402,24 +515,9 @@ function MarkDownInner({ content, className = '' }: { content: string; className
     );
   }
 
-  const hasSingleMdSegment = segments.length === 1 && segments[0].type === 'md';
-
-  if (hasSingleMdSegment) {
-    return (
-      <ReactMarkdown
-        remarkPlugins={remarkPlugins}
-        rehypePlugins={rehypePlugins}
-        className={mdClassName}
-        components={components}
-      >
-        {segments[0].content}
-      </ReactMarkdown>
-    );
-  }
-
   return (
     <div className={mdClassName}>
-      {segments.map((seg, i) =>
+      {blocks.map((seg, i) =>
         seg.type === 'visualizer' ? (
           <Suspense
             key={`viz-${i}`}
@@ -434,14 +532,12 @@ function MarkDownInner({ content, className = '' }: { content: string; className
             <VisualWidget code={seg.content} />
           </Suspense>
         ) : (
-          <ReactMarkdown
+          <MarkdownBlock
             key={`md-${i}`}
+            content={seg.content}
             remarkPlugins={remarkPlugins}
             rehypePlugins={rehypePlugins}
-            components={components}
-          >
-            {seg.content}
-          </ReactMarkdown>
+          />
         ),
       )}
     </div>

--- a/frontend/src/hooks/useSmoothText.ts
+++ b/frontend/src/hooks/useSmoothText.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react';
+
+// Reveal pending text over ~350ms so the display tracks the network position
+// closely while still reading as a steady stream instead of bursts.
+const CATCH_UP_MS = 350;
+// Minimum interval between reveal steps — caps markdown re-parses of the
+// growing tail block at ~30 updates/sec.
+const MIN_TICK_MS = 33;
+// Cap the per-step time delta so a pause (hidden tab, slow token gaps) doesn't
+// dump the whole backlog in one frame when ticks resume.
+const MAX_TICK_DELTA_MS = 100;
+const HIGH_SURROGATE_RE = /[\uD800-\uDBFF]/;
+
+export function useSmoothText(text: string, animate: boolean): string {
+  // Stream flushes grow `text` in multi-word chunks; this reveals it at a
+  // backlog-proportional rate so it reads word-by-word like a typewriter.
+  // When `animate` is false the input passes through untouched.
+  // Text present at mount shows immediately — reconnect/navigation mounts an
+  // in-progress stream with buffered output, and replaying it from blank would
+  // hide content the user already saw. Only post-mount appends animate.
+  const [visibleCount, setVisibleCount] = useState(text.length);
+  const visibleCountRef = useRef(visibleCount);
+  const textRef = useRef(text);
+  textRef.current = text;
+
+  // Snap to the full text the moment animation stops (stream finished or the
+  // segment is no longer the tail) so nothing stays hidden.
+  if (!animate && visibleCountRef.current !== text.length) {
+    visibleCountRef.current = text.length;
+    setVisibleCount(text.length);
+  }
+
+  useEffect(() => {
+    if (!animate) return;
+
+    let rafId = 0;
+    let lastTick = performance.now();
+
+    const tick = (now: number) => {
+      const target = textRef.current.length;
+      const visible = visibleCountRef.current;
+      if (visible >= target) {
+        lastTick = now;
+      } else if (now - lastTick >= MIN_TICK_MS) {
+        const delta = Math.min(now - lastTick, MAX_TICK_DELTA_MS);
+        lastTick = now;
+        const backlog = target - visible;
+        const step = Math.max(1, Math.round((backlog * delta) / CATCH_UP_MS));
+        let next = Math.min(target, visible + step);
+        // Don't split a surrogate pair — slicing mid-emoji flashes a replacement char
+        if (next < target && HIGH_SURROGATE_RE.test(textRef.current[next - 1])) next++;
+        visibleCountRef.current = next;
+        setVisibleCount(next);
+      }
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
+  }, [animate]);
+
+  return animate ? text.slice(0, visibleCount) : text;
+}

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -30,8 +30,10 @@ import type { PaginatedMessages } from '@/types/api.types';
 
 // Batching window for streaming content updates. Envelopes arrive at token-level
 // granularity (~10-50ms apart); flushing on every token would thrash React state
-// and the query cache. 130ms collects a visible chunk of text per paint cycle.
-const STREAM_FLUSH_INTERVAL_MS = 130;
+// and the query cache. 50ms keeps the text cadence smooth (~20 updates/sec) —
+// affordable because memoized markdown blocks and segments mean each flush only
+// re-renders the growing tail of the message.
+const STREAM_FLUSH_INTERVAL_MS = 50;
 
 // Cross-chat cache mutators: unlike the hook-scoped useMessageCache (which
 // closes over the currently viewed chatId), these target a specific chat by
@@ -216,7 +218,7 @@ interface StreamSessionState {
 
 // Core streaming pipeline: receives raw SSE envelopes, buffers renderable
 // content per stream, and flushes batched updates to React state and the query
-// cache on a 130ms coalescing timer. Also owns the start/replay/stop lifecycle
+// cache on a coalescing timer. Also owns the start/replay/stop lifecycle
 // and the terminal handlers (complete, error, queue continuation).
 export function useStreamCallbacks({
   messages,
@@ -317,7 +319,7 @@ export function useStreamCallbacks({
   );
 
   // Coalescing timer: only one pending flush per stream. Multiple envelopes arriving
-  // within the same 130ms window are batched into a single flushBufferedContent call.
+  // within the same window are batched into a single flushBufferedContent call.
   const scheduleContentFlush = useCallback(
     (streamId: string) => {
       if (flushTimersRef.current.has(streamId)) {


### PR DESCRIPTION
## Summary
- Introduces `useSmoothText` hook for smooth text reveal at ~350ms catch-up rate
- Refactors markdown block splitting to optimize rendering during active streams
- Prevents emoji corruption by tracking high surrogates during reveal
- Maintains full document semantics on stream completion