### PR TITLE
Remove Tailwind prose classes from markdown rendering

### DIFF
--- a/frontend/src/components/chat/message-bubble/SegmentView.tsx
+++ b/frontend/src/components/chat/message-bubble/SegmentView.tsx
@@ -23,7 +23,7 @@ const TextSegment = ({ text, isActive }: { text: string; isActive: boolean }) =>
   // of jumping a flush-sized chunk at a time.
   const smoothText = useSmoothText(text, isActive);
   return (
-    <div className="prose prose-sm dark:prose-invert max-w-none break-words">
+    <div className="max-w-none break-words">
       <LazyMarkDown content={smoothText} streaming={isActive} />
     </div>
   );

--- a/frontend/src/components/chat/tools/claude/PlanModeTool.tsx
+++ b/frontend/src/components/chat/tools/claude/PlanModeTool.tsx
@@ -73,7 +73,7 @@ const ExitPlanModeInner: React.FC<PlanModeToolProps> = ({ tool, chatId }) => {
 
           {planContent && (
             <div className="mt-3 overflow-auto rounded-md bg-black/5 px-2 py-1.5 text-xs dark:bg-white/5">
-              <div className="prose prose-sm dark:prose-invert max-w-none text-text-primary dark:text-text-dark-primary">
+              <div className="max-w-none text-text-primary dark:text-text-dark-primary">
                 <LazyMarkDown content={planContent} />
               </div>
             </div>
@@ -136,7 +136,7 @@ const ExitPlanModeInner: React.FC<PlanModeToolProps> = ({ tool, chatId }) => {
         <div className="space-y-2">
           {planContent && (
             <div className="overflow-auto rounded-md bg-black/5 px-2 py-1.5 text-xs dark:bg-white/5">
-              <div className="prose prose-sm dark:prose-invert max-w-none text-text-primary dark:text-text-dark-primary">
+              <div className="max-w-none text-text-primary dark:text-text-dark-primary">
                 <LazyMarkDown content={planContent} />
               </div>
             </div>

--- a/frontend/src/components/editor/file-preview/MarkdownPreview.tsx
+++ b/frontend/src/components/editor/file-preview/MarkdownPreview.tsx
@@ -20,7 +20,7 @@ export const MarkdownPreview = memo(function MarkdownPreview({
       fileName={getDisplayFileName(file)}
       isFullscreen={isFullscreen}
       onToggleFullscreen={onToggleFullscreen}
-      contentClassName="overflow-auto p-6 prose max-w-none dark:prose-invert"
+      contentClassName="overflow-auto p-6 max-w-none"
     >
       <LazyMarkDown content={file.content} />
     </PreviewContainer>

--- a/frontend/src/components/ui/MarkDown.tsx
+++ b/frontend/src/components/ui/MarkDown.tsx
@@ -270,7 +270,7 @@ const MARKDOWN_COMPONENTS: Components = {
 
     return (
       <p
-        className="mb-3 whitespace-pre-wrap leading-5 text-text-secondary [overflow-wrap:anywhere] last:mb-0 dark:text-text-dark-secondary"
+        className="mb-3 whitespace-pre-wrap leading-relaxed text-text-secondary [overflow-wrap:anywhere] last:mb-0 dark:text-text-dark-secondary"
         {...props}
       >
         {children}
@@ -359,7 +359,10 @@ const MARKDOWN_COMPONENTS: Components = {
     </ol>
   ),
   li: ({ children, ...props }: CommonProps) => (
-    <li className="pl-1 text-text-secondary dark:text-text-dark-secondary" {...props}>
+    <li
+      className="pl-1 leading-relaxed text-text-secondary dark:text-text-dark-secondary"
+      {...props}
+    >
       {children}
     </li>
   ),


### PR DESCRIPTION
## Summary
- Removed `prose`/`prose-invert` Tailwind Typography classes from markdown containers (`SegmentView`, `PlanModeTool`, `MarkdownPreview`) since spacing/typography is already handled by the custom `MARKDOWN_COMPONENTS` renderers in `MarkDown.tsx`
- Switched paragraph and list item line-height from `leading-5` to `leading-relaxed` in `MarkDown.tsx` to compensate for the removed prose defaults