### PR TITLE
feat: add unread indicator for chats with unseen activity

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -401,6 +401,16 @@ async def update_chat(
         ) from e
 
 
+@router.post("/chats/{chat_id}/viewed", status_code=status.HTTP_204_NO_CONTENT)
+async def mark_chat_viewed(
+    chat_id: UUID,
+    _chat: Chat = Depends(ensure_chat_access),
+    chat_service: ChatService = Depends(get_chat_service),
+) -> None:
+    # Stamps the read marker the sidebar's unread indicator is computed from.
+    await chat_service.mark_chat_viewed(chat_id)
+
+
 @router.delete("/chats/all", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_all_chats(
     current_user: User = Depends(get_current_user),

--- a/backend/app/models/db_models/chat.py
+++ b/backend/app/models/db_models/chat.py
@@ -48,6 +48,9 @@ class Chat(Base):
     )
     deleted_at: Mapped[datetime | None] = mapped_column(UTCDateTime(), nullable=True)
     pinned_at: Mapped[datetime | None] = mapped_column(UTCDateTime(), nullable=True)
+    last_viewed_at: Mapped[datetime | None] = mapped_column(
+        UTCDateTime(), nullable=True
+    )
     parent_chat_id: Mapped[UUID | None] = mapped_column(
         GUID(), ForeignKey("chats.id", ondelete="SET NULL"), nullable=True
     )
@@ -75,6 +78,12 @@ class Chat(Base):
         Index("idx_chats_user_id_updated_at_desc", "user_id", "updated_at"),
         Index("idx_chats_parent_chat_id", "parent_chat_id"),
     )
+
+    @property
+    def unread(self) -> bool:
+        # Activity since the user last opened the chat — updated_at advances on
+        # turn initiation, so out-of-band turns (automations, MCP) flag unread.
+        return self.last_viewed_at is None or self.updated_at > self.last_viewed_at
 
     @property
     def sandbox_id(self) -> str:

--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -89,6 +89,7 @@ class Chat(ChatBase):
     parent_chat_id: UUID | None = None
     sub_thread_count: int = 0
     session_agent_kind: str | None = None
+    unread: bool = False
 
 
 class ContextUsage(BaseModel):

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -478,7 +478,13 @@ class ChatService(BaseDbService[Chat]):
                     datetime.now(timezone.utc) if chat_update.pinned else None
                 )
 
-            chat.updated_at = datetime.now(timezone.utc)
+            # Rename/pin isn't new content — carry read state across the
+            # updated_at bump so an already-read chat doesn't flip to unread.
+            was_read = not chat.unread
+            now = datetime.now(timezone.utc)
+            chat.updated_at = now
+            if was_read:
+                chat.last_viewed_at = now
             await db.commit()
 
             return chat
@@ -512,6 +518,20 @@ class ChatService(BaseDbService[Chat]):
                 )
 
             return chat
+
+    async def mark_chat_viewed(self, chat_id: UUID) -> None:
+        # Explicitly keep updated_at in place — the Base onupdate would otherwise
+        # bump it, reordering the sidebar and re-flagging the chat unread.
+        async with self.session_factory() as db:
+            await db.execute(
+                update(Chat)
+                .where(Chat.id == chat_id)
+                .values(
+                    last_viewed_at=datetime.now(timezone.utc),
+                    updated_at=Chat.updated_at,
+                )
+            )
+            await db.commit()
 
     async def count_sub_threads(self, chat_id: UUID, user: User) -> int:
         async with self.session_factory() as db:

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -463,12 +463,16 @@ class ChatStreamRuntime:
         try:
             async with self.session_factory() as db:
                 chat_uuid = UUID(self.chat_id)
+                # Pin updated_at — session bookkeeping isn't unseen activity and
+                # this task is fire-and-forget, so an onupdate bump could land
+                # after the read stamp and falsely re-flag the chat unread.
                 await db.execute(
                     update(Chat)
                     .where(Chat.id == chat_uuid)
                     .values(
                         session_id=new_session_id,
                         session_agent_kind=agent_kind.value,
+                        updated_at=Chat.updated_at,
                     )
                 )
                 await db.commit()
@@ -600,10 +604,16 @@ class ChatStreamRuntime:
 
         try:
             async with self.session_factory() as db:
+                # Pin updated_at — usage accounting isn't unseen activity, and on
+                # local cancel this write lands after the client's read stamp,
+                # so an onupdate bump would falsely re-flag the chat unread.
                 await db.execute(
                     update(Chat)
                     .where(Chat.id == self.chat.id)
-                    .values(context_token_usage=token_usage)
+                    .values(
+                        context_token_usage=token_usage,
+                        updated_at=Chat.updated_at,
+                    )
                 )
                 await db.commit()
 
@@ -638,8 +648,13 @@ class ChatStreamRuntime:
         title = title[:255]
 
         async with self.session_factory() as db:
