### PR TITLE
perf: cache sandbox providers; isolate copied-message re-renders

### DIFF
--- a/backend/app/api/endpoints/skills.py
+++ b/backend/app/api/endpoints/skills.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.core.deps import get_skill_service
@@ -15,7 +17,9 @@ async def list_skills(
     current_user: User = Depends(get_current_user),
     skill_service: SkillService = Depends(get_skill_service),
 ) -> list[CustomSkillDict]:
-    return skill_service.list_all()
+    # SkillService does blocking filesystem walks — offload so the event loop
+    # (including active streams) isn't stalled. Matches workspace.py.
+    return await asyncio.to_thread(skill_service.list_all)
 
 
 @router.get("/{source}/{skill_name}/files", response_model=SkillFilesResponse)
@@ -26,7 +30,7 @@ async def get_skill_files(
     skill_service: SkillService = Depends(get_skill_service),
 ) -> SkillFilesResponse:
     try:
-        files = skill_service.get_files(source, skill_name)
+        files = await asyncio.to_thread(skill_service.get_files, source, skill_name)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -42,7 +46,9 @@ async def update_skill(
     skill_service: SkillService = Depends(get_skill_service),
 ) -> CustomSkillDict:
     try:
-        return skill_service.update(source, skill_name, request.files)
+        return await asyncio.to_thread(
+            skill_service.update, source, skill_name, request.files
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except FileNotFoundError as exc:

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -33,6 +33,12 @@ from app.utils.cache import CacheError, cache_connection
 
 logger = logging.getLogger(__name__)
 
+# Providers cached for the process lifetime — creating one per request pays
+# aiodocker client setup plus a container-inspect round-trip before any real
+# work on every sandbox operation. Keyed by workspace path so host providers
+# with different roots don't collide.
+sandbox_provider_cache: dict[tuple[str, str | None], SandboxProvider] = {}
+
 
 def get_user_service() -> UserService:
     return UserService(session_factory=SessionLocal)
@@ -102,7 +108,7 @@ async def get_sandbox_service(
     user: User | None = Depends(optional_current_active_user),
     db: AsyncSession = Depends(get_db),
     user_service: UserService = Depends(get_user_service),
-) -> AsyncIterator[SandboxService]:
+) -> SandboxService:
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -132,20 +138,21 @@ async def get_sandbox_service(
             detail="Sandbox not found",
         )
 
-    provider = SandboxProvider.create_provider(
-        SandboxProviderType(row.sandbox_provider),
-        workspace_path=row.workspace_path,
-    )
+    cache_key = (row.sandbox_provider, row.workspace_path)
+    provider = sandbox_provider_cache.get(cache_key)
+    if provider is None:
+        provider = SandboxProvider.create_provider(
+            SandboxProviderType(row.sandbox_provider),
+            workspace_path=row.workspace_path,
+        )
+        sandbox_provider_cache[cache_key] = provider
 
     env_vars = SandboxService.build_env_vars(
         user_settings.custom_env_vars,
         user_settings.github_personal_access_token,
     )
 
-    try:
-        yield SandboxService(provider, env_vars=env_vars)
-    finally:
-        await provider.cleanup()
+    return SandboxService(provider, env_vars=env_vars)
 
 
 def get_git_service(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import tests.bootstrap
 from app.api.endpoints import auth as auth_endpoint
+from app.core import deps
 from app.core.config import get_settings
 from app.core.security import get_password_hash
 from app.db.base_class import Base
@@ -129,6 +130,15 @@ async def database() -> AsyncIterator[None]:
     yield
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.fixture(autouse=True)
+def clear_sandbox_provider_cache() -> Iterator[None]:
+    # Providers persist across requests in deps.sandbox_provider_cache — clear
+    # it per test so one test's monkeypatched fake isn't served to the next.
+    deps.sandbox_provider_cache.clear()
+    yield
+    deps.sandbox_provider_cache.clear()
 
 
 @pytest.fixture

--- a/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
+++ b/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChatSessionProvider } from '@/contexts/ChatSessionContext';
 import { ChatInputMessageProvider } from '@/contexts/ChatInputMessageContext';
