### PR TITLE
feat: add sidebar chat grouping by workspace or status

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -38,10 +38,24 @@ import { UserProfileMenu } from './UserProfileMenu';
 import { SidebarResizeHandle } from './SidebarResizeHandle';
 import { SidebarChatRow, type ChatRowProps } from './SidebarChatRow';
 import { SidebarFilterMenu } from './SidebarFilterMenu';
-import { EMPTY_SIDEBAR_FILTERS, countActiveSidebarFilters } from '@/store/sidebarFilters';
+import {
+  clearSidebarFilters,
+  countActiveSidebarFilters,
+  type SidebarStatusFilter,
+} from '@/store/sidebarFilters';
 import { isCloudChat } from '@/utils/chatOrigin';
 import { ChatDropdown } from './ChatDropdown';
 import { DROPDOWN_WIDTH, DROPDOWN_HEIGHT, DROPDOWN_MARGIN } from '@/config/constants';
+
+// Group order mirrors the row badge precedence in SidebarChatItem, so a chat
+// lands in the group matching its visible badge; most urgent groups first.
+const STATUS_GROUP_ORDER: { key: SidebarStatusFilter | 'other'; label: string }[] = [
+  { key: 'needs-you', label: 'Needs you' },
+  { key: 'running', label: 'Running' },
+  { key: 'done', label: 'Done' },
+  { key: 'unread', label: 'Unread' },
+  { key: 'other', label: 'Other' },
+];
 
 async function mutateWithToast<T>(
   mutateFn: () => Promise<T>,
@@ -214,6 +228,60 @@ export function Sidebar({
     [hasActiveFilters, recentChats, chatMatchesFilters],
   );
   const hasVisibleContent = visiblePinnedChats.length > 0 || visibleRecentChats.length > 0;
+
+  const groupBy = filters.groupBy;
+  // Always a sections list so the JSX renders one shape — ungrouped is a single
+  // headerless section. Groups keep the flat list's recency order: workspace
+  // groups appear in order of their most recent chat; status groups follow
+  // badge urgency. Pinned stays flat — it's a small, user-curated list.
+  const recentChatSections = useMemo(() => {
+    if (groupBy === 'workspace') {
+      const groups = new Map<string, { key: string; label: string | null; chats: Chat[] }>();
+      for (const chat of visibleRecentChats) {
+        let group = groups.get(chat.workspace_id);
+        if (!group) {
+          group = {
+            key: chat.workspace_id,
+            // Briefly unresolved while the cloud workspaces query loads
+            label: workspaceBadgeById.get(chat.workspace_id)?.name ?? 'Unknown workspace',
+            chats: [],
+          };
+          groups.set(chat.workspace_id, group);
+        }
+        group.chats.push(chat);
+      }
+      return Array.from(groups.values());
+    }
+    if (groupBy === 'status') {
+      const byStatus = new Map<SidebarStatusFilter | 'other', Chat[]>();
+      for (const chat of visibleRecentChats) {
+        const status = blockedChatIdSet.has(chat.id)
+          ? 'needs-you'
+          : streamingChatIdSet.has(chat.id)
+            ? 'running'
+            : completedChatIds.has(chat.id)
+              ? 'done'
+              : chat.unread
+                ? 'unread'
+                : 'other';
+        const list = byStatus.get(status);
+        if (list) list.push(chat);
+        else byStatus.set(status, [chat]);
+      }
+      return STATUS_GROUP_ORDER.flatMap(({ key, label }) => {
+        const chats = byStatus.get(key);
+        return chats ? [{ key, label, chats }] : [];
+      });
+    }
+    return [{ key: 'all', label: null, chats: visibleRecentChats }];
+  }, [
+    groupBy,
+    visibleRecentChats,
+    workspaceBadgeById,
+    blockedChatIdSet,
+    streamingChatIdSet,
+    completedChatIds,
+  ]);
 
   // Opening a chat (or watching it finish while open) counts as seeing the
   // completion — clear its Done badge. Covers every open path since both ids
@@ -604,8 +672,17 @@ export function Sidebar({
                 </div>
                 {visibleRecentChats.length > 0 ? (
                   <div>
-                    {visibleRecentChats.map((chat) => (
-                      <SidebarChatRow key={chat.id} chat={chat} rowProps={rowProps} />
+                    {recentChatSections.map((section) => (
+                      <div key={section.key} className={section.label ? 'mb-1' : undefined}>
+                        {section.label && (
+                          <div className="truncate pb-1 pt-1.5 text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                            {section.label}
+                          </div>
+                        )}
+                        {section.chats.map((chat) => (
+                          <SidebarChatRow key={chat.id} chat={chat} rowProps={rowProps} />
+                        ))}
+                      </div>
                     ))}
                   </div>
                 ) : !hasVisibleContent ? (
@@ -616,7 +693,9 @@ export function Sidebar({
                     </p>
                     <Button
                       variant="unstyled"
-                      onClick={() => useUIStore.getState().setSidebarFilters(EMPTY_SIDEBAR_FILTERS)}
+                      onClick={() =>
+                        useUIStore.getState().setSidebarFilters(clearSidebarFilters(filters))
+                      }
                       className="text-2xs text-text-tertiary transition-colors duration-200 hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
                     >
                       Clear filters

--- a/frontend/src/components/layout/SidebarFilterMenu.tsx
+++ b/frontend/src/components/layout/SidebarFilterMenu.tsx
@@ -5,9 +5,10 @@ import { Button } from '@/components/ui/primitives/Button';
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
 import { cn } from '@/utils/cn';
 import {
-  EMPTY_SIDEBAR_FILTERS,
+  clearSidebarFilters,
   countActiveSidebarFilters,
   type SidebarFilters,
+  type SidebarGroupBy,
   type SidebarStatusFilter,
 } from '@/store/sidebarFilters';
 import type { AgentKind } from '@/types/chat.types';
@@ -29,6 +30,12 @@ const AGENT_OPTIONS: { value: AgentKind; label: string }[] = [
   { value: 'opencode', label: 'OpenCode' },
 ];
 
+const GROUP_BY_OPTIONS: { value: SidebarGroupBy; label: string }[] = [
+  { value: 'none', label: 'None' },
+  { value: 'workspace', label: 'Workspace' },
+  { value: 'status', label: 'Status' },
+];
+
 const PANEL_WIDTH = 240;
 const SUBMENU_WIDTH = 200;
 // Grace delay lets the pointer cross the gap between a row and its flyout
@@ -37,7 +44,7 @@ const SUBMENU_GRACE_MS = 150;
 
 // Category flyouts: hovering (or clicking, for touch) a root row opens its
 // option list beside the panel.
-type FilterCategory = 'status' | 'agent' | 'source' | 'workspace';
+type FilterCategory = 'status' | 'agent' | 'source' | 'workspace' | 'groupBy';
 
 // Category row on the root panel: label left, current value + chevron right.
 // The value reads muted when the filter is off ("All") and emphasized when set.
@@ -268,6 +275,7 @@ export function SidebarFilterMenu({
   const workspaceSummary = filters.workspaceId
     ? (workspaceOptions.find((w) => w.id === filters.workspaceId)?.name ?? '1 selected')
     : 'All';
+  const groupBySummary = GROUP_BY_OPTIONS.find((o) => o.value === filters.groupBy)?.label ?? 'None';
 
   return (
     <div ref={triggerRef} className="flex items-center">
@@ -338,11 +346,23 @@ export function SidebarFilterMenu({
                 onOpen={(e) => openSubmenu('workspace', e)}
                 onLeave={scheduleSubmenuClose}
               />
+              {/* Divider sets grouping apart from the rows above — it changes
+                  presentation, not which chats show */}
+              <div className="mt-1.5 border-t border-border/50 pt-1.5 dark:border-border-dark/50">
+                <FilterCategoryRow
+                  label="Group by"
+                  summary={groupBySummary}
+                  active={filters.groupBy !== 'none'}
+                  expanded={submenu?.view === 'groupBy'}
+                  onOpen={(e) => openSubmenu('groupBy', e)}
+                  onLeave={scheduleSubmenuClose}
+                />
+              </div>
               {activeCount > 0 && (
                 <div className="mt-1.5 border-t border-border/50 pt-1.5 dark:border-border-dark/50">
                   <Button
                     variant="unstyled"
-                    onClick={() => onChange(EMPTY_SIDEBAR_FILTERS)}
+                    onClick={() => onChange(clearSidebarFilters(filters))}
                     className="w-full rounded-md px-2 py-1.5 text-left text-xs text-text-tertiary transition-colors duration-200 hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary"
                   >
                     Clear all filters
@@ -428,6 +448,17 @@ export function SidebarFilterMenu({
                     </FilterOptionRow>
                   </>
                 )}
+
+                {submenu.view === 'groupBy' &&
+                  GROUP_BY_OPTIONS.map(({ value, label }) => (
+                    <FilterOptionRow
+                      key={value}
+                      selected={filters.groupBy === value}
+                      onSelect={() => selectAndClose({ groupBy: value })}
+                    >
+                      {label}
+                    </FilterOptionRow>
+                  ))}
 
                 {submenu.view === 'workspace' && (
                   <>

--- a/frontend/src/store/sidebarFilters.ts
+++ b/frontend/src/store/sidebarFilters.ts
@@ -7,6 +7,7 @@ import type { AgentKind } from '@/types/chat.types';
 // running/done/needs-you are session-only stream state that resets on reload.
 export type SidebarStatusFilter = 'unread' | 'running' | 'done' | 'needs-you';
 export type SidebarSourceFilter = 'all' | 'local' | 'cloud';
+export type SidebarGroupBy = 'none' | 'workspace' | 'status';
 
 // statuses is an array (not a Set) so the whole object survives JSON
 // persistence in uiStore; it's at most 4 entries.
@@ -15,6 +16,9 @@ export interface SidebarFilters {
   agentKind: AgentKind | null;
   source: SidebarSourceFilter;
   workspaceId: string | null;
+  // Presentation mode, not a filter — excluded from countActiveSidebarFilters
+  // and preserved when filters are cleared.
+  groupBy: SidebarGroupBy;
 }
 
 // Never mutated — filter changes always build a fresh object, so sharing one
@@ -24,7 +28,14 @@ export const EMPTY_SIDEBAR_FILTERS: SidebarFilters = {
   agentKind: null,
   source: 'all',
   workspaceId: null,
+  groupBy: 'none',
 };
+
+// Clearing resets the filter dimensions but keeps presentation (groupBy) —
+// the same filter/presentation split countActiveSidebarFilters encodes.
+export function clearSidebarFilters(filters: SidebarFilters): SidebarFilters {
+  return { ...EMPTY_SIDEBAR_FILTERS, groupBy: filters.groupBy };
+}
 
 export function countActiveSidebarFilters(filters: SidebarFilters): number {
   return (

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -518,6 +518,16 @@ export const useUIStore = create<UIStoreState>()(
         editorByChat: state.editorByChat,
         chatTabs: state.chatTabs,
       }),
+      // Backfill filter fields added after a user first persisted state (e.g.
+      // groupBy) — the default shallow merge would rehydrate them as undefined.
+      merge: (persisted, current) => {
+        const stored = persisted as Partial<UIStoreState> | undefined;
+        return {
+          ...current,
+          ...stored,
+          sidebarFilters: { ...EMPTY_SIDEBAR_FILTERS, ...stored?.sidebarFilters },
+        };
+      },
     },
   ),
 );


### PR DESCRIPTION
## Summary
- Adds a "Group by" option (None / Workspace / Status) to the sidebar filter menu, letting users organize the recent chats list into labeled sections instead of one flat feed
- Workspace groups follow the flat list's recency order; status groups follow badge urgency (Needs you → Running → Done → Unread → Other)
- `groupBy` is treated as presentation state, not a filter — excluded from the active filter count and preserved when filters are cleared
- Adds a `merge` function to the persisted UI store so new `sidebarFilters` fields (like `groupBy`) backfill correctly for users with existing persisted state