### PR TITLE
feat(chat): highlight @mention and /command tokens as pills

### DIFF
--- a/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
+++ b/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/primitives/Input';
 import { Spinner } from '@/components/ui/primitives/Spinner';
 import { apiClient } from '@/lib/api';
 import { detectFileType } from '@/utils/fileTypes';
+import { HighlightedText } from '@/components/ui/shared/HighlightedText';
 import { fetchAttachmentBlob } from '@/utils/file';
 import { isBrowserObjectUrl } from '@/utils/attachmentUrl';
 import type {
@@ -264,7 +265,7 @@ export const QueueMessageCard = memo(function QueueMessageCard({
             />
           ) : (
             <span className="truncate text-xs text-text-secondary dark:text-text-dark-secondary">
-              {message.content}
+              <HighlightedText text={message.content} />
             </span>
           )}
         </div>

--- a/frontend/src/components/chat/message-bubble/MessageContent.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageContent.tsx
@@ -30,7 +30,12 @@ export const UserMessageContent = memo(function UserMessageContent({
         uploadingAttachmentIds={uploadingAttachmentIds}
         chatId={chatId}
       />
-      <MessageRenderer events={contentRender.events} isStreaming={isStreaming} chatId={chatId} />
+      <MessageRenderer
+        events={contentRender.events}
+        isStreaming={isStreaming}
+        chatId={chatId}
+        highlightMentions
+      />
     </div>
   );
 });

--- a/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
@@ -15,6 +15,7 @@ interface MessageRendererProps {
   durationMs?: number | null;
   onSuggestionSelect?: (suggestion: string) => void;
   agentKind?: AgentKind;
+  highlightMentions?: boolean;
 }
 
 const MessageRendererInner: React.FC<MessageRendererProps> = ({
@@ -26,6 +27,7 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
   durationMs = null,
   onSuggestionSelect,
   agentKind,
+  highlightMentions = false,
 }) => {
   const prevSegmentsRef = React.useRef<Map<string, MessageSegment>>(new Map());
 
@@ -100,6 +102,7 @@ const MessageRendererInner: React.FC<MessageRendererProps> = ({
     agentKind,
     isLastBotMessage,
     onSuggestionSelect,
+    highlightMentions,
   };
   // Per-segment booleans instead of the active ids: when the active segment
   // changes, only the segments whose flag flipped lose their memo bailout.

--- a/frontend/src/components/chat/message-bubble/SegmentView.tsx
+++ b/frontend/src/components/chat/message-bubble/SegmentView.tsx
@@ -16,15 +16,28 @@ interface SegmentViewProps {
   isActiveText: boolean;
   isLastBotMessage: boolean;
   onSuggestionSelect?: (suggestion: string) => void;
+  highlightMentions?: boolean;
 }
 
-const TextSegment = ({ text, isActive }: { text: string; isActive: boolean }) => {
+const TextSegment = ({
+  text,
+  isActive,
+  highlightMentions,
+}: {
+  text: string;
+  isActive: boolean;
+  highlightMentions?: boolean;
+}) => {
   // The segment receiving stream output reveals its text word-by-word instead
   // of jumping a flush-sized chunk at a time.
   const smoothText = useSmoothText(text, isActive);
   return (
     <div className="prose prose-sm dark:prose-invert max-w-none break-words">
-      <LazyMarkDown content={smoothText} streaming={isActive} />
+      <LazyMarkDown
+        content={smoothText}
+        streaming={isActive}
+        highlightMentions={highlightMentions}
+      />
     </div>
   );
 };
@@ -37,12 +50,19 @@ export const SegmentView = memo(function SegmentView({
   isActiveText,
   isLastBotMessage,
   onSuggestionSelect,
+  highlightMentions,
 }: SegmentViewProps) {
   // Memoized so stream flushes only re-render segments whose object identity
   // changed — MessageRenderer keeps unchanged segments referentially stable.
   switch (segment.kind) {
     case 'text':
-      return <TextSegment text={segment.text} isActive={isActiveText} />;
+      return (
+        <TextSegment
+          text={segment.text}
+          isActive={isActiveText}
+          highlightMentions={highlightMentions}
+        />
+      );
     case 'thinking':
       return (
         <div className="mb-2 mt-0.5">

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/store/chatSettingsStore';
 import { resolvePersona } from '@/utils/settings';
 import { useChatContext } from '@/hooks/useChatContext';
+import { getHighlightTokenRanges } from '@/utils/mentionParser';
 import {
   InputContext,
   InputStateContext,
@@ -319,6 +320,31 @@ export function InputProvider({
     [chatId],
   );
 
+  const handleTokenDeleteKeyDown = useCallback((event: React.KeyboardEvent<Element>) => {
+    // First Backspace/Delete at a pill's boundary selects token + separator space;
+    // the next keystroke deletes it natively (undo intact). Backspace triggers only
+    // after the separator — at the bare token end the user is still composing.
+    if (event.key !== 'Backspace' && event.key !== 'Delete') return false;
+    const textarea = textareaRef.current;
+    if (!textarea) return false;
+    const { selectionStart, selectionEnd } = textarea;
+    if (selectionStart !== selectionEnd) return false;
+    const message = messageRef.current;
+    for (const [start, end] of getHighlightTokenRanges(message)) {
+      const hasSeparator = message[end] === ' ';
+      const atEdge =
+        event.key === 'Backspace'
+          ? hasSeparator && selectionStart === end + 1
+          : selectionStart === start;
+      if (atEdge) {
+        event.preventDefault();
+        textarea.setSelectionRange(start, hasSeparator ? end + 1 : end);
+        return true;
+      }
+    }
+    return false;
+  }, []);
+
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<Element>) => {
       const handledByMentions = handleMentionKeyDown(event);
@@ -327,12 +353,14 @@ export function InputProvider({
       const handledBySlashCommands = handleSlashCommandKeyDown(event);
       if (handledBySlashCommands) return;
 
+      if (handleTokenDeleteKeyDown(event)) return;
+
       if (event.key === 'Enter' && !event.shiftKey) {
         event.preventDefault();
         submitOrStop();
       }
     },
-    [handleMentionKeyDown, handleSlashCommandKeyDown, submitOrStop],
+    [handleMentionKeyDown, handleSlashCommandKeyDown, handleTokenDeleteKeyDown, submitOrStop],
   );
 
   const handleSendClick = useCallback(

--- a/frontend/src/components/chat/message-input/Textarea.tsx
+++ b/frontend/src/components/chat/message-input/Textarea.tsx
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useCallback,
   type CSSProperties,
@@ -8,9 +9,23 @@ import {
 } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { getHighlightTokenRanges } from '@/utils/mentionParser';
+import { HighlightedText } from '@/components/ui/shared/HighlightedText';
 import { Textarea as PrimitiveTextarea } from '@/components/ui/primitives/Textarea';
 
 const THIN_SCROLLBAR_STYLE: CSSProperties = { scrollbarWidth: 'thin' };
+
+// Backdrop variant of the pill: no text colors (the textarea's own glyphs render
+// on top) and negative margins so the painted background doesn't shift the flow.
+const BACKDROP_TOKEN_CLASSNAME =
+  '-mx-0.5 rounded box-decoration-clone bg-surface-active p-0.5 dark:bg-surface-dark-active';
+
+// Invisible scrollbar that still reserves the same thin gutter as the textarea's,
+// so both layers wrap long lines at the same width when content overflows.
+const BACKDROP_SCROLLBAR_STYLE: CSSProperties = {
+  scrollbarWidth: 'thin',
+  scrollbarColor: 'transparent transparent',
+};
 
 export interface TextareaProps {
   ref?: Ref<HTMLTextAreaElement>;
@@ -41,9 +56,18 @@ export function Textarea({
 }: TextareaProps) {
   const internalRef = useRef<HTMLTextAreaElement>(null);
   const textareaRef = (ref as React.RefObject<HTMLTextAreaElement>) || internalRef;
+  const backdropRef = useRef<HTMLDivElement>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastCursorPositionRef = useRef<number>(-1);
   const isMobile = useIsMobile();
+
+  const hasTokens = useMemo(() => getHighlightTokenRanges(message).length > 0, [message]);
+
+  const syncBackdropScroll = useCallback(() => {
+    if (backdropRef.current && textareaRef.current) {
+      backdropRef.current.scrollTop = textareaRef.current.scrollTop;
+    }
+  }, [textareaRef]);
 
   useLayoutEffect(() => {
     const textarea = textareaRef.current;
@@ -51,7 +75,9 @@ export function Textarea({
       textarea.style.height = 'auto';
       textarea.style.height = `${textarea.scrollHeight}px`;
     }
-  }, [message, textareaRef]);
+    // Content changes can shift the textarea's scroll position without a scroll event
+    syncBackdropScroll();
+  }, [message, textareaRef, syncBackdropScroll]);
 
   useEffect(() => {
     if (!isLoading && textareaRef.current && !isMobile) {
@@ -115,23 +141,42 @@ export function Textarea({
   );
 
   return (
-    <PrimitiveTextarea
-      ref={textareaRef}
-      variant="unstyled"
-      value={message}
-      onChange={handleChange}
-      onKeyDown={onKeyDown}
-      onPaste={onPaste}
-      onKeyUp={handleCursorChange}
-      onClick={handleCursorChange}
-      onSelect={handleCursorChange}
-      onFocus={scrollIntoViewOnMobile}
-      placeholder={placeholder}
-      disabled={isLoading || disabled}
-      rows={1}
-      className={`max-h-[180px] w-full resize-none overflow-y-auto bg-transparent py-1.5 text-xs leading-normal text-text-primary outline-none transition-all duration-200 placeholder:text-text-quaternary focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary ${isMobile && compact ? 'min-h-[28px]' : 'min-h-[36px]'}`}
-      style={THIN_SCROLLBAR_STYLE}
-      aria-label="Message input"
-    />
+    <div className="relative">
+      {hasTokens && (
+        // Paints pill backgrounds behind @mention and /command tokens; the textarea's own
+        // glyphs render on top, so this layer's text is transparent and must mirror the
+        // textarea's typography, padding, and wrapping exactly.
+        <div
+          ref={backdropRef}
+          aria-hidden
+          className={`pointer-events-none absolute inset-0 max-h-[180px] overflow-y-auto whitespace-pre-wrap break-words py-1.5 text-xs leading-normal text-transparent ${isLoading || disabled ? 'opacity-50' : ''}`}
+          style={BACKDROP_SCROLLBAR_STYLE}
+        >
+          <HighlightedText text={message} tokenClassName={BACKDROP_TOKEN_CLASSNAME} />
+          {/* Zero-width space so a trailing newline renders a line box — keeps this
+              layer's scrollHeight equal to the textarea's for scroll sync */}
+          {'\u200b'}
+        </div>
+      )}
+      <PrimitiveTextarea
+        ref={textareaRef}
+        variant="unstyled"
+        value={message}
+        onChange={handleChange}
+        onKeyDown={onKeyDown}
+        onPaste={onPaste}
+        onKeyUp={handleCursorChange}
+        onClick={handleCursorChange}
+        onSelect={handleCursorChange}
+        onFocus={scrollIntoViewOnMobile}
+        onScroll={syncBackdropScroll}
+        placeholder={placeholder}
+        disabled={isLoading || disabled}
+        rows={1}
+        className={`relative max-h-[180px] w-full resize-none overflow-y-auto bg-transparent py-1.5 text-xs leading-normal text-text-primary outline-none transition-all duration-200 placeholder:text-text-quaternary focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary ${isMobile && compact ? 'min-h-[28px]' : 'min-h-[36px]'}`}
+        style={THIN_SCROLLBAR_STYLE}
+        aria-label="Message input"
+      />
+    </div>
   );
 }

--- a/frontend/src/components/ui/LazyMarkDown.tsx
+++ b/frontend/src/components/ui/LazyMarkDown.tsx
@@ -6,16 +6,27 @@ interface LazyMarkDownProps {
   content: string;
   className?: string;
   streaming?: boolean;
+  highlightMentions?: boolean;
 }
 
-export function LazyMarkDown({ content, className, streaming }: LazyMarkDownProps) {
+export function LazyMarkDown({
+  content,
+  className,
+  streaming,
+  highlightMentions,
+}: LazyMarkDownProps) {
   return (
     <Suspense
       fallback={
         <div className={`whitespace-pre-wrap text-sm ${className ?? ''}`.trim()}>{content}</div>
       }
     >
-      <MarkDown content={content} className={className} streaming={streaming} />
+      <MarkDown
+        content={content}
+        className={className}
+        streaming={streaming}
+        highlightMentions={highlightMentions}
+      />
     </Suspense>
   );
 }

--- a/frontend/src/components/ui/MarkDown.tsx
+++ b/frontend/src/components/ui/MarkDown.tsx
@@ -2,11 +2,14 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useMemo, useState, memo, useEffect, lazy, Suspense } from 'react';
 import type { Components, Options } from 'react-markdown';
+import type { Element as HastElement, ElementContent, Root as HastRoot } from 'hast';
 import type { AnchorHTMLAttributes, HTMLAttributes, ImgHTMLAttributes } from 'react';
 import { AttachmentViewer } from './AttachmentViewer';
 import { Button } from './primitives/Button';
 import { Link } from './primitives/Link';
 import type { MessageAttachment } from '@/types/chat.types';
+import { buildHighlightSegments } from '@/utils/mentionParser';
+import { MENTION_PILL_CLASSNAME } from './shared/HighlightedText';
 import { isImageUrl } from '@/utils/fileTypes';
 
 const Mermaid = lazy(() => import('./Mermaid').then((m) => ({ default: m.Mermaid })));
@@ -144,6 +147,57 @@ function splitMarkdownBlocks(md: string): string[] {
   if (current.length > 0) blocks.push(current.join('\n'));
   return blocks;
 }
+
+function buildMentionPillNodes(value: string, allowCommand: boolean): ElementContent[] | null {
+  // Null when the text holds no tokens so the caller can keep the original node.
+  const segments = buildHighlightSegments(value, allowCommand);
+  if (!segments.some((segment) => segment.isToken)) return null;
+  return segments.map((segment) =>
+    segment.isToken
+      ? {
+          type: 'element',
+          tagName: 'span',
+          properties: { className: MENTION_PILL_CLASSNAME },
+          children: [{ type: 'text', value: segment.text }],
+        }
+      : { type: 'text', value: segment.text },
+  );
+}
+
+function walkMentionPills(node: HastRoot | HastElement, allowCommand: boolean): boolean {
+  // Returns the updated allowCommand flag: only the document's first text node
+  // may host a leading /command pill, mirroring the input's first-line rule.
+  const children = node.children;
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    if (child.type === 'text') {
+      const replacement = buildMentionPillNodes(child.value, allowCommand);
+      allowCommand = false;
+      if (replacement) {
+        children.splice(i, 1, ...replacement);
+        i += replacement.length - 1;
+      }
+    } else if (child.type === 'element') {
+      if (child.tagName === 'code' || child.tagName === 'pre') {
+        // Skip code content, but a code span before any text still means the
+        // message didn't start with a /command.
+        allowCommand = false;
+      } else {
+        allowCommand = walkMentionPills(child, allowCommand);
+      }
+    }
+  }
+  return allowCommand;
+}
+
+// Wraps @file mentions and the leading /command of user-authored messages in
+// pill spans, matching the input box's token highlighting. Code spans/blocks
+// are skipped so pasted snippets (e.g. Python decorators) aren't restyled.
+const rehypeMentionPills: NonNullable<Options['rehypePlugins']>[number] = () => {
+  return (tree: HastRoot) => {
+    walkMentionPills(tree, true);
+  };
+};
 
 interface CodeBlockProps extends HTMLAttributes<HTMLElement> {
   language: string;
@@ -448,9 +502,16 @@ interface MarkDownProps {
   // splitting trades cross-block references for cheap incremental re-parses,
   // so static content parses as one document.
   streaming?: boolean;
+  // Render @mention and leading /command tokens as pills — user messages only.
+  highlightMentions?: boolean;
 }
 
-function MarkDownInner({ content, className = '', streaming = false }: MarkDownProps) {
+function MarkDownInner({
+  content,
+  className = '',
+  streaming = false,
+  highlightMentions = false,
+}: MarkDownProps) {
   const [remarkMathPlugin, setRemarkMathPlugin] = useState<unknown>(null);
   const [rehypeKatexPlugin, setRehypeKatexPlugin] = useState<unknown>(null);
 
@@ -498,8 +559,11 @@ function MarkDownInner({ content, className = '', streaming = false }: MarkDownP
     [remarkMathPlugin],
   );
   const rehypePlugins = useMemo(
-    () => (rehypeKatexPlugin ? ([rehypeKatexPlugin] as never[]) : []),
-    [rehypeKatexPlugin],
+    () => [
+      ...(highlightMentions ? [rehypeMentionPills] : []),
+      ...(rehypeKatexPlugin ? ([rehypeKatexPlugin] as never[]) : []),
+    ],
+    [rehypeKatexPlugin, highlightMentions],
   );
   const mdClassName = `text-sm text-text-secondary dark:text-text-dark-secondary ${className}`;
 

--- a/frontend/src/components/ui/shared/HighlightedText.tsx
+++ b/frontend/src/components/ui/shared/HighlightedText.tsx
@@ -1,0 +1,32 @@
+import { buildHighlightSegments } from '@/utils/mentionParser';
+
+// Canonical pill look for @mention / /command tokens. Also consumed by
+// MarkDown's rehype transform, which builds hast nodes and can't render
+// this component.
+export const MENTION_PILL_CLASSNAME =
+  'rounded bg-surface-active box-decoration-clone px-1 py-0.5 text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary';
+
+interface HighlightedTextProps {
+  text: string;
+  // Override for layers that must not repaint glyphs (the input's transparent backdrop).
+  tokenClassName?: string;
+}
+
+export function HighlightedText({
+  text,
+  tokenClassName = MENTION_PILL_CLASSNAME,
+}: HighlightedTextProps) {
+  return (
+    <>
+      {buildHighlightSegments(text).map((segment, index) =>
+        segment.isToken ? (
+          <span key={index} className={tokenClassName}>
+            {segment.text}
+          </span>
+        ) : (
+          <span key={index}>{segment.text}</span>
+        ),
+      )}
+    </>
+  );
+}

--- a/frontend/src/utils/mentionParser.ts
+++ b/frontend/src/utils/mentionParser.ts
@@ -1,3 +1,15 @@
+export interface HighlightSegment {
+  text: string;
+  isToken: boolean;
+}
+
+// Leading /command token on the first line. Looser than useSlashCommandSuggestions'
+// trigger (which requires the whole first line to be spaceless) — only the token pills.
+const COMMAND_TOKEN_REGEX = /^([^\S\n]*)(\/\S+)/;
+// @path preceded by start-of-string or whitespace — mirrors parseMentionQuery's boundary rule.
+// Paths containing spaces truncate at the space, same as the unquoted mention insertion.
+const MENTION_TOKEN_REGEX = /(^|\s)(@\S+)/g;
+
 interface MentionParseResult {
   isActive: boolean;
   query: string;
@@ -39,4 +51,49 @@ export const parseMentionQuery = (message: string, cursorPosition: number): Ment
     mentionStartPos: lastAtIndex,
     mentionEndPos: cursorPosition,
   };
+};
+
+export const getHighlightTokenRanges = (
+  message: string,
+  allowCommand = true,
+): Array<[number, number]> => {
+  // [start, end) offsets of @file mentions and the leading /command.
+  // allowCommand=false for text fragments that don't start at the message head.
+  const tokenRanges: Array<[number, number]> = [];
+
+  const commandMatch = allowCommand ? COMMAND_TOKEN_REGEX.exec(message) : null;
+  if (commandMatch) {
+    const start = commandMatch[1].length;
+    tokenRanges.push([start, start + commandMatch[2].length]);
+  }
+
+  for (const match of message.matchAll(MENTION_TOKEN_REGEX)) {
+    const start = match.index + match[1].length;
+    tokenRanges.push([start, start + match[2].length]);
+  }
+
+  return tokenRanges;
+};
+
+export const buildHighlightSegments = (
+  message: string,
+  allowCommand = true,
+): HighlightSegment[] => {
+  // Split text into plain/token runs so callers can render pills behind the
+  // tokens without altering the raw value.
+  const tokenRanges = getHighlightTokenRanges(message, allowCommand);
+
+  const segments: HighlightSegment[] = [];
+  let cursor = 0;
+  for (const [start, end] of tokenRanges) {
+    if (start > cursor) {
+      segments.push({ text: message.slice(cursor, start), isToken: false });
+    }
+    segments.push({ text: message.slice(start, end), isToken: true });
+    cursor = end;
+  }
+  if (cursor < message.length) {
+    segments.push({ text: message.slice(cursor), isToken: false });
+  }
+  return segments;
 };


### PR DESCRIPTION
## Summary
- Renders `@file` mentions and the leading `/command` as visual pills in both the message input and rendered user messages, sharing token-detection logic via `utils/mentionParser.ts` and a new `HighlightedText` component
- Input box gets a transparent backdrop layer (synced scroll/height) that paints pill backgrounds behind the live textarea glyphs
- Rendered user messages get pills via a `rehype` plugin in `MarkDown.tsx` (skips code spans/blocks so pasted snippets aren't restyled)
- `Backspace`/`Delete` at a pill boundary now removes the whole token + separator in one keystroke instead of eating it character by character