### PR TITLE
feat(editor): add git diff view with change indicators

### DIFF
--- a/backend/app/api/endpoints/sandbox.py
+++ b/backend/app/api/endpoints/sandbox.py
@@ -21,10 +21,12 @@ from app.models.schemas.sandbox import (
     GitCheckoutRequest,
     GitCheckoutResponse,
     GitCommandResponse,
+    GitChangedPathsResponse,
     GitCommitRequest,
     GitCreateBranchRequest,
     GitCreateBranchResponse,
     GitDiffResponse,
+    GitFileBaselineResponse,
     GitRemoteUrlResponse,
     GitRestoreFileRequest,
     SandboxFilesMetadataResponse,
@@ -223,6 +225,37 @@ async def get_git_diff(
 ) -> GitDiffResponse:
     try:
         return await git_service.get_diff(sandbox_id, mode, full_context, cwd)
+    except (ValueError, SandboxException) as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.get("/{sandbox_id}/git/changed-paths", response_model=GitChangedPathsResponse)
+async def get_git_changed_paths(
+    sandbox_id: str = Depends(validate_sandbox_ownership),
+    git_service: GitService = Depends(get_git_service),
+    cwd: str | None = Query(None),
+) -> GitChangedPathsResponse:
+    try:
+        return await git_service.get_changed_paths(sandbox_id, cwd)
+    except (ValueError, SandboxException) as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.get("/{sandbox_id}/git/file-baseline", response_model=GitFileBaselineResponse)
+async def get_git_file_baseline(
+    sandbox_id: str = Depends(validate_sandbox_ownership),
+    git_service: GitService = Depends(get_git_service),
+    path: str = Query(..., min_length=1, max_length=1024),
+    cwd: str | None = Query(None),
+) -> GitFileBaselineResponse:
+    try:
+        return await git_service.get_file_baseline(sandbox_id, path, cwd)
     except (ValueError, SandboxException) as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/models/schemas/sandbox.py
+++ b/backend/app/models/schemas/sandbox.py
@@ -46,6 +46,17 @@ class GitDiffResponse(BaseModel):
     error: str | None = None
 
 
+class GitFileBaselineResponse(BaseModel):
+    path: str
+    content: str
+    is_git_repo: bool
+
+
+class GitChangedPathsResponse(BaseModel):
+    paths: list[str]
+    is_git_repo: bool
+
+
 class GitBranchesResponse(BaseModel):
     branches: list[str]
     current_branch: str

--- a/backend/app/services/git.py
+++ b/backend/app/services/git.py
@@ -9,10 +9,12 @@ from app.models.schemas.sandbox import (
     ChangedFile,
     FileDiffResponse,
     GitBranchesResponse,
+    GitChangedPathsResponse,
     GitCheckoutResponse,
     GitCommandResponse,
     GitCreateBranchResponse,
     GitDiffResponse,
+    GitFileBaselineResponse,
     GitRemoteUrlResponse,
 )
 from app.services.exceptions import SandboxException
@@ -166,6 +168,25 @@ GIT_DIFF_BRANCH_TEMPLATE = Template(
     ' git diff$ctx "$$merge_base" HEAD 2>/dev/null'
 )
 
+# Exit 2 distinguishes "not a repo" from "path not in HEAD" — `git show`
+# alone fails identically for both, and the editor renders them differently.
+GIT_SHOW_HEAD_TEMPLATE = Template(
+    "git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 2; "
+    "git show $spec 2>/dev/null"
+)
+
+# `--no-renames` keeps every record a plain `XY <path>` pair (renames split
+# into D + A), `-z` avoids quoting so paths with spaces parse cleanly, and
+# `--untracked-files=all` lists files inside untracked dirs (default collapses
+# them to `?? dir/`, which would never match a file path). Porcelain paths are
+# always repo-root-relative; `--show-prefix` (cwd relative to the repo root,
+# first line) lets the parser re-base them to cwd for the response contract.
+GIT_STATUS_PORCELAIN_CMD = (
+    "git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 2; "
+    "git rev-parse --show-prefix; "
+    "git status --porcelain --no-renames --untracked-files=all -z 2>/dev/null"
+)
+
 # Diff pathspecs are repo-root-relative and `git clean -fd` only cleans below
 # the current directory, so restore commands hop to the repo root before
 # running to keep pathspecs resolving and clean sweeps workspace-wide.
@@ -271,6 +292,57 @@ class GitService:
             has_changes=bool(diff_output.strip()),
             is_git_repo=True,
         )
