### PR TITLE
Merge sidebar caret into icon slot, portal tooltips

### DIFF
--- a/frontend/src/components/layout/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/SidebarChatItem.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { ChevronRight, MoreHorizontal } from 'lucide-react';
+import { ChevronRight, CornerDownRight, MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
@@ -54,27 +54,6 @@ export const SidebarChatItem = memo(function SidebarChatItem({
       onMouseEnter={() => onMouseEnter(chat.id)}
       onMouseLeave={onMouseLeave}
     >
-      {hasSubThreads ? (
-        <Button
-          onClick={() => onToggleSubThreads(chat.id)}
-          aria-expanded={isSubThreadsExpanded}
-          aria-label={`${isSubThreadsExpanded ? 'Collapse' : 'Expand'} ${chat.sub_thread_count} sub-threads`}
-          variant="unstyled"
-          // Leading disclosure caret toggles sub-threads; -m-1/p-1 keeps a large thumb target without shifting the row
-          className="-m-1 flex-shrink-0 p-1 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
-        >
-          <ChevronRight
-            className={cn(
-              'h-3 w-3 transition-transform duration-200',
-              isSubThreadsExpanded && 'rotate-90',
-            )}
-          />
-        </Button>
-      ) : (
-        // Spacer aligns childless-chat titles with rows that show a caret
-        <div className="h-3 w-3 flex-shrink-0" />
-      )}
-
       {/* Wider right padding when blocked reserves room for the "Awaiting approval"
           pill so long titles truncate before reaching it. */}
       <FloatingTooltip
@@ -94,6 +73,33 @@ export const SidebarChatItem = memo(function SidebarChatItem({
         {!isChatStreaming && !isActive && chat.unread && (
           <div className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-text-primary dark:bg-text-dark-primary" />
         )}
+        {/* One leading slot keeps all rows flush with the workspace name: the
+            disclosure caret swaps in for the provider icon on hover/expand. */}
+        {hasSubThreads && (isHovered || isSubThreadsExpanded) ? (
+          <Button
+            onClick={() => onToggleSubThreads(chat.id)}
+            aria-expanded={isSubThreadsExpanded}
+            aria-label={`${isSubThreadsExpanded ? 'Collapse' : 'Expand'} ${chat.sub_thread_count} sub-threads`}
+            variant="unstyled"
+            // -m-1/p-1 keeps a large thumb target without shifting the row
+            className="-m-1 flex-shrink-0 p-1 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+          >
+            <ChevronRight
+              className={cn(
+                'h-3.5 w-3.5 transition-transform duration-200',
+                isSubThreadsExpanded && 'rotate-90',
+              )}
+            />
+          </Button>
+        ) : chat.session_agent_kind ? (
+          <ProviderIcon
+            agentKind={chat.session_agent_kind}
+            className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary"
+          />
+        ) : hasSubThreads ? (
+          // Iconless chats still reserve the slot so the title doesn't shift when the caret swaps in
+          <div className="h-3.5 w-3.5 flex-shrink-0" />
+        ) : null}
         <Button
           onClick={(e) => {
             if (e.shiftKey && onOpenInSplit && !isActive) {
@@ -108,20 +114,12 @@ export const SidebarChatItem = memo(function SidebarChatItem({
           // flex-1 keeps the whole row width as the open-chat hit target, not just the text
           className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-[13px]"
         >
-          {chat.session_agent_kind && (
-            <ProviderIcon
-              agentKind={chat.session_agent_kind}
-              className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary"
-            />
-          )}
           <span className={cn('min-w-0 truncate', isActive && 'font-medium')}>
             {stripMarkdownTitle(chat.title)}
           </span>
-          {/* Quiet sub-thread count — the toggle itself lives in the leading caret */}
-          {hasSubThreads && !isSubThreadsExpanded && (
-            <span className="flex-shrink-0 text-2xs tabular-nums text-text-quaternary dark:text-text-dark-quaternary">
-              {chat.sub_thread_count}
-            </span>
+          {/* Resting hint that sub-threads exist; the caret conveys it on hover/expand */}
+          {hasSubThreads && !isHovered && !isSubThreadsExpanded && (
+            <CornerDownRight className="h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
           )}
         </Button>
       </FloatingTooltip>

--- a/frontend/src/components/ui/FloatingTooltip.tsx
+++ b/frontend/src/components/ui/FloatingTooltip.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '@/utils/cn';
 
 // Matches the native title-attribute hover delay so tooltips don't flash while scanning a list
@@ -15,14 +16,15 @@ interface FloatingTooltipProps {
 // (e.g. the sidebar) don't clip the bubble or add phantom scroll space.
 export function FloatingTooltip({ content, children, className }: FloatingTooltipProps) {
   const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
   const showTimerRef = useRef<number | null>(null);
 
-  const handleMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    showTimerRef.current = window.setTimeout(
-      () => setPosition({ top: rect.bottom + 4, left: rect.left }),
-      SHOW_DELAY_MS,
-    );
+  const handleMouseEnter = () => {
+    showTimerRef.current = window.setTimeout(() => {
+      // Measure at show time, not mouse-enter — the list may scroll during the delay
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (rect) setPosition({ top: rect.bottom + 4, left: rect.left });
+    }, SHOW_DELAY_MS);
   };
 
   const handleMouseLeave = () => {
@@ -32,21 +34,31 @@ export function FloatingTooltip({ content, children, className }: FloatingToolti
   };
 
   return (
-    <div className={className} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+    <div
+      ref={triggerRef}
+      className={className}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
       {children}
-      {position != null && content && (
-        <div
-          role="tooltip"
-          style={{ top: position.top, left: position.left }}
-          className={cn(
-            'pointer-events-none fixed z-50 max-w-[280px] whitespace-pre-line break-words rounded px-2 py-1',
-            'animate-fade-in bg-surface-tertiary text-xs font-medium text-text-primary shadow-lg',
-            'dark:bg-surface-dark-tertiary dark:text-text-dark-primary',
-          )}
-        >
-          {content}
-        </div>
-      )}
+      {/* Portal to body: transformed ancestors (e.g. the sliding sidebar) re-anchor
+          position:fixed, which offset the bubble away from the hovered trigger */}
+      {position != null &&
+        content &&
+        createPortal(
+          <div
+            role="tooltip"
+            style={{ top: position.top, left: position.left }}
+            className={cn(
+              'pointer-events-none fixed z-50 max-w-[280px] whitespace-pre-line break-words rounded px-2 py-1',
+              'animate-fade-in bg-surface-tertiary text-xs font-medium text-text-primary shadow-lg',
+              'dark:bg-surface-dark-tertiary dark:text-text-dark-primary',
+            )}
+          >
+            {content}
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Collapse the sidebar chat row's disclosure caret and provider icon into a single leading slot: the caret swaps in on hover/expand, otherwise the provider icon shows, keeping titles flush with the workspace name.
- Add a quiet corner-arrow hint next to the title for rows with collapsed sub-threads when not hovered.
- Portal `FloatingTooltip` to `document.body` and re-measure the trigger's position at show time instead of mouse-enter, since transformed ancestors (the sliding sidebar) were re-anchoring the fixed-position bubble away from the hovered element.