### PR TITLE
fix(ui): keep file tree collapsed when opening a file

### DIFF
--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -131,9 +131,9 @@ export const CodeView = memo(function CodeView({
     const file = findFileByToolPath(filesRef.current, pendingFileOpen.path);
     const path = file?.path ?? pendingFileOpen.path;
     onFileSelect(file ?? { path, type: 'file', content: '' });
-    const panel = fileTreePanelRef.current;
-    if (panel && panel.isCollapsed()) panel.expand();
-    treeRef.current?.reveal(path);
+    // Respect a collapsed file tree — opening a file shouldn't reopen it;
+    // handleFileTreeExpand re-reveals the selection if the user expands later.
+    if (!fileTreePanelRef.current?.isCollapsed()) treeRef.current?.reveal(path);
     if (pendingFileOpen.line != null) {
       setTargetLine({ path, line: pendingFileOpen.line, nonce: pendingFileOpen.nonce });
     }


### PR DESCRIPTION
## Summary
- Opening a file/diff no longer force-expands the file tree panel if the user had deliberately collapsed it
- `handleFileTreeExpand` already re-reveals the current selection when the user expands the tree later, so auto-expanding on file open was redundant and overrode user intent

## Test plan
- [ ] Collapse the file tree panel, open a file from chat/tool output, confirm the tree stays collapsed
- [ ] Expand the tree afterward and confirm the previously opened file is revealed/highlighted