### PR TITLE
fix(tauri): adjust default window dimensions

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -13,8 +13,8 @@
     "windows": [
       {
         "title": "Agentrove",
-        "width": 1280,
-        "height": 800,
+        "width": 1050,
+        "height": 1100,
         "minWidth": 940,
         "minHeight": 560,
         "resizable": true,


### PR DESCRIPTION
## Summary
- Change the desktop app's default launch window size from 1280x800 to 1050x1100.