### PR TITLE
fix(editor): move file tree close control to sidebar

### DIFF
--- a/frontend/src/components/editor/code-sidebar/CodeSidebar.tsx
+++ b/frontend/src/components/editor/code-sidebar/CodeSidebar.tsx
@@ -1,5 +1,13 @@
 import { memo, useCallback, useMemo, useState, type Ref } from 'react';
-import { ArrowLeft, Download, Loader2, MoreHorizontal, RefreshCw, Search } from 'lucide-react';
+import {
+  ArrowLeft,
+  Download,
+  Loader2,
+  MoreHorizontal,
+  PanelLeftClose,
+  RefreshCw,
+  Search,
+} from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { useDropdown } from '@/hooks/useDropdown';
 import { Tree, type TreeHandle } from '../file-tree/Tree';
@@ -21,6 +29,8 @@ export interface CodeSidebarProps {
   sandboxId: string | undefined;
   cwd?: string;
   treeRef?: Ref<TreeHandle>;
+  // Collapses the desktop panel / closes the mobile drawer — the caller decides which.
+  onCollapse?: () => void;
 }
 
 type View = 'files' | 'search';
@@ -38,6 +48,7 @@ export const CodeSidebar = memo(function CodeSidebar({
   sandboxId,
   cwd,
   treeRef,
+  onCollapse,
 }: CodeSidebarProps) {
   const [view, setView] = useState<View>('files');
 
@@ -61,9 +72,10 @@ export const CodeSidebar = memo(function CodeSidebar({
         onDownload={onDownload}
         isDownloading={isDownloading}
         onSearchFiles={handleSearchFiles}
+        onCollapse={onCollapse}
       />
     ),
-    [onRefresh, isRefreshing, onDownload, isDownloading, handleSearchFiles],
+    [onRefresh, isRefreshing, onDownload, isDownloading, handleSearchFiles, onCollapse],
   );
 
   return (
@@ -97,6 +109,7 @@ interface TreeHeaderProps {
   onDownload?: () => void;
   isDownloading: boolean;
   onSearchFiles: () => void;
+  onCollapse?: () => void;
 }
 
 function TreeHeader({
@@ -105,6 +118,7 @@ function TreeHeader({
   onDownload,
   isDownloading,
   onSearchFiles,
+  onCollapse,
 }: TreeHeaderProps) {
   const { isOpen, setIsOpen, dropdownRef } = useDropdown();
 
@@ -121,44 +135,56 @@ function TreeHeader({
       <span className="text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
         Files
       </span>
-      <div ref={dropdownRef} className="relative">
-        <Button
-          variant="unstyled"
-          onClick={() => setIsOpen((prev) => !prev)}
-          aria-label="File tree options"
-          aria-expanded={isOpen}
-          className="rounded-md p-1 text-text-quaternary transition-colors duration-150 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
-        >
-          <MoreHorizontal className="h-3 w-3" />
-        </Button>
-        {isOpen && (
-          <div
-            role="menu"
-            className="absolute right-0 top-full z-20 mt-1 min-w-[160px] animate-fadeIn overflow-hidden rounded-lg border border-border/50 bg-surface-secondary/95 shadow-medium backdrop-blur-xl dark:border-border-dark/50 dark:bg-surface-dark-secondary/95"
+      <div className="flex items-center gap-0.5">
+        <div ref={dropdownRef} className="relative">
+          <Button
+            variant="unstyled"
+            onClick={() => setIsOpen((prev) => !prev)}
+            aria-label="File tree options"
+            aria-expanded={isOpen}
+            className="rounded-md p-1 text-text-quaternary transition-colors duration-150 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
           >
-            <MenuItem
-              icon={Search}
-              label="Search in files"
-              onClick={() => handleAction(onSearchFiles)}
-            />
-            {onRefresh && (
+            <MoreHorizontal className="h-3 w-3" />
+          </Button>
+          {isOpen && (
+            <div
+              role="menu"
+              className="absolute right-0 top-full z-20 mt-1 min-w-[160px] animate-fadeIn overflow-hidden rounded-lg border border-border/50 bg-surface-secondary/95 shadow-medium backdrop-blur-xl dark:border-border-dark/50 dark:bg-surface-dark-secondary/95"
+            >
               <MenuItem
-                icon={isRefreshing ? Loader2 : RefreshCw}
-                iconSpinning={isRefreshing}
-                label="Refresh"
-                onClick={() => handleAction(onRefresh)}
+                icon={Search}
+                label="Search in files"
+                onClick={() => handleAction(onSearchFiles)}
               />
-            )}
-            {onDownload && (
-              <MenuItem
-                icon={isDownloading ? Loader2 : Download}
-                iconSpinning={isDownloading}
-                label="Download"
-                onClick={() => handleAction(onDownload)}
-                disabled={isDownloading}
-              />
-            )}
-          </div>
+              {onRefresh && (
+                <MenuItem
+                  icon={isRefreshing ? Loader2 : RefreshCw}
+                  iconSpinning={isRefreshing}
+                  label="Refresh"
+                  onClick={() => handleAction(onRefresh)}
+                />
+              )}
+              {onDownload && (
+                <MenuItem
+                  icon={isDownloading ? Loader2 : Download}
+                  iconSpinning={isDownloading}
+                  label="Download"
+                  onClick={() => handleAction(onDownload)}
+                  disabled={isDownloading}
+                />
+              )}
+            </div>
+          )}
+        </div>
+        {onCollapse && (
+          <Button
+            variant="unstyled"
+            onClick={onCollapse}
+            aria-label="Close file tree"
+            className="rounded-md p-1 text-text-quaternary transition-colors duration-150 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+          >
+            <PanelLeftClose className="h-3 w-3" />
+          </Button>
         )}
       </div>
     </div>

--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -76,6 +76,8 @@ export const CodeView = memo(function CodeView({
     }
   }, []);
 
+  const handleCloseMobileTree = useCallback(() => setShowMobileTree(false), []);
+
   const handleFileTreeExpand = useCallback(() => {
     setIsFileTreeCollapsed(false);
     if (!selectedFile || selectedFile.type !== 'file') return;
@@ -173,7 +175,11 @@ export const CodeView = memo(function CodeView({
                 backgroundClass,
               )}
             >
-              <CodeSidebar {...sharedSidebarProps} onFileSelect={handleMobileFileSelect} />
+              <CodeSidebar
+                {...sharedSidebarProps}
+                onFileSelect={handleMobileFileSelect}
+                onCollapse={handleCloseMobileTree}
+              />
             </div>
           </>
         )}
@@ -186,6 +192,7 @@ export const CodeView = memo(function CodeView({
             chatId={chatId}
             cwd={cwd}
             onToggleFileTree={() => setShowMobileTree(true)}
+            isFileTreeCollapsed={!showMobileTree}
             isSandboxSyncing={isSandboxSyncing}
             targetLine={targetLine}
             openFiles={openFiles}
@@ -214,7 +221,11 @@ export const CodeView = memo(function CodeView({
             data-code-sidebar
             className={`h-full overflow-hidden border-r border-border dark:border-border-dark ${backgroundClass}`}
           >
-            <CodeSidebar {...sharedSidebarProps} onFileSelect={onFileSelect} />
+            <CodeSidebar
+              {...sharedSidebarProps}
+              onFileSelect={onFileSelect}
+              onCollapse={handleToggleFileTree}
+            />
           </div>
         </Panel>
 

--- a/frontend/src/components/editor/editor-view/EmptyState.tsx
+++ b/frontend/src/components/editor/editor-view/EmptyState.tsx
@@ -6,9 +6,14 @@ import { cn } from '@/utils/cn';
 export interface EmptyStateProps {
   theme: string;
   onToggleFileTree?: () => void;
+  isFileTreeCollapsed?: boolean;
 }
 
-export const EmptyState = memo(function EmptyState({ theme, onToggleFileTree }: EmptyStateProps) {
+export const EmptyState = memo(function EmptyState({
+  theme,
+  onToggleFileTree,
+  isFileTreeCollapsed = false,
+}: EmptyStateProps) {
   return (
     <div
       className={cn(
@@ -16,13 +21,14 @@ export const EmptyState = memo(function EmptyState({ theme, onToggleFileTree }: 
         theme === 'light' ? 'bg-surface-secondary' : 'bg-surface-dark-secondary',
       )}
     >
-      {onToggleFileTree && (
+      {/* Reopen affordance only — closing happens from the FILES panel header. */}
+      {onToggleFileTree && isFileTreeCollapsed && (
         <div className="flex h-9 items-center border-b border-border/50 px-3 dark:border-border-dark/50">
           <Button
             variant="unstyled"
             onClick={onToggleFileTree}
             className="shrink-0 rounded-md p-1 text-text-quaternary transition-colors duration-150 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
-            aria-label="Toggle file tree"
+            aria-label="Open file tree"
           >
             <PanelLeft size={14} />
           </Button>

--- a/frontend/src/components/editor/editor-view/Header.tsx
+++ b/frontend/src/components/editor/editor-view/Header.tsx
@@ -5,7 +5,6 @@ import {
   FileText,
   GitCompareArrows,
   PanelLeft,
-  PanelLeftClose,
   Maximize2,
 } from 'lucide-react';
 import type { FileStructure } from '@/types/file-system.types';
@@ -51,7 +50,6 @@ export const Header = memo(function Header({
   isFileTreeCollapsed = false,
   onToggleFullscreen,
 }: HeaderProps) {
-  const ToggleIcon = isFileTreeCollapsed ? PanelLeft : PanelLeftClose;
   const isPreviewable = selectedFile ? isPreviewableFile(selectedFile) : false;
 
   if (!filePath) return null;
@@ -59,7 +57,8 @@ export const Header = memo(function Header({
   return (
     <div className="flex h-9 items-center justify-between border-b border-border/50 bg-surface-secondary px-3 dark:border-border-dark/50 dark:bg-surface-dark-secondary">
       <div className="flex min-w-0 items-center gap-2">
-        {onToggleFileTree && (
+        {/* The close affordance lives in the FILES panel header — the editor only reopens. */}
+        {onToggleFileTree && isFileTreeCollapsed && (
           <Button
             variant="unstyled"
             onClick={onToggleFileTree}
@@ -69,9 +68,9 @@ export const Header = memo(function Header({
               'dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary',
               'transition-colors duration-150',
             )}
-            aria-label={isFileTreeCollapsed ? 'Open file tree' : 'Close file tree'}
+            aria-label="Open file tree"
           >
-            <ToggleIcon size={14} />
+            <PanelLeft size={14} />
           </Button>
         )}
         <FileIcon name={getFileName(filePath)} className="h-3.5 w-3.5 shrink-0" />

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -366,7 +366,11 @@ export const View = memo(function View({
       />
 
       {!selectedFile || !isValidFile ? (
-        <EmptyState theme={theme} onToggleFileTree={onToggleFileTree} />
+        <EmptyState
+          theme={theme}
+          onToggleFileTree={onToggleFileTree}
+          isFileTreeCollapsed={isFileTreeCollapsed}
+        />
       ) : (
         <>
           <Header


### PR DESCRIPTION
## Summary
- Move the file-tree close affordance from the editor Header into the FILES panel header itself (`CodeSidebar`'s new `onCollapse` prop), since it lives right next to the panel it controls.
- `Header.tsx` and `EmptyState.tsx` now only show the reopen (`PanelLeft`) affordance when the tree is collapsed — closing is no longer duplicated there.
- `CodeView.tsx` wires `onCollapse` to the existing desktop toggle handler and a new mobile close handler; `EmptyState` gets `isFileTreeCollapsed` to gate the reopen button.