### PR TITLE
fix: re-check scroll state when chat content shrinks

### DIFF
--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -287,6 +287,11 @@ export const Chat = memo(function Chat() {
           const observer = new ResizeObserver(() => {
             if (isAtBottomRef.current) {
               node.scrollTop = node.scrollHeight;
+            } else {
+              // Content shrinking (e.g. collapsing a rollup) may leave scrollTop
+              // unchanged so no scroll event fires — re-check at-bottom state or
+              // the scroll button stays visible with nothing left to scroll.
+              handleScroll();
             }
           });
           observer.observe(content);


### PR DESCRIPTION
## Summary
- When content inside the chat scroll container shrinks (e.g. collapsing a rollup) while the user isn't at the bottom, `scrollTop` can stay unchanged and no scroll event fires, leaving the "scroll to bottom" button stuck visible even though there's nothing left to scroll to.
- The `ResizeObserver` callback now calls `handleScroll()` in that branch to re-evaluate the at-bottom state.