### PR TITLE
feat: add scheduled automations

### DIFF
--- a/backend/app/api/endpoints/automations.py
+++ b/backend/app/api/endpoints/automations.py
@@ -1,0 +1,90 @@
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.core.deps import get_automation_service
+from app.core.security import get_current_user
+from app.models.db_models.user import User
+from app.models.schemas.automation import (
+    Automation as AutomationSchema,
+    AutomationCreate,
+    AutomationRunResponse,
+    AutomationUpdate,
+)
+from app.services.automation import AutomationService
+from app.services.exceptions import AutomationException, ChatException
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.post(
+    "",
+    response_model=AutomationSchema,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_automation(
+    data: AutomationCreate,
+    current_user: User = Depends(get_current_user),
+    automation_service: AutomationService = Depends(get_automation_service),
+) -> AutomationSchema:
+    try:
+        return await automation_service.create_automation(current_user, data)
+    except AutomationException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
+    except SQLAlchemyError as e:
+        logger.error("Database error creating automation: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error while creating automation",
+        ) from e
+
+
+@router.get("", response_model=list[AutomationSchema])
+async def list_automations(
+    current_user: User = Depends(get_current_user),
+    automation_service: AutomationService = Depends(get_automation_service),
+) -> list[AutomationSchema]:
+    return await automation_service.list_automations(current_user)
+
+
+@router.patch("/{automation_id}", response_model=AutomationSchema)
+async def update_automation(
+    automation_id: UUID,
+    data: AutomationUpdate,
+    current_user: User = Depends(get_current_user),
+    automation_service: AutomationService = Depends(get_automation_service),
+) -> AutomationSchema:
+    try:
+        return await automation_service.update_automation(
+            automation_id, current_user, data
+        )
+    except AutomationException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
+
+
+@router.delete("/{automation_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_automation(
+    automation_id: UUID,
+    current_user: User = Depends(get_current_user),
+    automation_service: AutomationService = Depends(get_automation_service),
+) -> None:
+    try:
+        await automation_service.delete_automation(automation_id, current_user)
+    except AutomationException as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
+
+
+@router.post("/{automation_id}/run", response_model=AutomationRunResponse)
+async def run_automation(
+    automation_id: UUID,
+    current_user: User = Depends(get_current_user),
+    automation_service: AutomationService = Depends(get_automation_service),
+) -> AutomationRunResponse:
+    try:
+        chat = await automation_service.run_automation(automation_id, current_user)
+    except (AutomationException, ChatException) as e:
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
+    return AutomationRunResponse(chat_id=chat.id)

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -14,6 +14,7 @@ from app.models.db_models.chat import Chat
 from app.models.db_models.workspace import Workspace
 from app.models.db_models.user import User
 from app.services.attachment import AttachmentService
+from app.services.automation import AutomationService
 from app.services.chat import ChatService
 from app.services.agent import AgentService
 from app.services.exceptions import ChatException, UserException
@@ -199,6 +200,15 @@ async def get_chat_service(
 ) -> AsyncIterator[ChatService]:
     yield ChatService(
         user_service,
+        session_factory=SessionLocal,
+    )
+
+
+async def get_automation_service(
+    user_service: UserService = Depends(get_user_service),
+) -> AutomationService:
+    return AutomationService(
+        ChatService(user_service, session_factory=SessionLocal),
         session_factory=SessionLocal,
     )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.api.endpoints import (
     ai_model,
     attachments,
     auth,
+    automations,
     chat,
     github,
     sandbox,
@@ -151,6 +152,11 @@ def create_application() -> FastAPI:
         github.router,
         prefix=f"{settings.API_V1_STR}/github",
         tags=["GitHub"],
+    )
+    application.include_router(
+        automations.router,
+        prefix=f"{settings.API_V1_STR}/automations",
+        tags=["Automations"],
     )
     application.openapi = partial(custom_openapi, application)
 

--- a/backend/app/models/db_models/automation.py
+++ b/backend/app/models/db_models/automation.py
@@ -1,0 +1,63 @@
+import uuid
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import Boolean, ForeignKey, Index, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base_class import Base
+from app.db.migration_helpers import uuid_server_default
+from app.db.types import GUID, UTCDateTime
+
+
+class Automation(Base):
+    __tablename__ = "automations"
+
+    id: Mapped[UUID] = mapped_column(
+        GUID(),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=uuid_server_default(),
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    workspace_id: Mapped[UUID] = mapped_column(
+        GUID(), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    prompt: Mapped[str] = mapped_column(Text, nullable=False)
+    model_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    permission_mode: Mapped[str] = mapped_column(
+        String(32),
+        default="bypassPermissions",
+        server_default="bypassPermissions",
+        nullable=False,
+    )
+    thinking_mode: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    worktree: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+    plan_mode: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false", nullable=False
+    )
+    selected_persona_name: Mapped[str] = mapped_column(
+        String(100), default="Default", server_default="Default", nullable=False
+    )
+    cron_expression: Mapped[str] = mapped_column(String(128), nullable=False)
+    # IANA zone the cron is evaluated in, so "daily at 9am" tracks the user's
+    # local time (and DST) rather than the server clock.
+    timezone: Mapped[str] = mapped_column(
+        String(64), default="UTC", server_default="UTC", nullable=False
+    )
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, default=True, server_default="true", nullable=False
+    )
+    # Stored in UTC; the dispatch job fires rows where next_run_at <= now.
+    next_run_at: Mapped[datetime] = mapped_column(UTCDateTime(), nullable=False)
+    last_run_at: Mapped[datetime | None] = mapped_column(UTCDateTime(), nullable=True)
+
+    __table_args__ = (
+        Index("idx_automations_user_id", "user_id"),
+        Index("idx_automations_enabled_next_run_at", "enabled", "next_run_at"),
+    )

--- a/backend/app/models/schemas/automation.py
+++ b/backend/app/models/schemas/automation.py
@@ -1,0 +1,106 @@
+from datetime import datetime
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from croniter import croniter
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.models.types import PermissionMode
+from app.prompts.system_prompt import DEFAULT_PERSONA_NAME
+
+
+def validate_cron_expression(value: str) -> str:
+    if not croniter.is_valid(value):
+        raise ValueError("Invalid cron expression")
+    return value
+
+
+def validate_timezone_name(value: str) -> str:
+    try:
+        ZoneInfo(value)
+    except (KeyError, ValueError) as e:
+        raise ValueError("Unknown timezone") from e
+    return value
+
+
+class AutomationBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    prompt: str = Field(..., min_length=1, max_length=100000)
+    model_id: str = Field(..., min_length=1, max_length=255)
+    cron_expression: str = Field(..., min_length=1, max_length=128)
+    timezone: str = Field("UTC", min_length=1, max_length=64)
+    permission_mode: PermissionMode = "bypassPermissions"
+    thinking_mode: str | None = Field(None, max_length=50)
+    worktree: bool = False
+    plan_mode: bool = False
+    selected_persona_name: str = Field(DEFAULT_PERSONA_NAME, max_length=100)
+    enabled: bool = True
+
+    @field_validator("cron_expression")
+    @classmethod
+    def check_cron_expression(cls, value: str) -> str:
+        return validate_cron_expression(value)
+
+    @field_validator("timezone")
+    @classmethod
+    def check_timezone(cls, value: str) -> str:
+        return validate_timezone_name(value)
+
+
+class AutomationCreate(AutomationBase):
+    workspace_id: UUID
+
+
+class AutomationUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=255)
+    prompt: str | None = Field(None, min_length=1, max_length=100000)
+    model_id: str | None = Field(None, min_length=1, max_length=255)
+    workspace_id: UUID | None = None
+    cron_expression: str | None = Field(None, min_length=1, max_length=128)
+    timezone: str | None = Field(None, min_length=1, max_length=64)
+    permission_mode: PermissionMode | None = None
+    thinking_mode: str | None = Field(None, max_length=50)
+    worktree: bool | None = None
+    plan_mode: bool | None = None
+    selected_persona_name: str | None = Field(None, min_length=1, max_length=100)
+    enabled: bool | None = None
+
+    @field_validator("cron_expression")
+    @classmethod
+    def check_cron_expression(cls, value: str | None) -> str | None:
+        return None if value is None else validate_cron_expression(value)
+
+    @field_validator("timezone")
+    @classmethod
+    def check_timezone(cls, value: str | None) -> str | None:
+        return None if value is None else validate_timezone_name(value)
+
+
+class Automation(BaseModel):
+    # Standalone read model (not AutomationBase) so responses skip the input
+    # validators and stored rows survive later write-rule drift — mirrors the
+    # Workspace schema pattern.
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    user_id: UUID
+    workspace_id: UUID
+    name: str
+    prompt: str
+    model_id: str
+    cron_expression: str
+    timezone: str
+    permission_mode: str
+    thinking_mode: str | None = None
+    worktree: bool
+    plan_mode: bool
+    selected_persona_name: str
+    enabled: bool
+    next_run_at: datetime
+    last_run_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AutomationRunResponse(BaseModel):
+    chat_id: UUID

