### PR TITLE
feat: add Done badge for chats that finish unviewed

### DIFF
--- a/frontend/src/components/layout/ChatTabs.tsx
+++ b/frontend/src/components/layout/ChatTabs.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useMatch, useNavigate } from 'react-router-dom';
-import { Plus, X } from 'lucide-react';
+import { AlertCircle, Check, Loader2, Plus, X, type LucideIcon } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
@@ -13,20 +13,20 @@ import { cn } from '@/utils/cn';
 import { stripMarkdownTitle } from '@/utils/format';
 import { isSecondaryTile } from '@/utils/tileHelpers';
 
-type ChatTabStatus = 'blocked' | 'streaming' | 'finished';
+type ChatTabStatus = 'blocked' | 'streaming' | 'completed';
 
 const STATUS_LABELS: Record<ChatTabStatus, string> = {
-  blocked: 'Awaiting approval',
+  blocked: 'Needs you',
   streaming: 'Running',
-  finished: 'Finished',
+  completed: 'Done',
 };
 
-const STATUS_DOT_CLASS: Record<ChatTabStatus, string> = {
-  // Pulsing amber = running (same signal as the sidebar); steady amber = the
-  // agent is paused on an approval; green = a turn finished off-screen.
-  streaming: 'animate-pulse bg-warning-500',
-  blocked: 'bg-warning-500',
-  finished: 'bg-success-500',
+// Same status language as the sidebar, in its icon-only compact form (like
+// sub-thread rows): pulsing amber = needs you, spinner = running, check = done.
+const STATUS_ICON: Record<ChatTabStatus, { Icon: LucideIcon; className: string }> = {
+  blocked: { Icon: AlertCircle, className: 'animate-pulse text-warning-500' },
+  streaming: { Icon: Loader2, className: 'animate-spin text-warning-500' },
+  completed: { Icon: Check, className: 'text-success-600 dark:text-success-400' },
 };
 
 interface ChatTabProps {
@@ -49,6 +49,7 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
   }, [isChatGone, chatId]);
 
   const title = chatQuery.data?.title ? stripMarkdownTitle(chatQuery.data.title) : '…';
