### PR TITLE
fix(chat): stop ModelSelector from committing premature model defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@
 - When a terminal/completion handler needs metadata about the completed entity, capture it at session/handle creation — don't resolve from the currently-viewed entity at completion time; off-screen completions land when the user has navigated elsewhere
 - For off-screen entities that need fresh state on next mount, patch the cache optimistically during the stream/mutation (`queryClient.setQueryData`) — `invalidateQueries` alone isn't enough since `useQuery` serves cached data on mount during the background refetch
 - Terminal-kind gating (cancelled vs complete) applies only to UI-side concerns (notifications, toasts). Cache invalidations for server-side state mutated during the turn must run regardless — cancelled runs still leave real side effects
+- When a change makes a previously-always-present value possibly empty, add the guard to every submission path (send, queue, retry/reconnect) — parallel paths don't share validation
+- Before removing or gating a shared component's implicit behavior (auto-select, auto-commit defaults), audit every caller for reliance on it and move that behavior into the callers that need it
 
 ## Naming Conventions
 
@@ -172,6 +174,10 @@
 - Don't add nullability guards (`value && doSomething()`) on context values guaranteed by the provider
 - Don't add `?? null` / `?? false` / `?? []` coercions unless the upstream genuinely returns `undefined`
 
+### State Ownership
+- Don't write computed defaults into persisted stores (Zustand `persist`/localStorage) while their inputs (queries, message history) are still resolving — a persisted guess permanently wins over the later-derived value
+- Shared presentational components must not write to stores or commit defaults — defaulting/validation belongs to the single state-owner hook or provider; components take `value`/`onChange` only
+
 ### Existing Context Hierarchy
 - `ChatProvider` (`contexts/ChatContext.tsx`) — static chat metadata: `chatId`, `sandboxId`, `fileStructure`, `customAgents`, `customSlashCommands`, `customPrompts`
 - `ChatSessionProvider` (`contexts/ChatSessionContext.tsx`) — dynamic chat session state: messages, streaming, loading, permissions, input message, model selection
@@ -198,6 +204,8 @@
 - Distinguish "derived state" from "form state init" — if local state is a copy of server data the user then edits independently (secrets/settings forms), syncing via `useEffect` on query data change is correct
 - `useEffect` cleanup closures must not rely on hook-scoped utilities that close over the current entity ID when cleanup may serve sessions from a different entity — use refs or the underlying API (e.g., `queryClient.setQueryData` with `session.chatId`)
 - When state is keyed by an input so render derives a `pending` flag as `stored.input !== currentInput`, the effect must update state for every input value — bailing on falsy inputs (`if (!x) return`) leaves `stored.input` stale and the pending flag locked on forever
+- Ref-based render checks may only set the same component's state — when the value is parent-owned (written via a callback prop), use `useEffect`; updating a parent during a child's render is illegal
+- When local state overrides an ambient value that resolves asynchronously, derive the effective value (`local || ambient`) instead of seeding state from the prop at mount and patching it later
 
 ### Component Variants
 - Create explicit variant components instead of one with many boolean modes (e.g., `ThreadComposer`, `EditComposer` instead of `<Composer isThread isEditing />`)

