### PR TITLE
fix: relabel sidebar unread badge from "New" to "Unread"

### DIFF
--- a/frontend/src/components/layout/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/SidebarChatItem.tsx
@@ -170,7 +170,7 @@ export const SidebarChatItem = memo(function SidebarChatItem({
           </span>
         ) : isUnread ? (
           <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 font-medium text-text-primary dark:bg-surface-dark-tertiary/50 dark:text-text-dark-primary">
-            New
+            Unread
           </span>
         ) : (
           <span className="tabular-nums text-text-quaternary dark:text-text-dark-quaternary">


### PR DESCRIPTION
## Summary
- Renames the sidebar chat item unread badge text from "New" to "Unread" for clarity, since it marks unread chats rather than newly-created ones.