### PR TITLE
Remove open-in-editor button from codex SearchTool

### DIFF
--- a/frontend/src/components/chat/tools/codex/SearchTool.tsx
+++ b/frontend/src/components/chat/tools/codex/SearchTool.tsx
@@ -4,7 +4,6 @@ import type { ToolAggregate } from '@/types/tools.types';
 import { extractFilename } from '@/utils/format';
 import { ToolCard } from '../common/ToolCard';
 import { SearchLoadingDots } from '../common/SearchLoadingDots';
-import { OpenInEditorButton } from '../common/OpenInEditorButton';
 import {
   type ShellLikeInput,
   type ShellLikeOutput,
@@ -61,7 +60,6 @@ const SearchToolInner: React.FC<{ tool: ToolAggregate }> = ({ tool }) => {
         <SearchLoadingDots label="Searching files" />
       }
       error={tool.error}
-      actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
     >
       {(filePath || command || output) && (
         <div className="space-y-1.5">


### PR DESCRIPTION
## Summary
- Removed the "Open in Editor" action from the codex `SearchTool` card since search results don't resolve to a single file to jump to.