### PR TITLE
fix: disable tmux mouse mode in sandbox terminals

### DIFF
--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -395,7 +395,7 @@ class LocalDockerProvider(SandboxProvider):
         cmd = [
             "bash",
             "-c",
-            f"command -v tmux >/dev/null && tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off \\; set -g mouse on || exec bash",
+            f"command -v tmux >/dev/null && tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off \\; set -g mouse off || exec bash",
         ]
 
         exec_obj = await container.exec(

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -234,7 +234,7 @@ class LocalHostProvider(SandboxProvider):
         shell = env.get("SHELL", "/bin/bash")
         cmd = (
             "command -v tmux >/dev/null && "
-            f"tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off \\; set -g mouse on || exec {shlex.quote(shell)}"
+            f"tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off \\; set -g mouse off || exec {shlex.quote(shell)}"
         )
         process = await asyncio.to_thread(
             subprocess.Popen,


### PR DESCRIPTION
## Summary
- Disable tmux mouse mode (`set -g mouse off`) in both the Docker and host sandbox terminal providers
- Mouse mode intercepts scroll/click events inside tmux, breaking normal terminal text selection and scrollback for users attaching to the sandbox terminal