### PR TITLE
feat(ui): migrate remaining native title tooltips to FloatingTooltip

### DIFF
--- a/frontend/src/components/chat/github/CreateCommitDialog.tsx
+++ b/frontend/src/components/chat/github/CreateCommitDialog.tsx
@@ -3,6 +3,7 @@ import { GitCommitHorizontal, Sparkles } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Textarea } from '@/components/ui/primitives/Textarea';
 import { useActiveChat } from '@/hooks/useActiveChat';
 import { useModelStore } from '@/store/modelStore';
@@ -36,6 +37,11 @@ export function CreateCommitDialog({ onClose }: CreateCommitDialogProps) {
   const hasDiff = !!diffData?.diff && !isPlaceholderData;
   const hasModel = !!selectedModelId.trim();
   const canGenerate = hasDiff && hasModel && !generateMessage.isPending;
+  const generateDisabledReason = !hasModel
+    ? 'Select a model first'
+    : !hasDiff
+      ? (diffData?.error ?? 'No changes to commit')
+      : undefined;
 
   const [message, setMessage] = useState('');
 
@@ -102,27 +108,24 @@ export function CreateCommitDialog({ onClose }: CreateCommitDialogProps) {
             <label className="text-2xs font-medium uppercase tracking-wider text-text-quaternary dark:text-text-dark-quaternary">
               Commit message
             </label>
-            <Button
-              type="button"
-              variant="unstyled"
-              onClick={handleGenerate}
-              disabled={!canGenerate}
-              title={
-                !hasModel
-                  ? 'Select a model first'
-                  : !hasDiff
-                    ? (diffData?.error ?? 'No changes to commit')
-                    : undefined
-              }
-              className={`flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs text-text-tertiary transition-colors duration-200 dark:text-text-dark-tertiary ${
-                canGenerate
-                  ? 'hover:bg-surface-hover hover:text-text-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
-                  : 'cursor-not-allowed opacity-50'
-              }`}
-            >
-              <Sparkles className={`h-3 w-3 ${generateMessage.isPending ? 'animate-pulse' : ''}`} />
-              {generateMessage.isPending ? 'Generating...' : 'Generate with AI'}
-            </Button>
+            <FloatingTooltip content={generateDisabledReason ?? ''} className="flex">
+              <Button
+                type="button"
+                variant="unstyled"
+                onClick={handleGenerate}
+                disabled={!canGenerate}
+                className={`flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs text-text-tertiary transition-colors duration-200 dark:text-text-dark-tertiary ${
+                  canGenerate
+                    ? 'hover:bg-surface-hover hover:text-text-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
+                    : 'cursor-not-allowed opacity-50'
+                }`}
+              >
+                <Sparkles
+                  className={`h-3 w-3 ${generateMessage.isPending ? 'animate-pulse' : ''}`}
+                />
+                {generateMessage.isPending ? 'Generating...' : 'Generate with AI'}
+              </Button>
+            </FloatingTooltip>
           </div>
           <Textarea
             value={message}

--- a/frontend/src/components/chat/github/CreatePRDialog.tsx
+++ b/frontend/src/components/chat/github/CreatePRDialog.tsx
@@ -3,6 +3,7 @@ import { ExternalLink, GitPullRequest, Sparkles } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Input } from '@/components/ui/primitives/Input';
 import { Link } from '@/components/ui/primitives/Link';
 import { Select } from '@/components/ui/primitives/Select';
@@ -135,6 +136,11 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
   const diffError = diffData?.error;
   const hasModel = !!selectedModelId.trim();
   const canGenerate = hasDiff && hasModel && !generateDescription.isPending;
+  const generateDisabledReason = !hasModel
+    ? 'Select a model first'
+    : !hasDiff
+      ? (diffError ?? 'Commit your changes first')
+      : undefined;
   const titleInputId = 'create-pr-title';
   const bodyTextareaId = 'create-pr-description';
   const baseBranchSelectId = 'create-pr-base-branch';
@@ -300,29 +306,24 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
                 >
                   Description
                 </label>
-                <Button
-                  type="button"
-                  variant="unstyled"
-                  onClick={handleGenerateDescription}
-                  disabled={!canGenerate}
-                  title={
-                    !hasModel
-                      ? 'Select a model first'
-                      : !hasDiff
-                        ? (diffError ?? 'Commit your changes first')
-                        : undefined
-                  }
-                  className={`flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs text-text-tertiary transition-colors duration-200 dark:text-text-dark-tertiary ${
-                    canGenerate
-                      ? 'hover:bg-surface-hover hover:text-text-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
-                      : 'cursor-not-allowed opacity-50'
-                  }`}
-                >
-                  <Sparkles
-                    className={`h-3 w-3 ${generateDescription.isPending ? 'animate-pulse' : ''}`}
-                  />
-                  {generateDescription.isPending ? 'Generating...' : 'Generate with AI'}
-                </Button>
+                <FloatingTooltip content={generateDisabledReason ?? ''} className="flex">
+                  <Button
+                    type="button"
+                    variant="unstyled"
+                    onClick={handleGenerateDescription}
+                    disabled={!canGenerate}
+                    className={`flex items-center gap-1 rounded-md px-1.5 py-0.5 text-2xs text-text-tertiary transition-colors duration-200 dark:text-text-dark-tertiary ${
+                      canGenerate
+                        ? 'hover:bg-surface-hover hover:text-text-secondary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
+                        : 'cursor-not-allowed opacity-50'
+                    }`}
+                  >
+                    <Sparkles
+                      className={`h-3 w-3 ${generateDescription.isPending ? 'animate-pulse' : ''}`}
+                    />
+                    {generateDescription.isPending ? 'Generating...' : 'Generate with AI'}
+                  </Button>
+                </FloatingTooltip>
               </div>
               <Textarea
                 id={bodyTextareaId}

--- a/frontend/src/components/chat/message-input/ContextUsageIndicator.tsx
+++ b/frontend/src/components/chat/message-input/ContextUsageIndicator.tsx
@@ -1,3 +1,4 @@
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { formatNumberCompact } from '@/utils/format';
 
 export interface ContextUsageInfo {
@@ -32,9 +33,9 @@ export const ContextUsageIndicator = ({ usage }: { usage: ContextUsageInfo }) =>
   const tooltip = `${formatNumberCompact(usage.tokensUsed)}/${formatNumberCompact(usage.contextWindow)}`;
 
   return (
-    <div
+    <FloatingTooltip
+      content={tooltip}
       className="flex select-none items-center gap-1 text-2xs text-text-secondary dark:text-text-dark-secondary"
-      title={tooltip}
     >
       <span className="font-medium tabular-nums">{formattedPercentage}%</span>
       <svg viewBox="0 0 24 24" className="h-5 w-5" role="presentation" aria-hidden="true">
@@ -61,6 +62,6 @@ export const ContextUsageIndicator = ({ usage }: { usage: ContextUsageInfo }) =>
           transform="rotate(-90 12 12)"
         />
       </svg>
-    </div>
+    </FloatingTooltip>
   );
 };

--- a/frontend/src/components/chat/message-input/EnhanceButton.tsx
+++ b/frontend/src/components/chat/message-input/EnhanceButton.tsx
@@ -1,5 +1,6 @@
 import { Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 
 export interface EnhanceButtonProps {
   onEnhance?: () => void;
@@ -13,24 +14,28 @@ export function EnhanceButton({
   disabled = false,
 }: EnhanceButtonProps) {
   return (
-    <Button
-      type="button"
-      onClick={onEnhance}
-      onMouseDown={(event) => {
-        // Preserve the textarea selection so enhance can act on the current prompt without blurring the composer.
-        event.preventDefault();
-      }}
-      disabled={disabled || isEnhancing}
-      variant="unstyled"
-      className={`group rounded-full p-1.5 transition-colors duration-200 ${
-        disabled || isEnhancing
-          ? 'cursor-not-allowed text-text-tertiary opacity-50 dark:text-text-dark-tertiary'
-          : 'bg-transparent text-text-tertiary hover:bg-surface-hover hover:text-text-secondary active:scale-95 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
-      }`}
-      aria-label={isEnhancing ? 'Enhancing prompt\u2026' : 'Enhance prompt'}
-      title={isEnhancing ? 'Enhancing prompt\u2026' : 'Enhance prompt with AI'}
+    <FloatingTooltip
+      content={isEnhancing ? 'Enhancing prompt\u2026' : 'Enhance prompt with AI'}
+      className="flex"
     >
-      <Sparkles className={`h-3 w-3 ${isEnhancing ? 'animate-spin' : ''}`} />
-    </Button>
+      <Button
+        type="button"
+        onClick={onEnhance}
+        onMouseDown={(event) => {
+          // Preserve the textarea selection so enhance can act on the current prompt without blurring the composer.
+          event.preventDefault();
+        }}
+        disabled={disabled || isEnhancing}
+        variant="unstyled"
+        className={`group rounded-full p-1.5 transition-colors duration-200 ${
+          disabled || isEnhancing
+            ? 'cursor-not-allowed text-text-tertiary opacity-50 dark:text-text-dark-tertiary'
+            : 'bg-transparent text-text-tertiary hover:bg-surface-hover hover:text-text-secondary active:scale-95 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary'
+        }`}
+        aria-label={isEnhancing ? 'Enhancing prompt\u2026' : 'Enhance prompt'}
+      >
+        <Sparkles className={`h-3 w-3 ${isEnhancing ? 'animate-spin' : ''}`} />
+      </Button>
+    </FloatingTooltip>
   );
 }

--- a/frontend/src/components/chat/message-input/SelectionAttachments.tsx
+++ b/frontend/src/components/chat/message-input/SelectionAttachments.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { FileIcon } from '@/components/ui/shared/FileIcon';
 import { getFileName } from '@/utils/file';
 import type { EditorCodeSelection } from '@/store/uiStore';
@@ -19,10 +20,10 @@ export const SelectionAttachments = memo(function SelectionAttachments({
   return (
     <div className="flex flex-wrap gap-1.5 px-3 pt-2">
       {selections.map((selection, index) => (
-        <div
+        <FloatingTooltip
           // Duplicate chips of the same range are allowed, so the index keys them apart.
           key={`${selection.path}:${selection.startLine}:${index}`}
-          title={selection.comment ? `${selection.path}\n\n${selection.comment}` : selection.path}
+          content={selection.comment ? `${selection.path}\n\n${selection.comment}` : selection.path}
           className="flex items-center gap-1 rounded-md border border-border/50 bg-surface-tertiary py-0.5 pl-1.5 pr-0.5 dark:border-border-dark/50 dark:bg-surface-dark-tertiary"
         >
           <FileIcon name={getFileName(selection.path)} className="h-3 w-3" />
@@ -41,7 +42,7 @@ export const SelectionAttachments = memo(function SelectionAttachments({
           >
             <X className="h-3 w-3" />
           </Button>
-        </div>
+        </FloatingTooltip>
       ))}
     </div>
   );

--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo } from 'react';
 import { Star } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Dropdown } from '@/components/ui/primitives/Dropdown';
 import type { DropdownItemType } from '@/components/ui/primitives/Dropdown';
 import { useAuthStore } from '@/store/authStore';
@@ -130,17 +131,18 @@ export const ModelSelector = memo(function ModelSelector({
         const isFavorite = favoriteIdSet.has(model.model_id);
         return (
           <div className="flex items-center gap-2">
-            <span
-              className={cn(
-                'min-w-0 flex-1 truncate text-2xs font-medium',
-                isSelected
-                  ? 'text-text-primary dark:text-text-dark-primary'
-                  : 'text-text-secondary dark:text-text-dark-secondary',
-              )}
-              title={model.name}
-            >
-              {model.name}
-            </span>
+            <FloatingTooltip content={model.name} className="min-w-0 flex-1">
+              <span
+                className={cn(
+                  'truncate text-2xs font-medium',
+                  isSelected
+                    ? 'text-text-primary dark:text-text-dark-primary'
+                    : 'text-text-secondary dark:text-text-dark-secondary',
+                )}
+              >
+                {model.name}
+              </span>
+            </FloatingTooltip>
             {model.context_window != null && model.context_window > 0 && (
               <span className="flex-shrink-0 rounded-md bg-surface-tertiary px-1.5 py-0.5 text-2xs font-medium text-text-quaternary dark:bg-surface-dark-tertiary dark:text-text-dark-quaternary">
                 {formatNumberCompact(model.context_window)}

--- a/frontend/src/components/chat/workspace-selector/WorkspaceItem.tsx
+++ b/frontend/src/components/chat/workspace-selector/WorkspaceItem.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import toast from 'react-hot-toast';
 import { GitBranch, Box, HardDrive, Loader2, ChevronDown, ChevronRight, Check } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Input } from '@/components/ui/primitives/Input';
 import { useGitBranchesQuery, useCheckoutBranchMutation } from '@/hooks/queries/useSandboxQueries';
 import type { Workspace } from '@/types/workspace.types';
@@ -204,9 +205,9 @@ export function WorkspaceItem({
                                 ) : (
                                   <span className="h-3 w-3 shrink-0" />
                                 )}
-                                <span className="truncate font-mono" title={branch}>
-                                  {branch}
-                                </span>
+                                <FloatingTooltip content={branch} className="min-w-0 flex-1">
+                                  <span className="truncate font-mono">{branch}</span>
+                                </FloatingTooltip>
                               </Button>
                               {showDivider && (
                                 <div className="my-0.5 border-t border-border/50 dark:border-border-dark/50" />

--- a/frontend/src/components/editor/editor-view/Header.tsx
+++ b/frontend/src/components/editor/editor-view/Header.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import type { FileStructure } from '@/types/file-system.types';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { SaveButton } from '@/components/ui/shared/SaveButton';
 import { FileIcon } from '@/components/ui/shared/FileIcon';
 import { isPreviewableFile } from '@/utils/fileTypes';
@@ -134,15 +135,16 @@ export const Header = memo(function Header({
         )}
 
         {showPreview && onToggleFullscreen && (
-          <Button
-            onClick={onToggleFullscreen}
-            variant="unstyled"
-            className="rounded-md p-1 text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
-            title="Enter fullscreen"
-            aria-label="Enter fullscreen"
-          >
-            <Maximize2 className="h-3 w-3" />
-          </Button>
+          <FloatingTooltip content="Enter fullscreen" className="flex">
+            <Button
+              onClick={onToggleFullscreen}
+              variant="unstyled"
+              className="rounded-md p-1 text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+              aria-label="Enter fullscreen"
+            >
+              <Maximize2 className="h-3 w-3" />
+            </Button>
+          </FloatingTooltip>
         )}
       </div>
     </div>

--- a/frontend/src/components/editor/file-preview/PreviewHeader.tsx
+++ b/frontend/src/components/editor/file-preview/PreviewHeader.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import { Maximize2, Minimize2 } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 
 export interface PreviewHeaderProps {
   fileName: string;
@@ -19,15 +20,19 @@ export const PreviewHeader = memo(function PreviewHeader({
         {fileName}
       </h3>
       {onToggleFullscreen && (
-        <Button
-          onClick={onToggleFullscreen}
-          variant="unstyled"
-          className="rounded-lg p-1.5 text-text-secondary transition-colors hover:bg-surface-hover dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover"
-          title={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
-          aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+        <FloatingTooltip
+          content={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+          className="flex"
         >
-          {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
-        </Button>
+          <Button
+            onClick={onToggleFullscreen}
+            variant="unstyled"
+            className="rounded-lg p-1.5 text-text-secondary transition-colors hover:bg-surface-hover dark:text-text-dark-secondary dark:hover:bg-surface-dark-hover"
+            aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+          >
+            {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+          </Button>
+        </FloatingTooltip>
       )}
     </div>
   );

--- a/frontend/src/components/editor/file-preview/XlsxPreview.tsx
+++ b/frontend/src/components/editor/file-preview/XlsxPreview.tsx
@@ -3,6 +3,7 @@ import { logger } from '@/utils/logger';
 import { base64ToUint8Array } from '@/utils/base64';
 import type { FileStructure } from '@/types/file-system.types';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { useAsyncEffect } from '@/hooks/useAsyncEffect';
 import { PreviewContainer } from './PreviewContainer';
 import { PreviewEmptyState } from './PreviewEmptyState';
@@ -182,9 +183,10 @@ export const XlsxPreview = memo(function XlsxPreview({
                     <td
                       key={cellIndex}
                       className={`${tableBorderClass} break-words px-3 py-2 text-sm text-text-primary dark:text-text-dark-primary ${isFullscreen ? 'w-auto' : 'w-auto min-w-32'}`}
-                      title={cell.value}
                     >
-                      {cell.value || ''}
+                      <FloatingTooltip content={cell.value} className="block">
+                        {cell.value || ''}
+                      </FloatingTooltip>
                     </td>
                   ))}
                 </tr>

--- a/frontend/src/components/editor/file-search/SearchPanel.tsx
+++ b/frontend/src/components/editor/file-search/SearchPanel.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CaseSensitive, Loader2, Regex, Search, WholeWord, X } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Input } from '@/components/ui/primitives/Input';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useSearchInFilesQuery } from '@/hooks/queries/useSandboxQueries';
@@ -126,33 +127,34 @@ export const SearchPanel = memo(function SearchPanel({
           />
           <div className="flex items-center gap-0.5 pr-1">
             {TOGGLES.map(({ key, icon: Icon, label }) => (
-              <Button
-                key={key}
-                onClick={() => toggle(key)}
-                variant="unstyled"
-                title={label}
-                aria-label={label}
-                aria-pressed={toggles[key]}
-                className={cn(
-                  'flex h-5 w-5 items-center justify-center rounded transition-colors',
-                  toggles[key]
-                    ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
-                    : 'text-text-quaternary hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
-                )}
-              >
-                <Icon className="h-3 w-3" />
-              </Button>
+              <FloatingTooltip key={key} content={label} className="flex">
+                <Button
+                  onClick={() => toggle(key)}
+                  variant="unstyled"
+                  aria-label={label}
+                  aria-pressed={toggles[key]}
+                  className={cn(
+                    'flex h-5 w-5 items-center justify-center rounded transition-colors',
+                    toggles[key]
+                      ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
+                      : 'text-text-quaternary hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
+                  )}
+                >
+                  <Icon className="h-3 w-3" />
+                </Button>
+              </FloatingTooltip>
             ))}
             {query && (
-              <Button
-                onClick={handleClear}
-                variant="unstyled"
-                title="Clear search"
-                aria-label="Clear search"
-                className="flex h-5 w-5 items-center justify-center rounded text-text-quaternary transition-colors hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-              >
-                <X className="h-3 w-3" />
-              </Button>
+              <FloatingTooltip content="Clear search" className="flex">
+                <Button
+                  onClick={handleClear}
+                  variant="unstyled"
+                  aria-label="Clear search"
+                  className="flex h-5 w-5 items-center justify-center rounded text-text-quaternary transition-colors hover:text-text-primary dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              </FloatingTooltip>
             )}
           </div>
         </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useMatch } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { THEME_CYCLE, getThemeMeta } from '@/utils/theme';
 import type { Theme } from '@/types/ui.types';
 import { cn } from '@/utils/cn';
@@ -16,21 +17,22 @@ function ThemeToggleButton({ theme, onToggle }: { theme: Theme; onToggle: () => 
   const Icon = getThemeMeta(theme).icon;
   const next = THEME_CYCLE[(THEME_CYCLE.indexOf(theme) + 1) % THEME_CYCLE.length];
   return (
-    <Button
-      onClick={onToggle}
-      variant="unstyled"
-      className={cn(
-        'relative rounded-full p-1.5',
-        'text-text-tertiary hover:text-text-primary',
-        'dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
-        'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-        'transition-colors duration-200',
-      )}
-      aria-label="Toggle theme"
-      title={`Switch to ${getThemeMeta(next).label}`}
-    >
-      <Icon className="h-3.5 w-3.5" />
-    </Button>
+    <FloatingTooltip content={`Switch to ${getThemeMeta(next).label}`} className="flex">
+      <Button
+        onClick={onToggle}
+        variant="unstyled"
+        className={cn(
+          'relative rounded-full p-1.5',
+          'text-text-tertiary hover:text-text-primary',
+          'dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
+          'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+          'transition-colors duration-200',
+        )}
+        aria-label="Toggle theme"
+      >
+        <Icon className="h-3.5 w-3.5" />
+      </Button>
+    </FloatingTooltip>
   );
 }
 

--- a/frontend/src/components/layout/SidebarChatGroup.tsx
+++ b/frontend/src/components/layout/SidebarChatGroup.tsx
@@ -5,6 +5,7 @@ import type { Chat } from '@/types/chat.types';
 import type { Workspace } from '@/types/workspace.types';
 import type { PaginatedChats } from '@/types/api.types';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Spinner } from '@/components/ui/primitives/Spinner';
 import { useInfiniteChatsQuery } from '@/hooks/queries/useChatQueries';
 import { useInfiniteCloudChatsQuery } from '@/hooks/queries/useCloudQueries';
@@ -163,15 +164,17 @@ const SidebarChatGroup = memo(function SidebarChatGroup({
             </span>
           )}
         </Button>
-        <Button
-          variant="unstyled"
-          type="button"
-          title="New thread"
-          onClick={(e) => onNewThread(e, workspaceId)}
-          className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-        >
-          <SquarePen className="h-3 w-3" />
-        </Button>
+        <FloatingTooltip content="New thread" className="flex">
+          <Button
+            variant="unstyled"
+            type="button"
+            aria-label="New thread"
+            onClick={(e) => onNewThread(e, workspaceId)}
+            className="flex shrink-0 items-center justify-center rounded p-0.5 text-text-quaternary opacity-0 transition-all duration-200 hover:text-text-primary group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+          >
+            <SquarePen className="h-3 w-3" />
+          </Button>
+        </FloatingTooltip>
         <Button
           variant="unstyled"
           type="button"

--- a/frontend/src/components/sandbox/git/DiffCommentComposer.tsx
+++ b/frontend/src/components/sandbox/git/DiffCommentComposer.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { CornerDownLeft, X } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { Textarea } from '@/components/ui/primitives/Textarea';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 
 interface DiffCommentComposerProps {
   lineLabel: string;
@@ -59,16 +60,17 @@ export function DiffCommentComposer({ lineLabel, onSubmit, onCancel }: DiffComme
           placeholder="Leave feedback for the agent…"
           className="max-h-24 flex-1 resize-none bg-transparent px-1 py-1 text-sm text-text-primary placeholder:text-text-quaternary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary"
         />
-        <Button
-          type="submit"
-          variant="unstyled"
-          disabled={!trimmed}
-          title="Add to chat (Enter)"
-          aria-label="Add comment to chat"
-          className="rounded-md p-1.5 text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
-        >
-          <CornerDownLeft className="h-3.5 w-3.5" />
-        </Button>
+        <FloatingTooltip content="Add to chat (Enter)" className="flex">
+          <Button
+            type="submit"
+            variant="unstyled"
+            disabled={!trimmed}
+            aria-label="Add comment to chat"
+            className="rounded-md p-1.5 text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary disabled:opacity-50 dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+          >
+            <CornerDownLeft className="h-3.5 w-3.5" />
+          </Button>
+        </FloatingTooltip>
       </form>
     </div>
   );

--- a/frontend/src/components/sandbox/git/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView.tsx
@@ -14,6 +14,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import { FileIcon } from '@/components/ui/shared/FileIcon';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Button } from '@/components/ui/primitives/Button';
 import { SegmentedControl } from '@/components/ui/primitives/SegmentedControl';
 import { Spinner } from '@/components/ui/primitives/Spinner';
@@ -571,17 +572,18 @@ const DiffViewContent = memo(function DiffViewContent({ chatId, isVisible }: Dif
         className="flex h-full w-full flex-col bg-surface-secondary dark:bg-surface-dark-secondary"
       >
         <div className="flex h-9 items-center gap-1.5 overflow-x-auto border-b border-border/50 px-3 [scrollbar-width:none] dark:border-border-dark/50 [&::-webkit-scrollbar]:hidden">
-          <Button
-            onClick={() => refetch()}
-            variant="unstyled"
-            className="shrink-0 rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
-            title="Refresh diff"
-            aria-label="Refresh diff"
-          >
-            <RotateCcw
-              className={cn('h-3 w-3', isFetching && 'animate-spin motion-reduce:animate-none')}
-            />
-          </Button>
+          <FloatingTooltip content="Refresh diff" className="flex shrink-0">
+            <Button
+              onClick={() => refetch()}
+              variant="unstyled"
+              className="rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+              aria-label="Refresh diff"
+            >
+              <RotateCcw
+                className={cn('h-3 w-3', isFetching && 'animate-spin motion-reduce:animate-none')}
+              />
+            </Button>
+          </FloatingTooltip>
 
           <SegmentedControl
             options={DIFF_MODE_OPTIONS}
@@ -595,18 +597,19 @@ const DiffViewContent = memo(function DiffViewContent({ chatId, isVisible }: Dif
 
           {(showFiles || canDiscard) && (
             <>
-              <Button
-                ref={triggerRef}
-                onClick={toggleMenu}
-                variant="unstyled"
-                className="shrink-0 rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
-                title="More actions"
-                aria-label="More actions"
-                aria-haspopup="menu"
-                aria-expanded={menuOpen}
-              >
-                <MoreHorizontal className="h-3 w-3" />
-              </Button>
+              <FloatingTooltip content="More actions" className="flex shrink-0">
+                <Button
+                  ref={triggerRef}
+                  onClick={toggleMenu}
+                  variant="unstyled"
+                  className="rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary"
+                  aria-label="More actions"
+                  aria-haspopup="menu"
+                  aria-expanded={menuOpen}
+                >
+                  <MoreHorizontal className="h-3 w-3" />
+                </Button>
+              </FloatingTooltip>
               {menuOpen &&
                 createPortal(
                   <div
@@ -736,33 +739,35 @@ const DiffViewContent = memo(function DiffViewContent({ chatId, isVisible }: Dif
                         <FileStatusBadge type={file.type} />
                       </Button>
                       {file.type !== 'deleted' && (
-                        <Button
-                          variant="unstyled"
-                          type="button"
-                          onClick={() =>
-                            useUIStore
-                              .getState()
-                              .openFileInEditor(cwd ? `${cwd}/${file.name}` : file.name, chatId)
-                          }
-                          className="mr-1 shrink-0 rounded-md p-1 text-text-quaternary opacity-0 transition-opacity duration-200 hover:text-text-primary focus-visible:opacity-100 group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-                          title="Open in editor"
-                          aria-label={`Open ${file.name} in editor`}
-                        >
-                          <ExternalLink className="h-3 w-3" />
-                        </Button>
+                        <FloatingTooltip content="Open in editor" className="mr-1 flex shrink-0">
+                          <Button
+                            variant="unstyled"
+                            type="button"
+                            onClick={() =>
+                              useUIStore
+                                .getState()
+                                .openFileInEditor(cwd ? `${cwd}/${file.name}` : file.name, chatId)
+                            }
+                            className="rounded-md p-1 text-text-quaternary opacity-0 transition-opacity duration-200 hover:text-text-primary focus-visible:opacity-100 group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+                            aria-label={`Open ${file.name} in editor`}
+                          >
+                            <ExternalLink className="h-3 w-3" />
+                          </Button>
+                        </FloatingTooltip>
                       )}
                       {canDiscard && (
-                        <Button
-                          variant="unstyled"
-                          type="button"
-                          onClick={() => setDiscardTarget(file)}
-                          disabled={restoreFile.isPending}
-                          className="mr-1 shrink-0 rounded-md p-1 text-text-quaternary opacity-0 transition-opacity duration-200 hover:text-text-primary focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-50 group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
-                          title="Discard changes"
-                          aria-label={`Discard changes for ${file.name}`}
-                        >
-                          <Undo2 className="h-3 w-3" />
-                        </Button>
+                        <FloatingTooltip content="Discard changes" className="mr-1 flex shrink-0">
+                          <Button
+                            variant="unstyled"
+                            type="button"
+                            onClick={() => setDiscardTarget(file)}
+                            disabled={restoreFile.isPending}
+                            className="rounded-md p-1 text-text-quaternary opacity-0 transition-opacity duration-200 hover:text-text-primary focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-50 group-hover:opacity-100 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+                            aria-label={`Discard changes for ${file.name}`}
+                          >
+                            <Undo2 className="h-3 w-3" />
+                          </Button>
+                        </FloatingTooltip>
                       )}
                       <FileStats file={file} />
                     </div>

--- a/frontend/src/components/ui/AgentToolExpandedModal.tsx
+++ b/frontend/src/components/ui/AgentToolExpandedModal.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/primitives/Button';
 import { BaseModal } from '@/components/ui/shared/BaseModal';
 import { ModalHeader } from '@/components/ui/shared/ModalHeader';
 import { Spinner } from '@/components/ui/primitives/Spinner';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import type { ToolAggregate } from '@/types/tools.types';
 import { AgentToolsContext } from '@/contexts/AgentToolsContext';
 import { statusIndicator } from '@/components/chat/tools/common/statusIndicator';
@@ -64,19 +65,17 @@ function AgentToolExpandedModal({ agents, initialAgentId, onClose }: AgentToolEx
                 >
                   {statusIndicator[agent.status]}
                   <div className="min-w-0 flex-1">
-                    <div
-                      className="truncate text-xs text-text-primary dark:text-text-dark-primary"
-                      title={type}
-                    >
-                      {type}
-                    </div>
-                    {desc && (
-                      <div
-                        className="truncate text-2xs text-text-quaternary dark:text-text-dark-quaternary"
-                        title={desc}
-                      >
-                        {desc}
+                    <FloatingTooltip content={type} className="min-w-0">
+                      <div className="truncate text-xs text-text-primary dark:text-text-dark-primary">
+                        {type}
                       </div>
+                    </FloatingTooltip>
+                    {desc && (
+                      <FloatingTooltip content={desc} className="min-w-0">
+                        <div className="truncate text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                          {desc}
+                        </div>
+                      </FloatingTooltip>
                     )}
                   </div>
                 </Button>

--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { Button } from '@/components/ui/primitives/Button';
 import { Input } from '@/components/ui/primitives/Input';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { createPortal } from 'react-dom';
 import { GitBranch, Search, PanelRight, PanelBottom, File } from 'lucide-react';
 import toast from 'react-hot-toast';
@@ -681,24 +682,28 @@ export function CommandMenu() {
                         )}
                         {cmd.type === 'view' && !isMobile && !isActive && (
                           <div className="flex items-center gap-0.5">
-                            <Button
-                              variant="unstyled"
-                              onMouseDown={(e) => e.preventDefault()}
-                              onClick={() => handleSplit(cmd.id, 'row')}
-                              className={splitButtonClass}
-                              title="Split right"
-                            >
-                              <PanelRight className="h-3 w-3" />
-                            </Button>
-                            <Button
-                              variant="unstyled"
-                              onMouseDown={(e) => e.preventDefault()}
-                              onClick={() => handleSplit(cmd.id, 'column')}
-                              className={splitButtonClass}
-                              title="Split down"
-                            >
-                              <PanelBottom className="h-3 w-3" />
-                            </Button>
+                            <FloatingTooltip content="Split right" className="flex">
+                              <Button
+                                variant="unstyled"
+                                onMouseDown={(e) => e.preventDefault()}
+                                onClick={() => handleSplit(cmd.id, 'row')}
+                                className={splitButtonClass}
+                                aria-label="Split right"
+                              >
+                                <PanelRight className="h-3 w-3" />
+                              </Button>
+                            </FloatingTooltip>
+                            <FloatingTooltip content="Split down" className="flex">
+                              <Button
+                                variant="unstyled"
+                                onMouseDown={(e) => e.preventDefault()}
+                                onClick={() => handleSplit(cmd.id, 'column')}
+                                className={splitButtonClass}
+                                aria-label="Split down"
+                              >
+                                <PanelBottom className="h-3 w-3" />
+                              </Button>
+                            </FloatingTooltip>
                           </div>
                         )}
                       </div>

--- a/frontend/src/components/ui/FloatingTooltip.tsx
+++ b/frontend/src/components/ui/FloatingTooltip.tsx
@@ -34,7 +34,7 @@ export function FloatingTooltip({ content, children, className }: FloatingToolti
   return (
     <div className={className} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
       {children}
-      {position != null && (
+      {position != null && content && (
         <div
           role="tooltip"
           style={{ top: position.top, left: position.left }}

--- a/frontend/src/components/ui/RenameModal.tsx
+++ b/frontend/src/components/ui/RenameModal.tsx
@@ -4,6 +4,7 @@ import { BaseModal } from './shared/BaseModal';
 import { ModalHeader } from './shared/ModalHeader';
 import { Button } from './primitives/Button';
 import { Input } from './primitives/Input';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { cancelButtonClass } from './shared/modalConstants';
 
 interface RenameModalProps {
@@ -95,17 +96,21 @@ export function RenameModal({
           aria-label="New name"
         />
         {onGenerateTitle && (
-          <Button
-            type="button"
-            variant="unstyled"
-            onClick={handleGenerate}
-            disabled={isLoading || isGenerating}
-            className="shrink-0 rounded-md p-2 text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
-            aria-label={isGenerating ? 'Generating title…' : 'Generate title with AI'}
-            title={isGenerating ? 'Generating title…' : 'Generate title with AI'}
+          <FloatingTooltip
+            content={isGenerating ? 'Generating title…' : 'Generate title with AI'}
+            className="flex"
           >
-            <Sparkles className={`h-3.5 w-3.5 ${isGenerating ? 'animate-spin' : ''}`} />
-          </Button>
+            <Button
+              type="button"
+              variant="unstyled"
+              onClick={handleGenerate}
+              disabled={isLoading || isGenerating}
+              className="shrink-0 rounded-md p-2 text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+              aria-label={isGenerating ? 'Generating title…' : 'Generate title with AI'}
+            >
+              <Sparkles className={`h-3.5 w-3.5 ${isGenerating ? 'animate-spin' : ''}`} />
+            </Button>
+          </FloatingTooltip>
         )}
       </div>
 

--- a/frontend/src/components/ui/ToggleButton.tsx
+++ b/frontend/src/components/ui/ToggleButton.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import { PanelLeft, PanelLeftClose } from 'lucide-react';
 import { Button } from './primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 
 export interface ToggleButtonProps {
   isOpen: boolean;
@@ -32,16 +33,17 @@ export const ToggleButton = memo(function ToggleButton({
         : 'Open editor';
 
   return (
-    <Button
-      type="button"
-      onClick={onClick}
-      variant="ghost"
-      size="icon"
-      className={`h-8 w-8 transition-all duration-200 ${className}`}
-      aria-label={ariaLabel}
-      title={tooltipText}
-    >
-      <Icon className="h-4 w-4 text-text-secondary dark:text-text-dark-secondary" />
-    </Button>
+    <FloatingTooltip content={tooltipText} className="flex">
+      <Button
+        type="button"
+        onClick={onClick}
+        variant="ghost"
+        size="icon"
+        className={`h-8 w-8 transition-all duration-200 ${className}`}
+        aria-label={ariaLabel ?? tooltipText}
+      >
+        <Icon className="h-4 w-4 text-text-secondary dark:text-text-dark-secondary" />
+      </Button>
+    </FloatingTooltip>
   );
 });

--- a/frontend/src/components/ui/primitives/Dropdown.tsx
+++ b/frontend/src/components/ui/primitives/Dropdown.tsx
@@ -4,6 +4,7 @@ import { useDropdown } from '@/hooks/useDropdown';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { Button } from '@/components/ui/primitives/Button';
 import { SelectItem } from '@/components/ui/primitives/SelectItem';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { fuzzySearch } from '@/utils/fuzzySearch';
 import { cn } from '@/utils/cn';
 
@@ -148,11 +149,11 @@ function DropdownInner<T>({
   const displayItems = normalizeToGrouped(items, searchQuery);
 
   const showIconOnly = (compactOnMobile || forceCompact) && LeftIcon;
-  const labelClasses = showIconOnly
-    ? forceCompact
-      ? 'hidden truncate text-2xs font-medium text-text-secondary dark:text-text-dark-secondary'
-      : 'hidden sm:inline truncate text-2xs font-medium text-text-secondary dark:text-text-dark-secondary'
-    : 'truncate text-2xs font-medium text-text-secondary dark:text-text-dark-secondary';
+  // Visibility lives on the tooltip wrapper (the flex item) so a hidden label doesn't
+  // leave a zero-width slot that still consumes the trigger's gap in compact mode.
+  const labelVisibility = showIconOnly ? (forceCompact ? 'hidden' : 'hidden sm:block') : '';
+  const labelClasses =
+    'truncate text-2xs font-medium text-text-secondary dark:text-text-dark-secondary';
   const chevronClasses = showIconOnly
     ? forceCompact
       ? 'hidden'
@@ -187,12 +188,11 @@ function DropdownInner<T>({
                 )}
               />
             )}
-            <span
-              className={cn(labelClasses, 'text-inherit dark:text-inherit')}
-              title={triggerLabel}
-            >
-              {triggerLabel}
-            </span>
+            <FloatingTooltip content={triggerLabel} className={cn('min-w-0', labelVisibility)}>
+              <span className={cn(labelClasses, 'text-inherit dark:text-inherit')}>
+                {triggerLabel}
+              </span>
+            </FloatingTooltip>
           </>
         ) : (
           <>
@@ -204,9 +204,9 @@ function DropdownInner<T>({
                 )}
               />
             )}
-            <span className={labelClasses} title={triggerLabel}>
-              {triggerLabel}
-            </span>
+            <FloatingTooltip content={triggerLabel} className={cn('min-w-0', labelVisibility)}>
+              <span className={labelClasses}>{triggerLabel}</span>
+            </FloatingTooltip>
             {!disabled && (
               <ChevronDown className={`${chevronClasses} ${isOpen ? 'rotate-180' : ''}`} />
             )}
@@ -310,16 +310,17 @@ function DropdownInner<T>({
                     {renderItem ? (
                       renderItem(item, isSelected)
                     ) : (
-                      <span
-                        className={`block truncate text-2xs font-medium ${
-                          isSelected
-                            ? 'text-text-primary dark:text-text-dark-primary'
-                            : 'text-text-secondary dark:text-text-dark-secondary'
-                        }`}
-                        title={getItemLabel(item)}
-                      >
-                        {getItemLabel(item)}
-                      </span>
+                      <FloatingTooltip content={getItemLabel(item)} className="min-w-0">
+                        <span
+                          className={`block truncate text-2xs font-medium ${
+                            isSelected
+                              ? 'text-text-primary dark:text-text-dark-primary'
+                              : 'text-text-secondary dark:text-text-dark-secondary'
+                          }`}
+                        >
+                          {getItemLabel(item)}
+                        </span>
+                      </FloatingTooltip>
                     )}
                   </div>
                 </SelectItem>

--- a/frontend/src/components/ui/shared/ApprovalFooter.tsx
+++ b/frontend/src/components/ui/shared/ApprovalFooter.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle, Check, CheckCircle, X, XCircle } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { cn } from '@/utils/cn';
 import type { PermissionOption } from '@/types/chat.types';
 
@@ -123,54 +124,55 @@ function OptionRow({ option, isPrimary, onClick, disabled }: OptionRowProps) {
   const subtitle = KIND_SUBTITLES[option.kind];
 
   return (
-    <Button
-      variant="unstyled"
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      title={option.name}
-      className={cn(
-        'mb-0.5 flex w-full items-start gap-2.5 rounded-lg border p-2.5 text-left transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-60',
-        isPrimary
-          ? 'border-text-primary bg-text-primary text-surface hover:bg-text-secondary dark:border-text-dark-primary dark:bg-text-dark-primary dark:text-surface-dark dark:hover:bg-text-dark-secondary'
-          : 'border-transparent hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-      )}
-    >
-      <div
+    <FloatingTooltip content={option.name} className="w-full">
+      <Button
+        variant="unstyled"
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
         className={cn(
-          'mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md',
-          isPrimary ? 'bg-white/10 dark:bg-black/10' : 'bg-black/5 dark:bg-white/5',
+          'mb-0.5 flex w-full items-start gap-2.5 rounded-lg border p-2.5 text-left transition-colors duration-150 disabled:cursor-not-allowed disabled:opacity-60',
+          isPrimary
+            ? 'border-text-primary bg-text-primary text-surface hover:bg-text-secondary dark:border-text-dark-primary dark:bg-text-dark-primary dark:text-surface-dark dark:hover:bg-text-dark-secondary'
+            : 'border-transparent hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
         )}
       >
-        <Icon
-          className={cn(
-            'h-3.5 w-3.5',
-            isPrimary
-              ? 'text-surface dark:text-surface-dark'
-              : 'text-text-tertiary dark:text-text-dark-tertiary',
-          )}
-        />
-      </div>
-      <div className="min-w-0 flex-1">
         <div
           className={cn(
-            'text-xs font-medium leading-snug',
-            !isPrimary && 'text-text-primary dark:text-text-dark-primary',
+            'mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md',
+            isPrimary ? 'bg-white/10 dark:bg-black/10' : 'bg-black/5 dark:bg-white/5',
           )}
         >
-          {option.name}
+          <Icon
+            className={cn(
+              'h-3.5 w-3.5',
+              isPrimary
+                ? 'text-surface dark:text-surface-dark'
+                : 'text-text-tertiary dark:text-text-dark-tertiary',
+            )}
+          />
         </div>
-        <div
-          className={cn(
-            'mt-0.5 text-2xs leading-snug',
-            isPrimary
-              ? 'text-surface/60 dark:text-surface-dark/60'
-              : 'text-text-tertiary dark:text-text-dark-tertiary',
-          )}
-        >
-          {subtitle}
+        <div className="min-w-0 flex-1">
+          <div
+            className={cn(
+              'text-xs font-medium leading-snug',
+              !isPrimary && 'text-text-primary dark:text-text-dark-primary',
+            )}
+          >
+            {option.name}
+          </div>
+          <div
+            className={cn(
+              'mt-0.5 text-2xs leading-snug',
+              isPrimary
+                ? 'text-surface/60 dark:text-surface-dark/60'
+                : 'text-text-tertiary dark:text-text-dark-tertiary',
+            )}
+          >
+            {subtitle}
+          </div>
         </div>
-      </div>
-    </Button>
+      </Button>
+    </FloatingTooltip>
   );
 }

--- a/frontend/src/components/ui/shared/RefreshButton.tsx
+++ b/frontend/src/components/ui/shared/RefreshButton.tsx
@@ -1,5 +1,6 @@
 import { RefreshCw, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { cn } from '@/utils/cn';
 
 export interface RefreshButtonProps {
@@ -22,23 +23,24 @@ export function RefreshButton({
   useLoader = false,
 }: RefreshButtonProps) {
   return (
-    <Button
-      onClick={onClick}
-      disabled={disabled || isRefreshing}
-      variant="unstyled"
-      className={cn(
-        'rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary',
-        (disabled || isRefreshing) && 'disabled:cursor-wait disabled:opacity-50',
-        className,
-      )}
-      title={title}
-      aria-label={ariaLabel}
-    >
-      {useLoader && isRefreshing ? (
-        <Loader2 className="h-3 w-3 animate-spin" />
-      ) : (
-        <RefreshCw className={cn('h-3 w-3', isRefreshing && 'animate-spin')} />
-      )}
-    </Button>
+    <FloatingTooltip content={title} className="flex">
+      <Button
+        onClick={onClick}
+        disabled={disabled || isRefreshing}
+        variant="unstyled"
+        className={cn(
+          'rounded-md p-1 text-text-quaternary transition-colors duration-200 hover:text-text-secondary dark:text-text-dark-quaternary dark:hover:text-text-dark-secondary',
+          (disabled || isRefreshing) && 'disabled:cursor-wait disabled:opacity-50',
+          className,
+        )}
+        aria-label={ariaLabel}
+      >
+        {useLoader && isRefreshing ? (
+          <Loader2 className="h-3 w-3 animate-spin" />
+        ) : (
+          <RefreshCw className={cn('h-3 w-3', isRefreshing && 'animate-spin')} />
+        )}
+      </Button>
+    </FloatingTooltip>
   );
 }


### PR DESCRIPTION
## Summary
- Continues the FloatingTooltip migration (#742) into the remaining components still using the native `title` attribute
- Replaces `title` with `FloatingTooltip` across chat, editor, sandbox, layout, and shared UI components for consistent themed tooltips
- `FloatingTooltip` now skips rendering the tooltip element when `content` is empty