### PR TITLE
feat(ui): show connection overview in cloud settings tab

### DIFF
--- a/frontend/src/components/settings/tabs/CloudSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/CloudSettingsTab.tsx
@@ -1,22 +1,70 @@
 import { useState } from 'react';
 import toast from 'react-hot-toast';
-import { CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { Input } from '@/components/ui/primitives/Input';
 import { Label } from '@/components/ui/primitives/Label';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import { cloudChatService } from '@/services/cloudChatService';
+import {
+  useCloudActiveStreamsQuery,
+  useCloudChatsTotalQuery,
+  useCloudWorkspacesQuery,
+} from '@/hooks/queries/useCloudQueries';
+import { cn } from '@/utils/cn';
 
-// Connects the desktop to a remote AgentRove (VPS) instance so chats can be run
-// there with "Cloud" execution mode. All state here is client-side only.
+function StatusPill({ connected }: { connected: boolean }) {
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border/50 px-2 py-0.5 text-2xs text-text-tertiary dark:border-border-dark/50 dark:text-text-dark-tertiary">
+      <span
+        className={cn(
+          'h-1.5 w-1.5 rounded-full',
+          connected
+            ? 'bg-success-500 dark:bg-success-400'
+            : 'bg-text-quaternary dark:bg-text-dark-quaternary',
+        )}
+      />
+      {connected ? 'Connected' : 'Not connected'}
+    </span>
+  );
+}
+
+function StatTile({ label, value }: { label: string; value: number | undefined }) {
+  return (
+    <div className="rounded-lg border border-border/50 px-3 py-2 dark:border-border-dark/50">
+      <div className="text-sm font-medium text-text-primary dark:text-text-dark-primary">
+        {value ?? '—'}
+      </div>
+      <div className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">{label}</div>
+    </div>
+  );
+}
+
+function SetupStep({ step, children }: { step: number; children: React.ReactNode }) {
+  return (
+    <li className="flex items-center gap-2.5">
+      <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-border/50 text-2xs text-text-tertiary dark:border-border-dark/50 dark:text-text-dark-tertiary">
+        {step}
+      </span>
+      <span className="text-xs text-text-tertiary dark:text-text-dark-tertiary">{children}</span>
+    </li>
+  );
+}
+
 export function CloudSettingsTab() {
+  // Connects the desktop to a remote AgentRove (VPS) instance so chats can run
+  // there with "Cloud" execution mode. Connection state is client-side only.
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
   const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
+  const isConnected = !!connectedEmail;
 
   const [url, setUrl] = useState(cloudUrl);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isConnecting, setIsConnecting] = useState(false);
