### PR TITLE
fix: resolve git shortcuts without requiring an active chat

### DIFF
--- a/backend/app/models/db_models/chat.py
+++ b/backend/app/models/db_models/chat.py
@@ -77,11 +77,11 @@ class Chat(Base):
     )
 
     @property
-    def sandbox_id(self) -> str | None:
+    def sandbox_id(self) -> str:
         if self.workspace:
             sid: str = self.workspace.sandbox_id
             return sid
-        val: str | None = getattr(self, "_sandbox_id", None)
+        val: str = self._sandbox_id
         return val
 
     @property
@@ -111,7 +111,10 @@ class Chat(Base):
             session_agent_kind=data.get("session_agent_kind"),
         )
         # Stash sandbox fields for streaming runtime (workspace not loaded from DB)
-        chat._sandbox_id = data.get("sandbox_id")
+        sandbox_id = data.get("sandbox_id")
+        if sandbox_id is None:
+            raise ValueError("Missing sandbox_id in chat data")
+        chat._sandbox_id = sandbox_id
         chat._workspace_path = data.get("workspace_path")
         sandbox_provider = data.get("sandbox_provider")
         if sandbox_provider is None:

--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -80,7 +80,7 @@ class Chat(ChatBase):
     id: UUID
     user_id: UUID
     workspace_id: UUID
-    sandbox_id: str | None = None
+    sandbox_id: str
     created_at: datetime
     updated_at: datetime
     context_token_usage: int | None = None

