### PR TITLE
feat(chat): extend live chat events and stream restoration to cloud

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,9 @@ import { useCurrentUserQuery } from '@/hooks/queries/useAuthQueries';
 import { LoadingScreen } from '@/components/ui/LoadingScreen';
 import { useGlobalStream } from '@/hooks/useGlobalStream';
 import { useLocalStreamRestoration } from '@/hooks/useLocalStreamRestoration';
+import { useCloudStreamRestoration } from '@/hooks/useCloudStreamRestoration';
 import { useChatEvents } from '@/hooks/useChatEvents';
+import { useCloudChatEvents } from '@/hooks/useCloudChatEvents';
 import { authService } from '@/services/authService';
 import { toasterConfig } from '@/config/toaster';
 import { AuthRoute } from '@/components/routes/AuthRoute';
@@ -67,7 +69,9 @@ function AppContent() {
   }, [user, hasToken, isAuthenticated]);
 
   useLocalStreamRestoration({ enabled: isSessionAuthenticated });
+  useCloudStreamRestoration({ enabled: isSessionAuthenticated });
   useChatEvents({ enabled: isSessionAuthenticated });
+  useCloudChatEvents({ enabled: isSessionAuthenticated });
 
   const showLoading = hasToken && isLoading;
 

--- a/frontend/src/components/layout/SidebarChatGroup.tsx
+++ b/frontend/src/components/layout/SidebarChatGroup.tsx
@@ -9,7 +9,6 @@ import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Spinner } from '@/components/ui/primitives/Spinner';
 import { useInfiniteChatsQuery } from '@/hooks/queries/useChatQueries';
 import { useInfiniteCloudChatsQuery } from '@/hooks/queries/useCloudQueries';
-import { useCloudStreamRestoration } from '@/hooks/useCloudStreamRestoration';
 import { SidebarChatItem } from './SidebarChatItem';
 import { SubThreadList } from './SubThreadList';
 