+
+  const workspacesQuery = useCloudWorkspacesQuery(isConnected);
+  const activeStreamsQuery = useCloudActiveStreamsQuery(isConnected);
+  const chatsTotalQuery = useCloudChatsTotalQuery(isConnected);
 
   const handleConnect = async () => {
     // Normalize a bare host to https:// so the base URL is absolute, not relative.
@@ -52,45 +100,61 @@ export function CloudSettingsTab() {
     toast.success('Disconnected from cloud instance');
   };
 
-  return (
-    <div className="space-y-4">
-      <div className="rounded-xl border border-border p-5 dark:border-border-dark">
-        <h2 className="mb-1 text-xs font-medium text-text-tertiary dark:text-text-dark-tertiary">
-          Cloud Instance
-        </h2>
-        <p className="mb-4 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-          Run chats on a separate AgentRove instance (e.g. your VPS) so they keep running after you
-          close this app. The instance must allow this app&apos;s origin in its{' '}
-          <span className="font-mono">ALLOWED_ORIGINS</span>.
-        </p>
-
-        {connectedEmail ? (
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-2 text-xs text-text-secondary dark:text-text-dark-secondary">
-              <CheckCircle2 className="h-4 w-4 shrink-0 text-success-600 dark:text-success-400" />
-              <span>
-                Connected to <span className="font-mono">{cloudUrl}</span> as{' '}
-                <span className="font-medium">{connectedEmail}</span>
-              </span>
-            </div>
+  if (isConnected) {
+    return (
+      <div className="space-y-4">
+        <div className="rounded-xl border border-border p-5 dark:border-border-dark">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="min-w-0 truncate font-mono text-xs font-medium text-text-primary dark:text-text-dark-primary">
+              {cloudUrl}
+            </h2>
+            <StatusPill connected />
+          </div>
+          <p className="mt-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+            Signed in as <span className="font-medium">{connectedEmail}</span>
+          </p>
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            <StatTile label="Workspaces" value={workspacesQuery.data?.length} />
+            <StatTile label="Running chats" value={activeStreamsQuery.data?.length} />
+            <StatTile label="Total chats" value={chatsTotalQuery.data} />
+          </div>
+          <div className="mt-4 flex justify-end">
             <Button type="button" variant="outline" size="sm" onClick={handleDisconnect}>
               Disconnect
             </Button>
           </div>
-        ) : (
-          <div className="space-y-3">
-            <div>
-              <Label className="mb-1 text-xs text-text-secondary dark:text-text-dark-secondary">
-                Cloud URL
-              </Label>
-              <Input
-                type="url"
-                value={url}
-                onChange={(e) => setUrl(e.target.value)}
-                placeholder="https://your-vps.example.com"
-                autoComplete="off"
-              />
-            </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-border p-5 dark:border-border-dark">
+        <div className="mb-1 flex items-center justify-between gap-3">
+          <h2 className="text-xs font-medium text-text-tertiary dark:text-text-dark-tertiary">
+            Cloud Instance
+          </h2>
+          <StatusPill connected={false} />
+        </div>
+        <p className="mb-4 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+          Run chats on a separate AgentRove instance (e.g. your VPS) so they keep running after you
+          close this app.
+        </p>
+        <div className="space-y-3">
+          <div>
+            <Label className="mb-1 text-xs text-text-secondary dark:text-text-dark-secondary">
+              Cloud URL
+            </Label>
+            <Input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://your-vps.example.com"
+              autoComplete="off"
+            />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
             <div>
               <Label className="mb-1 text-xs text-text-secondary dark:text-text-dark-secondary">
                 Email
@@ -115,18 +179,30 @@ export function CloudSettingsTab() {
                 autoComplete="off"
               />
             </div>
-            <Button
-              type="button"
-              variant="primary"
-              size="sm"
-              onClick={handleConnect}
-              isLoading={isConnecting}
-              loadingText="Connecting..."
-            >
-              Connect
-            </Button>
           </div>
-        )}
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            onClick={handleConnect}
+            isLoading={isConnecting}
+            loadingText="Connecting..."
+          >
+            Connect
+          </Button>
+        </div>
+      </div>
+      <div className="rounded-xl border border-border p-5 dark:border-border-dark">
+        <h2 className="mb-3 text-xs font-medium text-text-tertiary dark:text-text-dark-tertiary">
+          Before You Connect
+        </h2>
+        <ol className="space-y-2">
+          <SetupStep step={1}>Deploy AgentRove on your server</SetupStep>
+          <SetupStep step={2}>
+            Add this app&apos;s origin to its <span className="font-mono">ALLOWED_ORIGINS</span>
+          </SetupStep>
+          <SetupStep step={3}>Sign in with an account on that instance</SetupStep>
+        </ol>
       </div>
     </div>
   );

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -85,6 +85,8 @@ export const queryKeys = {
     ['cloud', 'settings', cloudUrl, connectedEmail] as const,
   cloudChats: (cloudUrl?: string, connectedEmail?: string | null) =>
     ['cloud', 'chats', cloudUrl, connectedEmail] as const,
+  cloudActiveStreams: (cloudUrl?: string, connectedEmail?: string | null) =>
+    ['cloud', 'active-streams', cloudUrl, connectedEmail] as const,
   // Prefix key for invalidating every cloud chats query regardless of instance/account.
   cloudChatsAll: ['cloud', 'chats'] as const,
   models: 'models',

--- a/frontend/src/hooks/queries/useCloudQueries.ts
+++ b/frontend/src/hooks/queries/useCloudQueries.ts
@@ -9,6 +9,7 @@ import type {
   UpdateWorkspaceRequest,
 } from '@/types/workspace.types';
 import type { UserSettings } from '@/types/user.types';
+import type { ActiveStreamSnapshot } from '@/types/stream.types';
 
 const CLOUD_CHATS_PER_PAGE = 25;
 
@@ -82,6 +83,35 @@ export const useCloudSettingsQuery = (enabled: boolean) => {
   return useQuery<UserSettings>({
     queryKey: queryKeys.cloudSettings(cloudUrl, connectedEmail),
     queryFn: () => cloudChatService.getSettings(),
+    enabled: enabled && !!cloudUrl,
+    staleTime: 30_000,
+  });
+};
+
+// Chats currently running on the VPS — the settings tab shows the count in its
+// connection overview. Polled so the number stays live while the tab is open.
+export const useCloudActiveStreamsQuery = (enabled: boolean) => {
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
+  const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
+  return useQuery<ActiveStreamSnapshot[]>({
+    queryKey: queryKeys.cloudActiveStreams(cloudUrl, connectedEmail),
+    queryFn: () => cloudChatService.getActiveStreams(),
+    enabled: enabled && !!cloudUrl,
+    staleTime: 10_000,
+    refetchInterval: 15_000,
+  });
+};
+
+// Total chat count across all VPS workspaces for the settings connection
+// overview. per_page 1 keeps the payload minimal — only `total` is consumed.
+// Key extends queryKeys.cloudChats so existing invalidations prefix-match it.
+export const useCloudChatsTotalQuery = (enabled: boolean) => {
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
+  const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
+  return useQuery({
+    queryKey: [...queryKeys.cloudChats(cloudUrl, connectedEmail), 'total'] as const,
+    queryFn: () => cloudChatService.listChats({ page: 1, per_page: 1 }),
+    select: (data) => data.total,
     enabled: enabled && !!cloudUrl,
     staleTime: 30_000,
   });


### PR DESCRIPTION
## Summary
- Once connected, the Cloud Settings tab now shows a connection overview with live counts (workspaces, running chats, total chats) instead of just an email string
- Adds `useCloudActiveStreamsQuery` and `useCloudChatsTotalQuery` hooks (polling active streams every 15s) plus a `cloudActiveStreams` query key
- Replaces the pre-connect wall of text with numbered setup steps (deploy, allowlist origin, sign in)