+            # Pin updated_at — this task races past stream completion, and the
+            # onupdate bump would re-flag a just-watched chat unread; a backfilled
+            # title isn't unseen activity.
             await db.execute(
-                update(Chat).where(Chat.id == self.chat.id).values(title=title)
+                update(Chat)
+                .where(Chat.id == self.chat.id)
+                .values(title=title, updated_at=Chat.updated_at)
             )
             await db.commit()
 

--- a/backend/migrations/versions/f7a8b9c0d1e2_add_chat_last_viewed_at.py
+++ b/backend/migrations/versions/f7a8b9c0d1e2_add_chat_last_viewed_at.py
@@ -1,0 +1,26 @@
+# Revision ID: f7a8b9c0d1e2
+# Revises: e3f4a5b6c7d8
+# Create Date: 2026-07-05 00:00:00.000000
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from app.db.types import UTCDateTime
+
+# revision identifiers, used by Alembic.
+revision: str = "f7a8b9c0d1e2"
+down_revision: str | None = "e3f4a5b6c7d8"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("chats", sa.Column("last_viewed_at", UTCDateTime(), nullable=True))
+    # Backfill so pre-existing chats don't all flash unread after upgrade —
+    # only activity after this feature ships should flag the dot.
+    op.execute("UPDATE chats SET last_viewed_at = updated_at")
+
+
+def downgrade() -> None:
+    op.drop_column("chats", "last_viewed_at")

