### PR TITLE
feat(editor): add inline "Ask About Selection" chat (Cmd+I)

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -36,6 +36,8 @@ from app.models.db_models.user import User
 from app.models.types import MessageAttachmentDict, PermissionMode
 from app.models.schemas.chat import (
     ActiveStreamStatus,
+    AskCodeRequest,
+    AskCodeResponse,
     Chat as ChatSchema,
     ChatCompletionResponse,
     ChatCreate,
@@ -198,6 +200,32 @@ async def generate_chat_title(
             detail="Title generation failed",
         )
     return {"title": title[:255]}
+
+
+@router.post("/chats/{chat_id}/ask-code", response_model=AskCodeResponse)
+async def ask_about_code(
+    request: AskCodeRequest,
+    chat: Chat = Depends(ensure_chat_access),
+    current_user: User = Depends(get_current_user),
+    ai_service: AgentService = Depends(get_agent_service),
+) -> dict[str, str]:
+    # Editor inline chat: one-off Q&A about a code selection — no chat turn or
+    # message rows; the chat only supplies workspace context and access control.
+    try:
+        answer = await ai_service.answer_code_question(
+            request.question,
+            request.code,
+            request.file_path,
+            request.language,
+            request.start_line,
+            request.end_line,
+            request.model_id,
+            current_user,
+            chat=chat,
+        )
+    except AgentException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
+    return {"answer": answer}
 
 
 @router.get("/chats", response_model=PaginatedResponse[ChatSchema])

--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -108,6 +108,20 @@ class EnhancePromptResponse(BaseModel):
     enhanced_prompt: str
 
 
+class AskCodeRequest(BaseModel):
+    question: str = Field(..., min_length=1, max_length=10000)
+    code: str = Field(..., min_length=1, max_length=100000)
+    file_path: str = Field(..., min_length=1, max_length=1024)
+    language: str = Field(..., min_length=1, max_length=64)
+    start_line: int = Field(..., ge=1)
+    end_line: int = Field(..., ge=1)
+    model_id: str = Field(..., min_length=1, max_length=255)
+
+
+class AskCodeResponse(BaseModel):
+    answer: str
+
+
 class GenerateTitleResponse(BaseModel):
     title: str
 

--- a/backend/app/prompts/inline_chat.py
+++ b/backend/app/prompts/inline_chat.py
@@ -1,0 +1,7 @@
+INLINE_CHAT_SYSTEM_PROMPT = (
+    "You are answering a developer's question about a code selection from their "
+    "editor. Base your answer on the provided snippet, using the file path and "
+    "line range only as context. Answer directly and concisely in Markdown — "
+    "short paragraphs and small code examples, no headings or preamble. Do not "
+    "use tools and do not modify files."
+)

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -23,6 +23,7 @@ from app.prompts.generate_pr_description import (
     GENERATE_PR_DESCRIPTION_SYSTEM_PROMPT,
     GENERATE_PR_DESCRIPTION_TITLE_PREFIX,
 )
+from app.prompts.inline_chat import INLINE_CHAT_SYSTEM_PROMPT
 from app.prompts.system_prompt import DEFAULT_PERSONA_NAME
 from app.prompts.generate_title import GENERATE_TITLE_SYSTEM_PROMPT
 from app.services.acp.adapters import AGENT_ADAPTERS, NORMAL_SESSION_MODE, AgentKind
@@ -314,6 +315,37 @@ class AgentService:
         )
         if not result:
             raise AgentException("AI returned an empty commit message")
+        return result
+
+    async def answer_code_question(
+        self,
+        question: str,
+        code: str,
+        file_path: str,
+        language: str,
+        start_line: int,
+        end_line: int,
+        model_id: str,
+        user: User,
+        chat: Chat,
+    ) -> str:
+        line_ref = (
+            str(start_line)
+            if start_line == end_line
+            else str(start_line) + "-" + str(end_line)
+        )
+        # XML-ish wrapping instead of Markdown fences — snippets can contain
+        # backtick runs that would close any fence we pick.
+        user_message = (
+            "File: " + file_path + " (lines " + line_ref + ", " + language + ")\n"
+            "<code>\n" + code + "\n</code>\n\n"
+            "<question>\n" + question + "\n</question>"
+        )
+        result = await self._generate_text(
+            INLINE_CHAT_SYSTEM_PROMPT, user_message, model_id, user, chat=chat
+        )
+        if not result:
+            raise AgentException("AI returned an empty answer")
         return result
 
     async def _generate_text(

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -96,6 +96,7 @@ class ChatCompletionServiceOverride:
 class AgentServiceOverride:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, User]] = []
