### PR TITLE
feat(editor): add code selection chips for chat input

### DIFF
--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -9,6 +9,7 @@ import { EnhanceButton } from './EnhanceButton';
 import { Textarea } from './Textarea';
 import { InputControls } from './InputControls';
 import { InputAttachments } from './InputAttachments';
+import { SelectionAttachments } from './SelectionAttachments';
 import { InputSuggestionsPanel } from './InputSuggestionsPanel';
 import { ContextUsageIndicator } from './ContextUsageIndicator';
 import { InputProvider } from './InputProvider';
@@ -55,12 +56,12 @@ function InputLayout() {
     state.attachedFiles.length > 0;
 
   const sendStatus: SendButtonStatus = state.isStreaming
-    ? state.hasMessage
+    ? state.hasContent
       ? 'ready'
       : 'streaming'
     : state.isLoading
       ? 'loading'
-      : state.hasMessage
+      : state.hasContent
         ? 'ready'
         : 'idle';
 
@@ -84,6 +85,11 @@ function InputLayout() {
             onEditImage={actions.handleDrawClick}
           />
         )}
+
+        <SelectionAttachments
+          selections={state.attachedSelections}
+          onRemove={actions.handleRemoveSelection}
+        />
 
         <div className="relative px-4 pt-2.5">
           <Textarea

--- a/frontend/src/components/chat/message-input/InputContext.ts
+++ b/frontend/src/components/chat/message-input/InputContext.ts
@@ -1,5 +1,6 @@
 import { createContext, type RefObject } from 'react';
 import type { MentionItem, SlashCommand } from '@/types/ui.types';