+  const statusIcon = status ? STATUS_ICON[status] : null;
 
   return (
     <div
@@ -78,12 +79,10 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
           aria-current={isCurrent ? 'page' : undefined}
           className="flex w-full min-w-0 items-center gap-1.5 text-left text-2xs font-medium"
         >
-          {/* The status dot claims the icon slot while the turn is live; at rest
+          {/* The status icon claims the icon slot while a status is live; at rest
               the chat's provider glyph (Claude, Codex…) matches the sidebar. */}
-          {status ? (
-            <span
-              className={cn('h-1.5 w-1.5 flex-shrink-0 rounded-full', STATUS_DOT_CLASS[status])}
-            />
+          {statusIcon ? (
+            <statusIcon.Icon className={cn('h-3 w-3 flex-shrink-0', statusIcon.className)} />
           ) : (
             chatQuery.data?.session_agent_kind && (
               <ProviderIcon
@@ -124,7 +123,7 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
 
 // Title-bar chat tabs — the working set of open chats (the sidebar stays the
 // full archive). Each tab is also the chat's agent-view tab: clicking the
-// current chat's tab surfaces the agent pane. A live status dot fed by the
+// current chat's tab surfaces the agent pane. A live status icon fed by the
 // global stream and permission stores keeps background chats glanceable.
 export function ChatTabs() {
   const navigate = useNavigate();
@@ -136,12 +135,15 @@ export function ChatTabs() {
   const secondaryChatId = useUIStore((s) => s.secondaryChatId);
   const visibleLayout = useUIStore((s) => s.visibleLayout);
   const activeStreamMetadata = useStreamStore((s) => s.activeStreamMetadata);
+  // Shared with the sidebar: marked by the stream service on successful
+  // completion, cleared by the sidebar when the chat is viewed.
+  const completedChatIds = useStreamStore((s) => s.completedChatIds);
   const pendingRequests = usePermissionStore((s) => s.pendingRequests);
 
   // Chats with a pane on screen: secondary tiles belong to the split chat, all
   // others to the routed chat. Derived from the layout, not secondaryChatId —
   // a split chat hidden behind a full-screen primary view is off screen, so its
-  // tab must drop the active highlight and still earn a finished dot.
+  // tab must drop the active highlight.
   const visibleChatIds = useMemo(() => {
     const ids = new Set<string>();
     for (const tileId of visibleLayout.flat()) {
@@ -156,36 +158,6 @@ export function ChatTabs() {
     [activeStreamMetadata],
   );
   const blockedChatIdSet = useMemo(() => new Set(pendingRequests.keys()), [pendingRequests]);
-
-  // Chats whose stream ended while they weren't on screen — drives the
-  // "finished" dot until the user views the chat again.
-  const [finishedChatIds, setFinishedChatIds] = useState<Set<string>>(new Set());
-  const prevStreamingRef = useRef<Set<string>>(new Set());
-
-  // Detecting the streaming→settled transition needs the previous streaming
-  // set, so it can't be derived inline. Covers every end-of-stream path
-  // (complete/cancelled/error envelopes and the orphan-metadata prune), since
-  // all of them remove the chat's entry from activeStreamMetadata. Chats that
-  // settle while on screen are skipped — the user watched them finish.
-  useEffect(() => {
-    const prev = prevStreamingRef.current;
-    prevStreamingRef.current = streamingChatIdSet;
-    const ended = [...prev].filter((id) => !streamingChatIdSet.has(id) && !visibleChatIds.has(id));
-    if (ended.length > 0) {
-      setFinishedChatIds((prevSet) => new Set([...prevSet, ...ended]));
-    }
-  }, [streamingChatIdSet, visibleChatIds]);
-
-  // Viewing a chat clears its finished dot — render-phase reset keyed on the
-  // on-screen chat ids, per the state-reset-on-prop-change pattern.
-  const seenFinished = [...visibleChatIds].filter((id) => finishedChatIds.has(id));
-  if (seenFinished.length > 0) {
-    setFinishedChatIds((prev) => {
-      const next = new Set(prev);
-      seenFinished.forEach((id) => next.delete(id));
-      return next;
-    });
-  }
 
   const handleSelect = useCallback(
     (chatId: string) => {
@@ -231,8 +203,8 @@ export function ChatTabs() {
           ? 'blocked'
           : streamingChatIdSet.has(chatId)
             ? 'streaming'
-            : finishedChatIds.has(chatId)
-              ? 'finished'
+            : completedChatIds.has(chatId)
+              ? 'completed'
               : null;
         return (
           <ChatTab

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -119,6 +119,8 @@ export function Sidebar({
   const userDisplayName = currentUser?.username || currentUser?.email || '';
   const logoutMutation = useLogout();
   const activeStreamMetadata = useStreamStore((state) => state.activeStreamMetadata);
+  // Chats whose stream finished successfully since last viewed — drives the "Done" badge
+  const completedChatIds = useStreamStore((state) => state.completedChatIds);
   const secondaryChatId = useUIStore((state) => state.secondaryChatId);
   const streamingChatIdSet = useMemo(
     () => new Set(activeStreamMetadata.map((meta) => meta.chatId)),
@@ -209,6 +211,19 @@ export function Sidebar({
       return next;
     });
   }, [selectedChatWorkspaceId, setCollapsedWorkspaces]);
+
+  // Opening a chat (or watching it finish while open) counts as seeing the
+  // completion — clear its Done badge. Covers every open path since both ids
+  // are route/layout-derived, not sidebar-click-derived.
+  useEffect(() => {
+    const store = useStreamStore.getState();
+    if (selectedChatId && completedChatIds.has(selectedChatId)) {
+      store.clearCompleted(selectedChatId);
+    }
+    if (secondaryChatId && completedChatIds.has(secondaryChatId)) {
+      store.clearCompleted(secondaryChatId);
+    }
+  }, [selectedChatId, secondaryChatId, completedChatIds]);
 
   // Auto-expand parent when navigating to a sub-thread from outside the sidebar
   useEffect(() => {
@@ -514,6 +529,7 @@ export function Sidebar({
     dropdownChatId: dropdown?.chat.id ?? null,
     streamingChatIdSet,
     blockedChatIdSet,
+    completedChatIdSet: completedChatIds,
     onToggleCollapse: toggleWorkspaceCollapse,
     onChatSelect: handleChatSelect,
     onOpenInSplit: canOpenInSplit ? handleOpenInSplit : undefined,
@@ -569,6 +585,7 @@ export function Sidebar({
                           isDropdownOpen={dropdown?.chat.id === chat.id}
                           isChatStreaming={streamingChatIdSet.has(chat.id)}
                           isChatBlocked={blockedChatIdSet.has(chat.id)}
+                          isChatCompleted={completedChatIds.has(chat.id)}
                           onSelect={handleChatSelect}
                           onOpenInSplit={canOpenInSplit ? handleOpenInSplit : undefined}
                           onDropdownClick={handleDropdownClick}
@@ -590,6 +607,7 @@ export function Sidebar({
                             onDropdownClick={handleDropdownClick}
                             streamingChatIdSet={streamingChatIdSet}
                             blockedChatIdSet={blockedChatIdSet}
+                            completedChatIdSet={completedChatIds}
                           />
                         )}
                       </div>

--- a/frontend/src/components/layout/SidebarChatGroup.tsx
+++ b/frontend/src/components/layout/SidebarChatGroup.tsx
@@ -32,6 +32,7 @@ interface ChatRowProps {
   dropdownChatId: string | null;
   streamingChatIdSet: Set<string>;
   blockedChatIdSet: Set<string>;
+  completedChatIdSet: Set<string>;
   onChatSelect: (chatId: string) => void;
   onOpenInSplit?: (chatId: string) => void;
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
@@ -56,6 +57,7 @@ function SidebarChatRow({
     dropdownChatId,
     streamingChatIdSet,
     blockedChatIdSet,
+    completedChatIdSet,
     onChatSelect,
     onOpenInSplit,
     onDropdownClick,
@@ -74,6 +76,7 @@ function SidebarChatRow({
         isDropdownOpen={dropdownChatId === chat.id}
         isChatStreaming={streamingChatIdSet.has(chat.id)}
         isChatBlocked={blockedChatIdSet.has(chat.id)}
+        isChatCompleted={completedChatIdSet.has(chat.id)}
         onSelect={onChatSelect}
         onOpenInSplit={onOpenInSplit}
         onDropdownClick={onDropdownClick}
@@ -91,6 +94,7 @@ function SidebarChatRow({
           onDropdownClick={onDropdownClick}
           streamingChatIdSet={streamingChatIdSet}
           blockedChatIdSet={blockedChatIdSet}
+          completedChatIdSet={completedChatIdSet}
         />
       )}
     </div>

--- a/frontend/src/components/layout/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/SidebarChatItem.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { ChevronRight, CornerDownRight, MoreHorizontal } from 'lucide-react';
+import { Check, ChevronRight, CornerDownRight, Loader2, MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
@@ -16,6 +16,7 @@ interface SidebarChatItemProps {
   isDropdownOpen: boolean;
   isChatStreaming: boolean;
   isChatBlocked: boolean;
+  isChatCompleted: boolean;
   onSelect: (chatId: string) => void;
   onOpenInSplit?: (chatId: string) => void;
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
@@ -33,6 +34,7 @@ export const SidebarChatItem = memo(function SidebarChatItem({
   isDropdownOpen,
   isChatStreaming,
   isChatBlocked,
+  isChatCompleted,
   onSelect,
   onOpenInSplit,
   onDropdownClick,
@@ -43,6 +45,9 @@ export const SidebarChatItem = memo(function SidebarChatItem({
 }: SidebarChatItemProps) {
   // onToggleSubThreads is only set when sub_thread_count > 0
   const hasSubThreads = onToggleSubThreads != null;
+  // The open chat is being read — no unread signal for it
+  const isUnread = !isActive && chat.unread;
+  const hasStatusBadge = isChatBlocked || isChatStreaming || isChatCompleted || isUnread;
   return (
     <div
       className={cn(
@@ -54,25 +59,15 @@ export const SidebarChatItem = memo(function SidebarChatItem({
       onMouseEnter={() => onMouseEnter(chat.id)}
       onMouseLeave={onMouseLeave}
     >
-      {/* Wider right padding when blocked reserves room for the "Awaiting approval"
-          pill so long titles truncate before reaching it. */}
+      {/* Wider right padding when a status badge shows reserves room for it so
+          long titles truncate before reaching it. */}
       <FloatingTooltip
         content={onOpenInSplit ? `${chat.title} (Shift-click to open in split)` : chat.title}
         className={cn(
           'flex min-w-0 flex-1 items-center gap-1.5',
-          isChatBlocked ? 'pr-[104px]' : 'pr-10',
+          hasStatusBadge ? 'pr-[76px]' : 'pr-10',
         )}
       >
-        {/* A pending plan/question/permission request blocks the agent; show the
-            approval pill instead of the running pulse. */}
-        {isChatStreaming && !isChatBlocked && (
-          <div className="h-1.5 w-1.5 flex-shrink-0 animate-pulse rounded-full bg-warning-500" />
-        )}
-        {/* Unseen activity (e.g. an automation ran while away). The running pulse
-            takes precedence, and the open chat is being read — no dot for either. */}
-        {!isChatStreaming && !isActive && chat.unread && (
-          <div className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-text-primary dark:bg-text-dark-primary" />
-        )}
         {/* One leading slot keeps all rows flush with the workspace name: the
             disclosure caret swaps in for the provider icon on hover/expand. */}
         {hasSubThreads && (isHovered || isSubThreadsExpanded) ? (
@@ -114,7 +109,7 @@ export const SidebarChatItem = memo(function SidebarChatItem({
           // flex-1 keeps the whole row width as the open-chat hit target, not just the text
           className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-[13px]"
         >
-          <span className={cn('min-w-0 truncate', isActive && 'font-medium')}>
+          <span className={cn('min-w-0 truncate', (isActive || isUnread) && 'font-medium')}>
             {stripMarkdownTitle(chat.title)}
           </span>
           {/* Resting hint that sub-threads exist; the caret conveys it on hover/expand */}
@@ -124,16 +119,39 @@ export const SidebarChatItem = memo(function SidebarChatItem({
         </Button>
       </FloatingTooltip>
 
+      {/* One status badge by precedence: a pending request blocks the agent
+          (loudest, only pulsing element), then the live run, then done-since-
+          last-viewed, then unseen activity. Idle rows fall back to the timestamp. */}
       <span
         className={cn(
-          'absolute right-2 text-[10px] transition-opacity duration-200',
-          isChatBlocked
-            ? 'rounded-md bg-text-primary px-1.5 py-0.5 font-medium text-surface dark:bg-text-dark-primary dark:text-surface-dark'
-            : 'tabular-nums text-text-quaternary dark:text-text-dark-quaternary',
+          'absolute right-2 flex items-center text-[10px] transition-opacity duration-200',
           isHovered || isActive || isDropdownOpen ? 'opacity-0' : 'opacity-100',
         )}
       >
-        {isChatBlocked ? 'Awaiting approval' : getRelativeTime(chat.updated_at)}
+        {isChatBlocked ? (
+          <span className="animate-pulse rounded-md bg-warning-100 px-1.5 py-0.5 font-medium text-warning-600 dark:bg-warning-500/10 dark:text-warning-400">
+            Needs you
+          </span>
+        ) : isChatStreaming ? (
+          // Neutral fill keeps amber exclusive to "action required" — the spinner carries the signal
+          <span className="flex items-center gap-1 rounded-md bg-surface-tertiary px-1.5 py-0.5 font-medium text-text-tertiary dark:bg-surface-dark-tertiary/50 dark:text-text-dark-tertiary">
+            <Loader2 className="h-2.5 w-2.5 animate-spin text-warning-500" />
+            Running
+          </span>
+        ) : isChatCompleted ? (
+          <span className="flex items-center gap-1 rounded-md bg-success-100 px-1.5 py-0.5 font-medium text-success-600 dark:bg-success-500/10 dark:text-success-400">
+            <Check className="h-2.5 w-2.5" />
+            Done
+          </span>
+        ) : isUnread ? (
+          <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 font-medium text-text-primary dark:bg-surface-dark-tertiary/50 dark:text-text-dark-primary">
+            New
+          </span>
+        ) : (
+          <span className="tabular-nums text-text-quaternary dark:text-text-dark-quaternary">
+            {getRelativeTime(chat.updated_at)}
+          </span>
+        )}
       </span>
 
       <Button

--- a/frontend/src/components/layout/SubThreadList.tsx
+++ b/frontend/src/components/layout/SubThreadList.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useCallback } from 'react';
-import { MoreHorizontal } from 'lucide-react';
+import { AlertCircle, Check, Loader2, MoreHorizontal } from 'lucide-react';
 import { useSubThreadsQuery } from '@/hooks/queries/useChatQueries';
 import { Button } from '@/components/ui/primitives/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
@@ -17,6 +17,7 @@ interface SubThreadListProps {
   onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
   streamingChatIdSet: Set<string>;
   blockedChatIdSet: Set<string>;
+  completedChatIdSet: Set<string>;
 }
 
 export const SubThreadList = memo(function SubThreadList({
@@ -27,6 +28,7 @@ export const SubThreadList = memo(function SubThreadList({
   onDropdownClick,
   streamingChatIdSet,
   blockedChatIdSet,
+  completedChatIdSet,
 }: SubThreadListProps) {
   const { data: subThreads, isLoading, isError, refetch } = useSubThreadsQuery(parentChatId);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
@@ -63,6 +65,7 @@ export const SubThreadList = memo(function SubThreadList({
         const isActive = isSelected || thread.id === secondaryChatId;
         const isStreaming = streamingChatIdSet.has(thread.id);
         const isBlocked = blockedChatIdSet.has(thread.id);
+        const isCompleted = completedChatIdSet.has(thread.id);
         const isHovered = hoveredId === thread.id;
 
         return (
@@ -85,16 +88,12 @@ export const SubThreadList = memo(function SubThreadList({
                 type="button"
                 onClick={() => onSelect(thread.id)}
                 className={cn(
-                  'flex w-full min-w-0 items-center gap-2 px-2 py-1.5 transition-colors duration-200',
-                  isBlocked ? 'pr-[104px]' : 'pr-10',
+                  'flex w-full min-w-0 items-center gap-2 px-2 py-1.5 pr-10 transition-colors duration-200',
                   isActive
                     ? 'text-text-primary dark:text-text-dark-primary'
                     : 'text-text-tertiary hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-secondary',
                 )}
               >
-                {isStreaming && !isBlocked && (
-                  <div className="h-[5px] w-[5px] flex-shrink-0 animate-pulse rounded-full bg-warning-500" />
-                )}
                 {thread.session_agent_kind && (
                   <ProviderIcon
                     agentKind={thread.session_agent_kind}
@@ -107,16 +106,25 @@ export const SubThreadList = memo(function SubThreadList({
               </Button>
             </FloatingTooltip>
 
+            {/* Icon-only status — sub-thread rows are too tight for the labeled
+                badges top-level chats use. Same precedence: blocked > running > done. */}
             <span
               className={cn(
-                'absolute right-2 text-[10px] transition-opacity duration-200',
-                isBlocked
-                  ? 'rounded-md bg-text-primary px-1.5 py-0.5 font-medium text-surface dark:bg-text-dark-primary dark:text-surface-dark'
-                  : 'tabular-nums text-text-quaternary dark:text-text-dark-quaternary',
+                'absolute right-2 flex items-center transition-opacity duration-200',
                 isHovered || isActive ? 'opacity-0' : 'opacity-100',
               )}
             >
-              {isBlocked ? 'Awaiting approval' : getRelativeTime(thread.updated_at)}
+              {isBlocked ? (
+                <AlertCircle className="h-3 w-3 animate-pulse text-warning-500" />
+              ) : isStreaming ? (
+                <Loader2 className="h-3 w-3 animate-spin text-warning-500" />
+              ) : isCompleted ? (
+                <Check className="h-3 w-3 text-success-600 dark:text-success-400" />
+              ) : (
+                <span className="text-[10px] tabular-nums text-text-quaternary dark:text-text-dark-quaternary">
+                  {getRelativeTime(thread.updated_at)}
+                </span>
+              )}
             </span>
 
             <Button

--- a/frontend/src/hooks/useGlobalStream.ts
+++ b/frontend/src/hooks/useGlobalStream.ts
@@ -14,10 +14,15 @@ const STREAM_PRUNE_INTERVAL_MS = 5000;
 // attached (user opened/reconnected the sub-thread) while the status request was
 // in flight, and removeStreamMetadata would tear it down. Such streams self-clean
 // via removeStream on completion, so skip them.
-function pruneIfStillOrphan(chatId: string): void {
+function pruneIfStillOrphan(chatId: string, markDone: boolean): void {
   const store = useStreamStore.getState();
   if (!store.getStreamByChat(chatId)) {
     store.removeStreamMetadata(chatId);
+    // Orphan streams have no EventSource, so no complete envelope ever fires —
+    // the confirmed-settled prune is their only Done signal. A failed status
+    // probe is a cleanup guess, not evidence the turn completed, so it doesn't
+    // earn the badge.
+    if (markDone) store.markCompleted(chatId);
   }
 }
 
@@ -51,11 +56,11 @@ export function useGlobalStream(options?: UseGlobalStreamOptions) {
           const status = await chatService.checkChatStatus(streamMeta.chatId);
 
           if (!status?.has_active_task) {
-            pruneIfStillOrphan(streamMeta.chatId);
+            pruneIfStillOrphan(streamMeta.chatId, true);
           }
         } catch (error) {
           logger.error('Stream prune check failed', 'useGlobalStream', error);
-          pruneIfStillOrphan(streamMeta.chatId);
+          pruneIfStillOrphan(streamMeta.chatId, false);
         }
       });
 

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -189,6 +189,10 @@ class StreamService {
       const durationMs =
         typeof parsed.payload?.duration_ms === 'number' ? parsed.payload.duration_ms : null;
       useStreamStore.getState().removeStream(streamId);
+      // Cancelled turns skip the sidebar "Done" badge — only a successful finish earns it
+      if (parsed.kind === 'complete') {
+        useStreamStore.getState().markCompleted(chatId);
+      }
       callbacks?.onComplete?.(parsed.messageId, parsed.streamId, parsed.kind, durationMs);
       return;
     }

--- a/frontend/src/store/streamStore.ts
+++ b/frontend/src/store/streamStore.ts
@@ -6,6 +6,9 @@ interface StreamState {
   activeStreams: Map<string, ActiveStream>;
   streamIdByChatMessage: Map<string, string>;
   activeStreamMetadata: StreamMetadata[];
+  completedChatIds: Set<string>;
+  markCompleted: (chatId: string) => void;
+  clearCompleted: (chatId: string) => void;
   addStream: (stream: ActiveStream) => void;
   removeStream: (streamId: string) => void;
   getStream: (streamId: string) => ActiveStream | undefined;
@@ -69,6 +72,26 @@ export const useStreamStore = create<StreamState>((set, get) => ({
   activeStreams: new Map<string, ActiveStream>(),
   streamIdByChatMessage: new Map<string, string>(),
   activeStreamMetadata: [],
+  // Chats whose stream finished successfully since the user last viewed them —
+  // drives the sidebar "Done" badge until the chat is opened.
+  completedChatIds: new Set<string>(),
+
+  markCompleted: (chatId: string) => {
+    set((state) => {
+      const next = new Set(state.completedChatIds);
+      next.add(chatId);
+      return { completedChatIds: next };
+    });
+  },
+
+  clearCompleted: (chatId: string) => {
+    set((state) => {
+      if (!state.completedChatIds.has(chatId)) return state;
+      const next = new Set(state.completedChatIds);
+      next.delete(chatId);
+      return { completedChatIds: next };
+    });
+  },
 
   addStream: (stream: ActiveStream) => {
     set((state) => {


### PR DESCRIPTION
## Summary
- Track successful stream completions per chat in `streamStore` (`completedChatIds`, `markCompleted`/`clearCompleted`), set on the `complete` envelope (not `cancelled`) and on the confirmed-settled orphan prune path.
- Surface a "Done" badge in the sidebar (top-level rows and sub-threads) and in the title-bar `ChatTabs`, replacing the tab's ad-hoc `finishedChatIds` tracking with the shared store state.
- Badge precedence stays consistent everywhere: blocked (needs you) > streaming (running) > completed (done) > unread > idle timestamp.
- Clearing: opening a chat (primary or secondary/split) clears its Done badge via a `Sidebar` effect; `ChatTabs` reads the same store so it stays in sync without its own tracking.