### PR TITLE
feat(diff): add inline review comments on diff lines

### DIFF
--- a/frontend/src/components/chat/message-input/SelectionAttachments.tsx
+++ b/frontend/src/components/chat/message-input/SelectionAttachments.tsx
@@ -22,7 +22,7 @@ export const SelectionAttachments = memo(function SelectionAttachments({
         <div
           // Duplicate chips of the same range are allowed, so the index keys them apart.
           key={`${selection.path}:${selection.startLine}:${index}`}
-          title={selection.path}
+          title={selection.comment ? `${selection.path}\n\n${selection.comment}` : selection.path}
           className="flex items-center gap-1 rounded-md border border-border/50 bg-surface-tertiary py-0.5 pl-1.5 pr-0.5 dark:border-border-dark/50 dark:bg-surface-dark-tertiary"
         >
           <FileIcon name={getFileName(selection.path)} className="h-3 w-3" />

--- a/frontend/src/components/sandbox/git/DiffCommentComposer.tsx
+++ b/frontend/src/components/sandbox/git/DiffCommentComposer.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { CornerDownLeft, X } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { Textarea } from '@/components/ui/primitives/Textarea';
+
+interface DiffCommentComposerProps {
+  lineLabel: string;
+  onSubmit: (comment: string) => void;
+  onCancel: () => void;
+}
+
+// Inline comment card rendered as a pierre line annotation under the selected
+// diff lines — mirrors the editor InlineChatWidget's frosted-card look.
+// `font-sans` resets the diff's monospace context.
+export function DiffCommentComposer({ lineLabel, onSubmit, onCancel }: DiffCommentComposerProps) {
+  const [comment, setComment] = useState('');
+  const trimmed = comment.trim();
+
+  return (
+    <div
+      className="my-1.5 ml-2 w-[440px] max-w-[calc(100%-1rem)] rounded-xl border border-border bg-surface/95 font-sans shadow-medium backdrop-blur-xl dark:border-border-dark dark:bg-surface-dark/95"
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') onCancel();
+      }}
+    >
+      <div className="flex h-9 items-center gap-2 border-b border-border/50 px-3 dark:border-border-dark/50">
+        <span className="min-w-0 flex-1 truncate font-mono text-2xs text-text-tertiary dark:text-text-dark-tertiary">
+          Comment on {lineLabel}
+        </span>
+        <Button
+          type="button"
+          variant="unstyled"
+          onClick={onCancel}
+          aria-label="Discard comment"
+          className="text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      </div>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (trimmed) onSubmit(trimmed);
+        }}
+        className="flex items-center gap-1 px-2 py-1.5"
+      >
+        <Textarea
+          autoFocus
+          variant="unstyled"
+          rows={1}
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && !event.shiftKey) {
+              event.preventDefault();
+              if (trimmed) onSubmit(trimmed);
+            }
+          }}
+          placeholder="Leave feedback for the agent…"
+          className="max-h-24 flex-1 resize-none bg-transparent px-1 py-1 text-sm text-text-primary placeholder:text-text-quaternary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary"
+        />
+        <Button
+          type="submit"
+          variant="unstyled"
+          disabled={!trimmed}
+          title="Add to chat (Enter)"
+          aria-label="Add comment to chat"
+          className="rounded-md p-1.5 text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+        >
+          <CornerDownLeft className="h-3.5 w-3.5" />
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/sandbox/git/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView.tsx
@@ -30,7 +30,14 @@ import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback'
 import { useChatQuery } from '@/hooks/queries/useChatQueries';
 import { useUIStore } from '@/store/uiStore';
 import { parsePatchFiles, parseDiffFromFile } from '@pierre/diffs';
