### PR TITLE
Add editor go-to-definition/references and compact message trail

### DIFF
--- a/frontend/src/components/chat/chat-window/MessageTrail.tsx
+++ b/frontend/src/components/chat/chat-window/MessageTrail.tsx
@@ -5,6 +5,10 @@ import type { Message } from '@/types/chat.types';
 
 // Cap preview text so a huge message doesn't dump megabytes into the DOM
 const PREVIEW_MAX_CHARS = 200;
+const TICK_SPACING_PX = 12;
+// Width of the centered message column (lg:max-w-4xl = 56rem)
+const MESSAGE_COLUMN_MAX_PX = 896;
+const MIN_GUTTER_PX = 40;
 const ACTIVE_VIEWPORT_FRACTION = 0.4;
 
 interface TrailTurn {
@@ -45,10 +49,19 @@ export const MessageTrail = memo(function MessageTrail({
   }, [messages]);
 
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [isCompact, setIsCompact] = useState(false);
 
   useEffect(() => {
     const scroller = scrollerRef.current;
     if (!scroller || turns.length === 0) return;
+
+    // Compact by the pane's actual left gutter, not a viewport breakpoint — open
+    // sidebars narrow the pane until the message column reaches the edge; the
+    // slimmer rail fits within the column's edge padding without covering text.
+    const resizeObserver = new ResizeObserver(() => {
+      setIsCompact((scroller.clientWidth - MESSAGE_COLUMN_MAX_PX) / 2 < MIN_GUTTER_PX);
+    });
+    resizeObserver.observe(scroller);
 
     const updateActive = () => {
       // Active turn = last user message whose top has crossed the upper part of
@@ -78,6 +91,7 @@ export const MessageTrail = memo(function MessageTrail({
     scroller.addEventListener('scroll', onScroll, { passive: true });
     return () => {
       scroller.removeEventListener('scroll', onScroll);
+      resizeObserver.disconnect();
       if (frame) cancelAnimationFrame(frame);
     };
   }, [scrollerRef, turns]);
@@ -97,42 +111,50 @@ export const MessageTrail = memo(function MessageTrail({
   if (turns.length < 2) return null;
 
   return (
-    <div className="pointer-events-none absolute bottom-6 left-0 top-6 z-10 hidden lg:block">
-      {turns.map((turn, index) => (
-        <div
-          key={turn.id}
-          // Proportional placement instead of a stacked column: long chats densify
-          // the trail rather than clipping ticks past the overflow-hidden viewport.
-          style={{ top: `${(index / (turns.length - 1)) * 100}%` }}
-          className="group pointer-events-auto absolute left-0 flex -translate-y-1/2 items-center"
-        >
-          <Button
-            variant="unstyled"
-            onClick={() => scrollToTurn(turn.id)}
-            aria-label={`Jump to message: ${turn.userText.slice(0, 60)}`}
-            className="flex h-2.5 items-center px-2"
+    <div className="pointer-events-none absolute inset-y-6 left-0 z-10 hidden flex-col justify-center lg:flex">
+      {/* Rail height caps at preferred spacing so short chats stay a compact cluster,
+          while long chats distribute ticks proportionally without clipping */}
+      <div
+        className="relative"
+        style={{ height: `min(100%, ${turns.length * TICK_SPACING_PX}px)` }}
+      >
+        {turns.map((turn, index) => (
+          <div
+            key={turn.id}
+            style={{ top: `${(index / (turns.length - 1)) * 100}%` }}
+            className="group pointer-events-auto absolute left-0 flex -translate-y-1/2 items-center"
           >
-            <span
-              className={cn(
-                'h-0.5 rounded-full transition-all duration-200',
-                turn.id === activeId
-                  ? 'w-4 bg-text-primary dark:bg-text-dark-primary'
-                  : 'w-2.5 bg-text-quaternary/50 group-hover:w-3.5 group-hover:bg-text-tertiary dark:bg-text-dark-quaternary/50 dark:group-hover:bg-text-dark-tertiary',
-              )}
-            />
-          </Button>
-          <div className="pointer-events-none invisible absolute left-full top-1/2 z-20 w-72 -translate-y-1/2 rounded-xl border border-border/50 bg-surface/95 px-3 py-2 opacity-0 shadow-medium backdrop-blur-xl transition-opacity duration-200 group-hover:visible group-hover:opacity-100 dark:border-border-dark/50 dark:bg-surface-dark/95">
-            <p className="line-clamp-1 text-xs font-medium text-text-primary dark:text-text-dark-primary">
-              {turn.userText}
-            </p>
-            {turn.assistantText && (
-              <p className="mt-1 line-clamp-3 text-xs text-text-secondary dark:text-text-dark-secondary">
-                {turn.assistantText}
+            <Button
+              variant="unstyled"
+              onClick={() => scrollToTurn(turn.id)}
+              aria-label={`Jump to message: ${turn.userText.slice(0, 60)}`}
+              className={cn('flex h-2.5 items-center', isCompact ? 'px-1' : 'px-2')}
+            >
+              <span
+                className={cn(
+                  'h-0.5 rounded-full transition-all duration-200',
+                  turn.id === activeId
+                    ? cn('bg-text-primary dark:bg-text-dark-primary', isCompact ? 'w-2.5' : 'w-4')
+                    : cn(
+                        'bg-text-quaternary/50 group-hover:bg-text-tertiary dark:bg-text-dark-quaternary/50 dark:group-hover:bg-text-dark-tertiary',
+                        isCompact ? 'w-1.5 group-hover:w-2' : 'w-2.5 group-hover:w-3.5',
+                      ),
+                )}
+              />
+            </Button>
+            <div className="pointer-events-none invisible absolute left-full top-1/2 z-20 w-72 -translate-y-1/2 rounded-xl border border-border/50 bg-surface/95 px-3 py-2 opacity-0 shadow-medium backdrop-blur-xl transition-opacity duration-200 group-hover:visible group-hover:opacity-100 dark:border-border-dark/50 dark:bg-surface-dark/95">
+              <p className="line-clamp-1 text-xs font-medium text-text-primary dark:text-text-dark-primary">
+                {turn.userText}
               </p>
-            )}
+              {turn.assistantText && (
+                <p className="mt-1 line-clamp-3 text-xs text-text-secondary dark:text-text-dark-secondary">
+                  {turn.assistantText}
+                </p>
+              )}
+            </div>
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 });

--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -183,6 +183,8 @@ export const CodeView = memo(function CodeView({
             selectedFile={selectedFile}
             fileStructure={files}
             sandboxId={sandboxId}
+            chatId={chatId}
+            cwd={cwd}
             onToggleFileTree={() => setShowMobileTree(true)}
             isSandboxSyncing={isSandboxSyncing}
             targetLine={targetLine}
@@ -233,6 +235,8 @@ export const CodeView = memo(function CodeView({
               selectedFile={selectedFile}
               fileStructure={files}
               sandboxId={sandboxId}
+              chatId={chatId}
+              cwd={cwd}
               onToggleFileTree={handleToggleFileTree}
               isFileTreeCollapsed={isFileTreeCollapsed}
               isSandboxSyncing={isSandboxSyncing}

--- a/frontend/src/components/editor/editor-view/Content.tsx
+++ b/frontend/src/components/editor/editor-view/Content.tsx
@@ -36,6 +36,9 @@ const EDITOR_OPTIONS = {
     indentation: false,
   },
   renderLineHighlightOnlyWhenFocus: true,
+  // On by default since monaco 0.44; the peek preview inherits it and burns
+  // rows on pinned ancestor scopes in an already-small viewport.
+  stickyScroll: { enabled: false },
   cursorBlinking: 'smooth',
   cursorSmoothCaretAnimation: 'on',
   smoothScrolling: true,

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -7,6 +7,8 @@ import { EditorTabs } from './EditorTabs';
 import { FilePreview } from '../file-preview/FilePreview';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useEditorTheme } from '@/hooks/useEditorTheme';
+import { attachEditorNavigationContext, setupEditorNavigation } from '@/lib/editorNavigation';
+import type { EditorNavigationContext } from '@/lib/editorNavigation';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { useEditorDrafts } from '@/hooks/useEditorDrafts';
 import type { FileStructure } from '@/types/file-system.types';
@@ -19,6 +21,8 @@ export interface ViewProps {
   selectedFile: FileStructure | null;
   fileStructure?: FileStructure[];
   sandboxId?: string;
+  chatId: string | undefined;
+  cwd?: string;
   onToggleFileTree?: () => void;
   isFileTreeCollapsed?: boolean;
   isSandboxSyncing?: boolean;
@@ -32,6 +36,8 @@ export const View = memo(function View({
   selectedFile,
   fileStructure = [],
   sandboxId,
+  chatId,
+  cwd,
   onToggleFileTree,
   isFileTreeCollapsed,
   isSandboxSyncing = false,
@@ -53,6 +59,13 @@ export const View = memo(function View({
     editorRef.current = null;
     if (mountedEditorPath !== null) setMountedEditorPath(null);
   }
+
+  // Mutated in place each render: the navigation claim holds this same object,
+  // so chat/cwd prop changes apply to an already-mounted editor without remount.
+  const navigationContext = useRef<EditorNavigationContext>({ sandboxId, chatId, cwd });
+  navigationContext.current.sandboxId = sandboxId;
+  navigationContext.current.chatId = chatId;
+  navigationContext.current.cwd = cwd;
 
   const { currentTheme, setupEditorTheme } = useEditorTheme();
   const updateFileMutation = useUpdateFileMutation();
@@ -149,6 +162,10 @@ export const View = memo(function View({
 
       editorRef.current = editor;
       setupEditorTheme(monaco);
+      setupEditorNavigation(monaco);
+      // A sandbox-less context is inert (contextForResource rejects it), so
+      // attaching unconditionally is safe and picks up a late-arriving sandbox.
+      attachEditorNavigationContext(editor, navigationContext.current);
       setMountedEditorPath(selectedFilePath);
     },
     [selectedFilePath, setupEditorTheme],
@@ -313,7 +330,9 @@ export const View = memo(function View({
                 key={selectedFile.path}
                 content={displayContent}
                 language={language}
-                modelPath={`/${sandboxId ?? 'workspace'}/${selectedFile.path}`}
+                // The sandbox rides in the URI authority so uri.path stays the clean
+                // workspace path — peek widgets label results straight from uri.path.
+                modelPath={`sandbox://${sandboxId ?? 'workspace'}/${selectedFile.path}`}
                 // Lock edits while a save is in flight so the in-flight buffer can't
                 // diverge from what was submitted — the success handler then clears the
                 // draft unconditionally without risking newer keystrokes.

--- a/frontend/src/hooks/useEditorTheme.ts
+++ b/frontend/src/hooks/useEditorTheme.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { useUIStore } from '@/store/uiStore';
-import type { CustomPalette } from '@/utils/theme';
+import type { CustomPalette, PaletteTokens } from '@/utils/theme';
 import { CUSTOM_PALETTE_TOKENS, DARK_PALETTES } from '@/utils/theme';
 import type { Palette } from '@/types/ui.types';
 import type * as monaco from 'monaco-editor';
@@ -40,6 +40,30 @@ const LIGHT_THEME: monaco.editor.IStandaloneThemeData = {
     'editorIndentGuide.activeBackground': '#00000000',
     'scrollbar.shadow': '#00000000',
     'editorOverviewRuler.border': '#00000000',
+    // Monochrome go-to-definition affordances: ctrl+hover link + peek widget.
+    'editorLink.activeForeground': '#24292E',
+    'peekView.border': '#E5E5E5',
+    'peekViewEditor.background': '#FFFFFF',
+    'peekViewEditor.matchHighlightBackground': '#E8E8E8',
+    'peekViewResult.background': '#FFFFFF',
+    'peekViewResult.matchHighlightBackground': '#F0F0F0',
+    'peekViewResult.selectionBackground': '#F0F0F0',
+    'peekViewResult.selectionForeground': '#24292E',
+    'peekViewResult.fileForeground': '#24292E',
+    'peekViewResult.lineForeground': '#8B949E',
+    'peekViewTitle.background': '#FFFFFF',
+    'peekViewTitleLabel.foreground': '#24292E',
+    'peekViewTitleDescription.foreground': '#8B949E',
+    // The peek results tree is a generic Monaco list; kill the blue focus
+    // outline and badge so selection stays monochrome.
+    'list.focusOutline': '#00000000',
+    'list.focusBackground': '#F0F0F0',
+    'list.activeSelectionBackground': '#F0F0F0',
+    'list.activeSelectionForeground': '#24292E',
+    'list.inactiveSelectionBackground': '#F0F0F0',
+    'list.hoverBackground': '#F5F5F5',
+    'badge.background': '#E8E8E8',
+    'badge.foreground': '#5A5A5A',
   },
 };
 
@@ -77,6 +101,30 @@ const DARK_THEME: monaco.editor.IStandaloneThemeData = {
     'editorIndentGuide.activeBackground': '#00000000',
     'scrollbar.shadow': '#00000000',
     'editorOverviewRuler.border': '#00000000',
+    // Monochrome go-to-definition affordances: ctrl+hover link + peek widget.
+    'editorLink.activeForeground': '#C8C8C8',
+    'peekView.border': '#2A2A2A',
+    'peekViewEditor.background': '#1A1A1A',
+    'peekViewEditor.matchHighlightBackground': '#2A2A2A',
+    'peekViewResult.background': '#1A1A1A',
+    'peekViewResult.matchHighlightBackground': '#333333',
+    'peekViewResult.selectionBackground': '#252525',
+    'peekViewResult.selectionForeground': '#C8C8C8',
+    'peekViewResult.fileForeground': '#B0B0B0',
+    'peekViewResult.lineForeground': '#555555',
+    'peekViewTitle.background': '#1A1A1A',
+    'peekViewTitleLabel.foreground': '#B0B0B0',
+    'peekViewTitleDescription.foreground': '#555555',
+    // The peek results tree is a generic Monaco list; kill the blue focus
+    // outline and badge so selection stays monochrome.
+    'list.focusOutline': '#00000000',
+    'list.focusBackground': '#252525',
+    'list.activeSelectionBackground': '#252525',
+    'list.activeSelectionForeground': '#C8C8C8',
+    'list.inactiveSelectionBackground': '#252525',
+    'list.hoverBackground': '#202020',
+    'badge.background': '#2A2A2A',
+    'badge.foreground': '#A0A0A0',
   },
 };
 
@@ -85,9 +133,10 @@ const DARK_THEME: monaco.editor.IStandaloneThemeData = {
 // surface = editor.background; widget = suggest/widget popup background.
 function skin(
   base: monaco.editor.IStandaloneThemeData,
-  surface: string,
-  widget: string,
+  tokens: PaletteTokens,
 ): monaco.editor.IStandaloneThemeData {
+  const surface = tokens.surfaceSecondary;
+  const widget = tokens.surface;
   return {
     ...base,
     rules: base.rules.map((r) => (r.token === '' ? { ...r, background: surface } : r)),
@@ -96,6 +145,20 @@ function skin(
       'editor.background': surface,
       'editorSuggestWidget.background': widget,
       'editorWidget.background': widget,
+      'peekViewEditor.background': surface,
+      'peekViewResult.background': widget,
+      'peekViewTitle.background': widget,
+      // Selection/hover/badge must track the palette too — the base theme's
+      // grays read inverted against re-skinned surfaces.
+      'peekViewResult.selectionBackground': tokens.surfaceTertiary,
+      'peekViewResult.selectionForeground': tokens.textPrimary,
+      'list.focusBackground': tokens.surfaceTertiary,
+      'list.activeSelectionBackground': tokens.surfaceTertiary,
+      'list.activeSelectionForeground': tokens.textPrimary,
+      'list.inactiveSelectionBackground': tokens.surfaceTertiary,
+      'list.hoverBackground': tokens.surfaceTertiary,
+      'badge.background': tokens.surfaceTertiary,
+      'badge.foreground': tokens.textSecondary,
     },
   };
 }
@@ -105,7 +168,7 @@ const CUSTOM_THEMES = Object.fromEntries(
   (Object.keys(CUSTOM_PALETTE_TOKENS) as CustomPalette[]).map((p) => {
     const tokens = CUSTOM_PALETTE_TOKENS[p];
     const base = DARK_PALETTES.has(p) ? DARK_THEME : LIGHT_THEME;
-    return [p, skin(base, tokens.surfaceSecondary, tokens.surface)];
+    return [p, skin(base, tokens)];
   }),
 ) as Record<CustomPalette, monaco.editor.IStandaloneThemeData>;
 

--- a/frontend/src/lib/editorNavigation.ts
+++ b/frontend/src/lib/editorNavigation.ts
@@ -1,0 +1,200 @@
+import type * as monacoNs from 'monaco-editor';
+import { queryKeys } from '@/hooks/queries/queryKeys';
+import { queryClient } from '@/lib/queryClient';
+import { sandboxService } from '@/services/sandboxService';
+import { useUIStore } from '@/store/uiStore';
+import type { SearchFileResult, SearchParams } from '@/types/sandbox.types';
+import {
+  buildDefinitionSearch,
+  escapeSymbolForRegex,
+  searchIncludeForLanguage,
+} from '@/utils/definitionPatterns';
+import { detectLanguage } from '@/utils/file';
+
+type Monaco = typeof import('monaco-editor');
+
+export interface EditorNavigationContext {
+  // The owning pane mutates these fields in place on prop changes (chat swap,
+  // worktree cwd) — the claim holds the object, not a snapshot, so listeners
+  // attached at mount keep routing with current values without remounting.
+  sandboxId: string | undefined;
+  chatId: string | undefined;
+  // Worktree chats operate in a subdirectory; searches must be scoped to it so
+  // results don't leak from the base checkout or sibling worktrees.
+  cwd: string | undefined;
+}
+
+// Peek previews resolve models by URI, so every result file needs a live model;
+// cap how many files get hydrated per lookup to bound fetches and memory.
+const MAX_RESULT_FILES = 30;
+
+// Chats in one workspace share a sandbox, so sandbox alone can't route a jump —
+// the pane the user is interacting with claims the context via editor listeners.
+let activeContext: EditorNavigationContext | null = null;
+
+let installed = false;
+
+export function attachEditorNavigationContext(
+  editor: monacoNs.editor.IStandaloneCodeEditor,
+  context: EditorNavigationContext,
+): void {
+  // Mouse-move claims cover ctrl+hover in a not-yet-focused split pane; the
+  // focus listener covers keyboard-invoked navigation (F12). Listeners are
+  // disposed with the editor, and the next interacted pane overwrites the claim.
+  activeContext = context;
+  editor.onDidFocusEditorText(() => {
+    activeContext = context;
+  });
+  editor.onMouseMove(() => {
+    if (activeContext !== context) activeContext = context;
+  });
+}
+
+function contextForResource(
+  uri: monacoNs.Uri,
+): { sandboxId: string; chatId: string | undefined; cwd: string | undefined } | null {
+  // Editor models are `sandbox://{sandboxId}/{workspace-relative path}` (View.tsx).
+  // A mismatch means the model belongs to a pane that never claimed a context
+  // (diff views, the chat-less 'workspace' placeholder) — not navigable.
+  // Snapshot the fields: the claimed object mutates as pane props change.
+  if (!activeContext) return null;
+  const { sandboxId, chatId, cwd } = activeContext;
+  if (!sandboxId || uri.scheme !== 'sandbox' || uri.authority !== sandboxId) return null;
+  return { sandboxId, chatId, cwd };
+}
+
+async function searchQuietly(
+  sandboxId: string,
+  params: SearchParams,
+): Promise<SearchFileResult[] | null> {
+  // A toast per failed hover/jump would be noisy; on error Monaco just shows
+  // its own "no definition found" affordance.
+  try {
+    const response = await sandboxService.searchInFiles(sandboxId, params);
+    return response.results;
+  } catch (err) {
+    console.error('Symbol search failed', err);
+    return null;
+  }
+}
+
+async function ensureModel(
+  m: Monaco,
+  sandboxId: string,
+  filePath: string,
+): Promise<monacoNs.editor.ITextModel | null> {
+  // Hydrate missing models through the file-content query so the cache is
+  // already warm when the user actually opens the target file.
+  const uri = m.Uri.parse(`sandbox://${sandboxId}/${filePath}`);
+  const existing = m.editor.getModel(uri);
+  if (existing) return existing;
+  try {
+    const data = await queryClient.fetchQuery({
+      queryKey: queryKeys.sandbox.fileContent(sandboxId, filePath),
+      queryFn: () => sandboxService.getFileContent(sandboxId, filePath),
+    });
+    if (data.is_binary) return null;
+    // Re-check after the await: a concurrent lookup may have created it first.
+    return (
+      m.editor.getModel(uri) ?? m.editor.createModel(data.content, detectLanguage(filePath), uri)
+    );
+  } catch (err) {
+    console.error('Failed to load file for navigation', err);
+    return null;
+  }
+}
+
+async function resolveLocations(
+  m: Monaco,
+  sandboxId: string,
+  symbol: string,
+  files: SearchFileResult[],
+  token: monacoNs.CancellationToken,
+): Promise<monacoNs.languages.Location[]> {
+  const capped = files.slice(0, MAX_RESULT_FILES);
+  const models = await Promise.all(capped.map((f) => ensureModel(m, sandboxId, f.path)));
+  if (token.isCancellationRequested) return [];
+  const wordPattern = new RegExp(`\\b${escapeSymbolForRegex(symbol)}\\b`);
+  const locations: monacoNs.languages.Location[] = [];
+  capped.forEach((file, i) => {
+    const model = models[i];
+    if (!model) return;
+    for (const match of file.matches) {
+      // The model can be shorter than the on-disk hit (stale hydration, drafts).
+      if (match.line_number > model.getLineCount()) continue;
+      // Backend line_text is lstripped/windowed for the search sidebar, so its
+      // offsets aren't real columns — locate the symbol in the live model line.
+      const column = model.getLineContent(match.line_number).search(wordPattern);
+      locations.push({
+        uri: model.uri,
+        range: {
+          startLineNumber: match.line_number,
+          startColumn: column >= 0 ? column + 1 : 1,
+          endLineNumber: match.line_number,
+          endColumn: column >= 0 ? column + 1 + symbol.length : 1,
+        },
+      });
+    }
+  });
+  return locations;
+}
+
+export function setupEditorNavigation(m: Monaco): void {
+  // Providers are Monaco-global while the editor remounts per file, so install
+  // once and resolve per-call context from the claiming pane + model URI.
+  if (installed) return;
+  installed = true;
+
+  // Monaco calls this when a jump targets a resource the current editor isn't
+  // showing (single cross-file definition, or picking an entry in a peek).
+  m.editor.registerEditorOpener({
+    openCodeEditor: (_source, resource, selectionOrPosition) => {
+      const context = contextForResource(resource);
+      if (!context) return false;
+      let line: number | undefined;
+      if (selectionOrPosition) {
+        line =
+          'startLineNumber' in selectionOrPosition
+            ? selectionOrPosition.startLineNumber
+            : selectionOrPosition.lineNumber;
+      }
+      useUIStore.getState().openFileInEditor(resource.path.slice(1), context.chatId, line);
+      return true;
+    },
+  });
+
+  m.languages.registerDefinitionProvider('*', {
+    provideDefinition: async (model, position, token) => {
+      const context = contextForResource(model.uri);
+      const word = model.getWordAtPosition(position);
+      if (!context || !word) return null;
+      const search = buildDefinitionSearch(model.getLanguageId(), word.word);
+      const files = await searchQuietly(context.sandboxId, {
+        query: search.pattern,
+        cwd: context.cwd,
+        regex: true,
+        caseSensitive: true,
+        include: search.include,
+      });
+      if (!files || token.isCancellationRequested) return null;
+      return resolveLocations(m, context.sandboxId, word.word, files, token);
+    },
+  });
+
+  m.languages.registerReferenceProvider('*', {
+    provideReferences: async (model, position, _context, token) => {
+      const context = contextForResource(model.uri);
+      const word = model.getWordAtPosition(position);
+      if (!context || !word) return null;
+      const files = await searchQuietly(context.sandboxId, {
+        query: word.word,
+        cwd: context.cwd,
+        wholeWord: true,
+        caseSensitive: true,
+        include: searchIncludeForLanguage(model.getLanguageId()),
+      });
+      if (!files || token.isCancellationRequested) return null;
+      return resolveLocations(m, context.sandboxId, word.word, files, token);
+    },
+  });
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -237,3 +237,19 @@ body {
 .mermaid-container svg .nodeLabel {
   font-size: 10px !important;
 }
+
+/* Monaco peek widget (go-to-definition / references): monaco's CSS sets no
+   font-size on the results tree, so it inherits the page's 16px root font while
+   the editor renders at 12px. Pin the widget chrome to the editor scale and pad
+   labels away from the fixed-width twistie chevron. */
+.monaco-editor .peekview-widget .head .peekview-title {
+  font-size: 12px;
+}
+
+.monaco-editor .reference-zone-widget .ref-tree {
+  font-size: 12px;
+}
+
+.monaco-editor .reference-zone-widget .ref-tree .monaco-tl-contents {
+  padding-left: 3px;
+}

--- a/frontend/src/utils/definitionPatterns.ts
+++ b/frontend/src/utils/definitionPatterns.ts
@@ -1,0 +1,80 @@
+// Grep-based go-to-definition: per-language regex templates that match only
+// definition sites of a symbol, never call sites. The backend runs them through
+// ripgrep (Rust regex — no lookarounds), so alternatives anchor with \b instead.
+
+const SYMBOL = '__SYMBOL__';
+
+const REGEX_SPECIALS = /[.*+?^${}()|[\]\\]/g;
+
+interface LanguageQuery {
+  patterns: string[];
+  // Restricts the search to the language's file family so definition keywords
+  // appearing in docs or other languages don't produce junk hits.
+  include?: string;
+}
+
+const JS_QUERY: LanguageQuery = {
+  patterns: [
+    `\\b(?:function\\s*\\*?|class|interface|type|enum|namespace|const|let|var)\\s+${SYMBOL}\\b`,
+    // Object/interface members and arrow-function properties: `foo: (` / `foo = async (`
+    `\\b${SYMBOL}\\s*[:=]\\s*(?:async\\s*)?(?:function\\b|\\()`,
+  ],
+  include: '*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}',
+};
+
+const LANGUAGE_QUERIES: Record<string, LanguageQuery> = {
+  typescript: JS_QUERY,
+  javascript: JS_QUERY,
+  python: {
+    // `^SYMBOL [:=]` catches module-level constants without drowning in locals.
+    patterns: [`\\b(?:def|class)\\s+${SYMBOL}\\b`, `^${SYMBOL}\\s*[:=]`],
+    include: '*.py',
+  },
+  go: {
+    patterns: [
+      // `[` needs escaping — ripgrep's Rust regex nests character classes.
+      `\\bfunc\\s+(?:\\([^)]*\\)\\s*)?${SYMBOL}\\s*[(\\[]`,
+      `\\b(?:type|var|const)\\s+${SYMBOL}\\b`,
+    ],
+    include: '*.go',
+  },
+  rust: {
+    patterns: [
+      `\\b(?:fn|struct|enum|trait|mod|union|type|const|static)\\s+${SYMBOL}\\b`,
+      `\\blet\\s+(?:mut\\s+)?${SYMBOL}\\b`,
+    ],
+    include: '*.rs',
+  },
+  ruby: {
+    patterns: [`\\b(?:def|class|module)\\s+(?:self\\.)?${SYMBOL}\\b`],
+    include: '*.rb',
+  },
+};
+
+const DEFAULT_QUERY: LanguageQuery = {
+  patterns: [
+    `\\b(?:function|def|fn|func|class|struct|interface|trait|enum|type|module|namespace|const|let|var|val)\\s+${SYMBOL}\\b`,
+  ],
+};
+
+export interface DefinitionSearch {
+  pattern: string;
+  include?: string;
+}
+
+export function escapeSymbolForRegex(symbol: string): string {
+  return symbol.replace(REGEX_SPECIALS, '\\$&');
+}
+
+export function buildDefinitionSearch(languageId: string, symbol: string): DefinitionSearch {
+  const query = LANGUAGE_QUERIES[languageId] ?? DEFAULT_QUERY;
+  const escaped = escapeSymbolForRegex(symbol);
+  return {
+    pattern: query.patterns.map((p) => p.replaceAll(SYMBOL, escaped)).join('|'),
+    include: query.include,
+  };
+}
+
+export function searchIncludeForLanguage(languageId: string): string | undefined {
+  return (LANGUAGE_QUERIES[languageId] ?? DEFAULT_QUERY).include;
+}


### PR DESCRIPTION
## Summary
- Wire Monaco's definition/reference providers to the backend search API (`editorNavigation.ts`, `definitionPatterns.ts`) so ctrl-click/F12 jump across files in the sandbox, cross-file, scoped to worktree `cwd`
- Theme the peek widget (results tree, badges, selection) to match the monochrome light/dark palettes; disable sticky scroll to save vertical space in the peek preview
- Switch editor `modelPath` to a `sandbox://{sandboxId}/{path}` URI so `uri.path` stays clean for peek result labels
- Compact the message trail rail based on actual pane gutter width (ResizeObserver) instead of a viewport breakpoint, so it fits without covering message text when a sidebar narrows the pane

## Test plan
- [ ] Open a file in the editor, ctrl+hover / F12 a symbol defined in another file, verify it jumps/peeks correctly
- [ ] Verify peek widget styling in both light and dark mode, and across custom palettes
- [ ] Resize the window / toggle sidebars and verify the message trail rail switches to compact mode without overlapping message text