### PR TITLE
feat(chat): live SSE feed for out-of-band chat events

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -285,6 +285,24 @@ async def get_active_streams(
     )
 
 
+@router.get("/chats/events")
+async def stream_user_chat_events(
+    current_user: User = Depends(get_current_user),
+    chat_service: ChatService = Depends(get_chat_service),
+) -> EventSourceResponse:
+    # Global per-user feed of chat lifecycle events (chats created / turns started
+    # out-of-band, e.g. via MCP). Declared before /chats/{chat_id} so "events"
+    # isn't parsed as a UUID.
+    return EventSourceResponse(
+        chat_service.create_chat_events_stream(current_user.id),
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
 @router.get("/chats/{chat_id}/sub-threads", response_model=list[ChatSchema])
 async def get_sub_threads(
     chat_id: UUID,

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -13,6 +13,7 @@ class ModelInfo(NamedTuple):
 
 
 REDIS_KEY_CHAT_STREAM_LIVE: Final[str] = "chat:{chat_id}:stream:live"
+REDIS_KEY_USER_CHATS_LIVE: Final[str] = "user:{user_id}:chats:live"
 REDIS_KEY_USER_SETTINGS: Final[str] = "user_settings:{user_id}"
 REDIS_KEY_CHAT_CONTEXT_USAGE: Final[str] = "chat:{chat_id}:context_usage"
 REDIS_KEY_CHAT_QUEUE: Final[str] = "chat:{chat_id}:queue"

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -11,7 +11,11 @@ from sqlalchemy import exists, func, select, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import aliased, selectinload
 
-from app.constants import MODELS, REDIS_KEY_CHAT_STREAM_LIVE
+from app.constants import (
+    MODELS,
+    REDIS_KEY_CHAT_STREAM_LIVE,
+    REDIS_KEY_USER_CHATS_LIVE,
+)
 from app.models.db_models.chat import Chat, ChatCheckpoint, Message
 from app.models.db_models.enums import MessageRole, MessageStreamStatus, StreamEventKind
 from app.models.db_models.user import User
@@ -51,7 +55,7 @@ from app.services.storage import StorageService
 from app.services.streaming.runtime import ChatStreamRuntime
 from app.services.streaming.types import ChatStreamRequest, StreamEnvelope
 from app.services.user import UserService
-from app.utils.cache import CachePubSub, cache_connection, cache_pubsub
+from app.utils.cache import CacheError, CachePubSub, cache_connection, cache_pubsub
 
 logger = logging.getLogger(__name__)
 
@@ -355,7 +359,31 @@ class ChatService(BaseDbService[Chat]):
             result = await db.execute(query)
             loaded_chat: Chat = result.scalar_one()
 
-            return loaded_chat
+        # Announce so open browser sessions can show chats created out-of-band
+        # (e.g. via the MCP server) without a refresh.
+        await self._publish_user_chat_event(
+            user.id,
+            {
+                "kind": "chat_created",
+                "chat": ChatSchema.model_validate(loaded_chat).model_dump(mode="json"),
+            },
+        )
+
+        return loaded_chat
+
+    async def _publish_user_chat_event(
+        self, user_id: UUID, payload: dict[str, Any]
+    ) -> None:
+        # Best-effort broadcast on the user's live channel — a missed event only
+        # delays the sidebar/tab update until the next normal refetch.
+        try:
+            async with cache_connection() as cache:
+                await cache.publish(
+                    REDIS_KEY_USER_CHATS_LIVE.format(user_id=user_id),
+                    json.dumps(payload),
+                )
+        except CacheError:
+            logger.warning("Failed to publish %s user chat event", payload.get("kind"))
 
     async def get_sub_threads(self, chat_id: UUID, user: User) -> list[Chat]:
         # Returns ORM objects — sub_thread_count defaults to 0 in ChatSchema,
@@ -1081,6 +1109,28 @@ class ChatService(BaseDbService[Chat]):
                 error_message=str(exc),
             )
 
+    async def create_chat_events_stream(
+        self, user_id: UUID
+    ) -> AsyncIterator[dict[str, Any]]:
+        # Long-lived per-session feed of chat lifecycle events (chat_created,
+        # stream_started) for activity happening out-of-band, e.g. via the MCP
+        # server. Payloads pass through verbatim; the "kind" field inside them
+        # discriminates. No backlog/replay: an event missed while disconnected
+        # is recovered by the sidebar's next normal refetch.
+        async with cache_connection() as cache:
+            channel = REDIS_KEY_USER_CHATS_LIVE.format(user_id=user_id)
+            async with cache_pubsub(cache, channel) as pubsub:
+                while True:
+                    message = await pubsub.get_message(
+                        ignore_subscribe_messages=True, timeout=1.0
+                    )
+                    if not message or message.get("type") != "message":
+                        continue
+                    data = message.get("data")
+                    if not data:
+                        continue
+                    yield {"event": "chat_event", "data": data}
+
     async def initiate_chat_completion(
         self,
         request: ChatRequest,
@@ -1093,14 +1143,20 @@ class ChatService(BaseDbService[Chat]):
         user_settings = await self._user_service.get_user_settings(current_user.id)
         chat = await self.get_chat(request.chat_id, current_user)
 
+        # Bump ordering timestamps at initiation rather than first stream-event
+        # persist — open sessions refetch the sidebar on the stream_started
+        # broadcast and must already see the new order. Sub-threads bump their
+        # parent too, since top-level ordering follows the parent.
+        bump_ids = [chat.id]
         if chat.parent_chat_id:
-            async with self.session_factory() as db:
-                await db.execute(
-                    update(Chat)
-                    .where(Chat.id == chat.parent_chat_id)
-                    .values(updated_at=datetime.now(timezone.utc))
-                )
-                await db.commit()
+            bump_ids.append(chat.parent_chat_id)
+        async with self.session_factory() as db:
+            await db.execute(
+                update(Chat)
+                .where(Chat.id.in_(bump_ids))
+                .values(updated_at=datetime.now(timezone.utc))
+            )
+            await db.commit()
 
         chat_id = chat.id
 
@@ -1173,6 +1229,17 @@ class ChatService(BaseDbService[Chat]):
             logger.error("Failed to enqueue chat task: %s", e)
             await self.message_service.soft_delete_message(assistant_message.id)
             raise
+
+        # Lets open sessions mark this chat "running" even when the turn was
+        # started out-of-band (e.g. via the MCP server) with no client stream.
+        await self._publish_user_chat_event(
+            current_user.id,
+            {
+                "kind": "stream_started",
+                "chat_id": str(chat_id),
+                "message_id": str(assistant_message.id),
+            },
+        )
 
         return {
             "message_id": str(assistant_message.id),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { useCurrentUserQuery } from '@/hooks/queries/useAuthQueries';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { useGlobalStream } from '@/hooks/useGlobalStream';
 import { useLocalStreamRestoration } from '@/hooks/useLocalStreamRestoration';
+import { useChatEvents } from '@/hooks/useChatEvents';
 import { authService } from '@/services/authService';
 import { toasterConfig } from '@/config/toaster';
 import { AuthRoute } from '@/components/routes/AuthRoute';
@@ -66,6 +67,7 @@ function AppContent() {
   }, [user, hasToken, isAuthenticated]);
 
   useLocalStreamRestoration({ enabled: isSessionAuthenticated });
+  useChatEvents({ enabled: isSessionAuthenticated });
 
   const showLoading = hasToken && isLoading;
 

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -165,38 +165,52 @@ export const useMessageFileDiffQuery = (
   });
 };
 
