### PR TITLE
feat: add Cmd/Ctrl +/-/0 webview zoom for desktop app

### DIFF
--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "core:window:allow-toggle-maximize",
     "core:window:allow-is-maximized",
     "core:window:allow-start-dragging",
+    "core:webview:allow-set-webview-zoom",
     "store:default",
     "updater:default",
     "process:default",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { useEffect, useState, Suspense, lazy } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
+import { useDesktopZoom } from '@/hooks/useDesktopZoom';
 import { Layout } from '@/components/layout/Layout';
 import { Toaster } from 'react-hot-toast';
 import { useAuthStore } from '@/store/authStore';
@@ -248,6 +249,8 @@ export default function App() {
       console.error('Desktop updater check failed:', error);
     });
   });
+
+  useDesktopZoom();
 
   // Cmd+R / Ctrl+R reloads the webview — Tauri release builds disable this by default
   useMountEffect(() => {

--- a/frontend/src/hooks/useDesktopZoom.ts
+++ b/frontend/src/hooks/useDesktopZoom.ts
@@ -1,0 +1,49 @@
+import { getCurrentWebview } from '@tauri-apps/api/webview';
+import { useMountEffect } from '@/hooks/useMountEffect';
+import { isDesktopApp } from '@/utils/platform';
+
+const ZOOM_STORAGE_KEY = 'desktop-zoom';
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 2;
+const ZOOM_STEP = 0.1;
+
+let currentZoom = 1;
+
+function applyZoom(zoom: number) {
+  // Round to one decimal so repeated ±0.1 steps don't accumulate float drift
+  currentZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Math.round(zoom * 10) / 10));
+  localStorage.setItem(ZOOM_STORAGE_KEY, String(currentZoom));
+  getCurrentWebview()
+    .setZoom(currentZoom)
+    .catch((error) => console.error('Failed to set webview zoom:', error));
+}
+
+export function useDesktopZoom() {
+  // Cmd/Ctrl +/-/0 zoom the webview — Tauri has no built-in zoom shortcuts,
+  // and zoom doesn't survive restarts, so the stored level is reapplied on mount.
+  useMountEffect(() => {
+    if (!isDesktopApp()) return;
+
+    const stored = Number(localStorage.getItem(ZOOM_STORAGE_KEY));
+    if (stored && stored !== 1) applyZoom(stored);
+
+    function handler(e: KeyboardEvent) {
+      const accel = e.metaKey || e.ctrlKey;
+      if (!accel || e.altKey) return;
+      // '+' covers Cmd+Shift+= on US layouts and numpad plus
+      if (e.key === '=' || e.key === '+') {
+        e.preventDefault();
+        applyZoom(currentZoom + ZOOM_STEP);
+      } else if (e.key === '-') {
+        e.preventDefault();
+        applyZoom(currentZoom - ZOOM_STEP);
+      } else if (e.key === '0') {
+        e.preventDefault();
+        applyZoom(1);
+      }
+    }
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a `useDesktopZoom` hook that lets Tauri desktop users zoom the webview with Cmd/Ctrl `+`/`-`/`0`, since Tauri has no built-in zoom shortcuts
- Zoom level is persisted to `localStorage` and reapplied on mount, since it doesn't survive app restarts
- Grants the new `core:webview:allow-set-webview-zoom` capability required by `getCurrentWebview().setZoom()`