+        self.ask_code_calls: list[tuple[str, str, str, str, User, Chat]] = []
         self.fail = False
 
     def __call__(self) -> "AgentServiceOverride":
@@ -106,6 +107,23 @@ class AgentServiceOverride:
         if self.fail:
             raise AgentException("Enhance failed", status_code=503)
         return "Enhanced: " + prompt
+
+    async def answer_code_question(
+        self,
+        question: str,
+        code: str,
+        file_path: str,
+        language: str,
+        start_line: int,
+        end_line: int,
+        model_id: str,
+        user: User,
+        chat: Chat,
+    ) -> str:
+        self.ask_code_calls.append((question, code, file_path, model_id, user, chat))
+        if self.fail:
+            raise AgentException("Ask failed", status_code=503)
+        return "Answer: " + question
 
 
 @pytest.fixture
@@ -360,6 +378,71 @@ async def test_enhance_prompt_endpoint_uses_agent_service(
 
     assert failure_response.status_code == 503
     assert failure_response.json()["detail"] == "Enhance failed"
+
+
+async def test_ask_code_endpoint_answers_and_enforces_chat_access(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    agent_service = AgentServiceOverride()
+    app.dependency_overrides[get_agent_service] = agent_service
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="ask-code-owner@example.com",
+        username="askcodeowner",
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    payload = {
+        "question": "What does this do?",
+        "code": "def add(a, b):\n    return a + b",
+        "file_path": "src/math.py",
+        "language": "python",
+        "start_line": 1,
+        "end_line": 2,
+        "model_id": TEST_MODEL_ID,
+    }
+    response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/ask-code", json=payload, headers=headers
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"answer": "Answer: What does this do?"}
+    [(question, code, file_path, model_id, stored_user, stored_chat)] = (
+        agent_service.ask_code_calls
+    )
+    assert (question, code, file_path, model_id) == (
+        payload["question"],
+        payload["code"],
+        payload["file_path"],
+        TEST_MODEL_ID,
+    )
+    assert stored_user.id == user.id
+    assert stored_chat.id == chat.id
+
+    other_headers, _other_user, _other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="ask-code-other@example.com",
+        username="askcodeother",
+    )
+    other_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/ask-code", json=payload, headers=other_headers
+    )
+    assert other_response.status_code == 404
+
+    agent_service.fail = True
+    failure_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/ask-code", json=payload, headers=headers
+    )
+    assert failure_response.status_code == 503
+    assert failure_response.json()["detail"] == "Ask failed"
 
 
 async def test_chat_access_is_limited_to_owner(

--- a/frontend/src/components/editor/editor-view/InlineChatWidget.tsx
+++ b/frontend/src/components/editor/editor-view/InlineChatWidget.tsx
@@ -1,0 +1,177 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { CornerDownLeft, Loader2, X } from 'lucide-react';
+import type * as monacoNs from 'monaco-editor';
+import MarkDown from '@/components/ui/MarkDown';
+import { Button } from '@/components/ui/primitives/Button';
+import { Textarea } from '@/components/ui/primitives/Textarea';
+import { ModelSelector } from '@/components/chat/model-selector/ModelSelector';
+import { useAskAboutCodeMutation } from '@/hooks/queries/useChatQueries';
+import { useChatSessionState } from '@/hooks/useChatSessionContext';
+import type { EditorCodeSelection } from '@/store/uiStore';
+
+type Monaco = typeof import('monaco-editor');
+
+interface InlineChatWidgetProps {
+  monaco: Monaco;
+  editor: monacoNs.editor.IStandaloneCodeEditor;
+  chatId: string;
+  selection: EditorCodeSelection;
+  onClose: () => void;
+}
+
+export function InlineChatWidget({
+  monaco,
+  editor,
+  chatId,
+  selection,
+  onClose,
+}: InlineChatWidgetProps) {
+  // Monaco owns anchoring/scroll-tracking via the content-widget API; React
+  // portals the panel into this node so it stays inside the provider tree.
+  const [widgetNode] = useState(() => document.createElement('div'));
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [question, setQuestion] = useState('');
+  const { selectedModelId } = useChatSessionState();
+  // Widget-local model choice seeded from the chat's composer selection —
+  // picking a model here shouldn't silently retarget the main chat.
+  const [modelId, setModelId] = useState(selectedModelId);
+  const askMutation = useAskAboutCodeMutation();
+
+  useLayoutEffect(() => {
+    const widget: monacoNs.editor.IContentWidget = {
+      getId: () => 'agentrove.inlineChatWidget',
+      getDomNode: () => widgetNode,
+      // The panel is wider than most code lines — let it escape the scrollable
+      // text area instead of being clipped at the viewport edge.
+      allowEditorOverflow: true,
+      getPosition: () => ({
+        position: { lineNumber: selection.endLine, column: 1 },
+        preference: [
+          monaco.editor.ContentWidgetPositionPreference.BELOW,
+          monaco.editor.ContentWidgetPositionPreference.ABOVE,
+        ],
+      }),
+    };
+    editor.addContentWidget(widget);
+    editor.revealLineInCenterIfOutsideViewport(selection.endLine);
+    // Focus here, not via autoFocus — React commits the portal children while
+    // widgetNode is still detached, so autoFocus would no-op and leave typing
+    // routed to Monaco. addContentWidget attaches the node synchronously.
+    textareaRef.current?.focus();
+    // Monaco's scroll handler is a bubble-phase wheel listener on the editor
+    // root, which contains the overflowing-widgets layer — stop wheel events
+    // here so the answer pane scrolls natively instead of the editor.
+    const stopWheel = (e: WheelEvent) => e.stopPropagation();
+    widgetNode.addEventListener('wheel', stopWheel);
+    return () => {
+      widgetNode.removeEventListener('wheel', stopWheel);
+      editor.removeContentWidget(widget);
+    };
+  }, [monaco, editor, widgetNode, selection]);
+
+  const handleClose = () => {
+    onClose();
+    editor.focus();
+  };
+
+  const handleSubmit = () => {
+    const trimmed = question.trim();
+    if (!trimmed || askMutation.isPending) return;
+    askMutation.mutate({ chatId, selection, question: trimmed, modelId });
+  };
+
+  const lineRef =
+    selection.startLine === selection.endLine
+      ? `${selection.startLine}`
+      : `${selection.startLine}-${selection.endLine}`;
+  const hasResult = askMutation.isPending || askMutation.isError || askMutation.data != null;
+
+  return createPortal(
+    <div
+      className="mt-1 w-[440px] max-w-[80vw] rounded-xl border border-border bg-surface/95 shadow-medium backdrop-blur-xl dark:border-border-dark dark:bg-surface-dark/95"
+      onKeyDown={(e) => {
+        // Keep widget keys from falling through to Monaco's keybinding service.
+        e.stopPropagation();
+        // defaultPrevented = a descendant already consumed Escape (the model
+        // dropdown's search closes itself) — don't also close the widget.
+        if (e.key === 'Escape' && !e.defaultPrevented) handleClose();
+      }}
+    >
+      <div className="flex h-9 items-center gap-2 border-b border-border/50 px-3 dark:border-border-dark/50">
+        <span className="min-w-0 flex-1 truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-tertiary">
+          {selection.path}:{lineRef}
+        </span>
+        <ModelSelector
+          selectedModelId={modelId}
+          onModelChange={setModelId}
+          dropdownPosition="bottom"
+          dropdownAlign="right"
+          compact={false}
+        />
+        <Button
+          type="button"
+          variant="unstyled"
+          onClick={handleClose}
+          aria-label="Close inline chat"
+          className="text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+        className="flex items-center gap-1 px-2 py-1.5"
+      >
+        <Textarea
+          ref={textareaRef}
+          variant="unstyled"
+          rows={1}
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              handleSubmit();
+            }
+          }}
+          placeholder="Ask about this code…"
+          className="max-h-24 flex-1 resize-none bg-transparent px-1 py-1 text-sm text-text-primary placeholder:text-text-quaternary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary"
+        />
+        <Button
+          type="submit"
+          variant="unstyled"
+          disabled={!question.trim() || askMutation.isPending}
+          aria-label="Ask question"
+          className="rounded-md p-1.5 text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+        >
+          <CornerDownLeft className="h-3.5 w-3.5" />
+        </Button>
+      </form>
+
+      {hasResult && (
+        <div className="max-h-72 overflow-y-auto rounded-b-xl border-t border-border/50 px-3 py-2 dark:border-border-dark/50">
+          {askMutation.isPending && (
+            <div className="flex items-center gap-2 py-0.5 text-xs text-text-tertiary dark:text-text-dark-tertiary">
+              <Loader2 className="h-3 w-3 animate-spin text-text-quaternary dark:text-text-dark-quaternary" />
+              Thinking…
+            </div>
+          )}
+          {askMutation.isError && (
+            <div className="text-xs text-error-600 dark:text-error-400">
+              {askMutation.error.message}
+            </div>
+          )}
+          {!askMutation.isPending && askMutation.data != null && (
+            <MarkDown content={askMutation.data} />
+          )}
+        </div>
+      )}
+    </div>,
+    widgetNode,
+  );
+}

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -9,7 +9,9 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useEditorTheme } from '@/hooks/useEditorTheme';
 import { attachEditorNavigationContext, setupEditorNavigation } from '@/lib/editorNavigation';
 import type { EditorNavigationContext } from '@/lib/editorNavigation';
