### PR TITLE
fix: show provider icon during a chat's first stream

### DIFF
--- a/frontend/src/components/layout/ChatTabs.tsx
+++ b/frontend/src/components/layout/ChatTabs.tsx
@@ -8,6 +8,7 @@ import { useUIStore } from '@/store/uiStore';
 import { useStreamStore } from '@/store/streamStore';
 import { usePermissionStore } from '@/store/permissionStore';
 import { useChatQuery } from '@/hooks/queries/useChatQueries';
+import { useChatAgentKind } from '@/hooks/useChatAgentKind';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { cn } from '@/utils/cn';
 import { stripMarkdownTitle } from '@/utils/format';
@@ -50,6 +51,7 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
 
   const title = chatQuery.data?.title ? stripMarkdownTitle(chatQuery.data.title) : '…';
   const statusIcon = status ? STATUS_ICON[status] : null;
+  const agentKind = useChatAgentKind(chatId, chatQuery.data?.session_agent_kind);
 
   return (
     <div
@@ -84,12 +86,7 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
           {statusIcon ? (
             <statusIcon.Icon className={cn('h-3 w-3 flex-shrink-0', statusIcon.className)} />
           ) : (
-            chatQuery.data?.session_agent_kind && (
-              <ProviderIcon
-                agentKind={chatQuery.data.session_agent_kind}
-                className="h-3 w-3 flex-shrink-0"
-              />
-            )
+            agentKind && <ProviderIcon agentKind={agentKind} className="h-3 w-3 flex-shrink-0" />
           )}
           <span className="min-w-0 truncate">{title}</span>
         </Button>

--- a/frontend/src/components/layout/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/SidebarChatItem.tsx
@@ -3,6 +3,7 @@ import { Check, ChevronRight, Cloud, CornerDownRight, Loader2, MoreHorizontal } 
 import { Button } from '@/components/ui/primitives/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
+import { useChatAgentKind } from '@/hooks/useChatAgentKind';
 import { cn } from '@/utils/cn';
 import { stripMarkdownTitle } from '@/utils/format';
 import { getRelativeTime } from '@/utils/date';
@@ -53,8 +54,9 @@ export const SidebarChatItem = memo(function SidebarChatItem({
   // The open chat is being read — no unread signal for it
   const isUnread = !isActive && chat.unread;
   const hasStatusBadge = isChatBlocked || isChatStreaming || isChatCompleted || isUnread;
+  const agentKind = useChatAgentKind(chat.id, chat.session_agent_kind);
   // Mirrors the leading-slot render below — the workspace line indents to stay flush with the title
-  const hasLeadingSlot = hasSubThreads || chat.session_agent_kind != null;
+  const hasLeadingSlot = hasSubThreads || agentKind != null;
   return (
     <div
       className={cn(
@@ -91,9 +93,9 @@ export const SidebarChatItem = memo(function SidebarChatItem({
                 )}
               />
             </Button>
-          ) : chat.session_agent_kind ? (
+          ) : agentKind ? (
             <ProviderIcon
-              agentKind={chat.session_agent_kind}
+              agentKind={agentKind}
               className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary"
             />
           ) : hasSubThreads ? (

--- a/frontend/src/components/layout/SubThreadList.tsx
+++ b/frontend/src/components/layout/SubThreadList.tsx
@@ -1,6 +1,7 @@
 import { memo, useState, useCallback } from 'react';
 import { AlertCircle, Check, Loader2, MoreHorizontal } from 'lucide-react';
 import { useSubThreadsQuery } from '@/hooks/queries/useChatQueries';
+import { useChatAgentKind } from '@/hooks/useChatAgentKind';
 import { Button } from '@/components/ui/primitives/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
@@ -8,6 +9,108 @@ import { cn } from '@/utils/cn';
 import { stripMarkdownTitle } from '@/utils/format';
 import { getRelativeTime } from '@/utils/date';
 import type { Chat } from '@/types/chat.types';
+
+interface SubThreadRowProps {
+  thread: Chat;
+  isActive: boolean;
+  isStreaming: boolean;
+  isBlocked: boolean;
+  isCompleted: boolean;
+  isHovered: boolean;
+  onSelect: (chatId: string) => void;
+  onDropdownClick: (e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => void;
+  onMouseEnter: (chatId: string) => void;
+  onMouseLeave: () => void;
+}
+
+const SubThreadRow = memo(function SubThreadRow({
+  thread,
+  isActive,
+  isStreaming,
+  isBlocked,
+  isCompleted,
+  isHovered,
+  onSelect,
+  onDropdownClick,
+  onMouseEnter,
+  onMouseLeave,
+}: SubThreadRowProps) {
+  const agentKind = useChatAgentKind(thread.id, thread.session_agent_kind);
+  return (
+    <div
+      className={cn(
+        'group relative flex items-center rounded-lg transition-colors duration-200',
+        isActive
+          ? 'bg-surface-hover/50 dark:bg-surface-dark-hover/50'
+          : 'hover:bg-surface-hover/50 dark:hover:bg-surface-dark-hover/50',
+      )}
+      onMouseEnter={() => onMouseEnter(thread.id)}
+      onMouseLeave={onMouseLeave}
+    >
+      <div className="absolute -left-[22px] top-1/2 h-px w-[18px] bg-border-secondary dark:bg-border-dark-secondary" />
+
+      <FloatingTooltip content={thread.title} className="flex min-w-0 flex-1">
+        <Button
+          variant="unstyled"
+          type="button"
+          onClick={() => onSelect(thread.id)}
+          className={cn(
+            'flex w-full min-w-0 items-center gap-2 px-2 py-1.5 pr-10 transition-colors duration-200',
+            isActive
+              ? 'text-text-primary dark:text-text-dark-primary'
+              : 'text-text-tertiary hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-secondary',
+          )}
+        >
+          {agentKind && (
+            <ProviderIcon
+              agentKind={agentKind}
+              className="h-3 w-3 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary"
+            />
+          )}
+          <span className={cn('truncate text-xs', isActive && 'font-medium')}>
+            {stripMarkdownTitle(thread.title)}
+          </span>
+        </Button>
+      </FloatingTooltip>
+
+      {/* Icon-only status — sub-thread rows are too tight for the labeled
+          badges top-level chats use. Same precedence: blocked > running > done. */}
+      <span
+        className={cn(
+          'absolute right-2 flex items-center transition-opacity duration-200',
+          isHovered || isActive ? 'opacity-0' : 'opacity-100',
+        )}
+      >
+        {isBlocked ? (
+          <AlertCircle className="h-3 w-3 animate-pulse text-warning-500" />
+        ) : isStreaming ? (
+          <Loader2 className="h-3 w-3 animate-spin text-warning-500" />
+        ) : isCompleted ? (
+          <Check className="h-3 w-3 text-success-600 dark:text-success-400" />
+        ) : (
+          <span className="text-[10px] tabular-nums text-text-quaternary dark:text-text-dark-quaternary">
+            {getRelativeTime(thread.updated_at)}
+          </span>
+        )}
+      </span>
+
+      <Button
+        onClick={(e) => onDropdownClick(e, thread)}
+        onMouseDown={(e) => e.stopPropagation()}
+        variant="unstyled"
+        className={cn(
+          'absolute right-2 flex-shrink-0 rounded-md p-0.5 transition-all duration-200',
+          'text-text-quaternary dark:text-text-dark-quaternary',
+          'hover:text-text-primary dark:hover:text-text-dark-primary',
+          isHovered || isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+        )}
+        aria-label="Sub-thread options"
+      >
+        <MoreHorizontal className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+});
 
 interface SubThreadListProps {
   parentChatId: string;
@@ -60,90 +163,21 @@ export const SubThreadList = memo(function SubThreadList({
     <div className="relative ml-[11px] mt-0.5 pl-[22px]">
       <div className="absolute bottom-[14px] left-0 top-0 w-px bg-border-secondary dark:bg-border-dark-secondary" />
 
-      {subThreads.map((thread) => {
-        const isSelected = thread.id === selectedChatId;
-        const isActive = isSelected || thread.id === secondaryChatId;
-        const isStreaming = streamingChatIdSet.has(thread.id);
-        const isBlocked = blockedChatIdSet.has(thread.id);
-        const isCompleted = completedChatIdSet.has(thread.id);
-        const isHovered = hoveredId === thread.id;
-
-        return (
-          <div
-            key={thread.id}
-            className={cn(
-              'group relative flex items-center rounded-lg transition-colors duration-200',
-              isActive
-                ? 'bg-surface-hover/50 dark:bg-surface-dark-hover/50'
-                : 'hover:bg-surface-hover/50 dark:hover:bg-surface-dark-hover/50',
-            )}
-            onMouseEnter={() => handleMouseEnter(thread.id)}
-            onMouseLeave={handleMouseLeave}
-          >
-            <div className="absolute -left-[22px] top-1/2 h-px w-[18px] bg-border-secondary dark:bg-border-dark-secondary" />
-
-            <FloatingTooltip content={thread.title} className="flex min-w-0 flex-1">
-              <Button
-                variant="unstyled"
-                type="button"
-                onClick={() => onSelect(thread.id)}
-                className={cn(
-                  'flex w-full min-w-0 items-center gap-2 px-2 py-1.5 pr-10 transition-colors duration-200',
-                  isActive
-                    ? 'text-text-primary dark:text-text-dark-primary'
-                    : 'text-text-tertiary hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-secondary',
-                )}
-              >
-                {thread.session_agent_kind && (
-                  <ProviderIcon
-                    agentKind={thread.session_agent_kind}
-                    className="h-3 w-3 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary"
-                  />
-                )}
-                <span className={cn('truncate text-xs', isActive && 'font-medium')}>
-                  {stripMarkdownTitle(thread.title)}
-                </span>
-              </Button>
-            </FloatingTooltip>
-
-            {/* Icon-only status — sub-thread rows are too tight for the labeled
-                badges top-level chats use. Same precedence: blocked > running > done. */}
-            <span
-              className={cn(
-                'absolute right-2 flex items-center transition-opacity duration-200',
-                isHovered || isActive ? 'opacity-0' : 'opacity-100',
-              )}
-            >
-              {isBlocked ? (
-                <AlertCircle className="h-3 w-3 animate-pulse text-warning-500" />
-              ) : isStreaming ? (
-                <Loader2 className="h-3 w-3 animate-spin text-warning-500" />
-              ) : isCompleted ? (
-                <Check className="h-3 w-3 text-success-600 dark:text-success-400" />
-              ) : (
-                <span className="text-[10px] tabular-nums text-text-quaternary dark:text-text-dark-quaternary">
-                  {getRelativeTime(thread.updated_at)}
-                </span>
-              )}
-            </span>
-
-            <Button
-              onClick={(e) => onDropdownClick(e, thread)}
-              onMouseDown={(e) => e.stopPropagation()}
-              variant="unstyled"
-              className={cn(
-                'absolute right-2 flex-shrink-0 rounded-md p-0.5 transition-all duration-200',
-                'text-text-quaternary dark:text-text-dark-quaternary',
-                'hover:text-text-primary dark:hover:text-text-dark-primary',
-                isHovered || isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
-              )}
-              aria-label="Sub-thread options"
-            >
-              <MoreHorizontal className="h-3 w-3" />
-            </Button>
-          </div>
-        );
-      })}
+      {subThreads.map((thread) => (
+        <SubThreadRow
+          key={thread.id}
+          thread={thread}
+          isActive={thread.id === selectedChatId || thread.id === secondaryChatId}
+          isStreaming={streamingChatIdSet.has(thread.id)}
+          isBlocked={blockedChatIdSet.has(thread.id)}
+          isCompleted={completedChatIdSet.has(thread.id)}
+          isHovered={hoveredId === thread.id}
+          onSelect={onSelect}
+          onDropdownClick={onDropdownClick}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        />
+      ))}
     </div>
   );
 });

--- a/frontend/src/hooks/useChatAgentKind.ts
+++ b/frontend/src/hooks/useChatAgentKind.ts
@@ -1,0 +1,14 @@
+import { useModelStore } from '@/store/modelStore';
+import { getAgentKindForModelId, type AgentKind } from '@/types/chat.types';
+
+export function useChatAgentKind(
+  chatId: string,
+  sessionAgentKind: AgentKind | null | undefined,
+): AgentKind | null {
+  // session_agent_kind is only persisted server-side mid-stream and refetched after
+  // completion — until then, derive the kind from the locally selected model so the
+  // provider glyph shows during a chat's first stream. No stored model means the kind
+  // is genuinely unknown (e.g. pre-existing chat from another device) — show no icon.
+  const storedModelId = useModelStore((s) => s.modelByChat[chatId]);
+  return sessionAgentKind ?? (storedModelId ? getAgentKindForModelId(storedModelId) : null);
+}


### PR DESCRIPTION
## Summary
- `session_agent_kind` is only persisted server-side mid-stream and refetched after completion, so the provider icon (in tabs, sidebar, and sub-thread rows) stayed blank until a chat's first response finished.
- Added `useChatAgentKind` hook that falls back to the locally selected model (from `modelStore`) to derive the agent kind when `session_agent_kind` isn't yet available, so the icon shows immediately during the first stream.
- Extracted `SubThreadRow` out of `SubThreadList` so the new hook can be called per-row without violating rules of hooks inside `.map()`.