+// Shared by the create-chat mutation and the chat_created SSE feed — both must
+// patch the same caches. The prepend dedups by id because both paths fire for a
+// chat created in this session (mutation onSuccess + its own broadcast event);
+// the second pass's redundant invalidations are the accepted cost of keeping
+// the backend broadcast unconditional — don't "fix" it by suppressing them.
+export async function applyCreatedChat(queryClient: QueryClient, newChat: Chat): Promise<void> {
+  queryClient.setQueryData(queryKeys.chat(newChat.id), newChat);
+
+  if (newChat.parent_chat_id) {
+    // Workspaces too: creating a sub-thread bumps the parent's updated_at,
+    // which drives workspace ordering/last-activity.
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.subThreads(newChat.parent_chat_id) }),
+      queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.workspaces }),
+    ]);
+    return;
+  }
+
+  queryClient.setQueriesData<InfiniteData<PaginatedChats>>(
+    { queryKey: [queryKeys.chats, 'infinite'], predicate: isGlobalChatsQuery },
+    (oldData) => {
+      if (!oldData) return oldData;
+      if (oldData.pages.some((page) => page.items.some((chat) => chat.id === newChat.id))) {
+        return oldData;
+      }
+      return {
+        ...oldData,
+        pages: oldData.pages.map((page, index) =>
+          index === 0 ? { ...page, items: [newChat, ...page.items], total: page.total + 1 } : page,
+        ),
+      };
+    },
+  );
+
+  queryClient.invalidateQueries({
+    queryKey: [queryKeys.chats, 'infinite'],
+    predicate: (query) => !isGlobalChatsQuery(query),
+  });
+
+  queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
+}
+
 export const useCreateChatMutation = createMutation<Chat, Error, CreateChatRequest>(
   (data) => chatService.createChat(data),
-  async (queryClient, newChat) => {
-    queryClient.setQueryData(queryKeys.chat(newChat.id), newChat);
-
-    if (newChat.parent_chat_id) {
-      await queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
-      return;
-    }
-
-    queryClient.setQueriesData<InfiniteData<PaginatedChats>>(
-      { queryKey: [queryKeys.chats, 'infinite'], predicate: isGlobalChatsQuery },
-      (oldData) => {
-        if (!oldData) return oldData;
-        return {
-          ...oldData,
-          pages: oldData.pages.map((page, index) =>
-            index === 0
-              ? { ...page, items: [newChat, ...page.items], total: page.total + 1 }
-              : page,
-          ),
-        };
-      },
-    );
-
-    queryClient.invalidateQueries({
-      queryKey: [queryKeys.chats, 'infinite'],
-      predicate: (query) => !isGlobalChatsQuery(query),
-    });
-
-    queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
-  },
+  (queryClient, newChat) => applyCreatedChat(queryClient, newChat),
 );
 
 export const useUpdateChatMutation = createMutation<

