### PR TITLE
fix: clamp filter submenu position on narrow viewports

### DIFF
--- a/frontend/src/components/layout/SidebarFilterMenu.tsx
+++ b/frontend/src/components/layout/SidebarFilterMenu.tsx
@@ -162,11 +162,16 @@ export function SidebarFilterMenu({
   const openSubmenu = (view: FilterCategory, e: React.MouseEvent<HTMLButtonElement>) => {
     cancelSubmenuClose();
     const rect = e.currentTarget.getBoundingClientRect();
-    // Flip to the panel's left when the flyout would overflow the viewport
+    // Flip to the panel's left when the flyout would overflow the viewport;
+    // on narrow (mobile) viewports neither side fits, so clamp on-screen —
+    // overlapping the root panel beats rendering off the left edge
     const left =
       rect.right + 10 + SUBMENU_WIDTH <= window.innerWidth
         ? rect.right + 10
-        : rect.left - SUBMENU_WIDTH - 10;
+        : Math.max(
+            8,
+            Math.min(rect.left - SUBMENU_WIDTH - 10, window.innerWidth - SUBMENU_WIDTH - 8),
+          );
     const top = Math.max(8, rect.top - 6);
     setSubmenu({ view, top, left, maxHeight: window.innerHeight - top - 8 });
   };


### PR DESCRIPTION
## Summary
- The sidebar filter submenu flyout picked a side (right or left of the trigger) but never clamped the resulting `left` position to the viewport
- On narrow/mobile viewports, when neither side fully fits, the submenu could render partially or fully off-screen
- Clamp the computed `left` to stay within `[8, window.innerWidth - SUBMENU_WIDTH - 8]`, overlapping the root panel if necessary rather than going off-screen

## Test plan
- [ ] Open the sidebar filter menu on a narrow viewport and confirm the submenu stays fully visible
- [ ] Verify normal desktop-width behavior (right/left flip) is unchanged