-import type { FileDiffMetadata, FileContents } from '@pierre/diffs';
+import type {
+  FileDiffMetadata,
+  FileContents,
+  SelectedLineRange,
+  DiffLineAnnotation,
+} from '@pierre/diffs';
+import { DiffCommentComposer } from '@/components/sandbox/git/DiffCommentComposer';
+import { useDiffComments } from '@/hooks/useDiffComments';
 import { FileDiff, Virtualizer, WorkerPoolContextProvider } from '@pierre/diffs/react';
 import type { WorkerPoolOptions, WorkerInitializationRenderOptions } from '@pierre/diffs/worker';
 import DiffsWorker from '@pierre/diffs/worker/worker.js?worker';
@@ -82,6 +89,17 @@ const STATUS_COLORS: Record<string, string> = {
   'rename-changed':
     'bg-warning-600/15 text-warning-600 dark:bg-warning-400/15 dark:text-warning-400',
 };
+
+// Stable empty value — the library re-renders a file whenever the annotations
+// array identity changes.
+const NO_ANNOTATIONS: DiffLineAnnotation[] = [];
+
+// The library washes annotation rows with the line-selection tint when they sit
+// inside the selected range; keep the comment composer's row on the plain
+// annotation background. Injected into the shadow root, where unlayered rules
+// beat the library's @layer base styles.
+const DIFF_UNSAFE_CSS =
+  '[data-selected-line]:is([data-line-annotation],[data-gutter-buffer=annotation]){--diffs-computed-selected-line-bg:var(--diffs-annotation-bg)}';
 
 const MENU_ITEM_CLASS =
   'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-text-secondary transition-colors duration-200 hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover';
@@ -167,13 +185,76 @@ function DiffEmptyState({
   );
 }
 