--- a/frontend/src/hooks/useChatEvents.ts
+++ b/frontend/src/hooks/useChatEvents.ts
@@ -1,0 +1,76 @@
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { chatService } from '@/services/chatService';
+import { applyCreatedChat } from '@/hooks/queries/useChatQueries';
+import { useUIStore } from '@/store/uiStore';
+import { useStreamStore } from '@/store/streamStore';
+import { queryKeys } from '@/hooks/queries/queryKeys';
+import { logger } from '@/utils/logger';
+import type { Chat } from '@/types/chat.types';
+
+type ChatEvent =
+  | { kind: 'chat_created'; chat: Chat }
+  | { kind: 'stream_started'; chat_id: string; message_id: string };
+
+// Subscribes to the backend's per-user chat lifecycle SSE feed so chats created
+// and turns started out-of-band (e.g. by agents via the MCP server) surface
+// live — sidebar entry, chat tab, and running indicator — without a refresh.
+export function useChatEvents(options?: { enabled?: boolean }) {
+  const enabled = options?.enabled ?? true;
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let source: EventSource;
+    try {
+      source = chatService.createChatEventsSource();
+    } catch (error) {
+      logger.error('Chat events stream failed to open', 'useChatEvents', error);
+      return;
+    }
+
+    const onChatEvent = (event: MessageEvent) => {
+      if (!event.data) return;
+      let parsed: ChatEvent;
+      try {
+        parsed = JSON.parse(event.data) as ChatEvent;
+      } catch (error) {
+        logger.error('Malformed chat event', 'useChatEvents', error);
+        return;
+      }
+
+      if (parsed.kind === 'chat_created') {
+        void applyCreatedChat(queryClient, parsed.chat).catch((error) =>
+          logger.error('Chat cache update failed', 'useChatEvents', error),
+        );
+        useUIStore.getState().openChatTab(parsed.chat.id);
+        return;
+      }
+
+      if (parsed.kind === 'stream_started') {
+        // Turns started out-of-band on existing chats emit no chat_created,
+        // so the running chat must join the tab strip here.
+        useUIStore.getState().openChatTab(parsed.chat_id);
+        // The turn bumps updated_at ordering server-side — refetch the sidebar
+        // lists so the chat surfaces even from outside the loaded pages.
+        queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
+        const store = useStreamStore.getState();
+        // Skip chats already tracked (self-started turns register via addStream).
+        // Settled turns are cleaned up by useGlobalStream's orphan pruning.
+        if (store.activeStreamMetadata.some((meta) => meta.chatId === parsed.chat_id)) return;
+        store.addStreamMetadata({
+          chatId: parsed.chat_id,
+          messageId: parsed.message_id,
+          startTime: Date.now(),
+        });
+      }
+    };
+
+    // EventSource handles transient-error reconnects itself; no error handler needed.
+    // Custom event names hit the generic EventTarget overload, which takes Event.
+    source.addEventListener('chat_event', (event: Event) => onChatEvent(event as MessageEvent));
+    return () => source.close();
+  }, [enabled, queryClient]);
+}

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -298,6 +298,19 @@ function createEventSource(
   return eventSource;
 }
 