--- a/backend/app/services/automation.py
+++ b/backend/app/services/automation.py
@@ -1,0 +1,215 @@
+import logging
+from datetime import datetime, timezone
+from typing import Any, cast
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from croniter import croniter
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.constants import MODELS
+from app.models.db_models.automation import Automation
+from app.models.db_models.chat import Chat
+from app.models.db_models.user import User
+from app.models.db_models.workspace import Workspace
+from app.models.schemas.automation import AutomationCreate, AutomationUpdate
+from app.models.schemas.chat import ChatCreate, ChatRequest
+from app.models.types import PermissionMode
+from app.services.chat import ChatService
+from app.services.db import BaseDbService, SessionFactoryType
+from app.services.exceptions import AutomationException, ErrorCode
+
+logger = logging.getLogger(__name__)
+
+# Fields whose change invalidates the previously computed next_run_at.
+SCHEDULE_FIELDS = frozenset({"cron_expression", "timezone", "enabled"})
+
+
+class AutomationService(BaseDbService[Automation]):
+    def __init__(
+        self,
+        chat_service: ChatService,
+        session_factory: SessionFactoryType | None = None,
+    ) -> None:
+        super().__init__(session_factory)
+        self._chat_service = chat_service
+
+    @staticmethod
+    def compute_next_run(cron_expression: str, timezone_name: str) -> datetime:
+        # Evaluate the cron in the automation's own zone so "daily at 9am"
+        # follows the user's wall clock (incl. DST), then store UTC for the
+        # dispatch comparison.
+        base = datetime.now(ZoneInfo(timezone_name))
+        next_local: datetime = croniter(cron_expression, base).get_next(datetime)
+        return next_local.astimezone(timezone.utc)
+
+    @staticmethod
+    def _validate_model(model_id: str) -> None:
+        if model_id not in MODELS:
+            raise AutomationException(
+                "Unknown model",
+                error_code=ErrorCode.VALIDATION_ERROR,
+                details={"model_id": model_id},
+                status_code=400,
+            )
+
+    @staticmethod
+    async def _validate_workspace(
+        db: AsyncSession, workspace_id: UUID, user_id: UUID
+    ) -> None:
+        result = await db.execute(
+            select(Workspace.id).filter(
+                Workspace.id == workspace_id,
+                Workspace.user_id == user_id,
+                Workspace.deleted_at.is_(None),
+            )
+        )
+        if not result.one_or_none():
+            raise AutomationException(
+                "Workspace not found",
+                error_code=ErrorCode.WORKSPACE_NOT_FOUND,
+                details={"workspace_id": str(workspace_id)},
+                status_code=404,
+            )
+
+    async def _get_owned(
+        self, db: AsyncSession, automation_id: UUID, user_id: UUID
+    ) -> Automation:
+        result = await db.execute(
+            select(Automation).filter(
+                Automation.id == automation_id,
+                Automation.user_id == user_id,
+            )
+        )
+        automation = result.scalar_one_or_none()
+        if not automation:
+            raise AutomationException(
+                "Automation not found",
+                details={"automation_id": str(automation_id)},
+                status_code=404,
+            )
+        return automation
+
+    async def list_automations(self, user: User) -> list[Automation]:
+        async with self.session_factory() as db:
+            result = await db.execute(
+                select(Automation)
+                .filter(Automation.user_id == user.id)
+                .order_by(Automation.created_at.desc())
+            )
+            return list(result.scalars().all())
+
+    async def create_automation(self, user: User, data: AutomationCreate) -> Automation:
+        self._validate_model(data.model_id)
+        async with self.session_factory() as db:
+            await self._validate_workspace(db, data.workspace_id, user.id)
+            automation = Automation(
+                user_id=user.id,
+                **data.model_dump(),
+                next_run_at=self.compute_next_run(data.cron_expression, data.timezone),
+            )
+            db.add(automation)
+            await db.commit()
+            await db.refresh(automation)
+            return automation
+
+    async def update_automation(
+        self, automation_id: UUID, user: User, data: AutomationUpdate
+    ) -> Automation:
+        changes = data.model_dump(exclude_unset=True)
+        if "model_id" in changes:
+            self._validate_model(changes["model_id"])
+        async with self.session_factory() as db:
+            automation = await self._get_owned(db, automation_id, user.id)
+            if "workspace_id" in changes:
+                await self._validate_workspace(db, changes["workspace_id"], user.id)
+            for field, value in changes.items():
+                setattr(automation, field, value)
+            if SCHEDULE_FIELDS & changes.keys():
+                automation.next_run_at = self.compute_next_run(
+                    automation.cron_expression, automation.timezone
+                )
+            await db.commit()
+            await db.refresh(automation)
+            return automation
+
+    async def delete_automation(self, automation_id: UUID, user: User) -> None:
+        async with self.session_factory() as db:
+            automation = await self._get_owned(db, automation_id, user.id)
+            await db.delete(automation)
+            await db.commit()
+
+    async def run_automation(self, automation_id: UUID, user: User) -> Chat:
+        # Manual "run now" — records last_run_at but leaves next_run_at alone so
+        # the scheduled slot still fires.
+        async with self.session_factory() as db:
+            automation = await self._get_owned(db, automation_id, user.id)
+            automation.last_run_at = datetime.now(timezone.utc)
+            await db.commit()
+        return await self._fire(automation, user)
+
+    async def run_due_automations(self) -> dict[str, Any]:
+        # Dispatch job entry point. Advances schedules before firing so a crash
+        # mid-dispatch can't re-fire the same slot on the next poll.
+        now = datetime.now(timezone.utc)
+        async with self.session_factory() as db:
+            result = await db.execute(
+                select(Automation).filter(
+                    Automation.enabled.is_(True),
+                    Automation.next_run_at <= now,
+                )
+            )
+            due = list(result.scalars().all())
+            users: dict[UUID, User] = {}
+            for automation in due:
+                automation.last_run_at = now
+                automation.next_run_at = self.compute_next_run(
+                    automation.cron_expression, automation.timezone
+                )
+                if automation.user_id not in users:
+                    users[automation.user_id] = await db.get_one(
+                        User, automation.user_id
+                    )
+            await db.commit()
+
+        for automation in due:
+            try:
+                await self._fire(automation, users[automation.user_id])
+            except Exception:
+                # One broken automation (deleted workspace, retired model) must
+                # not block the rest of the batch.
+                logger.exception(
+                    "Automation %s (%s) failed to start", automation.id, automation.name
+                )
+        return {}
+
+    async def _fire(self, automation: Automation, user: User) -> Chat:
+        # Re-check the saved model before creating the chat — a model retired
+        # after creation would otherwise leave an orphan empty chat every slot.
+        self._validate_model(automation.model_id)
+        # Timestamp in the title keeps recurring runs distinguishable in the
+        # sidebar; sliced so a max-length name still fits ChatCreate's 255 cap.
+        stamp = datetime.now(ZoneInfo(automation.timezone)).strftime("%b %d, %H:%M")
+        chat = await self._chat_service.create_chat(
+            user,
+            ChatCreate(
+                title=(automation.name + " · " + stamp)[:255],
+                model_id=automation.model_id,
+                workspace_id=automation.workspace_id,
+            ),
+        )
+        await self._chat_service.initiate_chat_completion(
+            ChatRequest(
+                prompt=automation.prompt,
+                chat_id=chat.id,
+                model_id=automation.model_id,
+                permission_mode=cast(PermissionMode, automation.permission_mode),
+                thinking_mode=automation.thinking_mode,
+                worktree=automation.worktree,
+                plan_mode=automation.plan_mode,
+                selected_persona_name=automation.selected_persona_name,
+            ),
+            user,
+        )
+        return chat

