### PR TITLE
fix(ui): keep split layout when opening a visible tile

### DIFF
--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -248,7 +248,10 @@ export const useUIStore = create<UIStoreState>()(
           },
           openTabs: state.openTabs.includes(tileId) ? state.openTabs : [...state.openTabs, tileId],
         });
-        get().activateTab(tileId);
+        // Editor already on screen (possibly in a split) — keep the layout and just
+        // focus it; activateTab would collapse the split to a full-view editor.
+        if (state.visibleLayout.flat().includes(tileId)) get().focusTile(tileId);
+        else get().activateTab(tileId);
       },
       openInDiffView: (path, chatId) => {
         const state = get();
@@ -258,7 +261,9 @@ export const useUIStore = create<UIStoreState>()(
           pendingDiffFile: { path, chatId },
           openTabs: state.openTabs.includes(tileId) ? state.openTabs : [...state.openTabs, tileId],
         });
-        get().activateTab(tileId);
+        // Same as openFileInEditor: a diff tile visible in a split keeps its layout.
+        if (state.visibleLayout.flat().includes(tileId)) get().focusTile(tileId);
+        else get().activateTab(tileId);
       },
 
       openTabs: ['agent:primary'],


### PR DESCRIPTION
## Summary
- `openFileInEditor` and `openInDiffView` always called `activateTab`, which collapses the current split back to a single full-view editor even when the target tile is already visible in the split.
- Now, if the tile is already part of `visibleLayout`, we call `focusTile` instead so the split layout is preserved and the tile is just brought into focus.