### PR TITLE
feat(chat): insert /commands and @mentions at cursor position

### DIFF
--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/store/chatSettingsStore';
 import { resolvePersona } from '@/utils/settings';
 import { useChatContext } from '@/hooks/useChatContext';
-import { getHighlightTokenRanges } from '@/utils/mentionParser';
+import { getHighlightTokenRanges, insertToken } from '@/utils/mentionParser';
 import {
   InputContext,
   InputStateContext,
@@ -160,13 +160,29 @@ export function InputProvider({
 
   const isEnhancing = enhancePromptMutation.isPending;
 
-  const handleSlashCommandSelect = useCallback(
-    (command: SlashCommand) => {
-      const newMessage = `${command.value} `;
-      setMessage(newMessage);
-      focusTextarea(newMessage);
+  const insertTokenAt = useCallback(
+    (tokenText: string, startPos: number, endPos: number) => {
+      const { text, cursor } = insertToken(messageRef.current, tokenText, startPos, endPos);
+
+      setMessage(text);
+
+      setTimeout(() => {
+        const textarea = textareaRef.current;
+        if (textarea) {
+          textarea.focus();
+          textarea.setSelectionRange(cursor, cursor);
+          setCursorPosition(cursor);
+        }
+      }, 0);
     },
-    [setMessage, focusTextarea],
+    [setMessage],
+  );
+
+  const handleSlashCommandSelect = useCallback(
+    (command: SlashCommand, startPos: number, endPos: number) => {
+      insertTokenAt(command.value, startPos, endPos);
+    },
+    [insertTokenAt],
   );
 
   const {
@@ -176,6 +192,7 @@ export function InputProvider({
     handleKeyDown: handleSlashCommandKeyDown,
   } = useSlashCommandSuggestions({
     message,
+    cursorPosition,
     onSelect: handleSlashCommandSelect,
     customSkills,
     builtinSlashCommands,
@@ -184,25 +201,9 @@ export function InputProvider({
 
   const handleMentionSelect = useCallback(
     (item: MentionItem, mentionStartPos: number, mentionEndPos: number) => {
-      const msg = messageRef.current;
-      const beforeMention = msg.slice(0, mentionStartPos);
-      const afterMention = msg.slice(mentionEndPos);
-      const mentionText = `@${item.path}`;
-      const needsSeparator = !afterMention.startsWith(' ');
-      const separator = needsSeparator ? ' ' : '';
-      const newMessage = `${beforeMention}${mentionText}${separator}${afterMention}`;
-      const nextCursorPosition = beforeMention.length + mentionText.length + separator.length;
-
-      setMessage(newMessage);
-
-      setTimeout(() => {
-        if (textareaRef.current) {
-          textareaRef.current.setSelectionRange(nextCursorPosition, nextCursorPosition);
-          setCursorPosition(nextCursorPosition);
-        }
-      }, 0);
+      insertTokenAt(`@${item.path}`, mentionStartPos, mentionEndPos);
     },
-    [setMessage],
+    [insertTokenAt],
   );
 
   const {

--- a/frontend/src/components/chat/sub-threads/CreateSubThreadDialog.tsx
+++ b/frontend/src/components/chat/sub-threads/CreateSubThreadDialog.tsx
@@ -26,6 +26,7 @@ import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
 import { useCreateSubThreadMutation } from '@/hooks/queries/useChatQueries';
 import { useSlashCommandSuggestions } from '@/hooks/useSlashCommandSuggestions';
 import { useChatContext } from '@/hooks/useChatContext';
+import { insertToken } from '@/utils/mentionParser';
 import { useModelStore } from '@/store/modelStore';
 import {
   useChatSettingsStore,
@@ -73,18 +74,27 @@ export function CreateSubThreadDialog({ parentChat, onClose }: CreateSubThreadDi
     thinkingModes.find((mode) => mode.value === effectiveThinkingMode) ?? thinkingModes[0];
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [cursorPosition, setCursorPosition] = useState(0);
 
-  const handleSlashCommandSelect = useCallback((command: SlashCommand) => {
-    const newMessage = `${command.value} `;
-    setMessage(newMessage);
-    setTimeout(() => {
-      const textarea = textareaRef.current;
-      if (textarea) {
-        textarea.focus();
-        textarea.setSelectionRange(newMessage.length, newMessage.length);
-      }
-    }, 0);
+  const handleCursorChange = useCallback((e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+    setCursorPosition(e.currentTarget.selectionStart);
   }, []);
+
+  const handleSlashCommandSelect = useCallback(
+    (command: SlashCommand, startPos: number, endPos: number) => {
+      const { text, cursor } = insertToken(message, command.value, startPos, endPos);
+      setMessage(text);
+      setTimeout(() => {
+        const textarea = textareaRef.current;
+        if (textarea) {
+          textarea.focus();
+          textarea.setSelectionRange(cursor, cursor);
+        }
+        setCursorPosition(cursor);
+      }, 0);
+    },
+    [message],
+  );
 
   const {
     filteredCommands,
@@ -94,6 +104,7 @@ export function CreateSubThreadDialog({ parentChat, onClose }: CreateSubThreadDi
     handleKeyDown: handleSlashKeyDown,
   } = useSlashCommandSuggestions({
     message,
+    cursorPosition,
     onSelect: handleSlashCommandSelect,
     customSkills,
     builtinSlashCommands,
@@ -239,8 +250,14 @@ export function CreateSubThreadDialog({ parentChat, onClose }: CreateSubThreadDi
                 ref={textareaRef}
                 variant="unstyled"
                 value={message}
-                onChange={(e) => setMessage(e.target.value)}
+                onChange={(e) => {
+                  setMessage(e.target.value);
+                  setCursorPosition(e.target.selectionStart);
+                }}
                 onKeyDown={handleSlashKeyDown}
+                onKeyUp={handleCursorChange}
+                onClick={handleCursorChange}
+                onSelect={handleCursorChange}
                 placeholder="Message Agentrove... (/ for commands)"
                 rows={3}
                 className="w-full resize-none rounded-lg border border-border/50 bg-surface-secondary px-3 py-2 text-xs text-text-primary outline-none transition-colors duration-200 placeholder:text-text-quaternary focus:border-border-hover dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus:border-border-dark-hover"

--- a/frontend/src/components/settings/dialogs/StreamActionEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/StreamActionEditDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { GitBranch, Brain, Shield } from 'lucide-react';
 import type { CustomSkill, Persona, StreamAction } from '@/types/user.types';
 import type { SlashCommand } from '@/types/ui.types';
@@ -23,6 +23,7 @@ import {
 import { useModelsQuery } from '@/hooks/queries/useModelQueries';
 import { useWorkspacesList, useWorkspaceResourcesQuery } from '@/hooks/queries/useWorkspaceQueries';
 import { useSlashCommandSuggestions } from '@/hooks/useSlashCommandSuggestions';
+import { insertToken } from '@/utils/mentionParser';
 import { EMPTY_BUILTIN_COMMANDS } from '@/config/constants';
 import { DEFAULT_PERSONA } from '@/store/chatSettingsStore';
 
@@ -71,20 +72,26 @@ export const StreamActionEditDialog: React.FC<StreamActionEditDialogProps> = ({
   );
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [cursorPosition, setCursorPosition] = useState(0);
+
+  const handleCursorChange = useCallback((e: React.SyntheticEvent<HTMLTextAreaElement>) => {
+    setCursorPosition(e.currentTarget.selectionStart);
+  }, []);
 
   const handleSlashCommandSelect = useCallback(
-    (command: SlashCommand) => {
-      const newCommand = `${command.value} `;
-      onActionChange('command', newCommand);
+    (command: SlashCommand, startPos: number, endPos: number) => {
+      const { text, cursor } = insertToken(action.command, command.value, startPos, endPos);
+      onActionChange('command', text);
       setTimeout(() => {
         const textarea = textareaRef.current;
         if (textarea) {
           textarea.focus();
-          textarea.setSelectionRange(newCommand.length, newCommand.length);
+          textarea.setSelectionRange(cursor, cursor);
         }
+        setCursorPosition(cursor);
       }, 0);
     },
-    [onActionChange],
+    [action.command, onActionChange],
   );
 
   const {
@@ -95,6 +102,7 @@ export const StreamActionEditDialog: React.FC<StreamActionEditDialogProps> = ({
     handleKeyDown: handleSlashKeyDown,
   } = useSlashCommandSuggestions({
     message: action.command,
+    cursorPosition,
     onSelect: handleSlashCommandSelect,
     customSkills: EMPTY_SKILLS,
     builtinSlashCommands,
@@ -196,8 +204,14 @@ export const StreamActionEditDialog: React.FC<StreamActionEditDialogProps> = ({
               <Textarea
                 ref={textareaRef}
                 value={action.command}
-                onChange={(e) => onActionChange('command', e.target.value)}
+                onChange={(e) => {
+                  onActionChange('command', e.target.value);
+                  setCursorPosition(e.target.selectionStart);
+                }}
                 onKeyDown={handleSlashKeyDown}
+                onKeyUp={handleCursorChange}
+                onClick={handleCursorChange}
+                onSelect={handleCursorChange}
                 placeholder="/quality-review"
                 className="min-h-[120px] font-mono text-xs"
                 rows={5}

--- a/frontend/src/components/ui/MarkDown.tsx
+++ b/frontend/src/components/ui/MarkDown.tsx
@@ -148,9 +148,9 @@ function splitMarkdownBlocks(md: string): string[] {
   return blocks;
 }
 
-function buildMentionPillNodes(value: string, allowCommand: boolean): ElementContent[] | null {
+function buildMentionPillNodes(value: string): ElementContent[] | null {
   // Null when the text holds no tokens so the caller can keep the original node.
-  const segments = buildHighlightSegments(value, allowCommand);
+  const segments = buildHighlightSegments(value);
   if (!segments.some((segment) => segment.isToken)) return null;
   return segments.map((segment) =>
     segment.isToken
@@ -164,38 +164,28 @@ function buildMentionPillNodes(value: string, allowCommand: boolean): ElementCon
   );
 }
 
-function walkMentionPills(node: HastRoot | HastElement, allowCommand: boolean): boolean {
-  // Returns the updated allowCommand flag: only the document's first text node
-  // may host a leading /command pill, mirroring the input's first-line rule.
+function walkMentionPills(node: HastRoot | HastElement): void {
   const children = node.children;
   for (let i = 0; i < children.length; i++) {
     const child = children[i];
     if (child.type === 'text') {
-      const replacement = buildMentionPillNodes(child.value, allowCommand);
-      allowCommand = false;
+      const replacement = buildMentionPillNodes(child.value);
       if (replacement) {
         children.splice(i, 1, ...replacement);
         i += replacement.length - 1;
       }
-    } else if (child.type === 'element') {
-      if (child.tagName === 'code' || child.tagName === 'pre') {
-        // Skip code content, but a code span before any text still means the
-        // message didn't start with a /command.
-        allowCommand = false;
-      } else {
-        allowCommand = walkMentionPills(child, allowCommand);
-      }
+    } else if (child.type === 'element' && child.tagName !== 'code' && child.tagName !== 'pre') {
+      walkMentionPills(child);
     }
   }
-  return allowCommand;
 }
 
-// Wraps @file mentions and the leading /command of user-authored messages in
-// pill spans, matching the input box's token highlighting. Code spans/blocks
-// are skipped so pasted snippets (e.g. Python decorators) aren't restyled.
+// Wraps @file mention and /command tokens of user-authored messages in pill
+// spans, matching the input box's token highlighting. Code spans/blocks are
+// skipped so pasted snippets (e.g. Python decorators) aren't restyled.
 const rehypeMentionPills: NonNullable<Options['rehypePlugins']>[number] = () => {
   return (tree: HastRoot) => {
-    walkMentionPills(tree, true);
+    walkMentionPills(tree);
   };
 };
 

--- a/frontend/src/hooks/useMentionSuggestions.ts
+++ b/frontend/src/hooks/useMentionSuggestions.ts
@@ -3,7 +3,7 @@ import type { FileStructure } from '@/types/file-system.types';
 import type { MentionItem } from '@/types/ui.types';
 import { useSuggestionBase } from './useSuggestionBase';
 import { traverseFileStructure, getFileName } from '@/utils/file';
-import { parseMentionQuery } from '@/utils/mentionParser';
+import { parseTokenQuery } from '@/utils/mentionParser';
 import { fuzzySearch } from '@/utils/fuzzySearch';
 
 interface UseMentionOptions {
@@ -34,10 +34,12 @@ export const useMentionSuggestions = ({
 }: UseMentionOptions) => {
   const allFiles = useMemo(() => convertFilesToMentions(fileStructure), [fileStructure]);
 
-  const { isActive, query, mentionStartPos, mentionEndPos } = parseMentionQuery(
-    message,
-    cursorPosition,
-  );
+  const {
+    isActive,
+    query,
+    tokenStartPos: mentionStartPos,
+    tokenEndPos: mentionEndPos,
+  } = parseTokenQuery(message, cursorPosition, '@');
 
   const deferredQuery = useDeferredValue(query);
 

--- a/frontend/src/hooks/useSlashCommandSuggestions.ts
+++ b/frontend/src/hooks/useSlashCommandSuggestions.ts
@@ -1,12 +1,14 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useSuggestionBase } from './useSuggestionBase';
+import { parseTokenQuery } from '@/utils/mentionParser';
 import type { SlashCommand } from '@/types/ui.types';
 import type { CustomSkill } from '@/types/user.types';
 import type { AgentKind } from '@/types/chat.types';
 
 interface UseSlashCommandOptions {
   message: string;
-  onSelect: (command: SlashCommand) => void;
+  cursorPosition: number;
+  onSelect: (command: SlashCommand, commandStartPos: number, commandEndPos: number) => void;
   customSkills: CustomSkill[];
   builtinSlashCommands: Record<AgentKind, SlashCommand[]>;
   agentKind: AgentKind;
@@ -14,6 +16,7 @@ interface UseSlashCommandOptions {
 
 export const useSlashCommandSuggestions = ({
   message,
+  cursorPosition,
   onSelect,
   customSkills,
   builtinSlashCommands,
@@ -34,19 +37,11 @@ export const useSlashCommandSuggestions = ({
     return [...builtins, ...skillCommands];
   }, [builtinSlashCommands, agentKind, customSkills]);
 
-  const { isActive, query } = useMemo(() => {
-    const firstLine = message.split('\n', 1)[0];
-    const trimmedFirstLine = firstLine.trimStart();
-
-    if (trimmedFirstLine.startsWith('/') && !trimmedFirstLine.includes(' ')) {
-      return {
-        isActive: true,
-        query: trimmedFirstLine.slice(1).toLowerCase(),
-      } as const;
-    }
-
-    return { isActive: false, query: '' } as const;
-  }, [message]);
+  const { isActive, query, tokenStartPos, tokenEndPos } = parseTokenQuery(
+    message,
+    cursorPosition,
+    '/',
+  );
 
   const filteredCommands = useMemo(() => {
     if (!isActive) return [];
@@ -56,10 +51,23 @@ export const useSlashCommandSuggestions = ({
 
   const hasSuggestions = filteredCommands.length > 0;
 
+  const tokenStartPosRef = useRef(tokenStartPos);
+  tokenStartPosRef.current = tokenStartPos;
+  const tokenEndPosRef = useRef(tokenEndPos);
+  tokenEndPosRef.current = tokenEndPos;
+
+  const handleSelect = useCallback(
+    (command: SlashCommand) => {
+      if (tokenStartPosRef.current === -1) return;
+      onSelect(command, tokenStartPosRef.current, tokenEndPosRef.current);
+    },
+    [onSelect],
+  );
+
   const { highlightedIndex, selectItem, handleKeyDown } = useSuggestionBase({
     suggestions: filteredCommands,
     hasSuggestions,
-    onSelect,
+    onSelect: handleSelect,
   });
 
   return {

--- a/frontend/src/utils/mentionParser.ts
+++ b/frontend/src/utils/mentionParser.ts
@@ -3,71 +3,84 @@ export interface HighlightSegment {
   isToken: boolean;
 }
 
-// Leading /command token on the first line. Looser than useSlashCommandSuggestions'
-// trigger (which requires the whole first line to be spaceless) — only the token pills.
-const COMMAND_TOKEN_REGEX = /^([^\S\n]*)(\/\S+)/;
-// @path preceded by start-of-string or whitespace — mirrors parseMentionQuery's boundary rule.
-// Paths containing spaces truncate at the space, same as the unquoted mention insertion.
-const MENTION_TOKEN_REGEX = /(^|\s)(@\S+)/g;
+// @mention or /command preceded by start-of-string or whitespace — mirrors
+// parseTokenQuery's boundary rule, so anything the suggestion panels can insert
+// also pills. Paths containing spaces truncate at the space, same as the
+// unquoted mention insertion. One regex keeps the ranges position-sorted.
+const TOKEN_REGEX = /(^|\s)([@/]\S+)/g;
 
-interface MentionParseResult {
+interface TokenQueryResult {
   isActive: boolean;
   query: string;
-  mentionStartPos: number;
-  mentionEndPos: number;
+  tokenStartPos: number;
+  tokenEndPos: number;
 }
 
-const INACTIVE_RESULT: MentionParseResult = {
+const INACTIVE_RESULT: TokenQueryResult = {
   isActive: false,
   query: '',
-  mentionStartPos: -1,
-  mentionEndPos: -1,
+  tokenStartPos: -1,
+  tokenEndPos: -1,
 } as const;
 
-export const parseMentionQuery = (message: string, cursorPosition: number): MentionParseResult => {
+export const parseTokenQuery = (
+  message: string,
+  cursorPosition: number,
+  trigger: '@' | '/',
+): TokenQueryResult => {
+  // In-progress token at the cursor: trigger char at start-of-string or after
+  // whitespace, with no whitespace between it and the cursor.
   const textBeforeCursor = message.slice(0, cursorPosition);
-  const lastAtIndex = textBeforeCursor.lastIndexOf('@');
+  const lastTriggerIndex = textBeforeCursor.lastIndexOf(trigger);
 
-  if (lastAtIndex === -1) {
+  if (lastTriggerIndex === -1) {
     return INACTIVE_RESULT;
   }
 
-  const charBeforeAt = lastAtIndex > 0 ? message[lastAtIndex - 1] : ' ';
-  const isValidStart = charBeforeAt === ' ' || charBeforeAt === '\n' || lastAtIndex === 0;
+  const charBeforeTrigger = lastTriggerIndex > 0 ? message[lastTriggerIndex - 1] : ' ';
+  const isValidStart =
+    charBeforeTrigger === ' ' || charBeforeTrigger === '\n' || lastTriggerIndex === 0;
 
   if (!isValidStart) {
     return INACTIVE_RESULT;
   }
 
-  const textAfterAt = message.slice(lastAtIndex + 1, cursorPosition);
+  const textAfterTrigger = message.slice(lastTriggerIndex + 1, cursorPosition);
 
-  if (textAfterAt.includes(' ') || textAfterAt.includes('\n')) {
+  if (textAfterTrigger.includes(' ') || textAfterTrigger.includes('\n')) {
     return INACTIVE_RESULT;
   }
 
   return {
     isActive: true,
-    query: textAfterAt.toLowerCase(),
-    mentionStartPos: lastAtIndex,
-    mentionEndPos: cursorPosition,
+    query: textAfterTrigger.toLowerCase(),
+    tokenStartPos: lastTriggerIndex,
+    tokenEndPos: cursorPosition,
   };
 };
 
-export const getHighlightTokenRanges = (
+export const insertToken = (
   message: string,
-  allowCommand = true,
-): Array<[number, number]> => {
-  // [start, end) offsets of @file mentions and the leading /command.
-  // allowCommand=false for text fragments that don't start at the message head.
+  token: string,
+  startPos: number,
+  endPos: number,
+): { text: string; cursor: number } => {
+  // Replaces the in-progress [startPos, endPos) token with the selected value;
+  // the trailing space closes the suggestion query so the panel dismisses.
+  const before = message.slice(0, startPos);
+  const after = message.slice(endPos);
+  const separator = after.startsWith(' ') ? '' : ' ';
+  return {
+    text: `${before}${token}${separator}${after}`,
+    cursor: before.length + token.length + separator.length,
+  };
+};
+
+export const getHighlightTokenRanges = (message: string): Array<[number, number]> => {
+  // [start, end) offsets of @file mention and /command tokens.
   const tokenRanges: Array<[number, number]> = [];
 
-  const commandMatch = allowCommand ? COMMAND_TOKEN_REGEX.exec(message) : null;
-  if (commandMatch) {
-    const start = commandMatch[1].length;
-    tokenRanges.push([start, start + commandMatch[2].length]);
-  }
-
-  for (const match of message.matchAll(MENTION_TOKEN_REGEX)) {
+  for (const match of message.matchAll(TOKEN_REGEX)) {
     const start = match.index + match[1].length;
     tokenRanges.push([start, start + match[2].length]);
   }
@@ -75,13 +88,10 @@ export const getHighlightTokenRanges = (
   return tokenRanges;
 };
 
-export const buildHighlightSegments = (
-  message: string,
-  allowCommand = true,
-): HighlightSegment[] => {
+export const buildHighlightSegments = (message: string): HighlightSegment[] => {
   // Split text into plain/token runs so callers can render pills behind the
   // tokens without altering the raw value.
-  const tokenRanges = getHighlightTokenRanges(message, allowCommand);
+  const tokenRanges = getHighlightTokenRanges(message);
 
   const segments: HighlightSegment[] = [];
   let cursor = 0;


### PR DESCRIPTION
## Summary
- Unifies `/`-command and `@`-mention parsing into a shared cursor-aware `parseTokenQuery`/`insertToken` in `mentionParser.ts`
- Slash commands can now be triggered anywhere in the message (not just as the very first token) and are inserted at the cursor instead of replacing the whole input
- `useSlashCommandSuggestions` now tracks cursor position like `useMentionSuggestions` already did
- Simplifies `MarkDown.tsx` pill highlighting since both mentions and commands now share one token regex/walker