--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -123,10 +123,11 @@ export function CommandMenu() {
       ALL_COMMANDS.filter((cmd) => {
         if (isMobile && cmd.hideOnMobile) return false;
         if (cmd.requiresChat && !chatId) return false;
+        if (cmd.requiresSandbox && !sandboxId) return false;
         if (cmd.id === 'switch-branch' && !canSwitchBranch) return false;
         return true;
       }),
-    [isMobile, canSwitchBranch, chatId],
+    [isMobile, canSwitchBranch, chatId, sandboxId],
   );
 
   const filteredCommands = useMemo(
@@ -196,10 +197,10 @@ export function CommandMenu() {
 
   const handleSelectItem = useCallback(
     (cmd: CommandItem) => {
-      executeCommand(cmd, queryClient, navigate, false);
+      executeCommand(cmd, queryClient, navigate, false, { sandboxId, worktreeCwd });
       close();
     },
-    [close, queryClient, navigate],
+    [close, queryClient, navigate, sandboxId, worktreeCwd],
   );
 
   const handleSelectFile = useCallback(

--- a/frontend/src/components/ui/commandRegistry.ts
+++ b/frontend/src/components/ui/commandRegistry.ts
@@ -39,6 +39,7 @@ export interface ViewCommandItem {
   shortcut: string;
   hideOnMobile?: boolean;
   requiresChat?: boolean;
+  requiresSandbox?: boolean;
 }
 
 export interface ActionCommandItem {
@@ -49,6 +50,7 @@ export interface ActionCommandItem {
   shortcut: string;
   hideOnMobile?: boolean;
   requiresChat?: boolean;
+  requiresSandbox?: boolean;
 }
 
 export type CommandItem = ViewCommandItem | ActionCommandItem;
@@ -122,7 +124,7 @@ const ACTION_COMMANDS: ActionCommandItem[] = [
     label: 'Switch branch',
     icon: GitBranch,
     shortcut: 'b',
-    requiresChat: true,
+    requiresSandbox: true,
   },
   {
     type: 'action',
@@ -130,7 +132,7 @@ const ACTION_COMMANDS: ActionCommandItem[] = [
     label: 'Push to remote',
     icon: ArrowUpFromLine,
     shortcut: 'u',
-    requiresChat: true,
+    requiresSandbox: true,
   },
   {
     type: 'action',
@@ -138,7 +140,7 @@ const ACTION_COMMANDS: ActionCommandItem[] = [
     label: 'Pull from remote',
     icon: ArrowDownFromLine,
     shortcut: 'j',
-    requiresChat: true,
+    requiresSandbox: true,
   },
 ];
 
@@ -196,9 +198,16 @@ export function formatShortcut(key: string): string {
   return `${mod}⇧${key === '.' ? '.' : key.toUpperCase()}`;
 }
 
-// Chat-scoped actions (git, sub-threads) target the pane the user last interacted
-// with — in split view the secondary pane is a different chat. The secondary chat
-// is cache-warm here since it's rendered in the split.
+// The sandbox a git action targets. Resolved from the active pane's chat context
+// (or the selected workspace on the landing page), decoupled from whether a chat exists.
+export interface GitTarget {
+  sandboxId?: string;
+  worktreeCwd?: string;
+}
+
+// Chat-scoped actions (sub-threads) target the pane the user last interacted with —
+// in split view the secondary pane is a different chat. The secondary chat is
+// cache-warm here since it's rendered in the split.
 function getActiveChat(queryClient: QueryClient): Chat | null {
   const ui = useUIStore.getState();
   if (isSecondaryPaneActive(ui.activeAgentTile, ui.secondaryChatId) && ui.secondaryChatId) {
@@ -209,8 +218,19 @@ function getActiveChat(queryClient: QueryClient): Chat | null {
   return useChatStore.getState().currentChat;
 }
 
+// Git target for the global keyboard-shortcut path, which has no chat context.
+// Prefers the active chat; on the landing page (no chat) it falls back to the
+// selected workspace's sandbox so branch/pull/push shortcuts still resolve.
+export function resolveActiveGitTarget(queryClient: QueryClient): GitTarget {
+  const chat = getActiveChat(queryClient);
+  if (chat?.sandbox_id) {
+    return { sandboxId: chat.sandbox_id, worktreeCwd: chat.worktree_cwd ?? undefined };
+  }
+  return { sandboxId: useUIStore.getState().workspaceSandboxId ?? undefined };
+}
+
 function executeGitRemoteCommand(
-  chat: Chat | null,
+  target: GitTarget,
   fn: (
     sandboxId: string,
     cwd?: string,
@@ -218,11 +238,11 @@ function executeGitRemoteCommand(
   label: string,
   onSuccess?: () => void,
 ) {
-  if (!chat?.sandbox_id) {
+  if (!target.sandboxId) {
     toast.error('No sandbox connected');
     return;
   }
-  void fn(chat.sandbox_id, chat.worktree_cwd ?? undefined)
+  void fn(target.sandboxId, target.worktreeCwd)
     .then((r) => {
       if (r.success) {
         toast.success(`${label}${r.output ? `: ${r.output.slice(0, 80)}` : ''}`);
@@ -239,6 +259,7 @@ export function executeCommand(
   queryClient: QueryClient,
   navigate: NavigateFunction,
   toggle: boolean,
+  gitTarget: GitTarget,
 ) {
   const ui = useUIStore.getState();
 
@@ -261,9 +282,8 @@ export function executeCommand(
   } else if (cmd.id === 'create-branch') {
     ui.setCreateBranchDialogOpen(toggle ? !ui.createBranchDialogOpen : true);
   } else if (cmd.id === 'push-remote') {
-    const chat = getActiveChat(queryClient);
-    const sandboxId = chat?.sandbox_id;
-    executeGitRemoteCommand(chat, sandboxService.gitPush, 'Pushed to remote', () => {
+    const sandboxId = gitTarget.sandboxId;
+    executeGitRemoteCommand(gitTarget, sandboxService.gitPush, 'Pushed to remote', () => {
       if (sandboxId) {
         void queryClient.invalidateQueries({
           queryKey: queryKeys.sandbox.gitBranchesAll(sandboxId),
@@ -271,9 +291,8 @@ export function executeCommand(
       }
     });
   } else if (cmd.id === 'pull-remote') {
-    const chat = getActiveChat(queryClient);
-    const sandboxId = chat?.sandbox_id;
-    executeGitRemoteCommand(chat, sandboxService.gitPull, 'Pulled from remote', () => {
+    const sandboxId = gitTarget.sandboxId;
+    executeGitRemoteCommand(gitTarget, sandboxService.gitPull, 'Pulled from remote', () => {
       if (sandboxId) {
         void Promise.all([
           queryClient.invalidateQueries({
@@ -301,15 +320,14 @@ export function executeCommand(
     ui.setPendingMenuMode('files');
     ui.setCommandMenuOpen(true);
   } else if (cmd.id === 'switch-branch') {
-    const chat = getActiveChat(queryClient);
-    if (!chat?.sandbox_id) {
+    if (!gitTarget.sandboxId) {
       toast.error('No sandbox connected');
       return;
     }
     // Bail out only if we know the repo state and it's unavailable; if the cache is cold,
     // let the menu open and fall through to its loading/empty states.
     const cached = queryClient.getQueryData<GitBranchesData>(
-      queryKeys.sandbox.gitBranches(chat.sandbox_id, chat.worktree_cwd ?? undefined),
+      queryKeys.sandbox.gitBranches(gitTarget.sandboxId, gitTarget.worktreeCwd),
     );
     if (cached && (!cached.is_git_repo || cached.branches.length === 0)) {
       toast.error('No git branches available');

--- a/frontend/src/hooks/useCommandMenu.ts
+++ b/frontend/src/hooks/useCommandMenu.ts
@@ -3,7 +3,11 @@ import { useMountEffect } from '@/hooks/useMountEffect';
 import { useUIStore } from '@/store/uiStore';
 import { useChatStore } from '@/store/chatStore';
 import { useQueryClient } from '@tanstack/react-query';
-import { SHORTCUT_MAP, executeCommand } from '@/components/ui/commandRegistry';
+import {
+  SHORTCUT_MAP,
+  executeCommand,
+  resolveActiveGitTarget,
+} from '@/components/ui/commandRegistry';
 import { MOBILE_BREAKPOINT } from '@/config/constants';
 
 function isEmbeddedEditor(target: EventTarget | null): boolean {
@@ -36,9 +40,11 @@ export function useCommandMenu() {
 
       if (cmd.hideOnMobile && window.innerWidth < MOBILE_BREAKPOINT) return;
       if (cmd.requiresChat && !useChatStore.getState().currentChat) return;
+      const gitTarget = resolveActiveGitTarget(queryClient);
+      if (cmd.requiresSandbox && !gitTarget.sandboxId) return;
 
       e.preventDefault();
-      executeCommand(cmd, queryClient, navigate, true);
+      executeCommand(cmd, queryClient, navigate, true, gitTarget);
     };
 
     window.addEventListener('keydown', handleKeyDown, { capture: true });

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -190,6 +190,14 @@ export function LandingPage() {
     setSelectedFile(null);
   }, [selectedSandboxId, setSelectedFile]);
 
+  // Publish the selected workspace's sandbox so the context-less global git
+  // shortcuts resolve a target on landing; clear it on unmount so it can't leak
+  // into a later chat with no sandbox of its own.
+  useEffect(() => {
+    useUIStore.getState().setWorkspaceSandboxId(selectedSandboxId ?? null);
+    return () => useUIStore.getState().setWorkspaceSandboxId(null);
+  }, [selectedSandboxId]);
+
   useMountEffect(() => {
     useChatStore.getState().setCurrentChat(null);
     // Reset to the agent (workspace selector) view — a stale split layout from a prior chat

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -186,7 +186,7 @@ async function getChat(chatId: string): Promise<Chat> {
     const chat = ensureResponse(response, 'Failed to fetch chat');
     // Register a cloud chat's sandbox so its files/git/terminal route to the VPS
     // even on a cold deep-link, before the sidebar list has run.
-    if (isCloudChat(chatId) && chat.sandbox_id) {
+    if (isCloudChat(chatId)) {
       markCloudSandboxes([chat.sandbox_id]);
     }
     return chat;
@@ -203,7 +203,7 @@ async function createChat(data: CreateChatRequest): Promise<Chat> {
     const chat = ensureResponse(response, 'Failed to create chat');
     if (parentChatId && isCloudChat(parentChatId)) {
       markCloudChats([chat.id]);
-      if (chat.sandbox_id) markCloudSandboxes([chat.sandbox_id]);
+      markCloudSandboxes([chat.sandbox_id]);
     }
     return chat;
   });
@@ -308,9 +308,7 @@ async function getSubThreads(chatId: string): Promise<Chat[]> {
     // one routes its stream/files/terminal to the cloud, not local.
     if (isCloudChat(chatId)) {
       markCloudChats(subThreads.map((chat) => chat.id));
-      markCloudSandboxes(
-        subThreads.map((chat) => chat.sandbox_id).filter((id): id is string => !!id),
-      );
+      markCloudSandboxes(subThreads.map((chat) => chat.sandbox_id));
     }
     return subThreads;
   });

--- a/frontend/src/services/cloudChatService.ts
+++ b/frontend/src/services/cloudChatService.ts
@@ -50,9 +50,7 @@ async function listChats(params?: {
     const response = await remoteApiClient.get<PaginatedChats>(`/chat/chats${queryString}`);
     const data = ensureResponse(response, 'Failed to load cloud chats');
     markCloudChats(data.items.map((chat) => chat.id));
-    markCloudSandboxes(
-      data.items.map((chat) => chat.sandbox_id).filter((id): id is string => !!id),
-    );
+    markCloudSandboxes(data.items.map((chat) => chat.sandbox_id));
     return data;
   });
 }

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -68,6 +68,10 @@ type UIStoreState = ThemeState &
     consumeDiffFileJump: () => void;
     pendingChatMessage: { chatId: string; message: string } | null;
     setPendingChatMessage: (payload: { chatId: string; message: string } | null) => void;
+    // Sandbox of the workspace selected on the landing page. Lets context-less
+    // consumers (the global git shortcuts) resolve a target before a chat exists.
+    workspaceSandboxId: string | null;
+    setWorkspaceSandboxId: (sandboxId: string | null) => void;
   };
 
 const getInitialSidebarState = (): boolean => {
@@ -171,6 +175,9 @@ export const useUIStore = create<UIStoreState>()(
 
       pendingChatMessage: null,
       setPendingChatMessage: (payload) => set({ pendingChatMessage: payload }),
+
+      workspaceSandboxId: null,
+      setWorkspaceSandboxId: (sandboxId) => set({ workspaceSandboxId: sandboxId }),
 
       pendingFileOpen: null,
       pendingDiffFile: null,

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -57,7 +57,7 @@ export interface Chat {
   user_id: string;
   title: string;
   workspace_id: string;
-  sandbox_id: string | null;
+  sandbox_id: string;
   created_at: string;
   updated_at: string;
   context_token_usage?: number;


### PR DESCRIPTION
## Summary
- Global git shortcuts (switch branch / push / pull) now resolve their target sandbox from the active chat, or from the selected workspace on the landing page — previously they silently no-op'd without a chat
- Tightened `sandbox_id` from `str | None` to `str` across backend model/schema and frontend types, since a chat always has a sandbox