### PR TITLE
feat(ui): replace native title tooltips with FloatingTooltip

### DIFF
--- a/frontend/src/components/chat/chat-search/ChatSearchPanel.tsx
+++ b/frontend/src/components/chat/chat-search/ChatSearchPanel.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, Search, X } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Input } from '@/components/ui/primitives/Input';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useSearchChatsQuery } from '@/hooks/queries/useChatQueries';
@@ -109,15 +110,16 @@ export const ChatSearchPanel = memo(function ChatSearchPanel({
             )}
           />
           {query && (
-            <Button
-              onClick={handleClear}
-              variant="unstyled"
-              title="Clear search"
-              aria-label="Clear search"
-              className="mr-1 flex h-5 w-5 items-center justify-center rounded text-text-quaternary transition-colors hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-            >
-              <X className="h-3 w-3" />
-            </Button>
+            <FloatingTooltip content="Clear search" className="flex">
+              <Button
+                onClick={handleClear}
+                variant="unstyled"
+                aria-label="Clear search"
+                className="mr-1 flex h-5 w-5 items-center justify-center rounded text-text-quaternary transition-colors hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </FloatingTooltip>
           )}
         </div>
       </div>

--- a/frontend/src/components/chat/message-bubble/ChangedFilesPanel.tsx
+++ b/frontend/src/components/chat/message-bubble/ChangedFilesPanel.tsx
@@ -8,6 +8,7 @@ import {
   Loader2,
 } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { DiffView } from '@/components/chat/tools/common/DiffView';
 import { useMessageChangesQuery, useMessageFileDiffQuery } from '@/hooks/queries/useChatQueries';
 import { useUIStore } from '@/store/uiStore';
@@ -113,18 +114,16 @@ const ChangedFileRow: React.FC<{
           ) : (
             <ChevronRight className="h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
           )}
-          <span
-            className={`w-3.5 flex-shrink-0 text-center font-mono text-2xs ${STATUS_COLOR[file.status]}`}
-            title={STATUS_LABEL[file.status]}
-          >
-            {file.status}
-          </span>
-          <span
-            className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary dark:text-text-dark-secondary"
-            title={file.path}
-          >
-            {file.path}
-          </span>
+          <FloatingTooltip content={STATUS_LABEL[file.status]} className="flex flex-shrink-0">
+            <span className={`w-3.5 text-center font-mono text-2xs ${STATUS_COLOR[file.status]}`}>
+              {file.status}
+            </span>
+          </FloatingTooltip>
+          <FloatingTooltip content={file.path} className="min-w-0 flex-1">
+            <span className="block truncate font-mono text-xs text-text-secondary dark:text-text-dark-secondary">
+              {file.path}
+            </span>
+          </FloatingTooltip>
           <span className="flex-shrink-0 font-mono text-2xs tabular-nums text-success-600 dark:text-success-400">
             +{file.additions}
           </span>