+import type { EditorCodeSelection } from '@/store/uiStore';
 import type { ContextUsageInfo } from './ContextUsageIndicator';
 
 export interface InputState {
@@ -10,6 +11,7 @@ export interface InputState {
   isStreaming: boolean;
   isEnhancing: boolean;
   hasMessage: boolean;
+  hasContent: boolean;
   hasAttachments: boolean;
   showPreview: boolean;
   showFileUpload: boolean;
@@ -22,6 +24,7 @@ export interface InputState {
   selectedModelId: string;
   dropdownPosition: 'top' | 'bottom';
   attachedFiles: File[] | null;
+  attachedSelections: EditorCodeSelection[];
   previewUrls: string[];
   editingImageIndex: number | null;
   contextUsage?: ContextUsageInfo;
@@ -45,6 +48,7 @@ export interface InputActions {
   handleEnhancePrompt: () => void;
   handleFileSelect: (files: File[]) => void;
   handleRemoveFile: (index: number) => void;
+  handleRemoveSelection: (index: number) => void;
   handleDrawClick: (index: number) => void;
   handleDrawingSave: (dataUrl: string) => Promise<void>;
   closeDrawingModal: () => void;

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -7,6 +7,8 @@ import { useEnhancePromptMutation } from '@/hooks/queries/useChatQueries';
 import { useMentionSuggestions } from '@/hooks/useMentionSuggestions';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
 import { useAuthStore } from '@/store/authStore';
+import { useUIStore, type EditorCodeSelection } from '@/store/uiStore';
+import { formatEditorSelections } from '@/lib/editorChatActions';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
 import { coercePermissionModeForAgent } from '@/components/chat/permission-mode-selector/permissionModes';
 import { coerceThinkingModeForAgent } from '@/components/chat/thinking-mode-selector/thinkingModes';
@@ -41,6 +43,9 @@ const AGENTS_WITHOUT_USAGE_UPDATE: ReadonlySet<AgentKind> = new Set([
   'opencode',
 ]);
 
+// Stable fallback so chat-less composers (landing page) don't churn the selector.
+const NO_SELECTIONS: EditorCodeSelection[] = [];
+
 export function InputProvider({
   message,
   setMessage,
@@ -73,6 +78,11 @@ export function InputProvider({
   // UsageUpdate notifications — without those events the value stays 0 and
   // the bar is misleading.
   const visibleContextUsage = AGENTS_WITHOUT_USAGE_UPDATE.has(agentKind) ? undefined : contextUsage;
+  const storedSelections = useUIStore((s) =>
+    chatId ? s.editorSelectionsByChat[chatId] : undefined,
+  );
+  const attachedSelections = storedSelections ?? NO_SELECTIONS;
+
   const formRef = useRef<HTMLFormElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [previewDismissed, setPreviewDismissed] = useState(false);
@@ -81,6 +91,8 @@ export function InputProvider({
   messageRef.current = message;
 
   const hasMessage = message.trim().length > 0;
+  // A selection chip is prompt content on its own — it can be sent without text.
+  const hasContent = hasMessage || attachedSelections.length > 0;
   const hasAttachments = (attachedFiles?.length ?? 0) > 0;
 
   const prevHasAttachments = useRef(hasAttachments);
@@ -197,23 +209,23 @@ export function InputProvider({
     (event: React.FormEvent) => {
       event.preventDefault();
       if (disabled) return;
-      if (!hasMessage) return;
+      if (!hasContent) return;
 
       setPreviewDismissed(true);
       onSubmit(event);
     },
-    [disabled, hasMessage, onSubmit],
+    [disabled, hasContent, onSubmit],
   );
 
   const submitOrStop = useCallback(() => {
-    if (isStreaming && !hasMessage) {
+    if (isStreaming && !hasContent) {
       onStopStream?.();
       return;
     }
 
     if (disabled) return;
 
-    if (isStreaming && hasMessage && chatId) {
+    if (isStreaming && hasContent && chatId) {
       const settings = useChatSettingsStore.getState();
       const permissionMode = coercePermissionModeForAgent(
         settings.permissionModeByChat[chatId] ?? DEFAULT_PERMISSION_MODE,
@@ -229,7 +241,8 @@ export function InputProvider({
         agentKind === 'codex' && (settings.planModeByChat[chatId] ?? DEFAULT_PLAN_MODE);
       const storedPersona = settings.personaByChat[chatId] ?? DEFAULT_PERSONA;
       const validPersona = resolvePersona(storedPersona, personas);
-      const fullMessage = messageRef.current.trim();
+      // Queued messages are stored as plain text, so serialize chips here.
+      const fullMessage = formatEditorSelections(attachedSelections, messageRef.current.trim());
       void useMessageQueueStore
         .getState()
         .queueMessage(
@@ -245,6 +258,7 @@ export function InputProvider({
         );
       setMessage('');
       onAttach?.([]);
+      if (attachedSelections.length > 0) useUIStore.getState().clearEditorSelections(chatId);
       setPreviewDismissed(true);
       return;
     }
@@ -254,7 +268,7 @@ export function InputProvider({
       return;
     }
 
-    if (!hasMessage) return;
+    if (!hasContent) return;
 
     setPreviewDismissed(true);
 
@@ -271,19 +285,27 @@ export function InputProvider({
     onSubmit(formEvent);
   }, [
     disabled,
-    hasMessage,
+    hasContent,
     isLoading,
     isStreaming,
     onStopStream,
     onSubmit,
     chatId,
     attachedFiles,
+    attachedSelections,
     setMessage,
     onAttach,
     agentKind,
     selectedModelId,
     personas,
   ]);
+
+  const handleRemoveSelection = useCallback(
+    (index: number) => {
+      if (chatId) useUIStore.getState().removeEditorSelection(chatId, index);
+    },
+    [chatId],
+  );
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<Element>) => {
@@ -325,6 +347,7 @@ export function InputProvider({
       isStreaming,
       isEnhancing,
       hasMessage,
+      hasContent,
       hasAttachments,
       showPreview,
       showFileUpload,
@@ -337,6 +360,7 @@ export function InputProvider({
       selectedModelId,
       dropdownPosition,
       attachedFiles,
+      attachedSelections,
       previewUrls,
       editingImageIndex,
       contextUsage: visibleContextUsage,
@@ -355,6 +379,7 @@ export function InputProvider({
       isStreaming,
       isEnhancing,
       hasMessage,
+      hasContent,
       hasAttachments,
       showPreview,
       showFileUpload,
@@ -367,6 +392,7 @@ export function InputProvider({
       selectedModelId,
       dropdownPosition,
       attachedFiles,
+      attachedSelections,
       previewUrls,
       editingImageIndex,
       visibleContextUsage,
@@ -392,6 +418,7 @@ export function InputProvider({
       handleEnhancePrompt,
       handleFileSelect,
       handleRemoveFile,
+      handleRemoveSelection,
       handleDrawClick,
       handleDrawingSave,
       closeDrawingModal,
@@ -411,6 +438,7 @@ export function InputProvider({
       handleEnhancePrompt,
       handleFileSelect,
       handleRemoveFile,
+      handleRemoveSelection,
       handleDrawClick,
       handleDrawingSave,
       closeDrawingModal,

--- a/frontend/src/components/chat/message-input/SelectionAttachments.tsx
+++ b/frontend/src/components/chat/message-input/SelectionAttachments.tsx
@@ -1,0 +1,48 @@
+import { memo } from 'react';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { FileIcon } from '@/components/ui/shared/FileIcon';
+import { getFileName } from '@/utils/file';
+import type { EditorCodeSelection } from '@/store/uiStore';
+
+interface SelectionAttachmentsProps {
+  selections: EditorCodeSelection[];
+  onRemove: (index: number) => void;
+}
+
+export const SelectionAttachments = memo(function SelectionAttachments({
+  selections,
+  onRemove,
+}: SelectionAttachmentsProps) {
+  if (selections.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1.5 px-3 pt-2">
+      {selections.map((selection, index) => (
+        <div
+          // Duplicate chips of the same range are allowed, so the index keys them apart.
+          key={`${selection.path}:${selection.startLine}:${index}`}
+          title={selection.path}
+          className="flex items-center gap-1 rounded-md border border-border/50 bg-surface-tertiary py-0.5 pl-1.5 pr-0.5 dark:border-border-dark/50 dark:bg-surface-dark-tertiary"
+        >
+          <FileIcon name={getFileName(selection.path)} className="h-3 w-3" />
+          <span className="font-mono text-2xs text-text-secondary dark:text-text-dark-secondary">
+            {getFileName(selection.path)}:
+            {selection.startLine === selection.endLine
+              ? selection.startLine
+              : `${selection.startLine}-${selection.endLine}`}
+          </span>
+          <Button
+            type="button"
+            variant="unstyled"
+            onClick={() => onRemove(index)}
+            className="rounded p-0.5 text-text-quaternary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+            aria-label="Remove code selection"
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+});

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -9,6 +9,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useEditorTheme } from '@/hooks/useEditorTheme';
 import { attachEditorNavigationContext, setupEditorNavigation } from '@/lib/editorNavigation';
 import type { EditorNavigationContext } from '@/lib/editorNavigation';
+import { attachAddSelectionToChat } from '@/lib/editorChatActions';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { useEditorDrafts } from '@/hooks/useEditorDrafts';
 import type { FileStructure } from '@/types/file-system.types';
@@ -166,6 +167,7 @@ export const View = memo(function View({
       // A sandbox-less context is inert (contextForResource rejects it), so
       // attaching unconditionally is safe and picks up a late-arriving sandbox.
       attachEditorNavigationContext(editor, navigationContext.current);
+      attachAddSelectionToChat(monaco, editor, navigationContext.current);
       setMountedEditorPath(selectedFilePath);
     },
     [selectedFilePath, setupEditorTheme],

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -15,6 +15,8 @@ import { useClipboard } from '@/hooks/useClipboard';
 import { useStreamCallbacks } from '@/hooks/useStreamCallbacks';
 import { useStreamReconnect } from '@/hooks/useStreamReconnect';
 import { chatService } from '@/services/chatService';
+import { useUIStore } from '@/store/uiStore';
+import { formatEditorSelections } from '@/lib/editorChatActions';
 
 interface UseChatStreamingParams {
   chatId: string | undefined;
@@ -330,12 +332,21 @@ export function useChatStreaming({
   const handleMessageSend = useCallback(
     async (event: FormEvent) => {
       event.preventDefault();
-      const result = await handleMessageSendAction(inputMessageRef.current, inputFiles);
+      // Selection chips live in the UI store; serialize them into the prompt
+      // only now so the visible input text stays clean while they're attached.
+      const selections = chatId ? (useUIStore.getState().editorSelectionsByChat[chatId] ?? []) : [];
+      const result = await handleMessageSendAction(
+        formatEditorSelections(selections, inputMessageRef.current),
+        inputFiles,
+      );
       if (result?.success) {
         clearInput();
+        if (chatId && selections.length > 0) {
+          useUIStore.getState().clearEditorSelections(chatId);
+        }
       }
     },
-    [handleMessageSendAction, inputFiles, clearInput],
+    [chatId, handleMessageSendAction, inputFiles, clearInput],
   );
 
   return {

--- a/frontend/src/lib/editorChatActions.ts
+++ b/frontend/src/lib/editorChatActions.ts
@@ -1,0 +1,63 @@
+import type * as monacoNs from 'monaco-editor';
+import type { EditorNavigationContext } from '@/lib/editorNavigation';
+import { useUIStore, type EditorCodeSelection } from '@/store/uiStore';
+
+type Monaco = typeof import('monaco-editor');
+
+const BACKTICK_RUN = /`+/g;
+
+export function attachAddSelectionToChat(
+  m: Monaco,
+  editor: monacoNs.editor.IStandaloneCodeEditor,
+  context: EditorNavigationContext,
+): void {
+  // Registered per editor instance (disposed with it) rather than globally —
+  // the action reads chatId from the pane's mutable context object, so chat
+  // swaps on an already-mounted editor route to the right chat.
+  editor.addAction({
+    id: 'agentrove.addSelectionToChat',
+    label: 'Add Selection to Chat',
+    contextMenuGroupId: '0_chat',
+    contextMenuOrder: 1,
+    keybindings: [m.KeyMod.CtrlCmd | m.KeyCode.KeyL],
+    // Without a selection Cmd+L falls through to Monaco's default line-select.
+    precondition: 'editorHasSelection',
+    run: (ed) => {
+      const selection = ed.getSelection();
+      const model = ed.getModel();
+      const { chatId } = context;
+      if (!selection || selection.isEmpty() || !model || !chatId) return;
+      let text = model.getValueInRange(selection);
+      let endLine = selection.endLineNumber;
+      // Full-line drag selections end at column 1 of the line below — don't
+      // count that empty line in the range label or the snippet.
+      if (endLine > selection.startLineNumber && selection.endColumn === 1) {
+        endLine -= 1;
+        text = text.slice(0, -1);
+      }
+      useUIStore.getState().addEditorSelection(chatId, {
+        // Model URIs are `sandbox://{sandboxId}/{workspace path}` (View.tsx).
+        path: model.uri.path.slice(1),
+        startLine: selection.startLineNumber,
+        endLine,
+        languageId: model.getLanguageId(),
+        text,
+      });
+    },
+  });
+}
+
+export function formatEditorSelections(selections: EditorCodeSelection[], message: string): string {
+  // Chips are UI-only; at send time the code rides in the prompt as fenced
+  // blocks above the user's text.
+  const blocks = selections.map((s) => {
+    const lineRef = s.startLine === s.endLine ? `${s.startLine}` : `${s.startLine}-${s.endLine}`;
+    // Snippets can contain ``` (Markdown, nested fences) which would close a
+    // bare fence early — use one longer than the longest run in the text.
+    const longestRun =
+      s.text.match(BACKTICK_RUN)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+    const fence = '`'.repeat(Math.max(3, longestRun + 1));
+    return `${s.path}:${lineRef}\n${fence}${s.languageId}\n${s.text}\n${fence}`;
+  });
+  return [...blocks, message].filter(Boolean).join('\n\n');
+}

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -36,6 +36,14 @@ interface PendingFileOpen {
   nonce: number;
 }
 
+export interface EditorCodeSelection {
+  path: string;
+  startLine: number;
+  endLine: number;
+  languageId: string;
+  text: string;
+}
+
 type UIStoreState = ThemeState &
   Pick<UIState, 'sidebarOpen' | 'sidebarWidth'> &
   Pick<UIActions, 'setSidebarOpen' | 'setSidebarWidth'> &
@@ -68,6 +76,12 @@ type UIStoreState = ThemeState &
     consumeDiffFileJump: () => void;
     pendingChatMessage: { chatId: string; message: string } | null;
     setPendingChatMessage: (payload: { chatId: string; message: string } | null) => void;
+    // Code snippets attached to a chat's input as removable chips (VS Code
+    // "add selection to chat") — serialized into the prompt only at send time.
+    editorSelectionsByChat: Record<string, EditorCodeSelection[]>;
+    addEditorSelection: (chatId: string, selection: EditorCodeSelection) => void;
+    removeEditorSelection: (chatId: string, index: number) => void;
+    clearEditorSelections: (chatId: string) => void;
     // Sandbox of the workspace selected on the landing page. Lets context-less
     // consumers (the global git shortcuts) resolve a target before a chat exists.
     workspaceSandboxId: string | null;
@@ -175,6 +189,26 @@ export const useUIStore = create<UIStoreState>()(
 
       pendingChatMessage: null,
       setPendingChatMessage: (payload) => set({ pendingChatMessage: payload }),
+
+      editorSelectionsByChat: {},
+      addEditorSelection: (chatId, selection) =>
+        set((state) => ({
+          editorSelectionsByChat: {
+            ...state.editorSelectionsByChat,
+            [chatId]: [...(state.editorSelectionsByChat[chatId] ?? []), selection],
+          },
+        })),
+      removeEditorSelection: (chatId, index) =>
+        set((state) => ({
+          editorSelectionsByChat: {
+            ...state.editorSelectionsByChat,
+            [chatId]: (state.editorSelectionsByChat[chatId] ?? []).filter((_, i) => i !== index),
+          },
+        })),
+      clearEditorSelections: (chatId) =>
+        set((state) => ({
+          editorSelectionsByChat: { ...state.editorSelectionsByChat, [chatId]: [] },
+        })),
 
       workspaceSandboxId: null,
       setWorkspaceSandboxId: (sandboxId) => set({ workspaceSandboxId: sandboxId }),


### PR DESCRIPTION
## Summary
- Add a Monaco editor action (Cmd/Ctrl+L, right-click "Add Selection to Chat") that attaches the current selection to the active chat as a removable chip
- Chips render above the input via `SelectionAttachments` and are serialized into the prompt as fenced code blocks only at send time, keeping the visible input text clean
- Selections are tracked per-chat in `uiStore` and cleared after a successful send