### PR TITLE
feat(chat): support pasting images and files into message input

### DIFF
--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -100,6 +100,7 @@ function InputLayout() {
             isLoading={state.isLoading}
             disabled={state.isDisabled}
             onKeyDown={actions.handleKeyDown}
+            onPaste={actions.handlePaste}
             onCursorPositionChange={actions.setCursorPosition}
             compact={state.compact}
           />
@@ -155,8 +156,8 @@ function InputLayout() {
 
       {state.showTip && !state.hasAttachments && (
         <div className="mt-1 animate-fade-in text-center text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-          <span className="font-medium">Tip:</span> Drag and drop images, pdfs and xlsx files into
-          the input area, type `/` for slash commands, or `@` to mention files and agents
+          <span className="font-medium">Tip:</span> Drag and drop or paste images, pdfs and xlsx
+          files into the input area, type `/` for slash commands, or `@` to mention files and agents
         </div>
       )}
     </form>

--- a/frontend/src/components/chat/message-input/InputContext.ts
+++ b/frontend/src/components/chat/message-input/InputContext.ts
@@ -51,6 +51,7 @@ export interface InputActions {
   handleRemoveSelection: (index: number) => void;
   handleDrawClick: (index: number) => void;
   handleDrawingSave: (dataUrl: string) => Promise<void>;
+  handlePaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
   closeDrawingModal: () => void;
   resetDragState: () => void;
   selectSlashCommand: (command: SlashCommand) => void;

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -127,6 +127,18 @@ export function InputProvider({
     onFilesDrop: handleDroppedFiles,
   });
 
+  const handlePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      // Pasted screenshots/files arrive as clipboard files — route them through the
+      // same validated attach path as drag-and-drop instead of losing them.
+      const files = Array.from(event.clipboardData.files);
+      if (!onAttach || files.length === 0) return;
+      event.preventDefault();
+      handleDroppedFiles(files);
+    },
+    [onAttach, handleDroppedFiles],
+  );
+
   const focusTextarea = useCallback((text: string) => {
     const textarea = textareaRef.current;
     if (textarea) {
@@ -421,6 +433,7 @@ export function InputProvider({
       handleRemoveSelection,
       handleDrawClick,
       handleDrawingSave,
+      handlePaste,
       closeDrawingModal,
       resetDragState,
       selectSlashCommand,
@@ -441,6 +454,7 @@ export function InputProvider({
       handleRemoveSelection,
       handleDrawClick,
       handleDrawingSave,
+      handlePaste,
       closeDrawingModal,
       resetDragState,
       selectSlashCommand,

--- a/frontend/src/components/chat/message-input/Textarea.tsx
+++ b/frontend/src/components/chat/message-input/Textarea.tsx
@@ -20,6 +20,7 @@ export interface TextareaProps {
   isLoading: boolean;
   disabled?: boolean;
   onKeyDown: (e: React.KeyboardEvent) => void;
+  onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
   onCursorPositionChange?: (position: number) => void;
   compact?: boolean;
 }
@@ -34,6 +35,7 @@ export function Textarea({
   isLoading,
   disabled = false,
   onKeyDown,
+  onPaste,
   onCursorPositionChange,
   compact,
 }: TextareaProps) {
@@ -119,6 +121,7 @@ export function Textarea({
       value={message}
       onChange={handleChange}
       onKeyDown={onKeyDown}
+      onPaste={onPaste}
       onKeyUp={handleCursorChange}
       onClick={handleCursorChange}
       onSelect={handleCursorChange}


### PR DESCRIPTION
## Summary
- Adds an `onPaste` handler to the message input textarea that routes clipboard files (e.g. pasted screenshots) through the same validated attach path used for drag-and-drop, instead of losing them
- Updates the drop-zone tip text to mention pasting alongside drag-and-drop