### PR TITLE
chore(deps): bump @pierre/diffs to 1.2.12 and @pierre/trees to beta.5

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
-        "@pierre/diffs": "^1.2.2",
-        "@pierre/trees": "^1.0.0-beta.3",
+        "@pierre/diffs": "^1.2.12",
+        "@pierre/trees": "^1.0.0-beta.5",
         "@tanstack/query-sync-storage-persister": "^5.101.2",
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-query-devtools": "^5.101.2",
@@ -661,17 +661,18 @@
       }
     },
     "node_modules/@pierre/diffs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.2.tgz",
-      "integrity": "sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.12.tgz",
+      "integrity": "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ==",
       "license": "apache-2.0",
       "dependencies": {
-        "@pierre/theme": "1.0.3",
-        "@shikijs/transformers": "^3.0.0",
-        "diff": "8.0.3",
+        "@pierre/theme": "1.1.0",
+        "@pierre/theming": "0.0.2",
+        "@shikijs/transformers": "^3.0.0 || ^4.0.0",
+        "diff": "9.0.0",
         "hast-util-to-html": "9.0.5",
         "lru_map": "0.4.1",
-        "shiki": "^3.0.0"
+        "shiki": "^3.0.0 || ^4.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.1 || ^19.0.0",
@@ -679,29 +680,60 @@
       }
     },
     "node_modules/@pierre/diffs/node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
     },
     "node_modules/@pierre/theme": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.0.3.tgz",
-      "integrity": "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.1.0.tgz",
+      "integrity": "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ==",
       "license": "MIT",
       "engines": {
         "vscode": "^1.0.0"
       }
     },