@@ -322,12 +321,6 @@ export const SidebarCloudGroup = memo(function SidebarCloudGroup({
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } =
     useInfiniteCloudChatsQuery(workspace.id, !isCollapsed);
   const chats = useMemo(() => flattenChatPages(data), [data]);
-
-  // App-level restoration only covers the local backend — restore cloud streams
-  // here from this group's fetched pages so reopened active VPS runs show the
-  // sidebar pulse and get tracked by the global watcher without first opening
-  // the chat. Reruns on each poll that surfaces a newly active run.
-  useCloudStreamRestoration({ chats, isLoading, enabled: !isCollapsed });
 
   return (
     <SidebarChatGroup

--- a/frontend/src/hooks/queries/useCloudQueries.ts
+++ b/frontend/src/hooks/queries/useCloudQueries.ts
@@ -89,10 +89,11 @@ export const useCloudSettingsQuery = (enabled: boolean) => {
 
 // Cloud chats for one project, paginated like the local sidebar groups. The
 // queryFn registers returned IDs as cloud-owned (markCloudChats), so opening one
-// routes its messages/status/SSE to the VPS. Polled so cloud-side activity (new
-// chats, runs starting) surfaces without a manual refresh — the desktop has no
-// push channel for cloud state. Key extends queryKeys.cloudChats so the
-// LandingPage invalidation prefix-matches every project's query.
+// routes its messages/status/SSE to the VPS. New chats and runs arrive live via
+// the cloud events feed (useCloudChatEvents); the poll is a safety net for
+// changes the feed doesn't carry (titles, deletes, other-device edits). Key
+// extends queryKeys.cloudChats so the LandingPage invalidation prefix-matches
+// every project's query.
 export const useInfiniteCloudChatsQuery = (workspaceId: string, enabled: boolean) => {
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
   const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);

--- a/frontend/src/hooks/useChatEvents.ts
+++ b/frontend/src/hooks/useChatEvents.ts
@@ -6,11 +6,7 @@ import { useUIStore } from '@/store/uiStore';
 import { useStreamStore } from '@/store/streamStore';
 import { queryKeys } from '@/hooks/queries/queryKeys';
 import { logger } from '@/utils/logger';
-import type { Chat } from '@/types/chat.types';
-
-type ChatEvent =
-  | { kind: 'chat_created'; chat: Chat }
-  | { kind: 'stream_started'; chat_id: string; message_id: string };
+import type { ChatEvent } from '@/types/chat.types';
 
 // Subscribes to the backend's per-user chat lifecycle SSE feed so chats created
 // and turns started out-of-band (e.g. by agents via the MCP server) surface
@@ -56,11 +52,9 @@ export function useChatEvents(options?: { enabled?: boolean }) {
         // lists so the chat surfaces even from outside the loaded pages.
         queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
         queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
-        const store = useStreamStore.getState();
-        // Skip chats already tracked (self-started turns register via addStream).
-        // Settled turns are cleaned up by useGlobalStream's orphan pruning.
-        if (store.activeStreamMetadata.some((meta) => meta.chatId === parsed.chat_id)) return;
-        store.addStreamMetadata({
+        // Self-started turns are already tracked via addStream; settled turns
+        // are cleaned up by useGlobalStream's orphan pruning.
+        useStreamStore.getState().addStreamMetadataIfAbsent({
           chatId: parsed.chat_id,
           messageId: parsed.message_id,
           startTime: Date.now(),

--- a/frontend/src/hooks/useCloudChatEvents.ts
+++ b/frontend/src/hooks/useCloudChatEvents.ts
@@ -1,0 +1,122 @@
+import { useEffect } from 'react';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
+import { cloudChatService } from '@/services/cloudChatService';
+import { markCloudChats, markCloudSandboxes } from '@/utils/chatOrigin';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
+import { useUIStore } from '@/store/uiStore';
+import { useStreamStore } from '@/store/streamStore';
+import { queryKeys } from '@/hooks/queries/queryKeys';
+import { logger } from '@/utils/logger';
+import type { ChatEvent } from '@/types/chat.types';
+
+// Cloud lists reorder server-side and refetch on invalidation anyway, so a full
+// refetch is simpler than the local feed's optimistic first-page insert.
+function invalidateCloudLists(queryClient: QueryClient): void {
+  const { cloudUrl, connectedEmail } = useCloudSettingsStore.getState();
+  void queryClient.invalidateQueries({ queryKey: queryKeys.cloudChatsAll });
+  void queryClient.invalidateQueries({
+    queryKey: queryKeys.cloudWorkspaces(cloudUrl, connectedEmail),
+  });
+}
+
+// Cloud twin of useChatEvents: subscribes to the VPS's per-user chat lifecycle
+// SSE feed so chats created and turns started on the VPS (agents, other devices)
+// surface live instead of waiting for the next sidebar poll.
+export function useCloudChatEvents(options?: { enabled?: boolean }) {
+  const enabled = options?.enabled ?? true;
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!enabled || !cloudUrl) return;
+
+    const onChatEvent = (event: MessageEvent) => {
+      if (!event.data) return;
+      let parsed: ChatEvent;
+      try {
+        parsed = JSON.parse(event.data) as ChatEvent;
+      } catch (error) {
+        logger.error('Malformed cloud chat event', 'useCloudChatEvents', error);
+        return;
+      }
+
+      if (parsed.kind === 'chat_created') {
+        const chat = parsed.chat;
+        // Register origin before any consumer touches the chat — its reads,
+        // status checks, and SSE reconnects must route to the VPS.
+        markCloudChats([chat.id]);
+        markCloudSandboxes([chat.sandbox_id]);
+        queryClient.setQueryData(queryKeys.chat(chat.id), chat);
+        if (chat.parent_chat_id) {
+          void queryClient.invalidateQueries({
+            queryKey: queryKeys.subThreads(chat.parent_chat_id),
+          });
+        }
+        invalidateCloudLists(queryClient);
+        useUIStore.getState().openChatTab(chat.id);
+        return;
+      }
+
+      if (parsed.kind === 'stream_started') {
+        // Out-of-band turns can hit chats this device never listed (e.g. fresh
+        // sub-threads) — mark before the global watcher reconnects to them.
+        markCloudChats([parsed.chat_id]);
+        useUIStore.getState().openChatTab(parsed.chat_id);
+        invalidateCloudLists(queryClient);
+        // Self-started turns are already tracked via addStream; settled turns
+        // are cleaned up by useGlobalStream's orphan pruning.
+        useStreamStore.getState().addStreamMetadataIfAbsent({
+          chatId: parsed.chat_id,
+          messageId: parsed.message_id,
+          startTime: Date.now(),
+        });
+      }
+    };
+
+    // Opening is async (mints an access token first), so guard against the
+    // effect being cleaned up before the source resolves.
+    let source: EventSource | undefined;
+    let cancelled = false;
+    let retryTimer: number | undefined;
+
+    const scheduleReopen = () => {
+      if (cancelled) return;
+      retryTimer = window.setTimeout(openFeed, 15_000);
+    };
+
+    const openFeed = () => {
+      cloudChatService
+        .createChatEventsSource()
+        .then((eventSource) => {
+          if (cancelled) {
+            eventSource.close();
+            return;
+          }
+          source = eventSource;
+          source.addEventListener('chat_event', (event: Event) =>
+            onChatEvent(event as MessageEvent),
+          );
+          // EventSource retries transient drops itself (readyState CONNECTING) but
+          // treats HTTP errors as fatal — e.g. 401 once the query-param token
+          // expires. Reopen with a freshly minted token so the feed can't die
+          // silently while the UI looks connected.
+          source.onerror = () => {
+            if (source?.readyState !== EventSource.CLOSED) return;
+            scheduleReopen();
+          };
+        })
+        .catch((error) => {
+          logger.error('Cloud chat events stream failed to open', 'useCloudChatEvents', error);
+          scheduleReopen();
+        });
+    };
+
+    openFeed();
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(retryTimer);
+      source?.close();
+    };
+  }, [enabled, cloudUrl, queryClient]);
+}

--- a/frontend/src/hooks/useCloudStreamRestoration.ts
+++ b/frontend/src/hooks/useCloudStreamRestoration.ts
@@ -1,85 +1,33 @@
 import { useEffect } from 'react';
 import { logger } from '@/utils/logger';
 import { useStreamStore } from '@/store/streamStore';
-import type { Chat } from '@/types/chat.types';
-import type { StreamMetadata } from '@/types/stream.types';
-import { chatService } from '@/services/chatService';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
+import { cloudChatService } from '@/services/cloudChatService';
 
-interface UseCloudStreamRestorationOptions {
-  chats: Chat[] | undefined;
-  isLoading: boolean;
-  enabled?: boolean;
-}
+// Restores active VPS streams in one bulk request — the cloud instance runs the
+// same backend as local, so its registry-backed active-streams endpoint covers
+// every chat and sub-thread without a per-chat status fan-out. Runs once per
+// connection (keyed by cloudUrl); streams started while the app is open arrive
+// live via useCloudChatEvents.
+export function useCloudStreamRestoration({ enabled }: { enabled: boolean }) {
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
 
-// After each cloud chat-list poll, writes StreamMetadata entries for any chat (or
-// sub-thread) with an active backend task so the sidebar can show streaming
-// indicators without waiting for the user to open each chat. Checks the 20
-// most recent chats to keep the fan-out bounded. Cloud has no push channel, so
-// this reruns on each changed list (deduping already-tracked chats) instead of
-// latching after the first pass.
-export function useCloudStreamRestoration({
-  chats,
-  isLoading,
-  enabled = true,
-}: UseCloudStreamRestorationOptions) {
   useEffect(() => {
-    if (!enabled || isLoading || !chats || chats.length === 0) {
-      return;
-    }
+    if (!enabled || !cloudUrl) return;
 
-    const discoverActiveStreams = async () => {
-      // Skip chats already tracked — avoids redundant status checks on reruns and
-      // keeps an existing entry's startTime from resetting on each poll.
-      const tracked = new Set(
-        useStreamStore.getState().activeStreamMetadata.map((meta) => meta.chatId),
-      );
-      const chatsToCheck = chats.slice(0, 20);
-
-      const checkAndRegister = async (chatId: string) => {
-        if (tracked.has(chatId)) return;
-        try {
-          const status = await chatService.checkChatStatus(chatId);
-          if (status?.has_active_task && status.message_id) {
-            const metadata: StreamMetadata = {
-              chatId,
-              messageId: status.message_id,
-              startTime: Date.now(),
-            };
-            useStreamStore.getState().addStreamMetadata(metadata);
-          }
-        } catch (error) {
-          logger.error('Failed to check chat status', 'useCloudStreamRestoration', {
-            chatId,
-            error,
-          });
-        }
-      };
-
-      const chatCheckPromises = chatsToCheck.map((chat) => checkAndRegister(chat.id));
-
-      // Fetch sub-threads for parents that have them and check each for active
-      // streams. Per-chat fan-out is unavoidable here: only the chat-scoped client
-      // reaches the remote instance. Local restoration uses the bulk endpoint in
-      // useLocalStreamRestoration instead.
-      const subThreadPromises = chatsToCheck
-        .filter((chat) => chat.sub_thread_count > 0)
-        .map(async (chat) => {
-          try {
-            const subThreads = await chatService.getSubThreads(chat.id);
-            await Promise.allSettled(subThreads.map((sub) => checkAndRegister(sub.id)));
-          } catch (error) {
-            logger.error('Failed to restore sub-thread streams', 'useCloudStreamRestoration', {
-              chatId: chat.id,
-              error,
-            });
-          }
+    const restore = async () => {
+      const active = await cloudChatService.getActiveStreams();
+      for (const stream of active) {
+        useStreamStore.getState().addStreamMetadataIfAbsent({
+          chatId: stream.chat_id,
+          messageId: stream.message_id,
+          startTime: Date.now(),
         });
-
-      await Promise.allSettled([...chatCheckPromises, ...subThreadPromises]);
+      }
     };
 
-    discoverActiveStreams().catch((error) => {
-      logger.error('Stream restoration failed', 'useCloudStreamRestoration', error);
+    restore().catch((error) => {
+      logger.error('Cloud stream restoration failed', 'useCloudStreamRestoration', error);
     });
-  }, [chats, isLoading, enabled]);
+  }, [enabled, cloudUrl]);
 }

--- a/frontend/src/hooks/useLocalStreamRestoration.ts
+++ b/frontend/src/hooks/useLocalStreamRestoration.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { logger } from '@/utils/logger';
 import { useStreamStore } from '@/store/streamStore';
-import type { StreamMetadata } from '@/types/stream.types';
 import { chatService } from '@/services/chatService';
 
 // Restores local streams in one bulk request — the backend enumerates its
@@ -16,17 +15,12 @@ export function useLocalStreamRestoration({ enabled }: { enabled: boolean }) {
 
     const restore = async () => {
       const active = await chatService.getActiveStreams();
-      const tracked = new Set(
-        useStreamStore.getState().activeStreamMetadata.map((meta) => meta.chatId),
-      );
       for (const stream of active) {
-        if (tracked.has(stream.chat_id)) continue;
-        const metadata: StreamMetadata = {
+        useStreamStore.getState().addStreamMetadataIfAbsent({
           chatId: stream.chat_id,
           messageId: stream.message_id,
           startTime: Date.now(),
-        };
-        useStreamStore.getState().addStreamMetadata(metadata);
+        });
       }
     };
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -118,6 +118,24 @@ class APIClient {
     return this.auth.getToken();
   }
 
+  // For SSE openers that bypass request(): the token rides the URL and the cached
+  // one may be missing (after a restart) or expired (reopening a dead feed), so
+  // mint a fresh one from the refresh token on every open.
+  async getValidToken(): Promise<string | null> {
+    if (!this.auth.getRefreshToken()) return this.auth.getToken();
+    try {
+      return (await this.refreshTokenIfNeeded()).access_token;
+    } catch (error) {
+      // Mirror request(): a terminal refresh failure means the session is dead —
+      // tear it down instead of letting SSE reopen loops retry it forever.
+      if (shouldInvalidateSession(error)) {
+        this.auth.onSessionExpired();
+        return null;
+      }
+      throw error;
+    }
+  }
+
   setBaseUrl(url: string): void {
     this.baseURL = url;
   }

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -10,6 +10,7 @@ import type {
   CreateChatRequest,
   ContextUsage,
 } from '@/types/chat.types';
+import type { ActiveStreamSnapshot } from '@/types/stream.types';
 import type { ChangedFilesData, FileDiffData, GitCommitResult } from '@/types/sandbox.types';
 import type { CursorPaginationParams, PaginatedChats, PaginatedMessages } from '@/types/api.types';
 import type { EditorCodeSelection } from '@/store/uiStore';
@@ -101,14 +102,7 @@ async function checkChatStatus(chatId: string): Promise<{
   return serviceCall(() => resolveChatClient(chatId).get(`/chat/chats/${chatId}/status`));
 }
 
-async function getActiveStreams(): Promise<
-  Array<{
-    chat_id: string;
-    message_id: string;
-    stream_id: string | null;
-    last_seq: number;
-  }>
-> {
+async function getActiveStreams(): Promise<ActiveStreamSnapshot[]> {
   // Local backend only — its runtime registry covers every local chat and
   // sub-thread, so startup restoration needs a single request.
   return serviceCall(() => apiClient.get('/chat/chats/active-streams'));
@@ -299,8 +293,8 @@ function createEventSource(
 }
 
 function createChatEventsSource(): EventSource {
-  // Local backend only — cloud chats have their own sidebar list, and the MCP
-  // server this feed exists for always targets the local instance.
+  // Local backend only — the VPS feed is opened separately via
+  // cloudChatService.createChatEventsSource, against the remote client's auth.
   const token = apiClient.getToken();
   if (!token) {
     throw new Error('Authentication token required');

--- a/frontend/src/services/cloudChatService.ts
+++ b/frontend/src/services/cloudChatService.ts
@@ -11,6 +11,7 @@ import type {
   UpdateWorkspaceRequest,
 } from '@/types/workspace.types';
 import type { Chat, ChatRequest, CreateChatRequest } from '@/types/chat.types';
+import type { ActiveStreamSnapshot } from '@/types/stream.types';
 import type { PaginatedChats, PaginatedResponse } from '@/types/api.types';
 
 // Log into the VPS and persist its refresh token. The remote client mints
@@ -18,13 +19,23 @@ import type { PaginatedChats, PaginatedResponse } from '@/types/api.types';
 async function connect(url: string, email: string, password: string): Promise<void> {
   // Store the URL slash-trimmed — consumers compose paths like `${cloudUrl}/chat/{id}`.
   const trimmedUrl = trimTrailingSlash(url);
+  // The login must hit the new host, but a failed attempt while connected to
+  // another VPS must not leave remoteApiClient pointed at a URL that never
+  // authenticated — existing cloud chats would misroute until reconnect/reload.
+  const previousUrl = useCloudSettingsStore.getState().cloudUrl;
   setCloudApiBaseUrl(trimmedUrl);
   const formData = new FormData();
   formData.append('username', email);
   formData.append('password', password);
 
-  const response = await remoteApiClient.postForm<AuthResponse>('/auth/jwt/login', formData);
-  const auth = ensureResponse(response, 'Failed to connect to cloud instance');
+  let auth: AuthResponse;
+  try {
+    const response = await remoteApiClient.postForm<AuthResponse>('/auth/jwt/login', formData);
+    auth = ensureResponse(response, 'Failed to connect to cloud instance');
+  } catch (error) {
+    if (previousUrl) setCloudApiBaseUrl(previousUrl);
+    throw error;
+  }
 
   cloudAuthStorage.setRefreshToken(auth.refresh_token);
   cloudAuthStorage.setAccessToken(auth.access_token);
@@ -119,6 +130,32 @@ async function startCompletion(request: ChatRequest): Promise<void> {
   });
 }
 
+// Bulk snapshot of every active stream on the VPS — the same registry-backed
+// endpoint local restoration uses, so no per-chat status fan-out. Marks the chat
+// IDs cloud-owned so reconnects and status checks route back to the VPS.
+async function getActiveStreams(): Promise<ActiveStreamSnapshot[]> {
+  return serviceCall(async () => {
+    const response = await remoteApiClient.get<ActiveStreamSnapshot[]>(
+      '/chat/chats/active-streams',
+    );
+    const streams = ensureResponse(response, 'Failed to fetch cloud active streams');
+    markCloudChats(streams.map((stream) => stream.chat_id));
+    return streams;
+  });
+}
+
+// Per-user chat lifecycle SSE feed from the VPS — the cloud twin of
+// chatService.createChatEventsSource. Async because EventSource bypasses
+// APIClient's 401→refresh path, so the token must be minted up front.
+async function createChatEventsSource(): Promise<EventSource> {
+  const token = await remoteApiClient.getValidToken();
+  if (!token) {
+    throw new Error('Not connected to cloud instance');
+  }
+  const params = new URLSearchParams({ token });
+  return new EventSource(`${remoteApiClient.getBaseUrl()}/chat/chats/events?${params.toString()}`);
+}
+
 export const cloudChatService = {
   connect,
   disconnect,
@@ -130,4 +167,6 @@ export const cloudChatService = {
   getWorkspaceResources,
   getSettings,
   startCompletion,
+  getActiveStreams,
+  createChatEventsSource,
 };

--- a/frontend/src/store/streamStore.ts
+++ b/frontend/src/store/streamStore.ts
@@ -20,6 +20,7 @@ interface StreamState {
   abortStream: (streamId: string) => void;
   removeStreamMetadata: (chatId: string) => void;
   addStreamMetadata: (metadata: StreamMetadata) => void;
+  addStreamMetadataIfAbsent: (metadata: StreamMetadata) => void;
 }
 
 function getChatMessageKey(chatId: string, messageId: string): string {
@@ -203,5 +204,15 @@ export const useStreamStore = create<StreamState>((set, get) => ({
         activeStreamMetadata: upsertStreamMetadata(state.activeStreamMetadata, metadata),
       };
     });
+  },
+
+  addStreamMetadataIfAbsent: (metadata: StreamMetadata) => {
+    // Unlike addStreamMetadata's upsert, an already-tracked chat keeps its entry —
+    // restoration and event feeds must not reset a live stream's startTime.
+    set((state) =>
+      state.activeStreamMetadata.some((item) => item.chatId === metadata.chatId)
+        ? state
+        : { activeStreamMetadata: [...state.activeStreamMetadata, metadata] },
+    );
   },
 }));

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -68,6 +68,12 @@ export interface Chat {
   session_agent_kind: AgentKind | null;
 }
 
+// Wire contract of the per-user chat lifecycle SSE feed (/chat/chats/events),
+// consumed by useChatEvents (local) and useCloudChatEvents (VPS).
+export type ChatEvent =
+  | { kind: 'chat_created'; chat: Chat }
+  | { kind: 'stream_started'; chat_id: string; message_id: string };
+
 export interface ChatRequest {
   prompt: string;
   chat_id?: string;

--- a/frontend/src/types/stream.types.ts
+++ b/frontend/src/types/stream.types.ts
@@ -69,6 +69,14 @@ export interface StreamMetadata {
   startTime: number;
 }
 
+// Wire shape of GET /chat/chats/active-streams — one entry per running turn.
+export interface ActiveStreamSnapshot {
+  chat_id: string;
+  message_id: string;
+  stream_id: string | null;
+  last_seq: number;
+}
+
 export class StreamProcessingError extends Error {
   constructor(
     message: string,


### PR DESCRIPTION
## Summary
- Add `useCloudChatEvents`, the cloud twin of `useChatEvents`, subscribing to the VPS's per-user chat lifecycle SSE feed so chats created and turns started out-of-band on the VPS (agents, other devices) surface live instead of waiting for the next sidebar poll.
- Rework `useCloudStreamRestoration` to call a new bulk `GET /chat/chats/active-streams` endpoint via `cloudChatService.getActiveStreams` (mirroring local restoration), replacing the previous per-chat + per-sub-thread status fan-out.
- Add `addStreamMetadataIfAbsent` to `streamStore` so restoration and event feeds register a stream without resetting an already-tracked entry's `startTime`; both local and cloud paths now share this logic.
- Add `APIClient.getValidToken()` so SSE openers (which bypass the normal `request()` 401→refresh path) can mint a fresh access token on every open.
- Hoist `ChatEvent` and `ActiveStreamSnapshot` into shared types (`chat.types.ts`, `stream.types.ts`) used by both local and cloud services/hooks.

## Test plan
- [ ] Connect to a cloud/VPS instance and confirm chats created via the MCP server (or another device) appear in the sidebar without a manual refresh
- [ ] Start a turn on the VPS out-of-band and confirm the sidebar streaming indicator appears live
- [ ] Reload the app while a VPS stream is active and confirm it's restored via the bulk endpoint
- [ ] Verify local chat events/stream restoration still work unaffected