### PR TITLE
feat: add sidebar chat-list filter menu

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -37,6 +37,9 @@ import { useLogout } from '@/hooks/useLogout';
 import { UserProfileMenu } from './UserProfileMenu';
 import { SidebarResizeHandle } from './SidebarResizeHandle';
 import { SidebarChatRow, type ChatRowProps } from './SidebarChatRow';
+import { SidebarFilterMenu } from './SidebarFilterMenu';
+import { EMPTY_SIDEBAR_FILTERS, countActiveSidebarFilters } from '@/store/sidebarFilters';
+import { isCloudChat } from '@/utils/chatOrigin';
 import { ChatDropdown } from './ChatDropdown';
 import { DROPDOWN_WIDTH, DROPDOWN_HEIGHT, DROPDOWN_MARGIN } from '@/config/constants';
 
@@ -151,6 +154,9 @@ export function Sidebar({
   } | null>(null);
   // Tracks which parent chats have their sub-threads expanded — collapsed by default to keep the sidebar compact
   const [expandedSubThreads, toggleSubThreadExpand, setExpandedSubThreads] = useToggleSet<string>();
+  // Chats merge from two backends, so filters apply client-side over loaded
+  // pages. Lives in the persisted uiStore so reloads keep the narrowed view.
+  const filters = useUIStore((state) => state.sidebarFilters);
 
   const dropdownRef = useRef<HTMLDivElement>(null);
   const workspaceDropdownRef = useRef<HTMLDivElement>(null);
@@ -176,6 +182,38 @@ export function Sidebar({
   } = useSidebarChatLists(workspaces);
 
   const hasAnyContent = pinnedChats.length > 0 || recentChats.length > 0;
+
+  const hasActiveFilters = countActiveSidebarFilters(filters) > 0;
+  // Status filters OR together (any selected badge state matches); source and
+  // workspace AND with them. Cloud-ness comes from chatOrigin (marked at fetch
+  // time, hydrated at module load) — the workspace badge map lags behind the
+  // cloud workspaces query and would misclassify cloud chats as local meanwhile.
+  const chatMatchesFilters = useCallback(
+    (chat: Chat) => {
+      if (filters.workspaceId && chat.workspace_id !== filters.workspaceId) return false;
+      if (filters.agentKind && chat.session_agent_kind !== filters.agentKind) return false;
+      if (filters.source !== 'all' && isCloudChat(chat.id) !== (filters.source === 'cloud')) {
+        return false;
+      }
+      if (filters.statuses.length === 0) return true;
+      return (
+        (filters.statuses.includes('unread') && chat.unread) ||
+        (filters.statuses.includes('running') && streamingChatIdSet.has(chat.id)) ||
+        (filters.statuses.includes('done') && completedChatIds.has(chat.id)) ||
+        (filters.statuses.includes('needs-you') && blockedChatIdSet.has(chat.id))
+      );
+    },
+    [filters, streamingChatIdSet, completedChatIds, blockedChatIdSet],
+  );
+  const visiblePinnedChats = useMemo(
+    () => (hasActiveFilters ? pinnedChats.filter(chatMatchesFilters) : pinnedChats),
+    [hasActiveFilters, pinnedChats, chatMatchesFilters],
+  );
+  const visibleRecentChats = useMemo(
+    () => (hasActiveFilters ? recentChats.filter(chatMatchesFilters) : recentChats),
+    [hasActiveFilters, recentChats, chatMatchesFilters],
+  );
+  const hasVisibleContent = visiblePinnedChats.length > 0 || visibleRecentChats.length > 0;
 
   // Opening a chat (or watching it finish while open) counts as seeing the
   // completion — clear its Done badge. Covers every open path since both ids
@@ -536,7 +574,7 @@ export function Sidebar({
             )
           ) : (
             <div>
-              {pinnedChats.length > 0 && (
+              {visiblePinnedChats.length > 0 && (
                 <div className="mb-1">
                   <div className="pb-2 pt-2.5">
                     <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
@@ -544,27 +582,48 @@ export function Sidebar({
                     </span>
                   </div>
                   <div>
-                    {pinnedChats.map((chat) => (
+                    {visiblePinnedChats.map((chat) => (
                       <SidebarChatRow key={chat.id} chat={chat} rowProps={rowProps} />
                     ))}
                   </div>
                 </div>
               )}
 
-              {recentChats.length > 0 && (
-                <div>
-                  <div className="pb-2 pt-2.5">
-                    <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-                      Recents
-                    </span>
-                  </div>
+              {/* Header always renders — it anchors the filter menu, which must stay
+                  reachable when active filters empty the list */}
+              <div>
+                <div className="flex items-center justify-between pb-2 pt-2.5">
+                  <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                    Recents
+                  </span>
+                  <SidebarFilterMenu
+                    filters={filters}
+                    onChange={(next) => useUIStore.getState().setSidebarFilters(next)}
+                    workspaceBadgeById={workspaceBadgeById}
+                  />
+                </div>
+                {visibleRecentChats.length > 0 ? (
                   <div>
-                    {recentChats.map((chat) => (
+                    {visibleRecentChats.map((chat) => (
                       <SidebarChatRow key={chat.id} chat={chat} rowProps={rowProps} />
                     ))}
                   </div>
-                </div>
-              )}
+                ) : !hasVisibleContent ? (
+                  // Filters only narrow loaded pages — Load more below can still surface matches
+                  <div className="flex flex-col items-center gap-2 py-6">
+                    <p className="text-xs text-text-quaternary dark:text-text-dark-quaternary">
+                      No chats match the current filters
+                    </p>
+                    <Button
+                      variant="unstyled"
+                      onClick={() => useUIStore.getState().setSidebarFilters(EMPTY_SIDEBAR_FILTERS)}
+                      className="text-2xs text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+                    >
+                      Clear filters
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
               {/* Outside the Recents block: when a loaded cloud page holds only pinned
                   chats, Recents is empty but more pages may still exist. */}
               {hasMore && (

--- a/frontend/src/components/layout/SidebarFilterMenu.tsx
+++ b/frontend/src/components/layout/SidebarFilterMenu.tsx
@@ -1,0 +1,454 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { Check, ChevronRight, Cloud, SlidersVertical } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button';
+import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
+import { cn } from '@/utils/cn';
+import {
+  EMPTY_SIDEBAR_FILTERS,
+  countActiveSidebarFilters,
+  type SidebarFilters,
+  type SidebarStatusFilter,
+} from '@/store/sidebarFilters';
+import type { AgentKind } from '@/types/chat.types';
+import type { WorkspaceBadge } from '@/hooks/queries/useSidebarChatLists';
+
+const STATUS_OPTIONS: { value: SidebarStatusFilter; label: string }[] = [
+  { value: 'unread', label: 'Unread' },
+  { value: 'running', label: 'Running' },
+  { value: 'done', label: 'Done' },
+  { value: 'needs-you', label: 'Needs you' },
+];
+
+// Labels match the ModelSelector agent group headers
+const AGENT_OPTIONS: { value: AgentKind; label: string }[] = [
+  { value: 'claude', label: 'Claude' },
+  { value: 'codex', label: 'Codex' },
+  { value: 'copilot', label: 'Copilot' },
+  { value: 'cursor', label: 'Cursor' },
+  { value: 'opencode', label: 'OpenCode' },
+];
+
+const PANEL_WIDTH = 240;
+const SUBMENU_WIDTH = 200;
+// Grace delay lets the pointer cross the gap between a row and its flyout
+// without the flyout closing mid-travel
+const SUBMENU_GRACE_MS = 150;
+
+// Category flyouts: hovering (or clicking, for touch) a root row opens its
+// option list beside the panel.
+type FilterCategory = 'status' | 'agent' | 'source' | 'workspace';
+
+// Category row on the root panel: label left, current value + chevron right.
+// The value reads muted when the filter is off ("All") and emphasized when set.
+function FilterCategoryRow({
+  label,
+  summary,
+  active,
+  expanded,
+  onOpen,
+  onLeave,
+}: {
+  label: string;
+  summary: string;
+  active: boolean;
+  expanded: boolean;
+  onOpen: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onLeave: () => void;
+}) {
+  return (
+    <Button
+      variant="unstyled"
+      onClick={onOpen}
+      onMouseEnter={onOpen}
+      onMouseLeave={onLeave}
+      aria-haspopup="menu"
+      aria-expanded={expanded}
+      className={cn(
+        'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs text-text-primary transition-colors duration-200 hover:bg-surface-hover dark:text-text-dark-primary dark:hover:bg-surface-dark-hover',
+        expanded && 'bg-surface-hover dark:bg-surface-dark-hover',
+      )}
+    >
+      {label}
+      <span className="flex min-w-0 items-center gap-1">
+        <span
+          className={cn(
+            'truncate',
+            active
+              ? 'font-medium text-text-primary dark:text-text-dark-primary'
+              : 'text-text-quaternary dark:text-text-dark-quaternary',
+          )}
+        >
+          {summary}
+        </span>
+        <ChevronRight className="h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+      </span>
+    </Button>
+  );
+}
+
+// Option row in a category flyout: label left, check right when selected.
+function FilterOptionRow({
+  selected,
+  onSelect,
+  children,
+}: {
+  selected: boolean;
+  onSelect: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Button
+      variant="unstyled"
+      onClick={onSelect}
+      className={cn(
+        'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors duration-200 hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+        selected
+          ? 'font-medium text-text-primary dark:text-text-dark-primary'
+          : 'text-text-secondary dark:text-text-dark-secondary',
+      )}
+    >
+      <span className="flex min-w-0 items-center gap-1.5">{children}</span>
+      {selected && <Check className="h-3 w-3 flex-shrink-0" />}
+    </Button>
+  );
+}
+
+interface SidebarFilterMenuProps {
+  filters: SidebarFilters;
+  onChange: (filters: SidebarFilters) => void;
+  workspaceBadgeById: Map<string, WorkspaceBadge>;
+}
+
+export function SidebarFilterMenu({
+  filters,
+  onChange,
+  workspaceBadgeById,
+}: SidebarFilterMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [submenu, setSubmenu] = useState<{
+    view: FilterCategory;
+    top: number;
+    left: number;
+    maxHeight: number;
+  } | null>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const submenuRef = useRef<HTMLDivElement>(null);
+  const closeTimerRef = useRef<number | null>(null);
+  // Fixed positioning keeps the panel out of the scroll container's clipping;
+  // captured on open from the trigger rect, right-aligned to it.
+  const [position, setPosition] = useState({ top: 0, right: 0, maxHeight: 0 });
+  const activeCount = countActiveSidebarFilters(filters);
+
+  const cancelSubmenuClose = () => {
+    if (closeTimerRef.current != null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  };
+
+  const scheduleSubmenuClose = () => {
+    cancelSubmenuClose();
+    closeTimerRef.current = window.setTimeout(() => setSubmenu(null), SUBMENU_GRACE_MS);
+  };
+
+  const closeAll = () => {
+    cancelSubmenuClose();
+    setSubmenu(null);
+    setIsOpen(false);
+  };
+
+  const openSubmenu = (view: FilterCategory, e: React.MouseEvent<HTMLButtonElement>) => {
+    cancelSubmenuClose();
+    const rect = e.currentTarget.getBoundingClientRect();
+    // Flip to the panel's left when the flyout would overflow the viewport
+    const left =
+      rect.right + 10 + SUBMENU_WIDTH <= window.innerWidth
+        ? rect.right + 10
+        : rect.left - SUBMENU_WIDTH - 10;
+    const top = Math.max(8, rect.top - 6);
+    setSubmenu({ view, top, left, maxHeight: window.innerHeight - top - 8 });
+  };
+
+  const handleToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (isOpen) {
+      closeAll();
+      return;
+    }
+    const rect = e.currentTarget.getBoundingClientRect();
+    setPosition({
+      top: rect.bottom + 6,
+      right: Math.max(8, window.innerWidth - Math.max(rect.right, PANEL_WIDTH + 8)),
+      maxHeight: window.innerHeight - rect.bottom - 14,
+    });
+    setIsOpen(true);
+  };
+
+  // The panel and flyout portal to body (out of this subtree), so outside-click
+  // must check all three refs — a single-ref useDropdown would treat every
+  // panel/flyout click as outside and close the menu.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleMouseDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        panelRef.current?.contains(target) ||
+        submenuRef.current?.contains(target)
+      ) {
+        return;
+      }
+      cancelSubmenuClose();
+      setSubmenu(null);
+      setIsOpen(false);
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [isOpen]);
+
+  // Scrolling the chat list detaches the fixed panel from its trigger — close it.
+  // Scrolls inside the panel or flyout (workspace list) keep it open.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleScroll = (e: Event) => {
+      const target = e.target as Node;
+      if (panelRef.current?.contains(target) || submenuRef.current?.contains(target)) return;
+      cancelSubmenuClose();
+      setSubmenu(null);
+      setIsOpen(false);
+    };
+    window.addEventListener('scroll', handleScroll, true);
+    return () => window.removeEventListener('scroll', handleScroll, true);
+  }, [isOpen]);
+
+  // Single-select options close their flyout; the root panel stays open with
+  // the updated summary. Multi-select status stays put for further toggles.
+  const selectAndClose = (patch: Partial<SidebarFilters>) => {
+    onChange({ ...filters, ...patch });
+    setSubmenu(null);
+  };
+
+  const toggleStatus = (status: SidebarStatusFilter) => {
+    const statuses = filters.statuses.includes(status)
+      ? filters.statuses.filter((s) => s !== status)
+      : [...filters.statuses, status];
+    onChange({ ...filters, statuses });
+  };
+
+  // The badge map is the single owner of the local+cloud workspace merge; the
+  // picker just flattens it (insertion order: local first, then cloud).
+  const workspaceOptions = useMemo(
+    () =>
+      Array.from(workspaceBadgeById, ([id, badge]) => ({
+        id,
+        name: badge.name,
+        isCloud: badge.isCloud,
+      })),
+    [workspaceBadgeById],
+  );
+
+  const statusSummary =
+    filters.statuses.length === 0
+      ? 'All'
+      : filters.statuses.length === 1
+        ? (STATUS_OPTIONS.find((o) => o.value === filters.statuses[0])?.label ?? 'All')
+        : `${filters.statuses.length} selected`;
+  const agentSummary = filters.agentKind
+    ? (AGENT_OPTIONS.find((o) => o.value === filters.agentKind)?.label ?? 'All')
+    : 'All';
+  const sourceSummary =
+    filters.source === 'all' ? 'All' : filters.source === 'local' ? 'Local' : 'Cloud';
+  // The name can be briefly unresolved while the cloud workspaces query loads
+  const workspaceSummary = filters.workspaceId
+    ? (workspaceOptions.find((w) => w.id === filters.workspaceId)?.name ?? '1 selected')
+    : 'All';
+
+  return (
+    <div ref={triggerRef} className="flex items-center">
+      <Button
+        variant="unstyled"
+        onClick={handleToggle}
+        aria-label="Filter chats"
+        aria-expanded={isOpen}
+        // -m-1/p-1 keeps a comfortable hit target without inflating the header row
+        className={cn(
+          '-m-1 flex items-center gap-1 rounded-md p-1 transition-colors duration-200 hover:text-text-primary dark:hover:text-text-dark-primary',
+          activeCount > 0 || isOpen
+            ? 'text-text-primary dark:text-text-dark-primary'
+            : 'text-text-quaternary dark:text-text-dark-quaternary',
+        )}
+      >
+        <SlidersVertical className="h-3.5 w-3.5" />
+        {activeCount > 0 && (
+          <span className="text-[10px] font-medium tabular-nums">{activeCount}</span>
+        )}
+      </Button>
+
+      {/* Portal to body: the sliding sidebar's transform re-anchors position:fixed
+          (see FloatingTooltip), which would push the panel off-screen */}
+      {isOpen &&
+        createPortal(
+          <>
+            <div
+              ref={panelRef}
+              onMouseLeave={scheduleSubmenuClose}
+              className="fixed z-50 overflow-y-auto rounded-xl border border-border/50 bg-surface-secondary/95 p-1.5 shadow-medium backdrop-blur-xl dark:border-border-dark/50 dark:bg-surface-dark-secondary/95"
+              style={{
+                top: position.top,
+                right: position.right,
+                maxHeight: position.maxHeight,
+                width: PANEL_WIDTH,
+              }}
+            >
+              <FilterCategoryRow
+                label="Status"
+                summary={statusSummary}
+                active={filters.statuses.length > 0}
+                expanded={submenu?.view === 'status'}
+                onOpen={(e) => openSubmenu('status', e)}
+                onLeave={scheduleSubmenuClose}
+              />
+              <FilterCategoryRow
+                label="Agent"
+                summary={agentSummary}
+                active={filters.agentKind !== null}
+                expanded={submenu?.view === 'agent'}
+                onOpen={(e) => openSubmenu('agent', e)}
+                onLeave={scheduleSubmenuClose}
+              />
+              <FilterCategoryRow
+                label="Source"
+                summary={sourceSummary}
+                active={filters.source !== 'all'}
+                expanded={submenu?.view === 'source'}
+                onOpen={(e) => openSubmenu('source', e)}
+                onLeave={scheduleSubmenuClose}
+              />
+              <FilterCategoryRow
+                label="Workspace"
+                summary={workspaceSummary}
+                active={filters.workspaceId !== null}
+                expanded={submenu?.view === 'workspace'}
+                onOpen={(e) => openSubmenu('workspace', e)}
+                onLeave={scheduleSubmenuClose}
+              />
+              {activeCount > 0 && (
+                <div className="mt-1.5 border-t border-border/50 pt-1.5 dark:border-border-dark/50">
+                  <Button
+                    variant="unstyled"
+                    onClick={() => onChange(EMPTY_SIDEBAR_FILTERS)}
+                    className="w-full rounded-md px-2 py-1.5 text-left text-xs text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
+                  >
+                    Clear all filters
+                  </Button>
+                </div>
+              )}
+            </div>
+
+            {submenu && (
+              <div
+                ref={submenuRef}
+                onMouseEnter={cancelSubmenuClose}
+                onMouseLeave={scheduleSubmenuClose}
+                className="fixed z-50 overflow-y-auto rounded-xl border border-border/50 bg-surface-secondary/95 p-1.5 shadow-medium backdrop-blur-xl dark:border-border-dark/50 dark:bg-surface-dark-secondary/95"
+                style={{
+                  top: submenu.top,
+                  left: submenu.left,
+                  maxHeight: submenu.maxHeight,
+                  width: SUBMENU_WIDTH,
+                }}
+              >
+                {submenu.view === 'status' && (
+                  <>
+                    <FilterOptionRow
+                      selected={filters.statuses.length === 0}
+                      onSelect={() => onChange({ ...filters, statuses: [] })}
+                    >
+                      All
+                    </FilterOptionRow>
+                    {STATUS_OPTIONS.map(({ value, label }) => (
+                      <FilterOptionRow
+                        key={value}
+                        selected={filters.statuses.includes(value)}
+                        onSelect={() => toggleStatus(value)}
+                      >
+                        {label}
+                      </FilterOptionRow>
+                    ))}
+                  </>
+                )}
+
+                {submenu.view === 'agent' && (
+                  <>
+                    <FilterOptionRow
+                      selected={filters.agentKind === null}
+                      onSelect={() => selectAndClose({ agentKind: null })}
+                    >
+                      All
+                    </FilterOptionRow>
+                    {AGENT_OPTIONS.map(({ value, label }) => (
+                      <FilterOptionRow
+                        key={value}
+                        selected={filters.agentKind === value}
+                        onSelect={() => selectAndClose({ agentKind: value })}
+                      >
+                        <ProviderIcon agentKind={value} className="h-3 w-3 flex-shrink-0" />
+                        {label}
+                      </FilterOptionRow>
+                    ))}
+                  </>
+                )}
+
+                {submenu.view === 'source' && (
+                  <>
+                    <FilterOptionRow
+                      selected={filters.source === 'all'}
+                      onSelect={() => selectAndClose({ source: 'all' })}
+                    >
+                      All
+                    </FilterOptionRow>
+                    <FilterOptionRow
+                      selected={filters.source === 'local'}
+                      onSelect={() => selectAndClose({ source: 'local' })}
+                    >
+                      Local
+                    </FilterOptionRow>
+                    <FilterOptionRow
+                      selected={filters.source === 'cloud'}
+                      onSelect={() => selectAndClose({ source: 'cloud' })}
+                    >
+                      <Cloud className="h-3 w-3 flex-shrink-0" />
+                      Cloud
+                    </FilterOptionRow>
+                  </>
+                )}
+
+                {submenu.view === 'workspace' && (
+                  <>
+                    <FilterOptionRow
+                      selected={filters.workspaceId === null}
+                      onSelect={() => selectAndClose({ workspaceId: null })}
+                    >
+                      All
+                    </FilterOptionRow>
+                    {workspaceOptions.map((workspace) => (
+                      <FilterOptionRow
+                        key={workspace.id}
+                        selected={filters.workspaceId === workspace.id}
+                        onSelect={() => selectAndClose({ workspaceId: workspace.id })}
+                      >
+                        {workspace.isCloud && <Cloud className="h-3 w-3 flex-shrink-0" />}
+                        <span className="truncate">{workspace.name}</span>
+                      </FilterOptionRow>
+                    ))}
+                  </>
+                )}
+              </div>
+            )}
+          </>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/frontend/src/store/sidebarFilters.ts
+++ b/frontend/src/store/sidebarFilters.ts
@@ -1,0 +1,36 @@
+import type { AgentKind } from '@/types/chat.types';
+
+// Sidebar chat-list filter model — shared by uiStore (persistence), Sidebar
+// (count/clear), and SidebarFilterMenu (UI), so it lives outside the component.
+
+// Status filters mirror the row badge signals: unread is the persisted server flag;
+// running/done/needs-you are session-only stream state that resets on reload.
+export type SidebarStatusFilter = 'unread' | 'running' | 'done' | 'needs-you';
+export type SidebarSourceFilter = 'all' | 'local' | 'cloud';
+
+// statuses is an array (not a Set) so the whole object survives JSON
+// persistence in uiStore; it's at most 4 entries.
+export interface SidebarFilters {
+  statuses: SidebarStatusFilter[];
+  agentKind: AgentKind | null;
+  source: SidebarSourceFilter;
+  workspaceId: string | null;
+}
+
+// Never mutated — filter changes always build a fresh object, so sharing one
+// instance for the initial and cleared state is safe.
+export const EMPTY_SIDEBAR_FILTERS: SidebarFilters = {
+  statuses: [],
+  agentKind: null,
+  source: 'all',
+  workspaceId: null,
+};
+
+export function countActiveSidebarFilters(filters: SidebarFilters): number {
+  return (
+    filters.statuses.length +
+    (filters.agentKind ? 1 : 0) +
+    (filters.source !== 'all' ? 1 : 0) +
+    (filters.workspaceId ? 1 : 0)
+  );
+}

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -19,6 +19,7 @@ import {
 } from '@/utils/tileHelpers';
 import { clearTerminalStorage } from '@/utils/terminal';
 import type { MenuMode } from '@/components/ui/commandRegistry';
+import { EMPTY_SIDEBAR_FILTERS, type SidebarFilters } from '@/store/sidebarFilters';
 import { THEME_CYCLE } from '@/utils/theme';
 
 export const MIN_SIDEBAR_WIDTH = 220;
@@ -51,6 +52,9 @@ type UIStoreState = ThemeState &
   Pick<UIActions, 'setSidebarOpen' | 'setSidebarWidth'> &
   SplitViewState &
   SplitViewActions & {
+    // Sidebar chat-list filters — persisted so a reload keeps the narrowed view
+    sidebarFilters: SidebarFilters;
+    setSidebarFilters: (filters: SidebarFilters) => void;
     commandMenuOpen: boolean;
     setCommandMenuOpen: (open: boolean) => void;
     // Set by `executeCommand` when a mode-switching command (search, files, branches)
@@ -170,6 +174,8 @@ export const useUIStore = create<UIStoreState>()(
         if (next === get().sidebarWidth) return;
         set({ sidebarWidth: next });
       },
+      sidebarFilters: EMPTY_SIDEBAR_FILTERS,
+      setSidebarFilters: (filters) => set({ sidebarFilters: filters }),
 
       commandMenuOpen: false,
       setCommandMenuOpen: (open) => set({ commandMenuOpen: open }),
@@ -495,6 +501,10 @@ export const useUIStore = create<UIStoreState>()(
         theme: state.theme,
         sidebarOpen: state.sidebarOpen,
         sidebarWidth: state.sidebarWidth,
+        // Status filters read session-only stream state that's empty at mount —
+        // persisting them would rehydrate a view that can't match anything.
+        // Only the durable dimensions (agent/source/workspace) survive reloads.
+        sidebarFilters: { ...state.sidebarFilters, statuses: [] },
         secondaryChatId: state.secondaryChatId,
         // Persist the live workspace so a refresh restores the active view/tabs.
         // currentWorkspaceChatId must rehydrate too: loadWorkspaceForChat


### PR DESCRIPTION
## Summary
- Adds a filter menu to the sidebar Recents header (status, agent, source, workspace) to narrow the flat chat list client-side
- Status filters (unread/running/done/needs-you) OR together; agent/source/workspace AND with them and with each other
- Only durable filter dimensions (agent, source, workspace) persist across reloads — session-only status filters (running/done/needs-you) reset since their backing state is empty at mount
- Empty-result state shows a "Clear filters" action; the Recents header stays visible even when filters empty the list, since it anchors the filter menu