--- a/backend/app/services/automation.py
+++ b/backend/app/services/automation.py
@@ -82,7 +82,7 @@ class AutomationService(BaseDbService[Automation]):
                 Automation.user_id == user_id,
             )
         )
-        automation = result.scalar_one_or_none()
+        automation: Automation | None = result.scalar_one_or_none()
         if not automation:
             raise AutomationException(
                 "Automation not found",

--- a/backend/app/services/exceptions.py
+++ b/backend/app/services/exceptions.py
@@ -14,6 +14,7 @@ class ErrorCode(str, Enum):
     AI_SERVICE_ERROR = "AI_SERVICE_ERROR"
     API_KEY_MISSING = "API_KEY_MISSING"
     WORKSPACE_NOT_FOUND = "WORKSPACE_NOT_FOUND"
+    AUTOMATION_NOT_FOUND = "AUTOMATION_NOT_FOUND"
     VALIDATION_ERROR = "VALIDATION_ERROR"
     RATE_LIMIT_EXCEEDED = "RATE_LIMIT_EXCEEDED"
     GITHUB_TOKEN_INVALID = "GITHUB_TOKEN_INVALID"
@@ -139,6 +140,17 @@ class WorkspaceException(ServiceException):
         self,
         message: str,
         error_code: ErrorCode = ErrorCode.WORKSPACE_NOT_FOUND,
+        details: dict[str, str] | None = None,
+        status_code: int = 400,
+    ):
+        super().__init__(message, error_code, details, status_code)
+
+
+class AutomationException(ServiceException):
+    def __init__(
+        self,
+        message: str,
+        error_code: ErrorCode = ErrorCode.AUTOMATION_NOT_FOUND,
         details: dict[str, str] | None = None,
         status_code: int = 400,
     ):

--- a/backend/app/services/maintenance.py
+++ b/backend/app/services/maintenance.py
@@ -8,15 +8,22 @@ from dataclasses import dataclass
 from typing import Any
 
 from app.core.config import get_settings
+from app.services.automation import AutomationService
+from app.services.chat import ChatService
 from app.services.session_registry import (
     IDLE_CHECK_INTERVAL_SECONDS,
     session_registry,
 )
 from app.services.refresh_token import RefreshTokenService
+from app.services.user import UserService
 
 settings = get_settings()
 
 logger = logging.getLogger(__name__)
+
+# Polling resolution for due automations — a fired run lands within a minute of
+# its cron slot, which is plenty for hourly/daily schedules.
+AUTOMATION_DISPATCH_INTERVAL_SECONDS = 60.0
 
 
 @dataclass(frozen=True)
@@ -30,11 +37,13 @@ class MaintenanceService:
     def __init__(self) -> None:
         self._stop_event = asyncio.Event()
         self._tasks: list[asyncio.Task[None]] = []
+        self._automation_service = AutomationService(ChatService(UserService()))
 
     async def start(self) -> None:
         self._tasks = [
             asyncio.create_task(self._run_job_loop(self._refresh_tokens_job())),
             asyncio.create_task(self._run_job_loop(self._idle_session_cleanup_job())),
+            asyncio.create_task(self._run_job_loop(self._automation_dispatch_job())),
         ]
 
     async def stop(self) -> None:
@@ -51,6 +60,13 @@ class MaintenanceService:
             name="refresh_token_cleanup",
             interval_seconds=86400.0,
             run=RefreshTokenService.cleanup_expired_tokens_job,
+        )
+
+    def _automation_dispatch_job(self) -> MaintenanceJob:
+        return MaintenanceJob(
+            name="automation_dispatch",
+            interval_seconds=AUTOMATION_DISPATCH_INTERVAL_SECONDS,
+            run=self._automation_service.run_due_automations,
         )
 
     def _idle_session_cleanup_job(self) -> MaintenanceJob:

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -7,7 +7,13 @@ from sqlalchemy.engine import Connection
 from alembic import context
 from app.db.base_class import Base
 from app.db.sqlite import enable_foreign_keys
-from app.models.db_models import chat, refresh_token, user, workspace  # noqa: F401
+from app.models.db_models import (  # noqa: F401
+    automation,
+    chat,
+    refresh_token,
+    user,
+    workspace,
+)
 from app.core.config import get_settings
 from app.db.types import GUID, EncryptedString, EncryptedJSON, UTCDateTime
 