+    "node_modules/@pierre/theming": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@pierre/theming/-/theming-0.0.2.tgz",
+      "integrity": "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw==",
+      "license": "apache-2.0",
+      "peerDependencies": {
+        "@pierre/theme": "^1.1.0",
+        "@shikijs/themes": "^3.0.0 || ^4.0.0",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0",
+        "shiki": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@pierre/theme": {
+          "optional": true
+        },
+        "@shikijs/themes": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "shiki": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@pierre/trees": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@pierre/trees/-/trees-1.0.0-beta.3.tgz",
-      "integrity": "sha512-gfV7V1AoceIwTSFwiiWl/89gNtJROyo2dFeYYuAkT4F3AbE+ajCIGZEICBw1ygmVxVetF9Kq1Xpjz8BhXXZwTQ==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@pierre/trees/-/trees-1.0.0-beta.5.tgz",
+      "integrity": "sha512-IzxkB9qv6GLbeEXObhlAD205LfYHiLeRwJdnaIdX0f5keTZF4X9EfiuEQ3QiyxOxouVVmUX3rX7m6a8zNMo/wA==",
       "license": "apache-2.0",
       "dependencies": {
+        "@pierre/theming": "0.0.2",
         "preact": "11.0.0-beta.0",
         "preact-render-to-string": "6.6.5"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
-    "@pierre/diffs": "^1.2.2",
-    "@pierre/trees": "^1.0.0-beta.3",
+    "@pierre/diffs": "^1.2.12",
+    "@pierre/trees": "^1.0.0-beta.5",
     "@tanstack/query-sync-storage-persister": "^5.101.2",
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-query-devtools": "^5.101.2",

--- a/frontend/src/styles/generatePaletteCss.ts
+++ b/frontend/src/styles/generatePaletteCss.ts
@@ -66,45 +66,14 @@ const DIFF_OVERRIDES: Record<string, string> = {
   'bg-selection-number': 'surface-active',
 };
 
-// Add/delete tints are semantic, not per-palette: they mirror the success/error scale in
-// tailwind.config.js (light base → 600 step, dark base → 400 step), matching the +/- count
-// badges in DiffView. Only the diff's green/red rows are pulled onto our tokens so they stop
-// reading as Pierre's default theme; surfaces still come from DIFF_OVERRIDES.
-const DIFF_SEMANTIC_CHANNELS = {
-  light: { addition: hexToChannels('#16a34a'), deletion: hexToChannels('#dc2626') },
-  dark: { addition: hexToChannels('#4ade80'), deletion: hexToChannels('#f87171') },
-} as const;
-
-type DiffSemanticSide = keyof (typeof DIFF_SEMANTIC_CHANNELS)['light'];
-
-// Pierre var (sans `--diffs-`/`-override`) → [semantic side, alpha]. Rows and gutter cells get
-// a subtle tint; intra-line emphasis is stronger; number text and the accent marker are solid.
-const DIFF_SEMANTIC_OVERRIDES: Record<string, readonly [DiffSemanticSide, number]> = {
-  'bg-addition': ['addition', 0.15],
-  'bg-deletion': ['deletion', 0.15],
-  'bg-addition-emphasis': ['addition', 0.3],
-  'bg-deletion-emphasis': ['deletion', 0.3],
-  'bg-addition-number': ['addition', 0.15],
-  'bg-deletion-number': ['deletion', 0.15],
-  'fg-number-addition': ['addition', 1],
-  'fg-number-deletion': ['deletion', 1],
-  'addition-color': ['addition', 1],
-  'deletion-color': ['deletion', 1],
-};
-
 export function generateDiffPaletteCss(): string {
   const blocks = (Object.keys(PALETTES) as (keyof typeof PALETTES)[]).map((name) => {
     const dark = PALETTES[name].base === 'dark';
-    const channels = DIFF_SEMANTIC_CHANNELS[dark ? 'dark' : 'light'];
-    const surfaceLines = Object.entries(DIFF_OVERRIDES).map(([diffVar, token]) => {
+    const lines = Object.entries(DIFF_OVERRIDES).map(([diffVar, token]) => {
       const ref = dark ? toDarkVar(token) : token;
       return `  --diffs-${diffVar}-override: rgb(var(--${ref}) / 1);`;
     });
-    const semanticLines = Object.entries(DIFF_SEMANTIC_OVERRIDES).map(
-      ([diffVar, [side, alpha]]) =>
-        `  --diffs-${diffVar}-override: rgb(${channels[side]} / ${alpha});`,
-    );
-    return `:root[data-palette='${name}'] {\n${[...surfaceLines, ...semanticLines].join('\n')}\n}`;
+    return `:root[data-palette='${name}'] {\n${lines.join('\n')}\n}`;
   });
   return `${blocks.join('\n\n')}\n`;
 }

--- a/frontend/src/styles/generatePaletteCss.ts
+++ b/frontend/src/styles/generatePaletteCss.ts
@@ -66,14 +66,45 @@ const DIFF_OVERRIDES: Record<string, string> = {
   'bg-selection-number': 'surface-active',
 };
 
+// Add/delete tints are semantic, not per-palette: they mirror the success/error scale in
+// tailwind.config.js (light base → 600 step, dark base → 400 step), matching the +/- count
+// badges in DiffView. Only the diff's green/red rows are pulled onto our tokens so they stop
+// reading as Pierre's default theme; surfaces still come from DIFF_OVERRIDES.
+const DIFF_SEMANTIC_CHANNELS = {
+  light: { addition: hexToChannels('#16a34a'), deletion: hexToChannels('#dc2626') },
+  dark: { addition: hexToChannels('#4ade80'), deletion: hexToChannels('#f87171') },
+} as const;
+
+type DiffSemanticSide = keyof (typeof DIFF_SEMANTIC_CHANNELS)['light'];
+
+// Pierre var (sans `--diffs-`/`-override`) → [semantic side, alpha]. Rows and gutter cells get
+// a subtle tint; intra-line emphasis is stronger; number text and the accent marker are solid.
+const DIFF_SEMANTIC_OVERRIDES: Record<string, readonly [DiffSemanticSide, number]> = {
+  'bg-addition': ['addition', 0.15],
+  'bg-deletion': ['deletion', 0.15],
+  'bg-addition-emphasis': ['addition', 0.3],
+  'bg-deletion-emphasis': ['deletion', 0.3],
+  'bg-addition-number': ['addition', 0.15],
+  'bg-deletion-number': ['deletion', 0.15],
+  'fg-number-addition': ['addition', 1],
+  'fg-number-deletion': ['deletion', 1],
+  'addition-color': ['addition', 1],
+  'deletion-color': ['deletion', 1],
+};
+
 export function generateDiffPaletteCss(): string {
   const blocks = (Object.keys(PALETTES) as (keyof typeof PALETTES)[]).map((name) => {
     const dark = PALETTES[name].base === 'dark';
-    const lines = Object.entries(DIFF_OVERRIDES).map(([diffVar, token]) => {
+    const channels = DIFF_SEMANTIC_CHANNELS[dark ? 'dark' : 'light'];
+    const surfaceLines = Object.entries(DIFF_OVERRIDES).map(([diffVar, token]) => {
       const ref = dark ? toDarkVar(token) : token;
       return `  --diffs-${diffVar}-override: rgb(var(--${ref}) / 1);`;
     });
-    return `:root[data-palette='${name}'] {\n${lines.join('\n')}\n}`;
+    const semanticLines = Object.entries(DIFF_SEMANTIC_OVERRIDES).map(
+      ([diffVar, [side, alpha]]) =>
+        `  --diffs-${diffVar}-override: rgb(${channels[side]} / ${alpha});`,
+    );
+    return `:root[data-palette='${name}'] {\n${[...surfaceLines, ...semanticLines].join('\n')}\n}`;
   });
   return `${blocks.join('\n\n')}\n`;
 }


### PR DESCRIPTION
## Summary

Bumps the Pierre diff/tree libraries used by the git diff view and file tree:

- `@pierre/diffs` **1.2.2 → 1.2.12**
- `@pierre/trees` **1.0.0-beta.3 → 1.0.0-beta.5**

### Why

The 1.2.x releases fix several bugs on code paths our diff view exercises:

- **Quoted git diff headers** (#736) — we feed raw `git diff` output into `parsePatchFiles`; paths with spaces/unicode get quoted headers.
- **CodeView hunk expansion bugs** (#758) — we rely on click-to-expand hunks.
- **`WorkerPool.setRenderOptions` partial fix** + **virtualized-scroll keyboard focus** (#770, #771) — we use the worker pool and `Virtualizer`.
- **Unified diffs with SQL comments** (#796) — unified is our default style.
- Sticky layout, merge-conflict actions, and line-number focus fixes.

`@pierre/trees` beta.5 is a stability/refactor bump (rename, drag-drop, mutation events); we only render a read-only tree, so it's low-risk.

### Compatibility

- Public export surface is **unchanged** — no imports we use were removed or renamed.
- Adds transitive `@pierre/theming`; `@pierre/theme` bumps 1.0.3 → 1.1.0. Shiki stays on v3.
- No application source changes needed.

### Verification

- `tsc --noEmit` passes clean against the new versions.
- Deliberately skipped the 1.3.0 betas — the only new capability is an in-diff text editor we don't use.

> Note: these are runtime-rendering fixes that types can't catch — worth a quick manual smoke of the diff view (expand/collapse hunks, split vs unified, discard) before merge.