### PR TITLE
fix(ui): preserve expanded folders on file tree paths reset

### DIFF
--- a/frontend/src/components/editor/file-tree/Tree.tsx
+++ b/frontend/src/components/editor/file-tree/Tree.tsx
@@ -158,7 +158,18 @@ export const Tree = memo(function Tree({
   useEffect(() => {
     // useFileTree already consumed the initial paths; skip re-applying on mount.
     if (paths === initialPathsRef.current) return;
-    model.resetPaths(paths);
+    // resetPaths rebuilds the whole store from initialExpansion:'closed', so carry the
+    // currently-open folders across — otherwise any files refetch collapses the tree
+    // and drops the revealed selection.
+    const expanded = new Set<string>();
+    for (const path of paths) {
+      for (const ancestor of getAncestorFolderPaths(path)) {
+        if (!expanded.has(ancestor) && model.getItem(ancestor)?.isExpanded()) {
+          expanded.add(ancestor);
+        }
+      }
+    }
+    model.resetPaths(paths, { initialExpandedPaths: [...expanded] });
   }, [paths, model]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- `Tree.tsx` called `model.resetPaths(paths)` whenever the `paths` prop changed, but `resetPaths` rebuilds the whole tree store with `initialExpansion: 'closed'`, silently collapsing any folders the user had expanded.
- Now collects the currently-expanded ancestor folders before the reset and passes them via `initialExpandedPaths`, so expansion state survives a paths refetch.