--- a/frontend/src/components/layout/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/SidebarChatItem.tsx
@@ -89,6 +89,11 @@ export const SidebarChatItem = memo(function SidebarChatItem({
         {isChatStreaming && !isChatBlocked && (
           <div className="h-1.5 w-1.5 flex-shrink-0 animate-pulse rounded-full bg-warning-500" />
         )}
+        {/* Unseen activity (e.g. an automation ran while away). The running pulse
+            takes precedence, and the open chat is being read — no dot for either. */}
+        {!isChatStreaming && !isActive && chat.unread && (
+          <div className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-text-primary dark:bg-text-dark-primary" />
+        )}
         <Button
           onClick={(e) => {
             if (e.shiftKey && onOpenInSplit && !isActive) {

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -18,6 +18,7 @@ import { useMessageQueueStore } from '@/store/messageQueueStore';
 import { useUIStore, type EditorCodeSelection } from '@/store/uiStore';
 import type { Chat, ChatSearchResponse, ContextUsage, CreateChatRequest } from '@/types/chat.types';
 import type { PaginatedChats } from '@/types/api.types';
+import { logger } from '@/utils/logger';
 import { createMutation } from './createMutation';
 import { queryKeys } from './queryKeys';
 
@@ -175,6 +176,41 @@ export async function applyCreatedChat(queryClient: QueryClient, newChat: Chat):
   });
 
   queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
+}
+
+// Optimistically clears the unread flag in every cache the chat appears in,
+// then stamps the server-side read marker. Best-effort fire-and-forget: it
+// never rejects — a failed stamp just resurfaces the dot on the next refetch.
+export async function markChatViewed(queryClient: QueryClient, chatId: string): Promise<void> {
+  queryClient.setQueryData<Chat>(queryKeys.chat(chatId), (prev) =>
+    prev ? { ...prev, unread: false } : prev,
+  );
+
+  queryClient.setQueriesData<InfiniteData<PaginatedChats>>(
+    { queryKey: [queryKeys.chats, 'infinite'] },
+    (oldData) => {
+      if (!oldData) return oldData;
+      return {
+        ...oldData,
+        pages: oldData.pages.map((page) => ({
+          ...page,
+          items: page.items.map((chat) =>
+            chat.id === chatId && chat.unread ? { ...chat, unread: false } : chat,
+          ),
+        })),
+      };
+    },
+  );
+
+  try {
+    await chatService.markChatViewed(chatId);
+  } catch (error) {
+    logger.error('Failed to mark chat viewed', 'markChatViewed', error);
+    return;
+  }
+  // Cloud rows live in a separate query the patch above can't reach — refetch
+  // them only after the VPS stamp landed, or the refetch would restore the dot.
+  invalidateCloudChats(queryClient, chatId);
 }
 
 export const useCreateChatMutation = createMutation<Chat, Error, CreateChatRequest>(

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -5,6 +5,7 @@ import toast from 'react-hot-toast';
 import { StreamContentBuffer, type ContentRenderSnapshot } from '@/utils/stream';
 import { notifyStreamComplete } from '@/utils/notifications';
 import { queryKeys } from '@/hooks/queries/queryKeys';
+import { markChatViewed } from '@/hooks/queries/useChatQueries';
 import { invalidateGitState } from '@/hooks/queries/useSandboxQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
 import type { InfiniteData } from '@tanstack/react-query';
@@ -659,6 +660,13 @@ export function useStreamCallbacks({
 
       if (!isCurrentChat) return;
 
+      // The turn bumped updated_at at initiation and the user watched it finish —
+      // re-stamp the read marker so a later sidebar refetch doesn't flag it unread.
+      // Sub-thread completions routed through this pane weren't being viewed; skip.
+      if (targetChatId && targetChatId === chatId) {
+        void markChatViewed(queryClient, targetChatId);
+      }
+
       setPendingUserMessageId(null);
       setStreamState('idle');
       setCurrentMessageId(null);
@@ -713,13 +721,14 @@ export function useStreamCallbacks({
       }
       clearStreamSession(resolvedStreamId);
 
+      const targetChatId = sessionChatId ?? chatId;
+
       // Mark the assistant message as failed instead of removing it —
       // the user message and assistant message are already persisted in
       // the DB by the time the SSE error event arrives. Mirror the backend's
       // persisted snapshot update here so the live UI matches a refreshed chat.
       if (assistantMessageId) {
         const markFailed = buildFailedMessageUpdate(streamError);
-        const targetChatId = sessionChatId ?? chatId;
         if (targetChatId) {
           updateMessageInCacheForChat(queryClient, targetChatId, assistantMessageId, markFailed);
         }
@@ -731,6 +740,12 @@ export function useStreamCallbacks({
       }
 
       if (!isCurrentChat) return;
+
+      // Same read re-stamp as onComplete — a watched failure is still seen
+      // activity, and the initiation bump would otherwise flag the chat unread.
+      if (targetChatId && targetChatId === chatId) {
+        void markChatViewed(queryClient, targetChatId);
+      }
 
       if (!assistantMessageId) {
         toast.error(getStreamErrorMessage(streamError));

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -18,7 +18,8 @@ import { useChatData } from '@/hooks/useChatData';
 import { useActiveChat } from '@/hooks/useActiveChat';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useMountEffect } from '@/hooks/useMountEffect';
-import { useChatQuery } from '@/hooks/queries/useChatQueries';
+import { useQueryClient } from '@tanstack/react-query';
+import { useChatQuery, markChatViewed } from '@/hooks/queries/useChatQueries';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
 import { useWorkspacesList, useWorkspaceResourcesQuery } from '@/hooks/queries/useWorkspaceQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
@@ -112,6 +113,19 @@ export function ChatPage() {
       useUIStore.getState().openChatInSplit(secondaryChatId);
     }
   }, [chatId, isMobile, secondaryChatId]);
+
+  const queryClient = useQueryClient();
+  // Opening a chat in either pane marks it seen — stamps last_viewed_at
+  // server-side and drops the sidebar unread dot.
+  useEffect(() => {
+    if (chatId) void markChatViewed(queryClient, chatId);
+  }, [chatId, queryClient]);
+  useEffect(() => {
+    // On mobile the split isn't rebuilt, so the secondary chat is off-screen
+    // even though the store still holds its id — don't stamp it as seen.
+    // Returning to desktop re-runs this and stamps as the pane reappears.
+    if (secondaryChatId && !isMobile) void markChatViewed(queryClient, secondaryChatId);
+  }, [secondaryChatId, isMobile, queryClient]);
 
   const { fileStructure, refetchFilesMetadata } = useSandboxFiles(currentChat, chatId);
 

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -322,6 +322,14 @@ async function getSubThreads(chatId: string): Promise<Chat[]> {
   });
 }
 
+async function markChatViewed(chatId: string): Promise<void> {
+  validateId(chatId, 'Chat ID');
+
+  await serviceCall(async () => {
+    await resolveChatClient(chatId).post(`/chat/chats/${chatId}/viewed`);
+  });
+}
+
 async function pinChat(chatId: string): Promise<Chat> {
   validateId(chatId, 'Chat ID');
 
@@ -438,6 +446,7 @@ export const chatService = {
   askAboutCode,
   generateChatTitle,
   restoreMessageCheckpoint,
+  markChatViewed,
   pinChat,
   unpinChat,
   getSubThreads,

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -66,6 +66,7 @@ export interface Chat {
   parent_chat_id: string | null;
   sub_thread_count: number;
   session_agent_kind: AgentKind | null;
+  unread: boolean;
 }
 
 // Wire contract of the per-user chat lifecycle SSE feed (/chat/chats/events),


### PR DESCRIPTION
## Summary
- Add `last_viewed_at` to `Chat`, backfilled from `updated_at` for existing rows so the feature only affects activity going forward
- New `POST /chat/chats/{chat_id}/viewed` endpoint stamps the read marker
- Sidebar shows an unread dot (`chat.unread` = `last_viewed_at` is null or older than `updated_at`) for chats with activity the user hasn't seen — e.g. automations or MCP tool calls running while away
- Frontend stamps the read marker on chat open and on watched stream completion, with an optimistic cache update so the dot clears immediately
- Renames, pins, and other bookkeeping writes (session id, token usage, backfilled titles) explicitly pin `updated_at` so they don't falsely re-flag an already-read chat as unread