-function FileDiffRenderer({
+const FileDiffRenderer = memo(function FileDiffRenderer({
   file,
   options,
+  canComment,
+  commentRange,
+  isComposing,
+  onSelectionChange,
+  onSelectionEnd,
+  onSubmitComment,
+  onCancelComment,
 }: {
   file: FileDiffMetadata;
   options: Record<string, unknown>;
+  canComment: boolean;
+  commentRange: SelectedLineRange | null;
+  isComposing: boolean;
+  onSelectionChange: (fileName: string, range: SelectedLineRange | null) => void;
+  onSelectionEnd: (fileName: string, range: SelectedLineRange | null) => void;
+  onSubmitComment: (file: FileDiffMetadata, range: SelectedLineRange, comment: string) => void;
+  onCancelComment: () => void;
 }) {
+  // Selection is gated on a chat being connected — the comment has nowhere to
+  // go otherwise. Fully controlled via `selectedLines` so closing the composer
+  // clears the highlight; start/change echoes keep the drag highlight live
+  // (the library doesn't self-render selection in controlled mode).
+  const fileOptions = useMemo(
+    () =>
+      canComment
+        ? {
+            ...options,
+            enableLineSelection: true,
+            onLineSelectionStart: (range: SelectedLineRange | null) =>
+              onSelectionChange(file.name, range),
+            onLineSelectionChange: (range: SelectedLineRange | null) =>
+              onSelectionChange(file.name, range),
+            onLineSelectionEnd: (range: SelectedLineRange | null) =>
+              onSelectionEnd(file.name, range),
+          }
+        : options,
+    [options, canComment, file.name, onSelectionChange, onSelectionEnd],
+  );
+
+  const annotations = useMemo<DiffLineAnnotation[]>(
+    () =>
+      isComposing && commentRange
+        ? [
+            {
+              side: commentRange.endSide ?? commentRange.side ?? 'additions',
+              lineNumber: commentRange.end,
+            },
+          ]
+        : NO_ANNOTATIONS,
+    [isComposing, commentRange],
+  );
+
+  const renderComposer = useCallback(() => {
+    if (!commentRange) return null;
+    return (
+      <DiffCommentComposer
+        lineLabel={
+          commentRange.start === commentRange.end
+            ? `line ${commentRange.start}`
+            : `lines ${commentRange.start}-${commentRange.end}`
+        }
+        onSubmit={(comment) => onSubmitComment(file, commentRange, comment)}
+        onCancel={onCancelComment}
+      />
+    );
+  }, [file, commentRange, onSubmitComment, onCancelComment]);
+
   return (
     <ErrorBoundary
       fallback={
@@ -182,10 +263,16 @@ function FileDiffRenderer({
         </div>
       }
     >
-      <FileDiff fileDiff={file} options={options} />
+      <FileDiff
+        fileDiff={file}
+        options={fileOptions}
+        selectedLines={commentRange}
+        lineAnnotations={annotations}
+        renderAnnotation={renderComposer}
+      />
     </ErrorBoundary>
   );
-}
+});
 
 function FileStats({ file }: { file: FileDiffMetadata }) {
   const { hunks } = file;
@@ -256,6 +343,13 @@ const DiffViewContent = memo(function DiffViewContent({ chatId, isVisible }: Dif
   const [diffStyle, setDiffStyle] = useState<'unified' | 'split'>('unified');
   const [discardTarget, setDiscardTarget] = useState<FileDiffMetadata | null>(null);
   const [discardAllOpen, setDiscardAllOpen] = useState(false);
+  const {
+    pendingComment,
+    resetComments,
+    handleSelectionChange,
+    handleSelectionEnd,
+    handleSubmitComment,
+  } = useDiffComments(chatId, cwd);
 
   const {
     data: diffData,
@@ -283,6 +377,7 @@ const DiffViewContent = memo(function DiffViewContent({ chatId, isVisible }: Dif
     setExpandedFiles(new Set());
     setDiscardTarget(null);
     setDiscardAllOpen(false);
+    resetComments();
   }
 
   // Portal escapes the toolbar's overflow-x-auto clip (CSS clips both axes).
@@ -391,6 +486,7 @@ const DiffViewContent = memo(function DiffViewContent({ chatId, isVisible }: Dif
       diffStyle,
       expandUnchanged: false,
       disableFileHeader: true,
+      unsafeCSS: DIFF_UNSAFE_CSS,
     }),
     [theme, diffStyle],
   );
@@ -670,7 +766,23 @@ const DiffViewContent = memo(function DiffViewContent({ chatId, isVisible }: Dif
                       )}
                       <FileStats file={file} />
                     </div>
-                    {isExpanded && <FileDiffRenderer file={file} options={options} />}
+                    {isExpanded && (
+                      <FileDiffRenderer
+                        file={file}
+                        options={options}
+                        canComment={!!chatId}
+                        commentRange={
+                          pendingComment?.fileName === file.name ? pendingComment.range : null
+                        }
+                        isComposing={
+                          pendingComment?.fileName === file.name && pendingComment.composing
+                        }
+                        onSelectionChange={handleSelectionChange}
+                        onSelectionEnd={handleSelectionEnd}
+                        onSubmitComment={handleSubmitComment}
+                        onCancelComment={resetComments}
+                      />
+                    )}
                   </div>
                 );
               })}

--- a/frontend/src/hooks/useDiffComments.ts
+++ b/frontend/src/hooks/useDiffComments.ts
@@ -1,0 +1,69 @@
+import { useCallback, useState } from 'react';
+import type { FileDiffMetadata, SelectedLineRange } from '@pierre/diffs';
+import { useUIStore } from '@/store/uiStore';
+import { getSelectedDiffText } from '@/utils/diffSelection';
+
+interface PendingDiffComment {
+  fileName: string;
+  range: SelectedLineRange;
+  composing: boolean;
+}
+
+// The library reports selections in anchor→pointer order, so an upward drag
+// yields start > end. Old/new line numbers aren't comparable across sides
+// (split view), so only same-side selections can be safely reordered —
+// cross-side ranges keep the library's order.
+function normalizeSelection(range: SelectedLineRange): SelectedLineRange {
+  const sameSide = (range.endSide ?? range.side) === range.side;
+  if (!sameSide || range.start <= range.end) return range;
+  return { start: range.end, end: range.start, side: range.side, endSide: range.endSide };
+}
+
+// Diff-view review comments: one line selection at a time across all files;
+// `composing` flips on when the drag ends, which opens the composer. Submits
+// attach the selection + comment to the chat input as an editor-selection chip.
+export function useDiffComments(chatId: string | undefined, cwd: string | undefined) {
+  const [pendingComment, setPendingComment] = useState<PendingDiffComment | null>(null);
+
+  // Raw (anchor-order) range during the drag — it matches the library's own
+  // representation, so the equality guards inside the manager stay effective.
+  const handleSelectionChange = useCallback((fileName: string, range: SelectedLineRange | null) => {
+    setPendingComment(range ? { fileName, range, composing: false } : null);
+  }, []);
+
+  const handleSelectionEnd = useCallback((fileName: string, range: SelectedLineRange | null) => {
+    setPendingComment(
+      range ? { fileName, range: normalizeSelection(range), composing: true } : null,
+    );
+  }, []);
+
+  const resetComments = useCallback(() => setPendingComment(null), []);
+
+  const handleSubmitComment = useCallback(
+    (file: FileDiffMetadata, range: SelectedLineRange, comment: string) => {
+      if (!chatId) return;
+      // Attach even when snippet extraction comes up empty — losing the typed
+      // comment is worse than an empty code block.
+      const snippet = getSelectedDiffText(file, range);
+      useUIStore.getState().addEditorSelection(chatId, {
+        // Same workspace-root basis as "open in editor" and editor selections.
+        path: cwd ? `${cwd}/${file.name}` : file.name,
+        startLine: range.start,
+        endLine: range.end,
+        languageId: 'diff',
+        text: snippet ?? '',
+        comment,
+      });
+      setPendingComment(null);
+    },
+    [chatId, cwd],
+  );
+
+  return {
+    pendingComment,
+    resetComments,
+    handleSelectionChange,
+    handleSelectionEnd,
+    handleSubmitComment,
+  };
+}

--- a/frontend/src/lib/editorChatActions.ts
+++ b/frontend/src/lib/editorChatActions.ts
@@ -85,7 +85,8 @@ export function formatEditorSelections(selections: EditorCodeSelection[], messag
     const longestRun =
       s.text.match(BACKTICK_RUN)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
     const fence = '`'.repeat(Math.max(3, longestRun + 1));
-    return `${s.path}:${lineRef}\n${fence}${s.languageId}\n${s.text}\n${fence}`;
+    const block = `${s.path}:${lineRef}\n${fence}${s.languageId}\n${s.text}\n${fence}`;
+    return s.comment ? `${block}\n${s.comment}` : block;
   });
   return [...blocks, message].filter(Boolean).join('\n\n');
 }

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -42,6 +42,8 @@ export interface EditorCodeSelection {
   endLine: number;
   languageId: string;
   text: string;
+  // Set by diff-view review comments; serialized under the code block at send time.
+  comment?: string;
 }
 
 type UIStoreState = ThemeState &

--- a/frontend/src/utils/diffSelection.ts
+++ b/frontend/src/utils/diffSelection.ts
@@ -1,0 +1,114 @@
+import type { FileDiffMetadata, SelectedLineRange, SelectionSide } from '@pierre/diffs';
+
+// One rendered diff row in unified order; del/add are that side's line numbers.
+interface DiffRow {
+  prefix: ' ' | '+' | '-';
+  del?: number;
+  add?: number;
+  text: string;
+}
+
+const TRAILING_NEWLINE = /\n$/;
+
+function rowMatches(row: DiffRow, lineNumber: number, side: SelectionSide | undefined): boolean {
+  if (side === 'deletions') return row.del === lineNumber;
+  if (side === 'additions') return row.add === lineNumber;
+  return row.del === lineNumber || row.add === lineNumber;
+}
+
+function buildUnifiedRows(file: FileDiffMetadata): DiffRow[] {
+  const rows: DiffRow[] = [];
+  // Context gaps between hunks are only addressable when the line arrays hold
+  // complete file bodies (line number N ↔ index N-1). DiffView's
+  // rebuildWithCollapsedContext (re-diff from full contents) guarantees this
+  // for every rendered diff; partial patches can't expand gaps, so skipping
+  // them is safe.
+  const fullBodies = file.hunks.every(
+    (h) =>
+      h.additionLineIndex === h.additionStart - 1 && h.deletionLineIndex === h.deletionStart - 1,
+  );
+
+  let delNext = 1;
+  let addNext = 1;
+  for (const hunk of file.hunks) {
+    if (fullBodies) {
+      for (let i = 0; i < hunk.additionStart - addNext; i += 1) {
+        rows.push({
+          prefix: ' ',
+          del: delNext + i,
+          add: addNext + i,
+          text: file.additionLines[addNext + i - 1] ?? '',
+        });
+      }
+    }
+    let delNo = hunk.deletionStart;
+    let addNo = hunk.additionStart;
+    for (const content of hunk.hunkContent) {
+      if (content.type === 'context') {
+        for (let i = 0; i < content.lines; i += 1) {
+          rows.push({
+            prefix: ' ',
+            del: delNo + i,
+            add: addNo + i,
+            text: file.additionLines[content.additionLineIndex + i] ?? '',
+          });
+        }
+        delNo += content.lines;
+        addNo += content.lines;
+      } else {
+        for (let i = 0; i < content.deletions; i += 1) {
+          rows.push({
+            prefix: '-',
+            del: delNo + i,
+            text: file.deletionLines[content.deletionLineIndex + i] ?? '',
+          });
+        }
+        for (let i = 0; i < content.additions; i += 1) {
+          rows.push({
+            prefix: '+',
+            add: addNo + i,
+            text: file.additionLines[content.additionLineIndex + i] ?? '',
+          });
+        }
+        delNo += content.deletions;
+        addNo += content.additions;
+      }
+    }
+    delNext = delNo;
+    addNext = addNo;
+  }
+  if (fullBodies) {
+    for (let i = 0; addNext + i <= file.additionLines.length; i += 1) {
+      rows.push({
+        prefix: ' ',
+        del: delNext + i,
+        add: addNext + i,
+        text: file.additionLines[addNext + i - 1] ?? '',
+      });
+    }
+  }
+  return rows;
+}
+
+// Selected lines of a diff as unified-diff text (`-`/`+`/space prefixes).
+// Returns null when the range doesn't resolve against the file's hunks.
+export function getSelectedDiffText(
+  file: FileDiffMetadata,
+  range: SelectedLineRange,
+): string | null {
+  const rows = buildUnifiedRows(file);
+  const endSide = range.endSide ?? range.side;
+  let startIdx = -1;
+  let endIdx = -1;
+  for (let i = 0; i < rows.length; i += 1) {
+    if (startIdx === -1 && rowMatches(rows[i], range.start, range.side)) startIdx = i;
+    if (rowMatches(rows[i], range.end, endSide)) endIdx = i;
+  }
+  if (startIdx === -1 || endIdx === -1) return null;
+  const lo = Math.min(startIdx, endIdx);
+  const hi = Math.max(startIdx, endIdx);
+  return rows
+    .slice(lo, hi + 1)
+    .map((row) => `${row.prefix}${row.text.replace(TRAILING_NEWLINE, '')}`)
+    .join('\n');
+}


### PR DESCRIPTION
## Summary
- Adds line-selection + inline comment composer to the diff view, mirroring the editor's inline chat widget styling
- Comments are attached to the chat input as an editor-selection chip (path/lines/snippet + comment), submitted together with the message
- New: `DiffCommentComposer.tsx`, `useDiffComments.ts` hook, `diffSelection.ts` util (extracts unified-diff text for the selected range)
- `EditorCodeSelection` gains an optional `comment` field, threaded through selection chips and the formatted chat message