--- a/backend/migrations/versions/e3f4a5b6c7d8_add_automations.py
+++ b/backend/migrations/versions/e3f4a5b6c7d8_add_automations.py
@@ -1,0 +1,80 @@
+# Revision ID: e3f4a5b6c7d8
+# Revises: d2e3f4a5b6c7
+# Create Date: 2026-07-05 00:00:00.000000
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from app.db.migration_helpers import uuid_server_default, now_server_default
+from app.db.types import GUID, UTCDateTime
+
+# revision identifiers, used by Alembic.
+revision: str = "e3f4a5b6c7d8"
+down_revision: str | None = "d2e3f4a5b6c7"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "automations",
+        sa.Column("id", GUID(), server_default=uuid_server_default(), nullable=False),
+        sa.Column("user_id", GUID(), nullable=False),
+        sa.Column("workspace_id", GUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("prompt", sa.Text(), nullable=False),
+        sa.Column("model_id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "permission_mode",
+            sa.String(length=32),
+            server_default="bypassPermissions",
+            nullable=False,
+        ),
+        sa.Column("thinking_mode", sa.String(length=50), nullable=True),
+        sa.Column("worktree", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("plan_mode", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column(
+            "selected_persona_name",
+            sa.String(length=100),
+            server_default="Default",
+            nullable=False,
+        ),
+        sa.Column("cron_expression", sa.String(length=128), nullable=False),
+        sa.Column(
+            "timezone", sa.String(length=64), server_default="UTC", nullable=False
+        ),
+        sa.Column("enabled", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("next_run_at", UTCDateTime(), nullable=False),
+        sa.Column("last_run_at", UTCDateTime(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=now_server_default(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=now_server_default(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"], ["workspaces.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_automations_user_id", "automations", ["user_id"], unique=False)
+    op.create_index(
+        "idx_automations_enabled_next_run_at",
+        "automations",
+        ["enabled", "next_run_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_automations_enabled_next_run_at", table_name="automations")
+    op.drop_index("idx_automations_user_id", table_name="automations")
+    op.drop_table("automations")

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -50,6 +50,8 @@ cffi==2.0.0
     #   cryptography
 click==8.3.1
     # via uvicorn
+croniter==6.2.3
+    # via -r backend/requirements.txt
 cryptography==46.0.4
     # via
     #   -r backend/requirements.txt
@@ -162,6 +164,8 @@ pydantic-settings==2.12.0
     #   mcp
 pyjwt==2.8.0
     # via fastapi-users
+python-dateutil==2.9.0.post0
+    # via croniter
 python-dotenv==1.2.1
     # via
     #   pydantic-settings
@@ -193,7 +197,9 @@ rpds-py==2026.5.1
 rsa==4.9.1
     # via python-jose
 six==1.17.0
-    # via ecdsa
+    # via
+    #   ecdsa
+    #   python-dateutil
 slowapi==0.1.9
     # via -r backend/requirements.txt
 sqladmin==0.23.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,6 +24,7 @@ prometheus-fastapi-instrumentator
 slowapi
 sse-starlette
 wtforms
+croniter
 redis
 PyYAML>=6.0
 python-json-logger>=2.0.0

--- a/desktop/requirements.txt
+++ b/desktop/requirements.txt
@@ -22,6 +22,7 @@ aiosmtplib
 slowapi
 sse-starlette
 wtforms
+croniter
 PyYAML>=6.0
 python-json-logger>=2.0.0
 alembic

--- a/frontend/src/components/settings/dialogs/AutomationEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/AutomationEditDialog.tsx
@@ -1,0 +1,380 @@
+import { useEffect } from 'react';
+import { Clock, Brain, Shield, Cloud, GitFork, Monitor } from 'lucide-react';
+import type { Persona } from '@/types/user.types';
+import type { AutomationForm } from '@/types/automation.types';
+import { Input } from '@/components/ui/primitives/Input';
+import { Label } from '@/components/ui/primitives/Label';
+import { Select } from '@/components/ui/primitives/Select';
+import { Switch } from '@/components/ui/primitives/Switch';
+import { Textarea } from '@/components/ui/primitives/Textarea';
+import { Dropdown } from '@/components/ui/primitives/Dropdown';
+import { BaseModal } from '@/components/ui/shared/BaseModal';
+import { DialogFooter } from '@/components/ui/shared/DialogFooter';
+import { DialogError } from '@/components/ui/shared/DialogError';
+import { ToggleDropdown, type ToggleDropdownOption } from '@/components/ui/shared/ToggleDropdown';
+import { ModelSelector } from '@/components/chat/model-selector/ModelSelector';
+import {
+  getThinkingModesForAgent,
+  getThinkingModeOption,
+} from '@/components/chat/thinking-mode-selector/thinkingModes';
+import {
+  MODES_BY_AGENT,
+  getPermissionModeOption,
+} from '@/components/chat/permission-mode-selector/permissionModes';
+import { useModelsQuery } from '@/hooks/queries/useModelQueries';
+import { useWorkspacesList } from '@/hooks/queries/useWorkspaceQueries';
+import { useCloudWorkspacesQuery } from '@/hooks/queries/useCloudQueries';
+import { DEFAULT_PERSONA } from '@/store/chatSettingsStore';
+import {
+  buildCronExpression,
+  describeCron,
+  WEEKDAY_LABELS,
+  type ScheduleForm,
+  type ScheduleFrequency,
+} from '@/utils/automationSchedule';
+
+const RUN_LOCATION_OPTIONS: readonly [ToggleDropdownOption, ToggleDropdownOption] = [
+  { label: 'Local', icon: Monitor },
+  { label: 'Cloud', icon: Cloud },
+];
+
+const WORKTREE_OPTIONS: readonly [ToggleDropdownOption, ToggleDropdownOption] = [
+  { label: 'No worktree' },
+  { label: 'Worktree' },
+];
+
+interface AutomationEditDialogProps {
+  isOpen: boolean;
+  isEditing: boolean;
+  form: AutomationForm;
+  localPersonas: Persona[];
+  cloudPersonas: Persona[];
+  cloudConnected: boolean;
+  error: string | null;
+  isSaving: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+  onChange: <K extends keyof AutomationForm>(field: K, value: AutomationForm[K]) => void;
+}
+
+export const AutomationEditDialog: React.FC<AutomationEditDialogProps> = ({
+  isOpen,
+  isEditing,
+  form,
+  localPersonas,
+  cloudPersonas,
+  cloudConnected,
+  error,
+  isSaving,
+  onClose,
+  onSubmit,
+  onChange,
+}) => {
+  const { data: models = [] } = useModelsQuery();
+  const localWorkspaces = useWorkspacesList();
+  const { data: cloudWorkspaces = [] } = useCloudWorkspacesQuery(cloudConnected);
+
+  const workspaces = form.onCloud ? cloudWorkspaces : localWorkspaces;
+  const personas = form.onCloud ? cloudPersonas : localPersonas;
+
+  // Form-state init: seed new automations and ones whose saved model left the
+  // registry — ModelSelector no longer commits one, and save requires a model_id.
+  // Effect, not render-phase seeding: onChange writes parent-owned state.
+  // Never reseed an existing cloud automation: the VPS model registry can lag
+  // the local one, and a silent swap here would persist the wrong model on save.
+  useEffect(() => {
+    if (isEditing && form.onCloud) return;
+    if (models.length > 0 && !models.some((m) => m.model_id === form.model_id)) {
+      onChange('model_id', models[0].model_id);
+    }
+  }, [models, form.model_id, form.onCloud, isEditing, onChange]);
+
+  // Same for the workspace — also re-seeds when toggling local/cloud, since the
+  // selected workspace only exists on one backend. Unlike the model effect this
+  // needs no cloud-edit guard: workspaces are queried from the owning backend,
+  // so a missing id means the workspace was deleted, not a registry skew.
+  useEffect(() => {
+    if (workspaces.length > 0 && !workspaces.some((w) => w.id === form.workspace_id)) {
+      onChange('workspace_id', workspaces[0].id);
+    }
+  }, [workspaces, form.workspace_id, onChange]);
+
+  const selectedModel = models.find((m) => m.model_id === form.model_id);
+  const agentKind = selectedModel?.agent_kind ?? 'claude';
+
+  const permissionModes = MODES_BY_AGENT[agentKind];
+  const selectedPermissionOption = getPermissionModeOption(form.permission_mode, agentKind);
+  const thinkingModes = getThinkingModesForAgent(agentKind, form.model_id);
+  const selectedThinkingOption = getThinkingModeOption(
+    form.thinking_mode,
+    agentKind,
+    form.model_id,
+  );
+
+  const { schedule } = form;
+  const setSchedule = (patch: Partial<ScheduleForm>) =>
+    onChange('schedule', { ...schedule, ...patch });
+  const cronPreview = buildCronExpression(schedule);
+
+  const canSave =
+    !!form.name.trim() &&
+    !!form.prompt.trim() &&
+    !!form.model_id &&
+    !!form.workspace_id &&
+    (schedule.frequency !== 'custom' || !!schedule.cron.trim());
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="sm" className="overflow-visible">
+      <div className="p-5">
+        <div className="mb-5 flex items-center gap-2.5">
+          <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-surface-tertiary dark:bg-surface-dark-tertiary">
+            <Clock className="h-4 w-4 text-text-tertiary dark:text-text-dark-tertiary" />
+          </div>
+          <h3 className="text-sm font-medium text-text-primary dark:text-text-dark-primary">
+            {isEditing ? 'Edit automation' : 'Add automation'}
+          </h3>
+        </div>
+
+        <DialogError error={error} className="mb-4" />
+
+        <div className="space-y-4">
+          <div>
+            <Label className="mb-1.5 text-xs text-text-secondary dark:text-text-dark-secondary">
+              Name
+            </Label>
+            <Input
+              value={form.name}
+              onChange={(e) => onChange('name', e.target.value)}
+              placeholder="Check Gmail"
+              className="text-xs"
+            />
+          </div>
+
+          <div>
+            <Label className="mb-1.5 text-xs text-text-secondary dark:text-text-dark-secondary">
+              Workspace
+            </Label>
+            <div className="flex items-center gap-2">
+              {cloudConnected && (
+                <ToggleDropdown
+                  options={RUN_LOCATION_OPTIONS}
+                  value={form.onCloud}
+                  onSelect={(enabled) => onChange('onCloud', enabled)}
+                  width="w-32"
+                  // An automation is stored on the backend that runs it, so the
+                  // location can't move after creation.
+                  disabled={isEditing}
+                />
+              )}
+              <Select
+                value={form.workspace_id}
+                onChange={(e) => onChange('workspace_id', e.target.value)}
+                className="h-8 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary dark:bg-surface-dark-secondary dark:text-text-dark-primary"
+              >
+                {workspaces.map((w) => (
+                  <option key={w.id} value={w.id}>
+                    {w.name}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            {workspaces.length === 0 && (
+              <p className="mt-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                No {form.onCloud ? 'cloud' : 'local'} workspaces available yet.
+              </p>
+            )}
+          </div>
+
+          <div>
+            <Label className="mb-1.5 text-xs text-text-secondary dark:text-text-dark-secondary">
+              Model
+            </Label>
+            <ModelSelector
+              selectedModelId={form.model_id}
+              onModelChange={(modelId) => onChange('model_id', modelId)}
+              dropdownPosition="bottom"
+              compact={false}
+            />
+          </div>
+
+          <div>
+            <Label className="mb-1.5 text-xs text-text-secondary dark:text-text-dark-secondary">
+              Persona
+            </Label>
+            <Select
+              value={form.persona_name}
+              onChange={(e) => onChange('persona_name', e.target.value)}
+              className="h-8 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary dark:bg-surface-dark-secondary dark:text-text-dark-primary"
+            >
+              <option value={DEFAULT_PERSONA}>Default</option>
+              {personas.map((p) => (
+                <option key={p.name} value={p.name}>
+                  {p.name}
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            {selectedThinkingOption && (
+              <Dropdown
+                value={selectedThinkingOption}
+                items={thinkingModes}
+                getItemKey={(m) => m.value}
+                getItemLabel={(m) => m.label}
+                onSelect={(m) => onChange('thinking_mode', m.value)}
+                leftIcon={Brain}
+                dropdownPosition="bottom"
+              />
+            )}
+            <Dropdown
+              value={selectedPermissionOption}
+              items={permissionModes}
+              getItemKey={(m) => m.value}
+              getItemLabel={(m) => m.label}
+              onSelect={(m) => onChange('permission_mode', m.value)}
+              leftIcon={Shield}
+              dropdownPosition="bottom"
+            />
+            <ToggleDropdown
+              options={WORKTREE_OPTIONS}
+              value={form.worktree}
+              onSelect={(enabled) => onChange('worktree', enabled)}
+              icon={GitFork}
+              width="w-36"
+            />
+            {agentKind === 'codex' && (
+              <label className="flex items-center gap-1.5 text-2xs text-text-tertiary dark:text-text-dark-tertiary">
+                <Switch
+                  size="sm"
+                  checked={form.plan_mode}
+                  onCheckedChange={(enabled) => onChange('plan_mode', enabled)}
+                  aria-label="Plan mode"
+                />
+                Plan mode
+              </label>
+            )}
+          </div>
+
+          <div>
+            <Label className="mb-1.5 text-xs text-text-secondary dark:text-text-dark-secondary">
+              Schedule
+            </Label>
+            <div className="flex flex-wrap items-center gap-2">
+              {/* Width on a wrapper, not the Select — its chevron is positioned
+                  against the primitive's own w-full container */}
+              <div className="w-36">
+                <Select
+                  value={schedule.frequency}
+                  onChange={(e) => setSchedule({ frequency: e.target.value as ScheduleFrequency })}
+                  className="h-8 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary dark:bg-surface-dark-secondary dark:text-text-dark-primary"
+                >
+                  <option value="hourly">Hourly interval</option>
+                  <option value="daily">Daily</option>
+                  <option value="weekly">Weekly</option>
+                  <option value="monthly">Monthly</option>
+                  <option value="custom">Custom (cron)</option>
+                </Select>
+              </div>
+              {schedule.frequency === 'hourly' && (
+                <div className="flex items-center gap-1.5 text-2xs text-text-tertiary dark:text-text-dark-tertiary">
+                  every
+                  <Input
+                    type="number"
+                    min={1}
+                    max={23}
+                    value={schedule.everyHours}
+                    onChange={(e) =>
+                      // Cron's hour field only spans 0-23 — a */N step ≥ 24 silently
+                      // collapses to "daily at midnight", so clamp below that.
+                      setSchedule({
+                        everyHours: Math.min(23, Math.max(1, Number(e.target.value) || 1)),
+                      })
+                    }
+                    className="h-8 w-16 text-xs"
+                  />
+                  hours
+                </div>
+              )}
+              {schedule.frequency === 'weekly' && (
+                <div className="w-32">
+                  <Select
+                    value={schedule.dayOfWeek}
+                    onChange={(e) => setSchedule({ dayOfWeek: Number(e.target.value) })}
+                    className="h-8 bg-surface-secondary px-3 py-1.5 text-xs text-text-primary dark:bg-surface-dark-secondary dark:text-text-dark-primary"
+                  >
+                    {WEEKDAY_LABELS.map((label, day) => (
+                      <option key={label} value={day}>
+                        {label}
+                      </option>
+                    ))}
+                  </Select>
+                </div>
+              )}
+              {schedule.frequency === 'monthly' && (
+                <div className="flex items-center gap-1.5 text-2xs text-text-tertiary dark:text-text-dark-tertiary">
+                  day
+                  <Input
+                    type="number"
+                    min={1}
+                    max={31}
+                    value={schedule.dayOfMonth}
+                    onChange={(e) => setSchedule({ dayOfMonth: Number(e.target.value) || 1 })}
+                    className="h-8 w-16 text-xs"
+                  />
+                </div>
+              )}
+              {(schedule.frequency === 'daily' ||
+                schedule.frequency === 'weekly' ||
+                schedule.frequency === 'monthly') && (
+                <div className="flex items-center gap-1.5 text-2xs text-text-tertiary dark:text-text-dark-tertiary">
+                  at
+                  <Input
+                    type="time"
+                    value={schedule.time}
+                    onChange={(e) => setSchedule({ time: e.target.value })}
+                    className="h-8 w-28 text-xs"
+                  />
+                </div>
+              )}
+              {schedule.frequency === 'custom' && (
+                <Input
+                  value={schedule.cron}
+                  onChange={(e) => setSchedule({ cron: e.target.value })}
+                  placeholder="0 */6 * * *"
+                  className="h-8 w-40 font-mono text-xs"
+                />
+              )}
+            </div>
+            <p className="mt-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+              {describeCron(cronPreview)} · {form.timezone}
+            </p>
+          </div>
+
+          <div>
+            <Label className="mb-1.5 text-xs text-text-secondary dark:text-text-dark-secondary">
+              Prompt
+            </Label>
+            <Textarea
+              value={form.prompt}
+              onChange={(e) => onChange('prompt', e.target.value)}
+              placeholder="Check my Gmail inbox and summarize anything that needs a reply."
+              className="min-h-[120px] text-xs"
+              rows={5}
+            />
+            <p className="mt-1 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+              Each run starts a new chat in the selected workspace with this prompt.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter
+          onCancel={onClose}
+          onSave={onSubmit}
+          saveLabel={isEditing ? 'Update' : 'Add automation'}
+          disabled={!canSave || isSaving}
+        />
+      </div>
+    </BaseModal>
+  );
+};

--- a/frontend/src/components/settings/tabs/AutomationsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/AutomationsSettingsTab.tsx
@@ -1,0 +1,319 @@
+import { Suspense, useCallback, useMemo, useState } from 'react';
+import { Clock, Cloud, Play } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { ListManagementTab } from '@/components/ui/ListManagementTab';
+import { Button } from '@/components/ui/primitives/Button';
+import { Switch } from '@/components/ui/primitives/Switch';
+import { useSettingsContext } from '@/hooks/useSettingsContext';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
+import { useCloudSettingsQuery } from '@/hooks/queries/useCloudQueries';
+import {
+  useAutomationsQuery,
+  useCloudAutomationsQuery,
+  useCreateAutomationMutation,
+  useUpdateAutomationMutation,
+  useDeleteAutomationMutation,
+  useRunAutomationMutation,
+} from '@/hooks/queries/useAutomationQueries';
+import {
+  DEFAULT_PERMISSION_MODE,
+  DEFAULT_THINKING_MODE,
+  DEFAULT_WORKTREE,
+  DEFAULT_PLAN_MODE,
+  DEFAULT_PERSONA,
+} from '@/store/chatSettingsStore';
+import { useModelMap } from '@/hooks/queries/useModelQueries';
+import { buildAgentChatFields } from '@/utils/chatRequest';
+import {
+  buildCronExpression,
+  describeCron,
+  parseCronExpression,
+  DEFAULT_SCHEDULE,
+} from '@/utils/automationSchedule';
+import { lazyNamed } from '@/utils/lazyNamed';
+import type {
+  Automation,
+  AutomationCreateRequest,
+  AutomationForm,
+  AutomationUpdateRequest,
+} from '@/types/automation.types';
+
+const AutomationEditDialog = lazyNamed(
+  () => import('@/components/settings/dialogs/AutomationEditDialog'),
+  'AutomationEditDialog',
+);
+
+// An automation belongs to one backend; onCloud tags each row with its origin
+// so edits/deletes/runs route back to it.
+interface AutomationListItem {
+  automation: Automation;
+  onCloud: boolean;
+}
+
+const NEXT_RUN_FORMAT: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+};
+
+function createDefaultForm(): AutomationForm {
+  return {
+    name: '',
+    prompt: '',
+    model_id: '',
+    workspace_id: '',
+    schedule: { ...DEFAULT_SCHEDULE },
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    permission_mode: DEFAULT_PERMISSION_MODE,
+    thinking_mode: DEFAULT_THINKING_MODE,
+    worktree: DEFAULT_WORKTREE,
+    plan_mode: DEFAULT_PLAN_MODE,
+    persona_name: DEFAULT_PERSONA,
+    onCloud: false,
+  };
+}
+
+function formFromItem(item: AutomationListItem): AutomationForm {
+  const { automation } = item;
+  return {
+    name: automation.name,
+    prompt: automation.prompt,
+    model_id: automation.model_id,
+    workspace_id: automation.workspace_id,
+    schedule: parseCronExpression(automation.cron_expression),
+    // Keep the zone the schedule was authored in — editing from another
+    // timezone must not silently shift the automation's wall-clock time.
+    timezone: automation.timezone,
+    permission_mode: automation.permission_mode,
+    thinking_mode: automation.thinking_mode ?? '',
+    worktree: automation.worktree,
+    plan_mode: automation.plan_mode,
+    persona_name: automation.selected_persona_name,
+    onCloud: item.onCloud,
+  };
+}
+
+export const AutomationsSettingsTab: React.FC = () => {
+  const { localSettings } = useSettingsContext();
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
+  const cloudConnected = !!cloudUrl;
+
+  const { data: localAutomations } = useAutomationsQuery();
+  const { data: cloudAutomations } = useCloudAutomationsQuery(cloudConnected);
+  const { data: cloudSettings } = useCloudSettingsQuery(cloudConnected);
+  const modelMap = useModelMap();
+
+  const createMutation = useCreateAutomationMutation();
+  const updateMutation = useUpdateAutomationMutation();
+  const deleteMutation = useDeleteAutomationMutation();
+  const runMutation = useRunAutomationMutation();
+
+  const items = useMemo<AutomationListItem[] | null>(() => {
+    if (!localAutomations) return null;
+    return [
+      ...localAutomations.map((automation) => ({ automation, onCloud: false })),
+      ...(cloudAutomations ?? []).map((automation) => ({ automation, onCloud: true })),
+    ];
+  }, [localAutomations, cloudAutomations]);
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<AutomationListItem | null>(null);
+  const [form, setForm] = useState<AutomationForm>(createDefaultForm);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const handleFormChange = useCallback(
+    <K extends keyof AutomationForm>(field: K, value: AutomationForm[K]) => {
+      setForm((prev) => ({ ...prev, [field]: value }));
+    },
+    [],
+  );
+
+  const handleAdd = () => {
+    setEditingItem(null);
+    setForm(createDefaultForm());
+    setFormError(null);
+    setIsDialogOpen(true);
+  };
+
+  const handleEdit = (index: number) => {
+    const item = items?.[index];
+    if (!item) return;
+    setEditingItem(item);
+    setForm(formFromItem(item));
+    setFormError(null);
+    setIsDialogOpen(true);
+  };
+
+  const handleDelete = async (index: number) => {
+    const item = items?.[index];
+    if (!item) return;
+    await deleteMutation.mutateAsync({
+      automationId: item.automation.id,
+      onCloud: item.onCloud,
+    });
+  };
+
+  const handleSave = async () => {
+    const onCloud = editingItem?.onCloud ?? form.onCloud;
+    const personas = (onCloud ? cloudSettings?.personas : localSettings.personas) ?? [];
+    // Coerce raw form settings to the selected model's agent, same as normal
+    // sends — a stale mode from another agent family would fail at run time.
+    const agentFields = buildAgentChatFields(
+      form.model_id,
+      modelMap,
+      {
+        permissionMode: form.permission_mode,
+        thinkingMode: form.thinking_mode,
+        worktree: form.worktree,
+        planMode: form.plan_mode,
+        persona: form.persona_name,
+      },
+      personas,
+    );
+    const data: AutomationCreateRequest = {
+      name: form.name.trim(),
+      prompt: form.prompt,
+      model_id: form.model_id,
+      workspace_id: form.workspace_id,
+      cron_expression: buildCronExpression(form.schedule),
+      timezone: form.timezone,
+      permission_mode: agentFields.permission_mode,
+      thinking_mode: agentFields.thinking_mode || null,
+      worktree: agentFields.worktree ?? false,
+      plan_mode: agentFields.plan_mode ?? false,
+      selected_persona_name: agentFields.selected_persona_name,
+      enabled: editingItem?.automation.enabled ?? true,
+    };
+    try {
+      if (editingItem) {
+        await updateMutation.mutateAsync({
+          automationId: editingItem.automation.id,
+          data,
+          onCloud: editingItem.onCloud,
+        });
+      } else {
+        await createMutation.mutateAsync({ data, onCloud: form.onCloud });
+      }
+      setIsDialogOpen(false);
+      toast.success('Saved', { id: 'automation-saved' });
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : 'Failed to save automation');
+    }
+  };
+
+  const handleToggle = async (item: AutomationListItem, enabled: boolean) => {
+    const patch: AutomationUpdateRequest = { enabled };
+    try {
+      await updateMutation.mutateAsync({
+        automationId: item.automation.id,
+        data: patch,
+        onCloud: item.onCloud,
+      });
+    } catch {
+      toast.error('Failed to update automation');
+    }
+  };
+
+  const handleRunNow = async (item: AutomationListItem) => {
+    try {
+      await runMutation.mutateAsync({
+        automationId: item.automation.id,
+        onCloud: item.onCloud,
+      });
+      toast.success(`"${item.automation.name}" started — check the sidebar for its chat`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to run automation');
+    }
+  };
+
+  return (
+    <>
+      <ListManagementTab<AutomationListItem>
+        title="Automations"
+        description="Scheduled prompts that start a new chat with your chosen model, workspace, and settings — e.g. check email daily or triage errors every 6 hours."
+        items={items}
+        emptyIcon={Clock}
+        emptyText="No automations configured yet"
+        emptyButtonText="Add your first automation"
+        addButtonText="Add automation"
+        deleteConfirmTitle="Delete automation"
+        deleteConfirmMessage={(item) =>
+          `Are you sure you want to delete "${item.automation.name}"? This action cannot be undone.`
+        }
+        getItemKey={(item) => item.automation.id}
+        onAdd={handleAdd}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        renderItem={(item) => (
+          <>
+            <div className="mb-2 flex items-center gap-2">
+              <h3 className="truncate text-xs font-medium text-text-primary dark:text-text-dark-primary">
+                {item.automation.name}
+              </h3>
+              {item.onCloud && (
+                <span className="flex items-center gap-1 rounded-md border border-border/50 px-1.5 py-0.5 text-2xs text-text-tertiary dark:border-border-dark/50 dark:text-text-dark-tertiary">
+                  <Cloud className="h-3 w-3" />
+                  Cloud
+                </span>
+              )}
+            </div>
+            <div className="flex flex-wrap items-center gap-2 font-mono text-2xs text-text-secondary dark:text-text-dark-secondary">
+              <span className="rounded-md border border-border/50 px-1.5 py-0.5 dark:border-border-dark/50">
+                {item.automation.model_id}
+              </span>
+              <span className="rounded-md border border-border/50 px-1.5 py-0.5 dark:border-border-dark/50">
+                {describeCron(item.automation.cron_expression)}
+              </span>
+              {item.automation.enabled && (
+                <span className="text-text-quaternary dark:text-text-dark-quaternary">
+                  Next run{' '}
+                  {new Date(item.automation.next_run_at).toLocaleString([], NEXT_RUN_FORMAT)}
+                </span>
+              )}
+            </div>
+          </>
+        )}
+        renderItemActions={(item) => (
+          <>
+            <Button
+              variant="unstyled"
+              onClick={() => void handleRunNow(item)}
+              disabled={runMutation.isPending}
+              className="rounded-md p-1.5 text-text-quaternary transition-colors duration-200 hover:text-text-primary disabled:opacity-50 dark:text-text-dark-quaternary dark:hover:text-text-dark-primary"
+              aria-label="Run now"
+              title="Run now"
+            >
+              <Play className="h-3.5 w-3.5" />
+            </Button>
+            <Switch
+              size="sm"
+              className="mr-1.5"
+              checked={item.automation.enabled}
+              onCheckedChange={(enabled) => void handleToggle(item, enabled)}
+              aria-label={item.automation.enabled ? 'Disable automation' : 'Enable automation'}
+            />
+          </>
+        )}
+        logContext="AutomationsSettingsTab"
+      />
+      {isDialogOpen && (
+        <Suspense fallback={null}>
+          <AutomationEditDialog
+            isOpen={isDialogOpen}
+            isEditing={editingItem !== null}
+            form={form}
+            localPersonas={localSettings.personas ?? []}
+            cloudPersonas={cloudSettings?.personas ?? []}
+            cloudConnected={cloudConnected}
+            error={formError}
+            isSaving={createMutation.isPending || updateMutation.isPending}
+            onClose={() => setIsDialogOpen(false)}
+            onSubmit={() => void handleSave()}
+            onChange={handleFormChange}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+};

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -83,6 +83,9 @@ export const queryKeys = {
     ['cloud', 'active-streams', cloudUrl, connectedEmail] as const,
   // Prefix key for invalidating every cloud chats query regardless of instance/account.
   cloudChatsAll: ['cloud', 'chats'] as const,
+  automations: ['automations'] as const,
+  cloudAutomations: (cloudUrl?: string, connectedEmail?: string | null) =>
+    ['cloud', 'automations', cloudUrl, connectedEmail] as const,
   models: 'models',
   github: {
     repos: (query: string) => ['github-repos', query] as const,

--- a/frontend/src/hooks/queries/useAutomationQueries.ts
+++ b/frontend/src/hooks/queries/useAutomationQueries.ts
@@ -1,0 +1,89 @@
+import { useQuery, type QueryClient } from '@tanstack/react-query';
+import { automationService } from '@/services/automationService';
+import { queryKeys } from '@/hooks/queries/queryKeys';
+import { createMutation } from '@/hooks/queries/createMutation';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
+import type {
+  Automation,
+  AutomationCreateRequest,
+  AutomationUpdateRequest,
+} from '@/types/automation.types';
+
+// Each automation is owned by one backend, so mutations carry onCloud and
+// invalidate only that backend's list.
+function invalidateAutomations(queryClient: QueryClient, onCloud: boolean) {
+  if (onCloud) {
+    const { cloudUrl, connectedEmail } = useCloudSettingsStore.getState();
+    void queryClient.invalidateQueries({
+      queryKey: queryKeys.cloudAutomations(cloudUrl, connectedEmail),
+    });
+  } else {
+    void queryClient.invalidateQueries({ queryKey: queryKeys.automations });
+  }
+}
+
+export const useAutomationsQuery = () =>
+  useQuery<Automation[]>({
+    queryKey: queryKeys.automations,
+    queryFn: () => automationService.listAutomations(false),
+    staleTime: 30_000,
+  });
+
+// Keyed by cloudUrl + connectedEmail so switching instance or account never
+// serves the previous connection's cached list.
+export const useCloudAutomationsQuery = (enabled: boolean) => {
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
+  const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
+  return useQuery<Automation[]>({
+    queryKey: queryKeys.cloudAutomations(cloudUrl, connectedEmail),
+    queryFn: () => automationService.listAutomations(true),
+    enabled: enabled && !!cloudUrl,
+    staleTime: 30_000,
+  });
+};
+
+export const useCreateAutomationMutation = createMutation<
+  Automation,
+  Error,
+  { data: AutomationCreateRequest; onCloud: boolean }
+>(
+  ({ data, onCloud }) => automationService.createAutomation(data, onCloud),
+  (queryClient, _data, variables) => invalidateAutomations(queryClient, variables.onCloud),
+);
+
+export const useUpdateAutomationMutation = createMutation<
+  Automation,
+  Error,
+  { automationId: string; data: AutomationUpdateRequest; onCloud: boolean }
+>(
+  ({ automationId, data, onCloud }) =>
+    automationService.updateAutomation(automationId, data, onCloud),
+  (queryClient, _data, variables) => invalidateAutomations(queryClient, variables.onCloud),
+);
+
+export const useDeleteAutomationMutation = createMutation<
+  void,
+  Error,
+  { automationId: string; onCloud: boolean }
+>(
+  ({ automationId, onCloud }) => automationService.deleteAutomation(automationId, onCloud),
+  (queryClient, _data, variables) => invalidateAutomations(queryClient, variables.onCloud),
+);
+
+export const useRunAutomationMutation = createMutation<
+  { chat_id: string },
+  Error,
+  { automationId: string; onCloud: boolean }
+>(
+  ({ automationId, onCloud }) => automationService.runAutomation(automationId, onCloud),
+  (queryClient, _data, variables) => {
+    // Refresh last_run_at on the list, plus the sidebar chats of the backend
+    // the run landed on.
+    invalidateAutomations(queryClient, variables.onCloud);
+    if (variables.onCloud) {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.cloudChatsAll });
+    } else {
+      void queryClient.invalidateQueries({ queryKey: [queryKeys.chats] });
+    }
+  },
+);

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -6,6 +6,7 @@ import {
   Key,
   ScrollText,
   ChevronLeft,
+  Clock,
   Cloud,
   GitBranch,
 } from 'lucide-react';
@@ -39,6 +40,10 @@ const StreamActionsSettingsTab = lazyNamed(
   () => import('@/components/settings/tabs/StreamActionsSettingsTab'),
   'StreamActionsSettingsTab',
 );
+const AutomationsSettingsTab = lazyNamed(
+  () => import('@/components/settings/tabs/AutomationsSettingsTab'),
+  'AutomationsSettingsTab',
+);
 const EnvVarsSettingsTab = lazyNamed(
   () => import('@/components/settings/tabs/EnvVarsSettingsTab'),
   'EnvVarsSettingsTab',
@@ -53,6 +58,7 @@ type TabKey =
   | 'skills'
   | 'personas'
   | 'stream_actions'
+  | 'automations'
   | 'env_vars'
   | 'instructions'
   | 'cloud';
@@ -71,6 +77,7 @@ const SETTINGS_NAV: SettingsNavItem[] = [
   { id: 'skills', label: 'Skills', icon: Zap },
   { id: 'personas', label: 'Personas', icon: UserCircle },
   { id: 'stream_actions', label: 'Stream Actions', icon: GitBranch },
+  { id: 'automations', label: 'Automations', icon: Clock },
   { id: 'env_vars', label: 'Env Variables', icon: Key },
   { id: 'instructions', label: 'Instructions', icon: ScrollText },
   { id: 'cloud', label: 'Cloud', icon: Cloud },
@@ -429,6 +436,14 @@ const SettingsPage: React.FC = () => {
                     >
                       <Suspense fallback={tabLoadingFallback}>
                         <StreamActionsSettingsTab />
+                      </Suspense>
+                    </div>
+                  )}
+
+                  {activeTab === 'automations' && (
+                    <div role="tabpanel" id="automations-panel" aria-labelledby="automations-tab">
+                      <Suspense fallback={tabLoadingFallback}>
+                        <AutomationsSettingsTab />
                       </Suspense>
                     </div>
                   )}

--- a/frontend/src/services/automationService.ts
+++ b/frontend/src/services/automationService.ts
@@ -1,0 +1,73 @@
+import { apiClient, remoteApiClient } from '@/lib/api';
+import { ensureResponse, serviceCall } from '@/services/base/BaseService';
+import { markCloudChats } from '@/utils/chatOrigin';
+import type {
+  Automation,
+  AutomationCreateRequest,
+  AutomationUpdateRequest,
+} from '@/types/automation.types';
+
+// Automations live on whichever backend runs them — the local instance or the
+// connected cloud VPS (same API shape) — so every call routes by onCloud.
+function clientFor(onCloud: boolean) {
+  return onCloud ? remoteApiClient : apiClient;
+}
+
+async function listAutomations(onCloud: boolean): Promise<Automation[]> {
+  return serviceCall(async () => {
+    const response = await clientFor(onCloud).get<Automation[]>('/automations');
+    return ensureResponse(response, 'Failed to load automations');
+  });
+}
+
+async function createAutomation(
+  data: AutomationCreateRequest,
+  onCloud: boolean,
+): Promise<Automation> {
+  return serviceCall(async () => {
+    const response = await clientFor(onCloud).post<Automation>('/automations', data);
+    return ensureResponse(response, 'Failed to create automation');
+  });
+}
+
+async function updateAutomation(
+  automationId: string,
+  data: AutomationUpdateRequest,
+  onCloud: boolean,
+): Promise<Automation> {
+  return serviceCall(async () => {
+    const response = await clientFor(onCloud).patch<Automation>(
+      `/automations/${automationId}`,
+      data,
+    );
+    return ensureResponse(response, 'Failed to update automation');
+  });
+}
+
+async function deleteAutomation(automationId: string, onCloud: boolean): Promise<void> {
+  await serviceCall(async () => {
+    await clientFor(onCloud).delete(`/automations/${automationId}`);
+  });
+}
+
+async function runAutomation(automationId: string, onCloud: boolean): Promise<{ chat_id: string }> {
+  return serviceCall(async () => {
+    const response = await clientFor(onCloud).post<{ chat_id: string }>(
+      `/automations/${automationId}/run`,
+    );
+    const payload = ensureResponse(response, 'Failed to run automation');
+    // A cloud run's chat lives on the VPS — register it so opening it routes there.
+    if (onCloud) {
+      markCloudChats([payload.chat_id]);
+    }
+    return payload;
+  });
+}
+
+export const automationService = {
+  listAutomations,
+  createAutomation,
+  updateAutomation,
+  deleteAutomation,
+  runAutomation,
+};

--- a/frontend/src/types/automation.types.ts
+++ b/frontend/src/types/automation.types.ts
@@ -1,0 +1,57 @@
+import type { PermissionMode } from '@/store/chatSettingsStore';
+import type { ScheduleForm } from '@/utils/automationSchedule';
+
+export interface Automation {
+  id: string;
+  user_id: string;
+  workspace_id: string;
+  name: string;
+  prompt: string;
+  model_id: string;
+  cron_expression: string;
+  timezone: string;
+  permission_mode: PermissionMode;
+  thinking_mode: string | null;
+  worktree: boolean;
+  plan_mode: boolean;
+  selected_persona_name: string;
+  enabled: boolean;
+  next_run_at: string;
+  last_run_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AutomationCreateRequest {
+  name: string;
+  prompt: string;
+  model_id: string;
+  workspace_id: string;
+  cron_expression: string;
+  timezone: string;
+  permission_mode: PermissionMode;
+  thinking_mode: string | null;
+  worktree: boolean;
+  plan_mode: boolean;
+  selected_persona_name: string;
+  enabled: boolean;
+}
+
+export type AutomationUpdateRequest = Partial<AutomationCreateRequest>;
+
+// Snapshot of every inputbar setting an automation replays when its schedule
+// fires — the edit-dialog form state shared between the tab and the dialog.
+export interface AutomationForm {
+  name: string;
+  prompt: string;
+  model_id: string;
+  workspace_id: string;
+  schedule: ScheduleForm;
+  timezone: string;
+  permission_mode: PermissionMode;
+  thinking_mode: string;
+  worktree: boolean;
+  plan_mode: boolean;
+  persona_name: string;
+  onCloud: boolean;
+}

--- a/frontend/src/utils/automationSchedule.ts
+++ b/frontend/src/utils/automationSchedule.ts
@@ -1,0 +1,117 @@
+// Builds/parses the restricted cron shapes the automation schedule UI offers.
+// Anything the parser doesn't recognize round-trips through the 'custom' mode.
+
+export type ScheduleFrequency = 'hourly' | 'daily' | 'weekly' | 'monthly' | 'custom';
+
+export interface ScheduleForm {
+  frequency: ScheduleFrequency;
+  everyHours: number;
+  time: string; // "HH:MM"
+  dayOfWeek: number; // 0 = Sunday, matching cron
+  dayOfMonth: number;
+  cron: string;
+}
+
+export const WEEKDAY_LABELS = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+] as const;
+
+export const DEFAULT_SCHEDULE: ScheduleForm = {
+  frequency: 'daily',
+  everyHours: 6,
+  time: '09:00',
+  dayOfWeek: 1,
+  dayOfMonth: 1,
+  cron: '',
+};
+
+const TIME_PATTERN = /^(\d{1,2}):(\d{2})$/;
+const EVERY_HOURS_PATTERN = /^0 \*\/(\d{1,3}) \* \* \*$/;
+const DAILY_PATTERN = /^(\d{1,2}) (\d{1,2}) \* \* \*$/;
+const WEEKLY_PATTERN = /^(\d{1,2}) (\d{1,2}) \* \* (\d)$/;
+const MONTHLY_PATTERN = /^(\d{1,2}) (\d{1,2}) (\d{1,2}) \* \*$/;
+
+function splitTime(time: string): { hour: number; minute: number } {
+  const match = TIME_PATTERN.exec(time);
+  if (!match) return { hour: 9, minute: 0 };
+  return { hour: Number(match[1]), minute: Number(match[2]) };
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+export function buildCronExpression(schedule: ScheduleForm): string {
+  const { hour, minute } = splitTime(schedule.time);
+  switch (schedule.frequency) {
+    case 'hourly':
+      return `0 */${schedule.everyHours} * * *`;
+    case 'daily':
+      return `${minute} ${hour} * * *`;
+    case 'weekly':
+      return `${minute} ${hour} * * ${schedule.dayOfWeek}`;
+    case 'monthly':
+      return `${minute} ${hour} ${schedule.dayOfMonth} * *`;
+    case 'custom':
+      return schedule.cron.trim();
+  }
+}
+
+export function parseCronExpression(cron: string): ScheduleForm {
+  const hourly = EVERY_HOURS_PATTERN.exec(cron);
+  // Steps ≥ 24 exceed cron's 0-23 hour range (they collapse to daily) — leave
+  // them in custom mode so the label stays honest and re-saves don't clamp them.
+  if (hourly && Number(hourly[1]) <= 23) {
+    return { ...DEFAULT_SCHEDULE, frequency: 'hourly', everyHours: Number(hourly[1]) };
+  }
+  const daily = DAILY_PATTERN.exec(cron);
+  if (daily) {
+    return {
+      ...DEFAULT_SCHEDULE,
+      frequency: 'daily',
+      time: `${pad(Number(daily[2]))}:${pad(Number(daily[1]))}`,
+    };
+  }
+  const weekly = WEEKLY_PATTERN.exec(cron);
+  if (weekly) {
+    return {
+      ...DEFAULT_SCHEDULE,
+      frequency: 'weekly',
+      time: `${pad(Number(weekly[2]))}:${pad(Number(weekly[1]))}`,
+      // Cron allows Sunday as both 0 and 7 — normalize so labels/selects work.
+      dayOfWeek: Number(weekly[3]) % 7,
+    };
+  }
+  const monthly = MONTHLY_PATTERN.exec(cron);
+  if (monthly) {
+    return {
+      ...DEFAULT_SCHEDULE,
+      frequency: 'monthly',
+      time: `${pad(Number(monthly[2]))}:${pad(Number(monthly[1]))}`,
+      dayOfMonth: Number(monthly[3]),
+    };
+  }
+  return { ...DEFAULT_SCHEDULE, frequency: 'custom', cron };
+}
+
+export function describeCron(cron: string): string {
+  const schedule = parseCronExpression(cron);
+  switch (schedule.frequency) {
+    case 'hourly':
+      return schedule.everyHours === 1 ? 'Every hour' : `Every ${schedule.everyHours} hours`;
+    case 'daily':
+      return `Daily at ${schedule.time}`;
+    case 'weekly':
+      return `${WEEKDAY_LABELS[schedule.dayOfWeek]}s at ${schedule.time}`;
+    case 'monthly':
+      return `Monthly on day ${schedule.dayOfMonth} at ${schedule.time}`;
+    case 'custom':
+      return cron;
+  }
+}


### PR DESCRIPTION
## Summary
- Add automations feature: users can define cron-scheduled automations that dispatch chat messages on a recurring basis
- New backend service/model/schema/endpoint for automations, plus a maintenance job that polls due automations every 60s and runs them
- New frontend Settings tab for creating/editing/managing automations, with cron schedule helpers and React Query hooks
- Add `croniter` dependency for cron parsing

## Test plan
- [ ] Create an automation via Settings > Automations and verify it appears in the list
- [ ] Confirm a due automation dispatches a chat message at its scheduled time
- [ ] Edit and delete an automation from the UI
- [ ] Run the new alembic migration against a fresh DB