@@ -133,27 +132,29 @@ const ChangedFileRow: React.FC<{
           </span>
         </Button>
         <div className="flex flex-shrink-0 items-center gap-2">
-          <Button
-            type="button"
-            variant="unstyled"
-            onClick={() => chatId && useUIStore.getState().openInDiffView(file.path, chatId)}
-            aria-label="Open in diff view"
-            title="Open in diff view"
-            className="text-text-quaternary transition-colors duration-150 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-          >
-            <GitCompareArrows className="h-3 w-3" />
-          </Button>
-          {!isDeleted && (
+          <FloatingTooltip content="Open in diff view" className="flex">
             <Button
               type="button"
               variant="unstyled"
-              onClick={() => useUIStore.getState().openFileInEditor(editorPath, chatId)}
-              aria-label="Open in editor"
-              title="Open in editor"
+              onClick={() => chatId && useUIStore.getState().openInDiffView(file.path, chatId)}
+              aria-label="Open in diff view"
               className="text-text-quaternary transition-colors duration-150 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
             >
-              <ExternalLink className="h-3 w-3" />
+              <GitCompareArrows className="h-3 w-3" />
             </Button>
+          </FloatingTooltip>
+          {!isDeleted && (
+            <FloatingTooltip content="Open in editor" className="flex">
+              <Button
+                type="button"
+                variant="unstyled"
+                onClick={() => useUIStore.getState().openFileInEditor(editorPath, chatId)}
+                aria-label="Open in editor"
+                className="text-text-quaternary transition-colors duration-150 hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+              >
+                <ExternalLink className="h-3 w-3" />
+              </Button>
+            </FloatingTooltip>
           )}
         </div>
       </div>

--- a/frontend/src/components/chat/tools/claude/AgentTool.tsx
+++ b/frontend/src/components/chat/tools/claude/AgentTool.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState, useRef, lazy, Suspense } from 'react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Bot, Maximize2 } from 'lucide-react';
 import type { ToolAggregate } from '@/types/tools.types';
 import { ToolCard } from '../common/ToolCard';
@@ -44,18 +45,20 @@ export const AgentTool: React.FC<AgentToolProps> = ({ tool }) => {
   );
 
   const expandAction = (
-    <Button
-      variant="unstyled"
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation();
-        setModalOpen(true);
-      }}
-      className="rounded-sm opacity-0 transition-opacity duration-150 focus-visible:opacity-100 group-hover/tool:opacity-100"
-      title="Expand agent view"
-    >
-      <Maximize2 className="h-3 w-3 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary" />
-    </Button>
+    <FloatingTooltip content="Expand agent view" className="flex">
+      <Button
+        variant="unstyled"
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setModalOpen(true);
+        }}
+        className="rounded-sm opacity-0 transition-opacity duration-150 focus-visible:opacity-100 group-hover/tool:opacity-100"
+        aria-label="Expand agent view"
+      >
+        <Maximize2 className="h-3 w-3 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary" />
+      </Button>
+    </FloatingTooltip>
   );
 
   return (

--- a/frontend/src/components/chat/tools/common/OpenInEditorButton.tsx
+++ b/frontend/src/components/chat/tools/common/OpenInEditorButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { useUIStore } from '@/store/uiStore';
 import { useChatContext } from '@/hooks/useChatContext';
 
@@ -8,15 +9,16 @@ export const OpenInEditorButton: React.FC<{ filePath: string }> = ({ filePath })
   // Open into the editor of the chat this tool belongs to, not always the primary.
   const { chatId } = useChatContext();
   return (
-    <Button
-      type="button"
-      onClick={() => useUIStore.getState().openFileInEditor(filePath, chatId)}
-      variant="unstyled"
-      className="rounded-sm opacity-0 transition-opacity duration-150 focus-visible:opacity-100 group-hover/tool:opacity-100"
-      title="Open in editor"
-      aria-label="Open in editor"
-    >
-      <ExternalLink className="h-3 w-3 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary" />
-    </Button>
+    <FloatingTooltip content="Open in editor" className="flex">
+      <Button
+        type="button"
+        onClick={() => useUIStore.getState().openFileInEditor(filePath, chatId)}
+        variant="unstyled"
+        className="rounded-sm opacity-0 transition-opacity duration-150 focus-visible:opacity-100 group-hover/tool:opacity-100"
+        aria-label="Open in editor"
+      >
+        <ExternalLink className="h-3 w-3 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary" />
+      </Button>
+    </FloatingTooltip>
   );
 };