--- a/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
+++ b/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
@@ -77,6 +77,7 @@ export function ChatSessionOrchestrator({
   const { selectedModelId, selectedModel, selectModel } = useModelSelection({
     chatId,
     initialModelId: lastAssistantModelId,
+    lockedAgentKind: currentChat?.session_agent_kind ?? null,
   });
 
   const {

--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -36,7 +36,6 @@ export function InputControls() {
       <ModelSelector
         selectedModelId={state.selectedModelId}
         onModelChange={actions.onModelChange}
-        chatId={state.chatId}
         dropdownPosition={state.dropdownPosition}
         dropdownAlign="right"
         disabled={state.isLoading}

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useCallback, useMemo, type ReactNode } from 'react';
+import toast from 'react-hot-toast';
 import { useDragAndDrop } from '@/hooks/useDragAndDrop';
 import { useFileHandling } from '@/hooks/useFileHandling';
 import { useInputFileOperations } from '@/hooks/useInputFileOperations';
@@ -240,6 +241,12 @@ export function InputProvider({
     if (disabled) return;
 
     if (isStreaming && hasContent && chatId) {
+      // Mirror the send path's model guard — queueMessage is fire-and-forget
+      // and the draft is cleared below, so a rejected queue call loses the message.
+      if (!selectedModelId) {
+        toast.error('Please select an AI model');
+        return;
+      }
       const settings = useChatSettingsStore.getState();
       const permissionMode = coercePermissionModeForAgent(
         settings.permissionModeByChat[chatId] ?? DEFAULT_PERMISSION_MODE,

--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -1,11 +1,11 @@
-import { memo, useEffect, useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { Star } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { Dropdown } from '@/components/ui/primitives/Dropdown';
 import type { DropdownItemType } from '@/components/ui/primitives/Dropdown';
 import { useAuthStore } from '@/store/authStore';
 import { useModelStore } from '@/store/modelStore';
-import { useModelSelection } from '@/hooks/queries/useModelQueries';
+import { useModelsQuery } from '@/hooks/queries/useModelQueries';
 import { useIsSplitMode } from '@/hooks/useIsSplitMode';
 import { AGENT_ICONS } from '@/components/ui/icons/ProviderIcon';
 import { cn } from '@/utils/cn';
@@ -25,7 +25,6 @@ const AGENT_LABELS: Record<AgentKind, string> = {
 export interface ModelSelectorProps {
   selectedModelId: string;
   onModelChange: (modelId: string) => void;
-  chatId?: string;
   dropdownPosition?: 'top' | 'bottom';
   disabled?: boolean;
   compact?: boolean;
@@ -37,7 +36,6 @@ export interface ModelSelectorProps {
 export const ModelSelector = memo(function ModelSelector({
   selectedModelId,
   onModelChange,
-  chatId,
   dropdownPosition = 'bottom',
   dropdownAlign,
   disabled = false,
@@ -47,7 +45,9 @@ export const ModelSelector = memo(function ModelSelector({
 }: ModelSelectorProps) {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const isSplitMode = useIsSplitMode();
-  const { models, isLoading } = useModelSelection({ enabled: isAuthenticated, chatId });
+  // Read-only models query — useModelSelection would run the per-chat defaulting
+  // effect and persist models[0] before the owner derives the model from history.
+  const { data: models = [], isLoading } = useModelsQuery({ enabled: isAuthenticated });
   const favoriteModelIds = useModelStore((state) => state.favoriteModelIds);
 
   const filteredModels = useMemo(
@@ -87,12 +87,6 @@ export const ModelSelector = memo(function ModelSelector({
   }, [filteredModels, favoriteModelIds, favoriteIdSet]);
 
   const selectedModel = filteredModels.find((m) => m.model_id === selectedModelId);
-
-  useEffect(() => {
-    if (!selectedModel && filteredModels.length > 0) {
-      onModelChange(filteredModels[0].model_id);
-    }
-  }, [selectedModel, filteredModels, onModelChange]);
 
   if (isLoading) {
     return (

--- a/frontend/src/components/editor/editor-view/InlineChatWidget.tsx
+++ b/frontend/src/components/editor/editor-view/InlineChatWidget.tsx
@@ -33,9 +33,10 @@ export function InlineChatWidget({
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [question, setQuestion] = useState('');
   const { selectedModelId } = useChatSessionState();
-  // Widget-local model choice seeded from the chat's composer selection —
-  // picking a model here shouldn't silently retarget the main chat.
-  const [modelId, setModelId] = useState(selectedModelId);
+  // Widget-local override falling back to the composer selection (which may
+  // resolve after mount) — picking here shouldn't retarget the main chat.
+  const [modelId, setModelId] = useState('');
+  const effectiveModelId = modelId || selectedModelId;
   const askMutation = useAskAboutCodeMutation();
 
   useLayoutEffect(() => {
@@ -77,8 +78,8 @@ export function InlineChatWidget({
 
   const handleSubmit = () => {
     const trimmed = question.trim();
-    if (!trimmed || askMutation.isPending) return;
-    askMutation.mutate({ chatId, selection, question: trimmed, modelId });
+    if (!trimmed || !effectiveModelId || askMutation.isPending) return;
+    askMutation.mutate({ chatId, selection, question: trimmed, modelId: effectiveModelId });
   };
 
   const lineRef =
@@ -103,7 +104,7 @@ export function InlineChatWidget({
           {selection.path}:{lineRef}
         </span>
         <ModelSelector
-          selectedModelId={modelId}
+          selectedModelId={effectiveModelId}
           onModelChange={setModelId}
           dropdownPosition="bottom"
           dropdownAlign="right"
@@ -145,7 +146,7 @@ export function InlineChatWidget({
         <Button
           type="submit"
           variant="unstyled"
-          disabled={!question.trim() || askMutation.isPending}
+          disabled={!question.trim() || !effectiveModelId || askMutation.isPending}
           aria-label="Ask question"
           className="rounded-md p-1.5 text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
         >

--- a/frontend/src/components/settings/dialogs/StreamActionEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/StreamActionEditDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { GitBranch, Brain, Shield } from 'lucide-react';
 import type { CustomSkill, Persona, StreamAction } from '@/types/user.types';
 import type { SlashCommand } from '@/types/ui.types';
@@ -58,6 +58,15 @@ export const StreamActionEditDialog: React.FC<StreamActionEditDialogProps> = ({
   const workspaces = useWorkspacesList();
   const { data: resources } = useWorkspaceResourcesQuery(workspaces[0]?.id);
   const builtinSlashCommands = resources?.builtin_slash_commands ?? EMPTY_BUILTIN_COMMANDS;
+
+  // Form-state init: seed new actions and actions whose saved model left the
+  // registry — ModelSelector no longer commits one, and save requires a model_id.
+  // Effect, not render-phase seeding: onActionChange writes parent-owned state.
+  useEffect(() => {
+    if (models.length > 0 && !models.some((m) => m.model_id === action.model_id)) {
+      onActionChange('model_id', models[0].model_id);
+    }
+  }, [models, action.model_id, onActionChange]);
 
   const selectedModel = models.find((m) => m.model_id === action.model_id);
   const agentKind = selectedModel?.agent_kind ?? 'claude';

--- a/frontend/src/hooks/queries/useModelQueries.ts
+++ b/frontend/src/hooks/queries/useModelQueries.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { UseQueryOptions } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo } from 'react';
 import { modelService } from '@/services/modelService';
-import type { Model } from '@/types/chat.types';
+import type { AgentKind, Model } from '@/types/chat.types';
 import { useModelStore } from '@/store/modelStore';
 import { queryKeys } from './queryKeys';
 
@@ -22,29 +22,45 @@ export const useModelSelection = (options?: {
   chatId?: string;
   // null = still loading (defer default), undefined = no initial model (use models[0])
   initialModelId?: string | null;
+  // Restricts valid selections to one provider (chats with an established session)
+  lockedAgentKind?: AgentKind | null;
 }) => {
   const chatId = options?.chatId ?? DEFAULT_MODEL_KEY;
   const initialModelId = options?.initialModelId;
-  const { data: models = [], isLoading } = useModelsQuery({
+  const lockedAgentKind = options?.lockedAgentKind;
+  const { data: models = [] } = useModelsQuery({
     enabled: options?.enabled,
   });
 
-  const selectedModelId = useModelStore((state) => state.modelByChat[chatId] ?? '');
+  const storedModelId = useModelStore((state) => state.modelByChat[chatId] ?? '');
+
+  // Models valid for this chat — restricted to the locked provider once the
+  // session kind is known; stale entries (retired ids, wrong-kind values
+  // persisted by old versions) count as invalid.
+  const candidates = useMemo(
+    () => (lockedAgentKind ? models.filter((m) => m.agent_kind === lockedAgentKind) : models),
+    [models, lockedAgentKind],
+  );
+
+  const storedIsValid = candidates.some((m) => m.model_id === storedModelId);
+
+  // Expose invalid stored values as empty so a stale cross-provider selection
+  // can't be submitted while the real model is still resolving from history;
+  // pass stored through until the registry loads (nothing to validate yet).
+  const selectedModelId = models.length === 0 || storedIsValid ? storedModelId : '';
 
   useEffect(() => {
-    if (models.length === 0) return;
-    const selectedExists = models.some((m) => m.model_id === selectedModelId);
-    if (selectedExists) return;
+    if (candidates.length === 0 || storedIsValid) return;
 
     // Still loading initial model from message history — wait before defaulting
     if (initialModelId === null) return;
 
     const fallback =
-      initialModelId && models.some((m) => m.model_id === initialModelId)
+      initialModelId && candidates.some((m) => m.model_id === initialModelId)
         ? initialModelId
-        : models[0].model_id;
+        : candidates[0].model_id;
     useModelStore.getState().selectModel(chatId, fallback);
-  }, [models, selectedModelId, chatId, initialModelId]);
+  }, [candidates, storedIsValid, chatId, initialModelId]);
 
   const selectedModel = useMemo(
     () => models.find((m) => m.model_id === selectedModelId) ?? null,
@@ -56,7 +72,7 @@ export const useModelSelection = (options?: {
     [chatId],
   );
 
-  return { models, selectedModelId, selectedModel, selectModel, isLoading };
+  return { selectedModelId, selectedModel, selectModel };
 };
 
 // `/models/` is auth-protected — public-route callers must gate; default-on


### PR DESCRIPTION
## Summary
- `ModelSelector` had its own effect that persisted `models[0]` to the store as soon as models loaded, racing the real defaulting logic in `useModelSelection` (which waits for the chat's model to resolve from message history). A persisted guess would win permanently over the later-derived correct value.
- Moved all defaulting/selection ownership into `useModelSelection`; `ModelSelector` now reads models via the plain `useModelsQuery` and no longer writes to the store.
- Added `lockedAgentKind` to `useModelSelection`/`ChatSessionOrchestrator` so chats with an established session restrict candidate models to that session's provider, treating stale/wrong-provider stored ids as invalid.
- `InputProvider`'s queue-message path (streaming + send) now guards on a missing model the same way the primary send path already did, since `queueMessage` is fire-and-forget and the draft is cleared regardless.
- `InlineChatWidget` and `StreamActionEditDialog` updated to fall back to an effective/derived model id now that `ModelSelector` no longer auto-commits a default itself.

## Test plan
- [ ] Open an existing chat with prior assistant messages and confirm the composer resolves to the last-used model instead of flashing to the first model in the list.
- [ ] Open a chat with an established session (locked agent kind) and confirm the model dropdown only offers same-provider models.
- [ ] Trigger the streaming "queue message" flow with no model selected and confirm the same toast/guard as the normal send path fires.
- [ ] Open the inline editor chat widget and the stream action edit dialog and confirm a model is selected/submittable once models load.