### PR TITLE
feat(layout): browser-style raised active chat tab

### DIFF
--- a/frontend/src/components/layout/ChatTabs.tsx
+++ b/frontend/src/components/layout/ChatTabs.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMatch, useNavigate } from 'react-router-dom';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
@@ -57,11 +57,14 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
         if (e.button === 1) onClose(chatId);
       }}
       className={cn(
-        'group flex min-w-0 max-w-[180px] flex-shrink-0 items-center gap-1 rounded-md py-1 pl-2 pr-1',
+        'group flex h-8 min-w-0 max-w-[180px] flex-shrink-0 items-center gap-1 pl-2 pr-1',
         'transition-colors duration-200',
         isActive
-          ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
-          : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary',
+          ? // Browser-style: the active tab wears the page surface and sits over the
+            // band's hairline, merging into the content below.
+            'rounded-t-lg border border-b-0 border-border/50 bg-surface text-text-primary dark:border-border-dark/50 dark:bg-surface-dark dark:text-text-dark-primary'
+          : // mb-px lifts inactive tabs back above the hairline the strip overlaps.
+            'mb-px rounded-md text-text-tertiary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary',
       )}
     >
       <Button
@@ -202,8 +205,10 @@ export function ChatTabs() {
   if (isMobile || chatTabs.length === 0) return null;
 
   return (
-    <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
-      {chatTabs.map((chatId) => {
+    // -mb-px drops the strip over the title bar's hairline so the active tab's
+    // surface can cover its segment of the border.
+    <div className="-mb-px flex h-full min-w-0 items-end gap-1 overflow-x-auto">
+      {chatTabs.map((chatId, index) => {
         const status: ChatTabStatus | null = blockedChatIdSet.has(chatId)
           ? 'blocked'
           : streamingChatIdSet.has(chatId)
@@ -211,16 +216,27 @@ export function ChatTabs() {
             : finishedChatIds.has(chatId)
               ? 'finished'
               : null;
+        // Browser-tab convention: separators only between two inactive neighbors —
+        // the active tab's raised card draws its own boundary.
+        const showSeparator =
+          index > 0 && !visibleChatIds.has(chatId) && !visibleChatIds.has(chatTabs[index - 1]);
         return (
-          <ChatTab
-            key={chatId}
-            chatId={chatId}
-            isActive={visibleChatIds.has(chatId)}
-            isCurrent={chatId === routedChatId}
-            status={status}
-            onSelect={handleSelect}
-            onClose={handleClose}
-          />
+          <Fragment key={chatId}>
+            {showSeparator && (
+              <span
+                aria-hidden="true"
+                className="mb-2.5 h-3.5 w-px flex-shrink-0 bg-border dark:bg-border-dark"
+              />
+            )}
+            <ChatTab
+              chatId={chatId}
+              isActive={visibleChatIds.has(chatId)}
+              isCurrent={chatId === routedChatId}
+              status={status}
+              onSelect={handleSelect}
+              onClose={handleClose}
+            />
+          </Fragment>
         );
       })}
     </div>

--- a/frontend/src/components/layout/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar.tsx
@@ -159,16 +159,16 @@ export function TitleBar() {
       onMouseDown={handleMouseDown}
       onDoubleClick={handleDoubleClick}
     >
-      {/* Left section — wears the sidebar color only while the sidebar is open (so it
-          reads as the sidebar's header strip); otherwise matches the main bar to avoid
-          a floating two-tone block hugging the icons. */}
+      {/* Left section — same secondary surface as the main band. While the sidebar is
+          open it doubles as the sidebar's header strip (border-r, no hairline below so
+          it merges into the sidebar); when closed the band's hairline runs to the edge. */}
       <div
         className={cn(
-          'flex h-full items-center gap-1 pt-[env(safe-area-inset-top)]',
+          'flex h-full items-center gap-1 bg-surface-secondary pt-[env(safe-area-inset-top)] dark:bg-surface-dark-secondary',
           'transition-[width,padding] duration-[var(--sidebar-transition-duration,500ms)] ease-in-out',
           isAuthenticated && showSidebar && sidebarOpen
-            ? 'w-[var(--sidebar-width)] border-r border-border/50 bg-surface-secondary dark:border-border-dark/50 dark:bg-surface-dark-secondary'
-            : 'w-auto bg-surface dark:bg-surface-dark',
+            ? 'w-[var(--sidebar-width)] border-r border-border/50 dark:border-border-dark/50'
+            : 'w-auto border-b border-border/50 dark:border-border-dark/50',
         )}
       >
         {IS_MACOS_DESKTOP && <TrafficLights />}
@@ -204,10 +204,12 @@ export function TitleBar() {
         {IS_MACOS_DESKTOP && !(isAuthenticated && showSidebar) && <div className="w-1" />}
       </div>
 
-      {/* Main content area — matches main bg. Chat tabs (the open working set)
-          sit on the left; the view switcher stays pinned right. */}
-      <div className="flex h-full min-w-0 flex-1 items-center justify-between gap-2 bg-surface px-3 pt-[env(safe-area-inset-top)] dark:bg-surface-dark">
-        <div className="flex min-w-0 flex-1 items-center gap-1">
+      {/* Main content area — a secondary-surface band with a hairline below, so the
+          active chat tab (browser-style, bg-surface) merges into the page under it.
+          Chat tabs (the open working set) sit on the left; the view switcher stays
+          pinned right. */}
+      <div className="flex h-full min-w-0 flex-1 items-center justify-between gap-2 border-b border-border/50 bg-surface-secondary px-3 pt-[env(safe-area-inset-top)] dark:border-border-dark/50 dark:bg-surface-dark-secondary">
+        <div className="flex h-full min-w-0 flex-1 items-end gap-1">
           {/* Auth gate: on macOS desktop the bar renders even when logged out, and
               persisted chatTabs would fire protected chat queries (and self-close
               on the resulting 401s, wiping the working set). */}


### PR DESCRIPTION
## Summary
- Active chat tab now wears the page surface and sits over the title bar's hairline, merging visually into the content below (browser-tab convention)
- Inactive tabs get subtle separators only between two adjacent inactive tabs — the active tab's raised card draws its own boundary
- Title bar's main band switched to a secondary-surface with a bottom hairline so the active tab reads as "lifted" above it