-import { attachAddSelectionToChat } from '@/lib/editorChatActions';
+import { attachAddSelectionToChat, attachAskAboutSelection } from '@/lib/editorChatActions';
+import { InlineChatWidget } from './InlineChatWidget';
+import type { EditorCodeSelection } from '@/store/uiStore';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { useEditorDrafts } from '@/hooks/useEditorDrafts';
 import type { FileStructure } from '@/types/file-system.types';
@@ -50,9 +52,20 @@ export const View = memo(function View({
   const theme = useResolvedTheme();
   const [showPreview, setShowPreview] = useState(false);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  const monacoRef = useRef<typeof import('monaco-editor') | null>(null);
   const selectedFilePath = selectedFile?.path ?? null;
   const mountedEditorPathRef = useRef(selectedFilePath);
   const [mountedEditorPath, setMountedEditorPath] = useState<string | null>(null);
+  const [inlineChat, setInlineChat] = useState<{
+    selection: EditorCodeSelection;
+    nonce: number;
+  } | null>(null);
+
+  // Nonce remounts the widget on every trigger — line ranges alone can't tell
+  // a new selection from the last one (same lines, different text/columns).
+  const openInlineChat = useCallback((selection: EditorCodeSelection) => {
+    setInlineChat((prev) => ({ selection, nonce: (prev?.nonce ?? 0) + 1 }));
+  }, []);
 
   if (mountedEditorPathRef.current !== selectedFilePath) {
     // Content remounts by path; clear stale Monaco refs before jump effects run.
@@ -162,15 +175,17 @@ export const View = memo(function View({
       if (!selectedFilePath) return;
 
       editorRef.current = editor;
+      monacoRef.current = monaco;
       setupEditorTheme(monaco);
       setupEditorNavigation(monaco);
       // A sandbox-less context is inert (contextForResource rejects it), so
       // attaching unconditionally is safe and picks up a late-arriving sandbox.
       attachEditorNavigationContext(editor, navigationContext.current);
       attachAddSelectionToChat(monaco, editor, navigationContext.current);
+      attachAskAboutSelection(monaco, editor, openInlineChat);
       setMountedEditorPath(selectedFilePath);
     },
-    [selectedFilePath, setupEditorTheme],
+    [selectedFilePath, setupEditorTheme, openInlineChat],
   );
 
   const lastAppliedTargetRef = useRef<string>('');
@@ -243,7 +258,14 @@ export const View = memo(function View({
     if (isPreviewFullscreen) {
       setIsPreviewFullscreen(false);
     }
+    // Sole inline-chat reset: preview toggles and file switches both remount
+    // Content, so the widget's captured editor would go stale either way.
+    if (inlineChat !== null) setInlineChat(null);
   }
+
+  const handleCloseInlineChat = useCallback(() => {
+    setInlineChat(null);
+  }, []);
 
   const handleTogglePreviewFullscreen = useCallback(() => {
     setIsPreviewFullscreen((prev) => !prev);
@@ -326,6 +348,23 @@ export const View = memo(function View({
                 </div>
               </div>
             )}
+
+            {/* Listed before Content so its cleanup removes the content widget
+                before @monaco-editor/react disposes the editor on unmount. */}
+            {!(isPreviewable && showPreview) &&
+              inlineChat &&
+              chatId &&
+              editorRef.current &&
+              monacoRef.current && (
+                <InlineChatWidget
+                  key={inlineChat.nonce}
+                  monaco={monacoRef.current}
+                  editor={editorRef.current}
+                  chatId={chatId}
+                  selection={inlineChat.selection}
+                  onClose={handleCloseInlineChat}
+                />
+              )}
 
             {!(isPreviewable && showPreview) && (
               <Content

--- a/frontend/src/components/ui/primitives/Dropdown.tsx
+++ b/frontend/src/components/ui/primitives/Dropdown.tsx
@@ -150,9 +150,9 @@ function DropdownInner<T>({
   const showIconOnly = (compactOnMobile || forceCompact) && LeftIcon;
   const labelClasses = showIconOnly
     ? forceCompact
-      ? 'hidden truncate text-2xs font-medium text-text-primary dark:text-text-dark-secondary'
-      : 'hidden sm:inline truncate text-2xs font-medium text-text-primary dark:text-text-dark-secondary'
-    : 'truncate text-2xs font-medium text-text-primary dark:text-text-dark-secondary';
+      ? 'hidden truncate text-2xs font-medium text-text-secondary dark:text-text-dark-secondary'
+      : 'hidden sm:inline truncate text-2xs font-medium text-text-secondary dark:text-text-dark-secondary'
+    : 'truncate text-2xs font-medium text-text-secondary dark:text-text-dark-secondary';
   const chevronClasses = showIconOnly
     ? forceCompact
       ? 'hidden'

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -15,7 +15,7 @@ import type {
 import { chatService } from '@/services/chatService';
 import { isCloudChat } from '@/utils/chatOrigin';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
-import { useUIStore } from '@/store/uiStore';
+import { useUIStore, type EditorCodeSelection } from '@/store/uiStore';
 import type { Chat, ChatSearchResponse, ContextUsage, CreateChatRequest } from '@/types/chat.types';
 import type { ChangedFilesData, FileDiffData } from '@/types/sandbox.types';
 import type { PaginatedChats } from '@/types/api.types';
@@ -367,5 +367,19 @@ export const useEnhancePromptMutation = (
     mutationFn: ({ prompt, modelId }: EnhancePromptParams) =>
       chatService.enhancePrompt(prompt, modelId),
     ...options,
+  });
+};
+
+interface AskAboutCodeParams {
+  chatId: string;
+  selection: EditorCodeSelection;
+  question: string;
+  modelId: string;
+}
+
+export const useAskAboutCodeMutation = () => {
+  return useMutation({
+    mutationFn: ({ chatId, selection, question, modelId }: AskAboutCodeParams) =>
+      chatService.askAboutCode(chatId, selection, question, modelId),
   });
 };

--- a/frontend/src/lib/editorChatActions.ts
+++ b/frontend/src/lib/editorChatActions.ts
@@ -6,6 +6,28 @@ type Monaco = typeof import('monaco-editor');
 
 const BACKTICK_RUN = /`+/g;
 
+function getSelectionSnippet(ed: monacoNs.editor.ICodeEditor): EditorCodeSelection | null {
+  const selection = ed.getSelection();
+  const model = ed.getModel();
+  if (!selection || selection.isEmpty() || !model) return null;
+  let text = model.getValueInRange(selection);
+  let endLine = selection.endLineNumber;
+  // Full-line drag selections end at column 1 of the line below — don't
+  // count that empty line in the range label or the snippet.
+  if (endLine > selection.startLineNumber && selection.endColumn === 1) {
+    endLine -= 1;
+    text = text.slice(0, -1);
+  }
+  return {
+    // Model URIs are `sandbox://{sandboxId}/{workspace path}` (View.tsx).
+    path: model.uri.path.slice(1),
+    startLine: selection.startLineNumber,
+    endLine,
+    languageId: model.getLanguageId(),
+    text,
+  };
+}
+
 export function attachAddSelectionToChat(
   m: Monaco,
   editor: monacoNs.editor.IStandaloneCodeEditor,
@@ -23,26 +45,32 @@ export function attachAddSelectionToChat(
     // Without a selection Cmd+L falls through to Monaco's default line-select.
     precondition: 'editorHasSelection',
     run: (ed) => {
-      const selection = ed.getSelection();
-      const model = ed.getModel();
+      const snippet = getSelectionSnippet(ed);
       const { chatId } = context;
-      if (!selection || selection.isEmpty() || !model || !chatId) return;
-      let text = model.getValueInRange(selection);
-      let endLine = selection.endLineNumber;
-      // Full-line drag selections end at column 1 of the line below — don't
-      // count that empty line in the range label or the snippet.
-      if (endLine > selection.startLineNumber && selection.endColumn === 1) {
-        endLine -= 1;
-        text = text.slice(0, -1);
-      }
-      useUIStore.getState().addEditorSelection(chatId, {
-        // Model URIs are `sandbox://{sandboxId}/{workspace path}` (View.tsx).
-        path: model.uri.path.slice(1),
-        startLine: selection.startLineNumber,
-        endLine,
-        languageId: model.getLanguageId(),
-        text,
-      });
+      if (!snippet || !chatId) return;
+      useUIStore.getState().addEditorSelection(chatId, snippet);
+    },
+  });
+}
+
+export function attachAskAboutSelection(
+  m: Monaco,
+  editor: monacoNs.editor.IStandaloneCodeEditor,
+  onOpen: (selection: EditorCodeSelection) => void,
+): void {
+  // Cmd+I mirrors VS Code's inline chat trigger; the pane owning the editor
+  // renders the widget, so this action only reports the captured selection.
+  editor.addAction({
+    id: 'agentrove.askAboutSelection',
+    label: 'Ask About Selection',
+    contextMenuGroupId: '0_chat',
+    contextMenuOrder: 2,
+    keybindings: [m.KeyMod.CtrlCmd | m.KeyCode.KeyI],
+    precondition: 'editorHasSelection',
+    run: (ed) => {
+      const snippet = getSelectionSnippet(ed);
+      if (!snippet) return;
+      onOpen(snippet);
     },
   });
 }

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/types/chat.types';
 import type { ChangedFilesData, FileDiffData, GitCommitResult } from '@/types/sandbox.types';
 import type { CursorPaginationParams, PaginatedChats, PaginatedMessages } from '@/types/api.types';
+import type { EditorCodeSelection } from '@/store/uiStore';
 
 export function buildChatFormData(request: ChatRequest): FormData {
   // Single encoding of the /chat/chat multipart contract — shared with
@@ -354,6 +355,34 @@ async function enhancePrompt(prompt: string, modelId: string): Promise<string> {
   });
 }
 
+async function askAboutCode(
+  chatId: string,
+  selection: EditorCodeSelection,
+  question: string,
+  modelId: string,
+): Promise<string> {
+  validateId(chatId, 'Chat ID');
+  validateRequired(question, 'Question');
+  validateRequired(modelId, 'Model ID');
+
+  return serviceCall(async () => {
+    const response = await resolveChatClient(chatId).post<{ answer: string }>(
+      `/chat/chats/${chatId}/ask-code`,
+      {
+        question,
+        code: selection.text,
+        file_path: selection.path,
+        language: selection.languageId,
+        start_line: selection.startLine,
+        end_line: selection.endLine,
+        model_id: modelId,
+      },
+    );
+
+    return ensureResponse(response, 'Failed to answer question').answer;
+  });
+}
+
 async function generateChatTitle(chatId: string): Promise<string> {
   validateId(chatId, 'Chat ID');
 
@@ -430,6 +459,7 @@ export const chatService = {
   deleteAllChats,
   getContextUsage,
   enhancePrompt,
+  askAboutCode,
   generateChatTitle,
   getMessageChanges,
   getMessageFileDiff,


### PR DESCRIPTION
## Summary
- Adds a Cmd+I editor action that opens a floating inline chat widget anchored to the current selection, mirroring VS Code's inline chat trigger
- New backend `POST /chats/{chat_id}/ask-code` endpoint answers one-off questions about a code snippet using the chat only for workspace context/access control — no chat turn or message rows are created
- Widget lets the user pick a model (seeded from the chat's composer selection) and renders the streamed answer as Markdown inline in the editor

## Test plan
- [x] Backend: `test_ask_code_endpoint_answers_and_enforces_chat_access` covers success, cross-user 404, and upstream failure passthrough
- [ ] Manual: select code in the editor, press Cmd+I, ask a question, verify answer renders and widget closes on Escape/file switch