### PR TITLE
fix(backend): trim checkpoint diff bloat, prune finished message events

### DIFF
--- a/backend/app/services/git.py
+++ b/backend/app/services/git.py
@@ -138,10 +138,14 @@ GIT_DIFF_ALL_TEMPLATE = Template(
     " || { git diff$ctx --cached 2>/dev/null; git diff$ctx 2>/dev/null; }; };"
     "$untracked"
 )
+# Default context (no -U flag): restore resets --hard to base_head before
+# applying, and changed-files builds its temp index from exactly base_head, so
+# the patch base is always byte-identical — full-file context would only bloat
+# every checkpoint row stored in the DB.
 GIT_CHECKPOINT_DIFF_ALL_TEMPLATE = Template(
-    "{ git diff --binary -U99999 HEAD 2>/dev/null"
-    " || { git diff --binary -U99999 --cached 2>/dev/null; "
-    "git diff --binary -U99999 2>/dev/null; }; };"
+    "{ git diff --binary HEAD 2>/dev/null"
+    " || { git diff --binary --cached 2>/dev/null; "
+    "git diff --binary 2>/dev/null; }; };"
     "$untracked"
 )
 GIT_UNTRACKED_DIFF_TEMPLATE = Template(
@@ -151,7 +155,7 @@ GIT_UNTRACKED_DIFF_TEMPLATE = Template(
 GIT_CHECKPOINT_UNTRACKED_DIFF_TEMPLATE = (
     " git ls-files --others --exclude-standard -z"
     " | xargs -0 -I{} "
-    "git diff --binary -U99999 --no-index -- /dev/null {} 2>/dev/null"
+    "git diff --binary --no-index -- /dev/null {} 2>/dev/null"
 )
 # Diff HEAD against the merge-base with the default branch. Default branch is
 # detected via the remote HEAD symref, falling back to main/master/develop/

--- a/backend/app/services/message.py
+++ b/backend/app/services/message.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from typing import Any, cast
 from uuid import UUID, uuid4
 
-from sqlalchemy import and_, case, insert, or_, select, update
+from sqlalchemy import and_, case, delete, insert, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -172,6 +172,18 @@ class MessageService(BaseDbService[Message]):
             result = await db.execute(stmt)
             if int(getattr(result, "rowcount", 0)) == 0:
                 return None
+
+            # Terminal snapshot supersedes the event log: history renders from
+            # content_render and event reads are seq-gated catch-up past
+            # last_seq, so a finished message's events are never read again —
+            # drop them so message_events doesn't grow unbounded.
+            if (
+                stream_status is not None
+                and stream_status != MessageStreamStatus.IN_PROGRESS
+            ):
+                await db.execute(
+                    delete(MessageEvent).where(MessageEvent.message_id == message_id)
+                )
 
             await db.commit()
 


### PR DESCRIPTION
## Summary
- Drop `-U99999` full-file context from checkpoint diff templates — restore resets hard to `base_head` before applying and changed-files builds its temp index from exactly `base_head`, so the patch base is always byte-identical and the extra context only bloats every checkpoint row stored in the DB.
- Delete a message's `message_events` rows once it reaches a terminal stream status — history renders from `content_render` and event reads are seq-gated catch-up past `last_seq`, so a finished message's events are never read again, and leaving them causes `message_events` to grow unbounded.