+
+    async def get_file_baseline(
+        self,
+        sandbox_id: str,
+        path: str,
+        cwd: str | None = None,
+    ) -> GitFileBaselineResponse:
+        # `HEAD:./<path>` resolves relative to the directory git runs in, so
+        # cwd-relative editor paths work even when the repo root sits above cwd.
+        self._validate_relative_path(path)
+        cd_prefix = git_cd_prefix(cwd)
+        cmd = GIT_SHOW_HEAD_TEMPLATE.substitute(spec=shlex.quote(f"HEAD:./{path}"))
+        result = await self.sandbox_service.execute_command(
+            sandbox_id, f"{cd_prefix}{cmd}"
+        )
+        if result.exit_code == 2:
+            return GitFileBaselineResponse(path=path, content="", is_git_repo=False)
+        # Any other failure means the path isn't in HEAD (new/untracked file or
+        # unborn branch) — an empty baseline renders the whole file as added.
+        content = result.stdout if result.exit_code == 0 else ""
+        return GitFileBaselineResponse(path=path, content=content, is_git_repo=True)
+
+    async def get_changed_paths(
+        self,
+        sandbox_id: str,
+        cwd: str | None = None,
+    ) -> GitChangedPathsResponse:
+        # Cheap existence check for change indicators — the diff endpoints stay
+        # the source of the actual content.
+        cd_prefix = git_cd_prefix(cwd)
+        result = await self.sandbox_service.execute_command(
+            sandbox_id, f"{cd_prefix}{GIT_STATUS_PORCELAIN_CMD}"
+        )
+        if result.exit_code == 2:
+            return GitChangedPathsResponse(paths=[], is_git_repo=False)
+        # First line is cwd's path inside the repo ("" at the repo root); the
+        # rest are -z records of `XY <path>` — strip the status chars + space,
+        # then re-base repo-root paths to cwd, dropping files outside it (the
+        # editor tree can't display them anyway).
+        prefix, _, status_out = result.stdout.partition("\n")
+        paths = []
+        for entry in status_out.split("\0"):
+            if len(entry) <= 3:
+                continue
+            path = entry[3:]
+            if prefix:
+                if not path.startswith(prefix):
+                    continue
+                path = path[len(prefix) :]
+            paths.append(path)
+        return GitChangedPathsResponse(paths=paths, is_git_repo=True)
 
     async def get_branches(
         self,

--- a/frontend/src/components/editor/code-sidebar/CodeSidebar.tsx
+++ b/frontend/src/components/editor/code-sidebar/CodeSidebar.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/primitives/Button';
 import { useDropdown } from '@/hooks/useDropdown';
 import { Tree, type TreeHandle } from '../file-tree/Tree';
 import { SearchPanel } from '../file-search/SearchPanel';
+import { useGitChangedPathsQuery } from '@/hooks/queries/useSandboxQueries';
 import type { FileStructure } from '@/types/file-system.types';
 import { cn } from '@/utils/cn';
 
@@ -43,6 +44,14 @@ export const CodeSidebar = memo(function CodeSidebar({
   const handleSearchFiles = useCallback(() => setView('search'), []);
   const handleBackToFiles = useCallback(() => setView('files'), []);
 
+  // Git paths are cwd-relative while tree paths are workspace-root-relative —
+  // re-prefix cwd so the change indicators match the tree's paths.
+  const { data: changedPathsData } = useGitChangedPathsQuery(sandboxId, cwd);
+  const modifiedPaths = useMemo(
+    () => new Set((changedPathsData?.paths ?? []).map((p) => (cwd ? `${cwd}/${p}` : p))),
+    [changedPathsData, cwd],
+  );
+
   // Stable element preserves Tree's memo when unrelated sidebar props change.
   const treeHeader = useMemo(
     () => (
@@ -66,6 +75,7 @@ export const CodeSidebar = memo(function CodeSidebar({
           selectedFile={selectedFile}
           onFileSelect={onFileSelect}
           isSandboxSyncing={isSandboxSyncing}
+          modifiedPaths={modifiedPaths}
           header={treeHeader}
         />
       </div>

--- a/frontend/src/components/editor/editor-view/DiffContent.tsx
+++ b/frontend/src/components/editor/editor-view/DiffContent.tsx
@@ -1,0 +1,154 @@
+import { memo, lazy, Suspense } from 'react';
+import { GitCompareArrows } from 'lucide-react';
+import { MONACO_FONT_FAMILY } from '@/config/constants';
+import { Button } from '@/components/ui/primitives/Button';
+import { cn } from '@/utils/cn';
+
+const DiffEditor = lazy(() =>
+  import('@monaco-editor/react').then((m) => ({ default: m.DiffEditor })),
+);
+
+const DIFF_OPTIONS = {
+  readOnly: true,
+  originalEditable: false,
+  renderSideBySide: true,
+  // Collapses to the inline view when the editor pane is too narrow for split.
+  useInlineViewWhenSpaceIsLimited: true,
+  hideUnchangedRegions: { enabled: true },
+  renderOverviewRuler: false,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  padding: { top: 8, bottom: 8 },
+  automaticLayout: true,
+  fontFamily: MONACO_FONT_FAMILY,
+  fontSize: 12,
+  lineHeight: 1.5,
+  renderLineHighlight: 'none',
+  scrollbar: {
+    useShadows: false,
+    vertical: 'auto',
+    horizontal: 'auto',
+    horizontalScrollbarSize: 6,
+    verticalScrollbarSize: 6,
+  },
+  guides: {
+    indentation: false,
+  },
+  stickyScroll: { enabled: false },
+  smoothScrolling: true,
+} as const;
+
+export interface DiffContentProps {
+  // HEAD version of the file; undefined until the baseline query resolves.
+  original: string | undefined;
+  modified: string;
+  language: string;
+  theme: string;
+  isLoading: boolean;
+  isError: boolean;
+  isGitRepo: boolean;
+  // Git can report the path changed while the contents match (staged-only
+  // change, new empty file) — don't claim the file matches the last commit then.
+  hasGitChanges: boolean;
+  onRetry: () => void;
+  onBeforeMount: (monaco: typeof import('monaco-editor')) => void;
+}
+
+export const DiffContent = memo(function DiffContent({
+  original,
+  modified,
+  language,
+  theme,
+  isLoading,
+  isError,
+  isGitRepo,
+  hasGitChanges,
+  onRetry,
+  onBeforeMount,
+}: DiffContentProps) {
+  const stateClassName = cn(
+    'flex h-full w-full flex-col items-center justify-center gap-2',
+    'bg-surface-secondary dark:bg-surface-dark-secondary',
+  );
+
+  if (isLoading || (!isError && original === undefined)) {
+    return (
+      <div className={stateClassName}>
+        <div className="animate-pulse text-xs text-text-quaternary dark:text-text-dark-quaternary">
+          Loading changes...
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className={stateClassName}>
+        <span className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
+          Failed to load changes
+        </span>
+        <Button
+          onClick={onRetry}
+          variant="unstyled"
+          className="text-2xs text-text-tertiary underline transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-secondary"
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (!isGitRepo) {
+    return (
+      <div className={stateClassName}>
+        <GitCompareArrows className="h-5 w-5 text-text-quaternary dark:text-text-dark-quaternary" />
+        <span className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
+          Not a git repository
+        </span>
+      </div>
+    );
+  }
+
+  if (original === modified) {
+    return (
+      <div className={stateClassName}>
+        <GitCompareArrows className="h-5 w-5 text-text-quaternary dark:text-text-dark-quaternary" />
+        <span className="text-xs text-text-tertiary dark:text-text-dark-tertiary">
+          {hasGitChanges ? 'No content changes to show' : 'No changes since last commit'}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full">
+      <Suspense
+        fallback={
+          <div className={stateClassName}>
+            <div className="animate-pulse text-xs text-text-quaternary dark:text-text-dark-quaternary">
+              Loading editor...
+            </div>
+          </div>
+        }
+      >
+        <DiffEditor
+          height="100%"
+          language={language}
+          original={original}
+          modified={modified}
+          theme={theme}
+          options={DIFF_OPTIONS}
+          beforeMount={onBeforeMount}
+          loading={
+            <div className={stateClassName}>
+              <div className="animate-pulse text-xs text-text-quaternary dark:text-text-dark-quaternary">
+                Loading editor...
+              </div>
+            </div>
+          }
+          className="bg-surface-secondary dark:bg-surface-dark-secondary"
+        />
+      </Suspense>
+    </div>
+  );
+});

--- a/frontend/src/components/editor/editor-view/Header.tsx
+++ b/frontend/src/components/editor/editor-view/Header.tsx
@@ -1,5 +1,13 @@
 import { memo } from 'react';
-import { AlertTriangle, Code, FileText, PanelLeft, PanelLeftClose, Maximize2 } from 'lucide-react';
+import {
+  AlertTriangle,
+  Code,
+  FileText,
+  GitCompareArrows,
+  PanelLeft,
+  PanelLeftClose,
+  Maximize2,
+} from 'lucide-react';
 import type { FileStructure } from '@/types/file-system.types';
 import { Button } from '@/components/ui/primitives/Button';
 import { SaveButton } from '@/components/ui/shared/SaveButton';
@@ -14,6 +22,11 @@ export interface HeaderProps {
   selectedFile?: FileStructure | null;
   showPreview?: boolean;
   onTogglePreview?: (showPreview: boolean) => void;
+  showDiff?: boolean;
+  onToggleDiff?: () => void;
+  // Whether the file has uncommitted or unsaved changes — shows the dot on the
+  // Changes toggle so users can tell the diff view has content before opening it.
+  hasChanges?: boolean;
   hasUnsavedChanges?: boolean;
   isSaving?: boolean;
   onSave?: () => void;
@@ -28,6 +41,9 @@ export const Header = memo(function Header({
   selectedFile,
   showPreview = false,
   onTogglePreview,
+  showDiff = false,
+  onToggleDiff,
+  hasChanges = false,
   hasUnsavedChanges = false,
   isSaving = false,
   onSave,
@@ -73,6 +89,25 @@ export const Header = memo(function Header({
         )}
 
         {onSave && hasUnsavedChanges && <SaveButton onClick={onSave} isSaving={isSaving} />}
+
+        {onToggleDiff && (
+          <Button
+            onClick={onToggleDiff}
+            variant="unstyled"
+            className={cn(
+              'flex items-center gap-1 rounded-md px-2 py-0.5 text-2xs font-medium transition-colors duration-200',
+              showDiff
+                ? 'bg-surface-active text-text-primary dark:bg-surface-dark-hover dark:text-text-dark-primary'
+                : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary',
+            )}
+          >
+            <GitCompareArrows className="h-3 w-3" />
+            Changes
+            {hasChanges && (
+              <span className="h-1 w-1 rounded-full bg-text-quaternary dark:bg-text-dark-quaternary" />
+            )}
+          </Button>
+        )}
 
         {isPreviewable && onTogglePreview && (
           <Button

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -2,6 +2,7 @@ import { memo, useState, useRef, useCallback, useEffect } from 'react';
 import type * as monaco from 'monaco-editor';
 import { Header } from './Header';
 import { Content } from './Content';
+import { DiffContent } from './DiffContent';
 import { EmptyState } from './EmptyState';
 import { EditorTabs } from './EditorTabs';
 import { FilePreview } from '../file-preview/FilePreview';
@@ -16,9 +17,24 @@ import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { useEditorDrafts } from '@/hooks/useEditorDrafts';
 import type { FileStructure } from '@/types/file-system.types';
 import { detectLanguage, findFileInStructure, getFileName } from '@/utils/file';
-import { useUpdateFileMutation, useFileContentQuery } from '@/hooks/queries/useSandboxQueries';
+import {
+  useUpdateFileMutation,
+  useFileContentQuery,
+  useGitChangedPathsQuery,
+  useGitFileBaselineQuery,
+} from '@/hooks/queries/useSandboxQueries';
 import { isPreviewableFile, isHtmlFile } from '@/utils/fileTypes';
 import toast from 'react-hot-toast';
+
+// The content area's mutually-exclusive modes — a single union so an illegal
+// combination (e.g. preview+diff) can't be represented.
+type ViewMode = 'code' | 'preview' | 'diff';
+
+// Previewable types open in preview; HTML opens raw (its preview is opt-in
+// via the toggle).
+function defaultViewMode(file: FileStructure | null): ViewMode {
+  return file && isPreviewableFile(file) && !isHtmlFile(file) ? 'preview' : 'code';
+}
 
 export interface ViewProps {
   selectedFile: FileStructure | null;
@@ -50,7 +66,7 @@ export const View = memo(function View({
   onCloseFile,
 }: ViewProps) {
   const theme = useResolvedTheme();
-  const [showPreview, setShowPreview] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>(() => defaultViewMode(selectedFile));
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<typeof import('monaco-editor') | null>(null);
   const selectedFilePath = selectedFile?.path ?? null;
@@ -113,9 +129,23 @@ export const View = memo(function View({
     commitSave,
   } = useEditorDrafts({ selectedFile, selectedFileContent, sandboxId, onCloseFile });
 
-  const shouldShowSelectedFilePreview = selectedFile
-    ? isPreviewableFile(selectedFile) && !isHtmlFile(selectedFile)
-    : false;
+  // Git paths are cwd-relative while editor paths are workspace-root-relative
+  // (see invalidateAfterGitRestore) — strip the cwd prefix before asking git.
+  const gitRelativePath =
+    selectedFilePath && cwd && selectedFilePath.startsWith(`${cwd}/`)
+      ? selectedFilePath.slice(cwd.length + 1)
+      : selectedFilePath;
+
+  const {
+    data: baselineData,
+    isLoading: isLoadingBaseline,
+    isError: isBaselineError,
+    refetch: refetchBaseline,
+  } = useGitFileBaselineQuery(sandboxId, gitRelativePath ?? undefined, cwd, {
+    enabled: viewMode === 'diff' && !!sandboxId && !!gitRelativePath,
+  });
+
+  const { data: changedPathsData } = useGitChangedPathsQuery(sandboxId, cwd);
 
   const error = fileContentError
     ? fileContentError instanceof Error
@@ -123,19 +153,13 @@ export const View = memo(function View({
       : 'Failed to load file content'
     : null;
 
-  useEffect(() => {
-    if (!selectedFilePath) {
-      setShowPreview(false);
-      return;
-    }
-
-    setShowPreview((current) =>
-      current === shouldShowSelectedFilePreview ? current : shouldShowSelectedFilePreview,
-    );
-  }, [selectedFilePath, shouldShowSelectedFilePreview]);
-
   const language = selectedFile ? detectLanguage(selectedFile.path) : 'javascript';
   const displayHasUnsavedChanges = hasLoadedSelectedFile && hasUnsavedChanges;
+
+  const fileChangedInGit = !!gitRelativePath && !!changedPathsData?.paths.includes(gitRelativePath);
+  // Whether the diff view has anything to show: uncommitted disk changes or an
+  // unsaved draft (the diff compares HEAD against the live buffer).
+  const fileHasChanges = displayHasUnsavedChanges || fileChangedInGit;
 
   const handleUpdateFile = useCallback(async () => {
     if (!selectedFile || !sandboxId || !hasUnsavedChanges || !hasLoadedSelectedFile) return;
@@ -197,15 +221,18 @@ export const View = memo(function View({
     // would still hold the old model and the line would be clamped wrong.
     if (!targetLine || !selectedFile) return;
     if (selectedFile.path !== targetLine.path) return;
-    if (selectedFileContent === undefined) return;
-    if (mountedEditorPath !== selectedFile.path) return;
-    const editor = editorRef.current;
-    if (!editor) return;
     // Dedupe by the requested target, not the resolved/clamped line — after a
     // jump to line 100, editing the file down to fewer lines shouldn't re-fire
     // the same target and yank focus back to the clamped position.
     const key = `${targetLine.path}:${targetLine.line}:${targetLine.nonce}`;
     if (lastAppliedTargetRef.current === key) return;
+    // Jumps land in the code editor — leave preview/diff so it can mount and
+    // apply. Idempotent, so re-runs while the target is pending are no-ops.
+    setViewMode('code');
+    if (selectedFileContent === undefined) return;
+    if (mountedEditorPath !== selectedFile.path) return;
+    const editor = editorRef.current;
+    if (!editor) return;
 
     const raf = requestAnimationFrame(() => {
       if (editorRef.current !== editor) return;
@@ -245,22 +272,31 @@ export const View = memo(function View({
   ]);
 
   const [isPreviewFullscreen, setIsPreviewFullscreen] = useState(false);
-  const prevShowPreviewRef = useRef(showPreview);
+  const prevViewModeRef = useRef(viewMode);
   const prevFilePathRef = useRef(selectedFile?.path);
 
-  // Reset fullscreen when preview is hidden or file changes
-  if (
-    prevShowPreviewRef.current !== showPreview ||
-    prevFilePathRef.current !== selectedFile?.path
-  ) {
-    prevShowPreviewRef.current = showPreview;
+  // Reset fullscreen when the mode or file changes
+  if (prevViewModeRef.current !== viewMode || prevFilePathRef.current !== selectedFile?.path) {
+    const fileChanged = prevFilePathRef.current !== selectedFile?.path;
+    const enteredDiff = prevViewModeRef.current !== 'diff' && viewMode === 'diff';
+    prevViewModeRef.current = viewMode;
     prevFilePathRef.current = selectedFile?.path;
     if (isPreviewFullscreen) {
       setIsPreviewFullscreen(false);
     }
-    // Sole inline-chat reset: preview toggles and file switches both remount
+    // Sole inline-chat reset: mode toggles and file switches all remount
     // Content, so the widget's captured editor would go stale either way.
     if (inlineChat !== null) setInlineChat(null);
+    // Each file opens in its own default mode (preview for previewable types).
+    if (fileChanged) {
+      setViewMode(defaultViewMode(selectedFile));
+    }
+    if (enteredDiff) {
+      // Content unmounts while the diff is shown; drop the disposed editor so
+      // the jump-to-line effect waits for the remount instead of touching it.
+      editorRef.current = null;
+      if (mountedEditorPath !== null) setMountedEditorPath(null);
+    }
   }
 
   const handleCloseInlineChat = useCallback(() => {
@@ -296,10 +332,19 @@ export const View = memo(function View({
     (isTreePending || findFileInStructure(fileStructure, selectedFile.path) !== undefined);
 
   const isPreviewable = selectedFile ? isPreviewableFile(selectedFile) : false;
+  const isPreviewActive = isPreviewable && viewMode === 'preview';
 
   const handlePreviewToggle = (showPreviewState: boolean) => {
-    setShowPreview(showPreviewState);
+    setViewMode(showPreviewState ? 'preview' : 'code');
   };
+
+  const handleToggleDiff = useCallback(() => {
+    setViewMode((prev) => (prev === 'diff' ? 'code' : 'diff'));
+  }, []);
+
+  const handleRetryBaseline = useCallback(() => {
+    void refetchBaseline().catch((err: unknown) => console.error(err));
+  }, [refetchBaseline]);
 
   const fileForPreview = selectedFile
     ? {
@@ -328,16 +373,17 @@ export const View = memo(function View({
             filePath={selectedFile.path}
             error={error}
             selectedFile={selectedFile}
-            showPreview={showPreview}
+            showPreview={isPreviewActive}
             onTogglePreview={handlePreviewToggle}
+            showDiff={viewMode === 'diff'}
+            onToggleDiff={handleToggleDiff}
+            hasChanges={fileHasChanges}
             hasUnsavedChanges={displayHasUnsavedChanges}
             isSaving={updateFileMutation.isPending}
             onSave={handleUpdateFile}
             onToggleFileTree={onToggleFileTree}
             isFileTreeCollapsed={isFileTreeCollapsed}
-            onToggleFullscreen={
-              isPreviewable && showPreview ? handleTogglePreviewFullscreen : undefined
-            }
+            onToggleFullscreen={isPreviewActive ? handleTogglePreviewFullscreen : undefined}
           />
 
           <div className="relative flex-1 overflow-hidden">
@@ -351,7 +397,7 @@ export const View = memo(function View({
 
             {/* Listed before Content so its cleanup removes the content widget
                 before @monaco-editor/react disposes the editor on unmount. */}
-            {!(isPreviewable && showPreview) &&
+            {viewMode === 'code' &&
               inlineChat &&
               chatId &&
               editorRef.current &&
@@ -366,7 +412,23 @@ export const View = memo(function View({
                 />
               )}
 
-            {!(isPreviewable && showPreview) && (
+            {viewMode === 'diff' && (
+              <DiffContent
+                key={selectedFile.path}
+                original={baselineData?.content}
+                modified={displayContent}
+                language={language}
+                theme={currentTheme}
+                isLoading={isLoadingBaseline}
+                isError={isBaselineError}
+                isGitRepo={baselineData?.is_git_repo ?? true}
+                hasGitChanges={fileChangedInGit}
+                onRetry={handleRetryBaseline}
+                onBeforeMount={setupEditorTheme}
+              />
+            )}
+
+            {viewMode !== 'diff' && !isPreviewActive && (
               <Content
                 key={selectedFile.path}
                 content={displayContent}
@@ -384,7 +446,7 @@ export const View = memo(function View({
               />
             )}
 
-            {isPreviewable && showPreview && fileForPreview && (
+            {isPreviewActive && fileForPreview && (
               <div className="h-full">
                 <FilePreview
                   file={fileForPreview}

--- a/frontend/src/components/ui/commandRegistry.ts
+++ b/frontend/src/components/ui/commandRegistry.ts
@@ -23,6 +23,7 @@ import { useUIStore } from '@/store/uiStore';
 import { useChatStore } from '@/store/chatStore';
 import { sandboxService } from '@/services/sandboxService';
 import { queryKeys } from '@/hooks/queries/queryKeys';
+import { invalidateGitState } from '@/hooks/queries/useSandboxQueries';
 import { isSecondaryPaneActive } from '@/utils/tileHelpers';
 import { traverseFileStructure, getFileName } from '@/utils/file';
 import { IS_MAC_PLATFORM } from '@/utils/platform';
@@ -301,7 +302,7 @@ export function executeCommand(
           queryClient.invalidateQueries({
             queryKey: queryKeys.sandbox.filesMetadataAll(sandboxId),
           }),
-          queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitDiffAll(sandboxId) }),
+          invalidateGitState(queryClient, sandboxId),
         ]);
       }
     });

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -34,6 +34,14 @@ export const queryKeys = {
       cwd?: string,
     ) => ['sandbox', sandboxId, 'git-diff', mode, fullContext, cwd] as const,
     gitDiffAll: (sandboxId?: string) => ['sandbox', sandboxId, 'git-diff'] as const,
+    gitFileBaseline: (sandboxId?: string, path?: string, cwd?: string) =>
+      ['sandbox', sandboxId, 'git-file-baseline', path, cwd] as const,
+    gitFileBaselineAll: (sandboxId?: string) =>
+      ['sandbox', sandboxId, 'git-file-baseline'] as const,
+    gitChangedPaths: (sandboxId?: string, cwd?: string) =>
+      ['sandbox', sandboxId, 'git-changed-paths', cwd] as const,
+    gitChangedPathsAll: (sandboxId?: string) =>
+      ['sandbox', sandboxId, 'git-changed-paths'] as const,
     gitBranches: (sandboxId?: string, cwd?: string) =>
       ['sandbox', sandboxId, 'git-branches', cwd] as const,
     gitBranchesAll: (sandboxId?: string) => ['sandbox', sandboxId, 'git-branches'] as const,

--- a/frontend/src/hooks/queries/useSandboxQueries.ts
+++ b/frontend/src/hooks/queries/useSandboxQueries.ts
@@ -8,6 +8,7 @@ import type {
   GitCommitResult,
   GitCreateBranchResult,
   GitDiffData,
+  GitFileBaselineData,
   GitPushPullResult,
   SearchParams,
   SearchResponse,
@@ -77,6 +78,7 @@ export const useUpdateFileMutation = createMutation<UpdateFileResult, Error, Upd
       queryClient.invalidateQueries({
         queryKey: queryKeys.sandbox.filesMetadataAll(sandboxId),
       }),
+      invalidateGitState(queryClient, sandboxId),
     ]);
   },
 );
@@ -102,6 +104,16 @@ export const useUpdateSecretMutation = createSecretMutation<SecretMutationVariab
 export const useDeleteSecretMutation = createSecretMutation<{ sandboxId: string; key: string }>(
   ({ sandboxId, key }) => sandboxService.deleteSecret(sandboxId, key),
 );
+
+// Every query derived from git state (diff content, per-file HEAD baselines,
+// change indicators) — git actions must refresh them together; one forgotten
+// key leaves the diff view or indicators stale.
+export const invalidateGitState = (queryClient: QueryClient, sandboxId: string) =>
+  Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitDiffAll(sandboxId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitFileBaselineAll(sandboxId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitChangedPathsAll(sandboxId) }),
+  ]);
 
 export const useGitBranchesQuery = (
   sandboxId: string | undefined,
@@ -139,9 +151,7 @@ export const useCheckoutBranchMutation = () => {
         queryClient.invalidateQueries({
           queryKey: queryKeys.sandbox.filesMetadataAll(variables.sandboxId),
         }),
-        queryClient.invalidateQueries({
-          queryKey: queryKeys.sandbox.gitDiffAll(variables.sandboxId),
-        }),
+        invalidateGitState(queryClient, variables.sandboxId),
       ]);
     },
   });
@@ -164,6 +174,39 @@ export const useGitDiffQuery = (
   });
 };
 
+// Repo-relative paths with uncommitted changes — powers change indicators
+// without fetching diff content.
+export const useGitChangedPathsQuery = (sandboxId: string | undefined, cwd?: string) => {
+  return useQuery({
+    queryKey: queryKeys.sandbox.gitChangedPaths(sandboxId, cwd),
+    queryFn: () => sandboxService.getGitChangedPaths(sandboxId!, cwd),
+    enabled: !!sandboxId,
+    // The working tree changes out-of-band (terminal commands, external tools),
+    // so refetch on window focus with a short stale window like branches do.
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+};
+
+// The committed (HEAD) version of a single file — the diff baseline the editor
+// compares the working buffer against.
+export const useGitFileBaselineQuery = (
+  sandboxId: string | undefined,
+  path: string | undefined,
+  cwd?: string,
+  options?: Partial<UseQueryOptions<GitFileBaselineData>>,
+) => {
+  return useQuery({
+    queryKey: queryKeys.sandbox.gitFileBaseline(sandboxId, path, cwd),
+    queryFn: () => sandboxService.getGitFileBaseline(sandboxId!, path!, cwd),
+    enabled: !!sandboxId && !!path,
+    // HEAD only moves on explicit git actions (which invalidate this key); the
+    // short stale window still picks up out-of-band terminal commits on re-toggle.
+    staleTime: 30_000,
+    ...options,
+  });
+};
+
 export const useGitRemoteUrlQuery = (sandboxId: string, enabled: boolean, cwd?: string) => {
   return useQuery({
     queryKey: queryKeys.sandbox.gitRemoteUrl(sandboxId, cwd),
@@ -180,9 +223,7 @@ export const useGitCommitMutation = createMutation<
 >(
   ({ sandboxId, message, cwd }) => sandboxService.gitCommit(sandboxId, message, cwd),
   async (queryClient, _data, variables) => {
-    await queryClient.invalidateQueries({
-      queryKey: queryKeys.sandbox.gitDiffAll(variables.sandboxId),
-    });
+    await invalidateGitState(queryClient, variables.sandboxId);
   },
 );
 
@@ -213,9 +254,7 @@ export const useGitPullMutation = createMutation<
       queryClient.invalidateQueries({
         queryKey: queryKeys.sandbox.filesMetadataAll(variables.sandboxId),
       }),
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.sandbox.gitDiffAll(variables.sandboxId),
-      }),
+      invalidateGitState(queryClient, variables.sandboxId),
     ]);
   },
 );
@@ -248,12 +287,14 @@ export const useSearchInFilesQuery = (
 // Diff paths are cwd-relative while the editor caches workspace-root-relative
 // paths (e.g. `.worktrees/<id>/src/App.tsx`), so targeting a specific
 // `fileContent` key would miss worktree entries. Invalidate the whole
-// file-content space under this sandbox instead.
+// file-content space under this sandbox instead. Restore doesn't move HEAD,
+// so gitFileBaselineAll is deliberately not refreshed here.
 export const invalidateAfterGitRestore = (queryClient: QueryClient, sandboxId: string) =>
   Promise.all([
     queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitDiffAll(sandboxId) }),
     queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.filesMetadataAll(sandboxId) }),
     queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.fileContentAll(sandboxId) }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitChangedPathsAll(sandboxId) }),
   ]);
 
 export const useGitRestoreFileMutation = createMutation<
@@ -294,9 +335,7 @@ export const useGitCreateBranchMutation = createMutation<
       queryClient.invalidateQueries({
         queryKey: queryKeys.sandbox.filesMetadataAll(variables.sandboxId),
       }),
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.sandbox.gitDiffAll(variables.sandboxId),
-      }),
+      invalidateGitState(queryClient, variables.sandboxId),
     ]);
   },
 );

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -5,6 +5,7 @@ import toast from 'react-hot-toast';
 import { StreamContentBuffer, type ContentRenderSnapshot } from '@/utils/stream';
 import { notifyStreamComplete } from '@/utils/notifications';
 import { queryKeys } from '@/hooks/queries/queryKeys';
+import { invalidateGitState } from '@/hooks/queries/useSandboxQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
 import type { InfiniteData } from '@tanstack/react-query';
 import type {
@@ -651,6 +652,9 @@ export function useStreamCallbacks({
         queryClient.invalidateQueries({
           queryKey: queryKeys.sandbox.gitBranchesAll(targetSandboxId),
         });
+        // The turn's file edits change git state (and the agent may have
+        // committed mid-turn) — refresh diff, baselines, and change indicators.
+        void invalidateGitState(queryClient, targetSandboxId);
       }
 
       if (!isCurrentChat) return;

--- a/frontend/src/services/sandboxService.ts
+++ b/frontend/src/services/sandboxService.ts
@@ -6,10 +6,12 @@ import type {
   FileContent,
   FileMetadata,
   GitBranchesData,
+  GitChangedPathsData,
   GitCheckoutData,
   GitCommitResult,
   GitCreateBranchResult,
   GitDiffData,
+  GitFileBaselineData,
   GitPushPullResult,
   GitRemoteUrlData,
   SearchParams,
@@ -149,6 +151,35 @@ async function getGitDiff(
       `/sandbox/${sandboxId}/git/diff${qs}`,
     );
     return ensureResponse(response, 'Failed to get git diff');
+  });
+}
+
+async function getGitChangedPaths(sandboxId: string, cwd?: string): Promise<GitChangedPathsData> {
+  validateRequired(sandboxId, 'Sandbox ID');
+
+  return serviceCall(async () => {
+    const qs = buildQueryString({ cwd });
+    const response = await resolveSandboxClient(sandboxId).get<GitChangedPathsData>(
+      `/sandbox/${sandboxId}/git/changed-paths${qs}`,
+    );
+    return ensureResponse(response, 'Failed to get changed paths');
+  });
+}
+
+async function getGitFileBaseline(
+  sandboxId: string,
+  path: string,
+  cwd?: string,
+): Promise<GitFileBaselineData> {
+  validateRequired(sandboxId, 'Sandbox ID');
+  validateRequired(path, 'File path');
+
+  return serviceCall(async () => {
+    const qs = buildQueryString({ path, cwd });
+    const response = await resolveSandboxClient(sandboxId).get<GitFileBaselineData>(
+      `/sandbox/${sandboxId}/git/file-baseline${qs}`,
+    );
+    return ensureResponse(response, 'Failed to get file baseline');
   });
 }
 
@@ -323,6 +354,8 @@ export const sandboxService = {
   deleteSecret,
   downloadZip,
   getGitDiff,
+  getGitChangedPaths,
+  getGitFileBaseline,
   getGitBranches,
   checkoutGitBranch,
   gitCommit,

--- a/frontend/src/types/sandbox.types.ts
+++ b/frontend/src/types/sandbox.types.ts
@@ -40,6 +40,17 @@ export interface GitDiffData {
   error?: string;
 }
 
+export interface GitFileBaselineData {
+  path: string;
+  content: string;
+  is_git_repo: boolean;
+}
+
+export interface GitChangedPathsData {
+  paths: string[];
+  is_git_repo: boolean;
+}
+
 export interface GitBranchesData {
   branches: string[];
   current_branch: string;


### PR DESCRIPTION
## Summary
- Add a "Changes" toggle to the editor header that shows a diff of the current file against the git HEAD baseline
- Mark modified/untracked files in the file tree via new change indicators
- New backend endpoints (`/git/changed-paths`, `/git/file-baseline`) and a `GitService` layer to back them
- Centralize git-derived query invalidation (`invalidateGitState`) so diff content, file baselines, and change indicators all refresh together after commits, restores, branch switches, and agent turns

## Test plan
- [ ] Open a file with uncommitted changes and confirm the "Changes" toggle shows a dot and renders a correct diff
- [ ] Edit a file and confirm the diff updates against the live (unsaved) buffer
- [ ] Commit/restore/checkout a branch and confirm the diff view and file-tree indicators refresh
- [ ] Verify files outside the sandbox's `cwd` don't appear as modified in the tree