+import { ChatCopiedMessageProvider } from '@/contexts/ChatCopiedMessageContext';
 import type { ChatSessionState, ChatSessionActions } from '@/contexts/ChatSessionContextDefinition';
 import { useChatStore } from '@/store/chatStore';
 import {
@@ -194,7 +195,6 @@ export function ChatSessionOrchestrator({
       isLoading,
       isStreaming,
       isInitialLoading: messagesQuery.isLoading || (hasFetchedMessages && messages.length === 0),
-      copiedMessageId: streamingState.copiedMessageId,
       pendingUserMessageId: streamingState.pendingUserMessageId,
       attachedFiles: streamingState.inputFiles,
       selectedModelId,
@@ -207,7 +207,6 @@ export function ChatSessionOrchestrator({
     }),
     [
       messages,
-      streamingState.copiedMessageId,
       streamingState.pendingUserMessageId,
       streamingState.inputFiles,
       isLoading,
@@ -249,12 +248,14 @@ export function ChatSessionOrchestrator({
 
   return (
     <ChatSessionProvider state={chatSessionState} actions={chatSessionActions}>
-      <ChatInputMessageProvider
-        inputMessage={streamingState.inputMessage}
-        setInputMessage={streamingState.setInputMessage}
-      >
-        {children}
-      </ChatInputMessageProvider>
+      <ChatCopiedMessageProvider copiedMessageId={streamingState.copiedMessageId}>
+        <ChatInputMessageProvider
+          inputMessage={streamingState.inputMessage}
+          setInputMessage={streamingState.setInputMessage}
+        >
+          {children}
+        </ChatInputMessageProvider>
+      </ChatCopiedMessageProvider>
     </ChatSessionProvider>
   );
 }

--- a/frontend/src/components/chat/message-bubble/MessageActions.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageActions.tsx
@@ -2,7 +2,8 @@ import { memo } from 'react';
 import { CheckCircle2, Copy } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { Tooltip } from '@/components/ui/Tooltip';
-import { useChatSessionState, useChatSessionActions } from '@/hooks/useChatSessionContext';
+import { useChatSessionActions } from '@/hooks/useChatSessionContext';
+import { useChatCopiedMessageContext } from '@/hooks/useChatCopiedMessageContext';
 
 interface MessageActionsProps {
   messageId: string;
@@ -17,7 +18,10 @@ export const MessageActions = memo(function MessageActions({
   copyLabel = 'Copy',
   showTooltip = true,
 }: MessageActionsProps) {
-  const { copiedMessageId } = useChatSessionState();
+  // Read from the dedicated context, not ChatSessionState — the session state
+  // object changes on every stream flush, which would re-render every visible
+  // message's action bar for the whole turn.
+  const { copiedMessageId } = useChatCopiedMessageContext();
   const { onCopy } = useChatSessionActions();
 
   const button = (

--- a/frontend/src/contexts/ChatCopiedMessageContext.tsx
+++ b/frontend/src/contexts/ChatCopiedMessageContext.tsx
@@ -1,0 +1,20 @@
+import { type ReactNode, useMemo } from 'react';
+import { ChatCopiedMessageContext } from './ChatCopiedMessageContextDefinition';
+
+interface ChatCopiedMessageProviderProps {
+  copiedMessageId: string | null;
+  children: ReactNode;
+}
+
+export function ChatCopiedMessageProvider({
+  copiedMessageId,
+  children,
+}: ChatCopiedMessageProviderProps) {
+  // Kept out of ChatSessionState so per-message action bars don't re-render
+  // on every stream flush — the session state object changes identity ~20x/sec
+  // while streaming, but copiedMessageId only changes on copy clicks.
+  const value = useMemo(() => ({ copiedMessageId }), [copiedMessageId]);
+  return (
+    <ChatCopiedMessageContext.Provider value={value}>{children}</ChatCopiedMessageContext.Provider>
+  );
+}

--- a/frontend/src/contexts/ChatCopiedMessageContextDefinition.ts
+++ b/frontend/src/contexts/ChatCopiedMessageContextDefinition.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+interface ChatCopiedMessageContextValue {
+  copiedMessageId: string | null;
+}
+
+export const ChatCopiedMessageContext = createContext<ChatCopiedMessageContextValue | null>(null);

--- a/frontend/src/contexts/ChatSessionContextDefinition.ts
+++ b/frontend/src/contexts/ChatSessionContextDefinition.ts
@@ -7,7 +7,6 @@ export interface ChatSessionState {
   isLoading: boolean;
   isStreaming: boolean;
   isInitialLoading: boolean;
-  copiedMessageId: string | null;
   pendingUserMessageId: string | null;
   attachedFiles: File[] | null;
   selectedModelId: string;

--- a/frontend/src/hooks/useChatCopiedMessageContext.ts
+++ b/frontend/src/hooks/useChatCopiedMessageContext.ts
@@ -1,0 +1,8 @@
+import { ChatCopiedMessageContext } from '@/contexts/ChatCopiedMessageContextDefinition';
+import { createContextHook } from '@/hooks/createContextHook';
+
+export const useChatCopiedMessageContext = createContextHook(
+  ChatCopiedMessageContext,
+  'useChatCopiedMessageContext',
+  'ChatCopiedMessageProvider',
+);


### PR DESCRIPTION
## Summary
- Cache `SandboxProvider` instances by `(provider type, workspace path)` for the process lifetime instead of creating/tearing one down per request — avoids paying aiodocker client setup and a container-inspect round-trip on every sandbox operation.
- Offload `SkillService`'s blocking filesystem walks to a thread via `asyncio.to_thread`, matching the existing pattern in `workspace.py`, so they don't stall the event loop.
- Move `copiedMessageId` out of `ChatSessionState` into a dedicated `ChatCopiedMessageContext`. The session state object changes identity on every stream flush (~20x/sec), which was re-rendering every visible message's action bar for the whole turn even though `copiedMessageId` only changes on copy clicks.