### PR TITLE
fix: run resize check immediately after mounting listener

### DIFF
--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -13,6 +13,10 @@ export function useIsMobile(): boolean {
     };
 
     window.addEventListener('resize', handleResize, { passive: true });
+    // Re-check after attaching: a resize between the initial render and this
+    // effect (e.g. Tauri sizing the window during startup) is otherwise missed
+    // forever, leaving the sidebar stuck in mobile overlay mode on desktop.
+    handleResize();
     return () => window.removeEventListener('resize', handleResize);
   });
 


### PR DESCRIPTION
## Summary
- `useIsMobile` only updated its mobile/desktop state on subsequent `resize` events, missing any resize that happened between the initial render and the effect attaching the listener
- This left the sidebar stuck in mobile overlay mode on desktop when the window was resized during startup (e.g. Tauri sizing the window before mount)
- Now calls `handleResize()` immediately after attaching the listener to catch that race