+function createChatEventsSource(): EventSource {
+  // Local backend only — cloud chats have their own sidebar list, and the MCP
+  // server this feed exists for always targets the local instance.
+  const token = apiClient.getToken();
+  if (!token) {
+    throw new Error('Authentication token required');
+  }
+
+  const params = new URLSearchParams();
+  params.append('token', token);
+  return new EventSource(`${apiClient.getBaseUrl()}/chat/chats/events?${params.toString()}`);
+}
+
 async function getSubThreads(chatId: string): Promise<Chat[]> {
   validateId(chatId, 'Chat ID');
   return serviceCall(async () => {
@@ -467,4 +480,5 @@ export const chatService = {
   pinChat,
   unpinChat,
   getSubThreads,
+  createChatEventsSource,
 };


### PR DESCRIPTION
## Summary
- Adds a per-user `/chat/chats/events` SSE endpoint publishing `chat_created` and `stream_started` events over Redis pub/sub, so chats created or turns started outside the active tab (e.g. via the MCP server) show up live in the sidebar, tab strip, and running indicator without a manual refresh.
- Backend: `ChatService.create_chat_events_stream` streams the per-user channel; `create_chat` and `initiate_chat_completion` publish best-effort events (`_publish_user_chat_event`); sub-thread creation now bumps parent `updated_at` at turn initiation rather than first stream persist, matching when clients refetch.
- Frontend: new `useChatEvents` hook subscribes to the feed, opens the relevant chat tab, and patches the same query caches the create-chat mutation uses (`applyCreatedChat`, extracted for reuse).

## Test plan
- [ ] Start a chat via the MCP server while the web UI is open; confirm the chat appears in the sidebar/tabs and shows as running without a refresh
- [ ] Create a sub-thread out-of-band; confirm parent chat reorders in the sidebar/workspace list
- [ ] Verify existing in-app chat creation/streaming flows are unaffected