--- a/frontend/src/components/chat/tools/common/SourceChip.tsx
+++ b/frontend/src/components/chat/tools/common/SourceChip.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Globe } from 'lucide-react';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Link } from '@/components/ui/primitives/Link';
 
 interface SourceChipProps {
@@ -20,36 +21,37 @@ export const SourceChip: React.FC<SourceChipProps> = ({ source, index }) => {
   }
 
   return (
-    <Link
-      href={source.url}
-      variant="unstyled"
-      target="_blank"
-      rel="noopener noreferrer"
-      title={source.title}
-      className="group/chip flex items-center gap-1.5 rounded-md bg-black/5 px-2 py-1 transition-colors duration-150 hover:bg-surface-hover dark:bg-white/5 dark:hover:bg-surface-dark-hover"
-    >
-      <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded text-2xs font-medium text-text-quaternary dark:text-text-dark-quaternary">
-        {faviconUrl ? (
-          <img
-            src={faviconUrl}
-            alt=""
-            className="h-3 w-3 rounded-sm"
-            onError={(e) => {
-              e.currentTarget.style.display = 'none';
-              e.currentTarget.nextElementSibling?.classList.remove('hidden');
-            }}
+    <FloatingTooltip content={source.title} className="flex">
+      <Link
+        href={source.url}
+        variant="unstyled"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group/chip flex items-center gap-1.5 rounded-md bg-black/5 px-2 py-1 transition-colors duration-150 hover:bg-surface-hover dark:bg-white/5 dark:hover:bg-surface-dark-hover"
+      >
+        <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded text-2xs font-medium text-text-quaternary dark:text-text-dark-quaternary">
+          {faviconUrl ? (
+            <img
+              src={faviconUrl}
+              alt=""
+              className="h-3 w-3 rounded-sm"
+              onError={(e) => {
+                e.currentTarget.style.display = 'none';
+                e.currentTarget.nextElementSibling?.classList.remove('hidden');
+              }}
+            />
+          ) : null}
+          <Globe
+            className={`h-3 w-3 text-text-quaternary dark:text-text-dark-quaternary ${faviconUrl ? 'hidden' : ''}`}
           />
-        ) : null}
-        <Globe
-          className={`h-3 w-3 text-text-quaternary dark:text-text-dark-quaternary ${faviconUrl ? 'hidden' : ''}`}
-        />
-      </span>
-      <span className="max-w-32 truncate text-2xs text-text-secondary transition-colors duration-150 group-hover/chip:text-text-primary dark:text-text-dark-tertiary dark:group-hover/chip:text-text-dark-primary">
-        {domain}
-      </span>
-      <span className="text-2xs tabular-nums text-text-quaternary/60 dark:text-text-dark-quaternary/60">
-        {index + 1}
-      </span>
-    </Link>
+        </span>
+        <span className="max-w-32 truncate text-2xs text-text-secondary transition-colors duration-150 group-hover/chip:text-text-primary dark:text-text-dark-tertiary dark:group-hover/chip:text-text-dark-primary">
+          {domain}
+        </span>
+        <span className="text-2xs tabular-nums text-text-quaternary/60 dark:text-text-dark-quaternary/60">
+          {index + 1}
+        </span>
+      </Link>
+    </FloatingTooltip>
   );
 };

--- a/frontend/src/components/chat/tools/common/ToolCard.tsx
+++ b/frontend/src/components/chat/tools/common/ToolCard.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useState } from 'react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { ChevronRight } from 'lucide-react';
 import type { ToolEventStatus } from '@/types/tools.types';
 import { TOOL_ERROR_PRE_CLASS } from '@/utils/toolStyles';
@@ -59,12 +60,11 @@ const ToolCardInner: React.FC<ToolCardProps> = ({
       <div className="flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary">
         {icon}
       </div>
-      <span
-        className="max-w-md truncate text-2xs text-text-tertiary dark:text-text-dark-tertiary"
-        title={resolvedTitle}
-      >
-        {resolvedTitle}
-      </span>
+      <FloatingTooltip content={resolvedTitle} className="min-w-0">
+        <span className="block max-w-md truncate text-2xs text-text-tertiary dark:text-text-dark-tertiary">
+          {resolvedTitle}
+        </span>
+      </FloatingTooltip>
       {statusIndicator[status]}
       {hasExpandableContent && (
         <ChevronRight

--- a/frontend/src/components/layout/ChatTabs.tsx
+++ b/frontend/src/components/layout/ChatTabs.tsx
@@ -2,6 +2,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { useMatch, useNavigate } from 'react-router-dom';
 import { Plus, X } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { useUIStore } from '@/store/uiStore';
 import { useStreamStore } from '@/store/streamStore';
 import { usePermissionStore } from '@/store/permissionStore';
@@ -67,24 +68,28 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
             'mb-px rounded-md text-text-tertiary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary',
       )}
     >
-      <Button
-        variant="unstyled"
-        onClick={() => onSelect(chatId)}
-        aria-current={isCurrent ? 'page' : undefined}
-        title={status ? `${title} · ${STATUS_LABELS[status]}` : title}
-        className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-2xs font-medium"
+      <FloatingTooltip
+        content={status ? `${title} · ${STATUS_LABELS[status]}` : title}
+        className="flex min-w-0 flex-1"
       >
-        {/* The status dot claims the icon slot while the turn is live — the
-            agent glyph carries no information a colored dot doesn't. */}
-        {status ? (
-          <span
-            className={cn('h-1.5 w-1.5 flex-shrink-0 rounded-full', STATUS_DOT_CLASS[status])}
-          />
-        ) : (
-          <AgentIcon className="h-3 w-3 flex-shrink-0" />
-        )}
-        <span className="min-w-0 truncate">{title}</span>
-      </Button>
+        <Button
+          variant="unstyled"
+          onClick={() => onSelect(chatId)}
+          aria-current={isCurrent ? 'page' : undefined}
+          className="flex w-full min-w-0 items-center gap-1.5 text-left text-2xs font-medium"
+        >
+          {/* The status dot claims the icon slot while the turn is live — the
+              agent glyph carries no information a colored dot doesn't. */}
+          {status ? (
+            <span
+              className={cn('h-1.5 w-1.5 flex-shrink-0 rounded-full', STATUS_DOT_CLASS[status])}
+            />
+          ) : (
+            <AgentIcon className="h-3 w-3 flex-shrink-0" />
+          )}
+          <span className="min-w-0 truncate">{title}</span>
+        </Button>
+      </FloatingTooltip>
       <Button
         variant="unstyled"
         onClick={() => onClose(chatId)}

--- a/frontend/src/components/layout/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/SidebarChatItem.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import { ChevronRight, MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
 import { cn } from '@/utils/cn';
 import { stripMarkdownTitle } from '@/utils/format';
@@ -76,7 +77,8 @@ export const SidebarChatItem = memo(function SidebarChatItem({
 
       {/* Wider right padding when blocked reserves room for the "Awaiting approval"
           pill so long titles truncate before reaching it. */}
-      <div
+      <FloatingTooltip
+        content={onOpenInSplit ? `${chat.title} (Shift-click to open in split)` : chat.title}
         className={cn(
           'flex min-w-0 flex-1 items-center gap-1.5',
           isChatBlocked ? 'pr-[104px]' : 'pr-10',
@@ -98,7 +100,6 @@ export const SidebarChatItem = memo(function SidebarChatItem({
           }}
           aria-current={isSelected ? 'page' : undefined}
           variant="unstyled"
-          title={onOpenInSplit ? `${chat.title} (Shift-click to open in split)` : chat.title}
           // flex-1 keeps the whole row width as the open-chat hit target, not just the text
           className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-[13px]"
         >
@@ -118,7 +119,7 @@ export const SidebarChatItem = memo(function SidebarChatItem({
             </span>
           )}
         </Button>
-      </div>
+      </FloatingTooltip>
 
       <span
         className={cn(

--- a/frontend/src/components/layout/SubThreadList.tsx
+++ b/frontend/src/components/layout/SubThreadList.tsx
@@ -2,6 +2,7 @@ import { memo, useState, useCallback } from 'react';
 import { MoreHorizontal } from 'lucide-react';
 import { useSubThreadsQuery } from '@/hooks/queries/useChatQueries';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
 import { cn } from '@/utils/cn';
 import { stripMarkdownTitle } from '@/utils/format';
@@ -78,32 +79,33 @@ export const SubThreadList = memo(function SubThreadList({
           >
             <div className="absolute -left-[22px] top-1/2 h-px w-[18px] bg-border-secondary dark:bg-border-dark-secondary" />
 
-            <Button
-              variant="unstyled"
-              type="button"
-              onClick={() => onSelect(thread.id)}
-              title={thread.title}
-              className={cn(
-                'flex w-full items-center gap-2 px-2 py-1.5 transition-colors duration-200',
-                isBlocked ? 'pr-[104px]' : 'pr-10',
-                isActive
-                  ? 'text-text-primary dark:text-text-dark-primary'
-                  : 'text-text-tertiary hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-secondary',
-              )}
-            >
-              {isStreaming && !isBlocked && (
-                <div className="h-[5px] w-[5px] flex-shrink-0 animate-pulse rounded-full bg-warning-500" />
-              )}
-              {thread.session_agent_kind && (
-                <ProviderIcon
-                  agentKind={thread.session_agent_kind}
-                  className="h-3 w-3 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary"
-                />
-              )}
-              <span className={cn('truncate text-xs', isActive && 'font-medium')}>
-                {stripMarkdownTitle(thread.title)}
-              </span>
-            </Button>
+            <FloatingTooltip content={thread.title} className="flex min-w-0 flex-1">
+              <Button
+                variant="unstyled"
+                type="button"
+                onClick={() => onSelect(thread.id)}
+                className={cn(
+                  'flex w-full min-w-0 items-center gap-2 px-2 py-1.5 transition-colors duration-200',
+                  isBlocked ? 'pr-[104px]' : 'pr-10',
+                  isActive
+                    ? 'text-text-primary dark:text-text-dark-primary'
+                    : 'text-text-tertiary hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-secondary',
+                )}
+              >
+                {isStreaming && !isBlocked && (
+                  <div className="h-[5px] w-[5px] flex-shrink-0 animate-pulse rounded-full bg-warning-500" />
+                )}
+                {thread.session_agent_kind && (
+                  <ProviderIcon
+                    agentKind={thread.session_agent_kind}
+                    className="h-3 w-3 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary"
+                  />
+                )}
+                <span className={cn('truncate text-xs', isActive && 'font-medium')}>
+                  {stripMarkdownTitle(thread.title)}
+                </span>
+              </Button>
+            </FloatingTooltip>
 
             <span
               className={cn(

--- a/frontend/src/components/ui/FloatingTooltip.tsx
+++ b/frontend/src/components/ui/FloatingTooltip.tsx
@@ -1,0 +1,52 @@
+import { ReactNode, useRef, useState } from 'react';
+import { cn } from '@/utils/cn';
+
+// Matches the native title-attribute hover delay so tooltips don't flash while scanning a list
+const SHOW_DELAY_MS = 500;
+
+interface FloatingTooltipProps {
+  content: string;
+  children: ReactNode;
+  className?: string;
+}
+
+// Themed replacement for the native title attribute. Unlike Tooltip (pure CSS,
+// absolute), it renders position:fixed so triggers inside overflow-y-auto lists
+// (e.g. the sidebar) don't clip the bubble or add phantom scroll space.
+export function FloatingTooltip({ content, children, className }: FloatingTooltipProps) {
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+  const showTimerRef = useRef<number | null>(null);
+
+  const handleMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    showTimerRef.current = window.setTimeout(
+      () => setPosition({ top: rect.bottom + 4, left: rect.left }),
+      SHOW_DELAY_MS,
+    );
+  };
+
+  const handleMouseLeave = () => {
+    if (showTimerRef.current != null) window.clearTimeout(showTimerRef.current);
+    showTimerRef.current = null;
+    setPosition(null);
+  };
+
+  return (
+    <div className={className} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      {children}
+      {position != null && (
+        <div
+          role="tooltip"
+          style={{ top: position.top, left: position.left }}
+          className={cn(
+            'pointer-events-none fixed z-50 max-w-[280px] whitespace-pre-line break-words rounded px-2 py-1',
+            'animate-fade-in bg-surface-tertiary text-xs font-medium text-text-primary shadow-lg',
+            'dark:bg-surface-dark-tertiary dark:text-text-dark-primary',
+          )}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `FloatingTooltip`, a themed, fixed-position tooltip component that replaces the native `title` attribute
- Native tooltips are unstyled and get clipped/add phantom scroll space inside `overflow-y-auto` sidebar lists (e.g. chat list, sub-threads); `FloatingTooltip` renders via `position: fixed` to avoid both issues
- Applied across chat search clear button, changed files panel rows/actions, agent tool expand button, open-in-editor buttons, source chips, tool card titles, chat tabs, sidebar chat items, and sub-thread list items