### PR TITLE
feat: spawn worktree chat terminals inside their worktree

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -151,6 +151,7 @@ async def send_message(
             "message_id": result["message_id"],
             "last_seq": result["last_seq"],
             "checkpoint_id": result["checkpoint_id"],
+            "worktree_cwd": result["worktree_cwd"],
         }
     except ChatException as e:
         raise HTTPException(

--- a/backend/app/api/endpoints/websocket.py
+++ b/backend/app/api/endpoints/websocket.py
@@ -11,6 +11,7 @@ from app.constants import (
     DEFAULT_PTY_ROWS,
     DEFAULT_TERMINAL_ID,
     WS_CLOSE_AUTH_FAILED,
+    WS_CLOSE_INVALID_CWD,
     WS_MSG_CLOSE,
     WS_MSG_DETACH,
     WS_MSG_INIT,
@@ -23,6 +24,7 @@ from app.core.security import (
 )
 from app.services.terminal import terminal_session_registry
 from app.utils.parsing import parse_pty_dimension
+from app.utils.sandbox import normalize_relative_path
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -50,11 +52,21 @@ async def terminal_websocket(
         return
     provider_type, workspace_path = access
 
+    # Workspace-relative start dir for the shell — a worktree-backed chat
+    # passes its worktree_cwd so the terminal lands in the worktree, not the
+    # shared workspace root.
+    try:
+        cwd = normalize_relative_path(websocket.query_params.get("cwd"))
+    except ValueError:
+        await websocket.close(code=WS_CLOSE_INVALID_CWD, reason="Invalid terminal cwd")
+        return
+
     terminal_id = websocket.query_params.get("terminalId") or DEFAULT_TERMINAL_ID
     session = await terminal_session_registry.get_or_create(
         user_id=str(user.id),
         sandbox_id=sandbox_id,
         terminal_id=terminal_id,
+        cwd=cwd,
         provider_type=provider_type,
         workspace_path=workspace_path,
     )

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -118,6 +118,7 @@ WS_MSG_DETACH: Final[str] = "detach"
 
 WS_CLOSE_AUTH_FAILED: Final[int] = 4001
 WS_CLOSE_SANDBOX_NOT_FOUND: Final[int] = 4004
+WS_CLOSE_INVALID_CWD: Final[int] = 4005
 
 TERMINAL_TYPE: Final[str] = "xterm-256color"
 DEFAULT_PTY_ROWS: Final[int] = 24

--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -103,6 +103,9 @@ class ChatCompletionResponse(BaseModel):
     message_id: UUID
     last_seq: int = 0
     checkpoint_id: UUID | None = None
+    # Set when this turn bound the chat to a worktree — lets the client update
+    # branch/terminal UI immediately instead of waiting for the stream config event.
+    worktree_cwd: str | None = None
 
 
 class EnhancePromptResponse(BaseModel):

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -58,6 +58,7 @@ class ChatCompletionResult(TypedDict):
     chat_id: str
     last_seq: int
     checkpoint_id: str | None
+    worktree_cwd: str | None
 
 
 class YamlMetadata(TypedDict, total=False):

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -1252,6 +1252,10 @@ class ChatService(BaseDbService[Chat]):
             "chat_id": str(chat_id),
             "last_seq": chat.last_event_seq,
             "checkpoint_id": str(checkpoint_id) if checkpoint_id else None,
+            # Checkpoint creation resolves the turn's cwd, so a worktree
+            # requested this turn already exists here — surface it now instead
+            # of making the client wait for the stream config event.
+            "worktree_cwd": chat.worktree_cwd,
         }
 
     async def _enqueue_chat_task(

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -106,6 +106,7 @@ class SandboxService:
         rows: int,
         cols: int,
         tmux_session: str,
+        cwd: str,
         on_data: PtyDataCallbackType,
     ) -> str:
         return await self.provider.create_pty(
@@ -113,6 +114,7 @@ class SandboxService:
             rows,
             cols,
             tmux_session,
+            cwd,
             on_data=on_data,
         )
 

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -126,9 +126,11 @@ class SandboxProvider:
         rows: int,
         cols: int,
         tmux_session: str,
+        cwd: str,
         on_data: PtyDataCallbackType,
     ) -> str:
-        # Returns the new PTY session id.
+        # Returns the new PTY session id. `cwd` is workspace-relative; ""
+        # means the provider's default start dir.
         raise NotImplementedError
 
     async def send_pty_input(

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -384,6 +384,7 @@ class LocalDockerProvider(SandboxProvider):
         rows: int,
         cols: int,
         tmux_session: str,
+        cwd: str,
         on_data: PtyDataCallbackType,
     ) -> str:
         # Spawn a PTY-attached shell inside the container via docker exec.
@@ -398,12 +399,15 @@ class LocalDockerProvider(SandboxProvider):
             f"command -v tmux >/dev/null && tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off \\; set -g mouse off || exec bash",
         ]
 
+        # Root terminals keep $HOME as the start dir (dotfiles, existing
+        # behavior); worktree terminals must start inside the worktree.
+        workdir = self.resolve_workspace_path(cwd) if cwd else self.config.user_home
         exec_obj = await container.exec(
             cmd=cmd,
             stdin=True,
             tty=True,
             environment={"TERM": TERMINAL_TYPE},
-            workdir=self.config.user_home,
+            workdir=workdir,
         )
         stream = exec_obj.start()
         # aiodocker creates the stream lazily — _init() opens the actual

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -210,9 +210,11 @@ class LocalHostProvider(SandboxProvider):
         rows: int,
         cols: int,
         tmux_session: str,
+        cwd: str,
         on_data: PtyDataCallbackType,
     ) -> str:
-        # Spawn a PTY-attached shell in the workspace directory. Tries tmux
+        # Spawn a PTY-attached shell in the workspace directory (or a
+        # workspace-relative cwd, e.g. a chat's worktree). Tries tmux
         # for session persistence across WebSocket reconnections, falls back
         # to the user's default shell if tmux is not installed.
         session_id = str(uuid.uuid4())
@@ -239,7 +241,7 @@ class LocalHostProvider(SandboxProvider):
         process = await asyncio.to_thread(
             subprocess.Popen,
             ["bash", "-lc", cmd],
-            cwd=str(self._workspace),
+            cwd=self.resolve_workspace_path(cwd),
             env=env,
             stdin=slave_fd,
             stdout=slave_fd,

--- a/backend/app/services/terminal.py
+++ b/backend/app/services/terminal.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import re
 import shlex
 from asyncio import QueueEmpty, QueueFull
 from dataclasses import dataclass
@@ -17,6 +18,8 @@ from app.services.sandbox_providers.base import SandboxProvider
 
 logger = logging.getLogger(__name__)
 
+TMUX_NAME_UNSAFE_RE = re.compile(r"[^A-Za-z0-9]")
+
 _T = TypeVar("_T")
 
 
@@ -25,6 +28,8 @@ class TerminalSessionRecord:
     user_id: str
     sandbox_id: str
     terminal_id: str
+    # Workspace-relative shell start dir; "" means the workspace root.
+    cwd: str
     sandbox_service: SandboxService
     on_close: Callable[[], None]
     pty_id: str | None = None
@@ -44,6 +49,7 @@ class TerminalSessionRecord:
                 rows,
                 cols,
                 tmux_session,
+                self.cwd,
                 on_data=self._enqueue_output,
             )
             self.input_queue = asyncio.Queue(maxsize=PTY_INPUT_QUEUE_SIZE)
@@ -151,7 +157,12 @@ class TerminalSessionRecord:
         if self.tmux_session_name is None:
             safe_terminal = self.terminal_id.replace("-", "_")
             safe_sandbox = self.sandbox_id.replace("-", "_")
-            self.tmux_session_name = f"agentrove_{safe_sandbox}_{safe_terminal}"
+            name = f"agentrove_{safe_sandbox}_{safe_terminal}"
+            if self.cwd:
+                # Worktree terminals need their own tmux session — reattaching
+                # a root-cwd session would land the user outside the worktree.
+                name += "_" + TMUX_NAME_UNSAFE_RE.sub("_", self.cwd)
+            self.tmux_session_name = name
         return self.tmux_session_name
 
     async def _input_worker(self, session_id: str) -> None:
@@ -236,8 +247,13 @@ class TerminalSessionRegistry:
         self._lock = asyncio.Lock()
 
     @staticmethod
-    def build_session_key(user_id: str, sandbox_id: str, terminal_id: str) -> str:
-        return f"{user_id}:{sandbox_id}:{terminal_id}"
+    def build_session_key(
+        user_id: str, sandbox_id: str, terminal_id: str, cwd: str
+    ) -> str:
+        # cwd is part of the identity — chats in the same workspace share
+        # terminal ids, but a worktree chat must not reattach to a root-cwd
+        # session (or vice versa).
+        return f"{user_id}:{sandbox_id}:{terminal_id}:{cwd}"
 
     async def get_or_create(
         self,
@@ -245,10 +261,11 @@ class TerminalSessionRegistry:
         user_id: str,
         sandbox_id: str,
         terminal_id: str,
+        cwd: str,
         provider_type: SandboxProviderType,
         workspace_path: str | None,
     ) -> TerminalSessionRecord:
-        key = self.build_session_key(user_id, sandbox_id, terminal_id)
+        key = self.build_session_key(user_id, sandbox_id, terminal_id, cwd)
         async with self._lock:
             existing = self._sessions.get(key)
             if existing:
@@ -263,6 +280,7 @@ class TerminalSessionRegistry:
                 user_id=user_id,
                 sandbox_id=sandbox_id,
                 terminal_id=terminal_id,
+                cwd=cwd,
                 sandbox_service=service,
                 on_close=partial(self._remove, key),
             )

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -152,6 +152,7 @@ class FakeSandboxProvider(SandboxProvider):
         rows: int,
         cols: int,
         tmux_session: str,
+        cwd: str,
         on_data: PtyDataCallbackType,
     ) -> str:
         return "pty-1"

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -80,7 +80,7 @@ class ChatCompletionServiceOverride:
 
     async def initiate_chat_completion(
         self, request: ChatRequest, user: User
-    ) -> dict[str, UUID | int | None]:
+    ) -> dict[str, UUID | int | str | None]:
         self.requests.append(request)
         self.users.append(user)
         if self.fail:
@@ -90,6 +90,7 @@ class ChatCompletionServiceOverride:
             "message_id": UUID("00000000-0000-0000-0000-000000000123"),
             "last_seq": 4,
             "checkpoint_id": None,
+            "worktree_cwd": None,
         }
 
 
@@ -299,6 +300,7 @@ async def test_send_message_endpoint_passes_form_fields_to_chat_service(
         "message_id": "00000000-0000-0000-0000-000000000123",
         "last_seq": 4,
         "checkpoint_id": None,
+        "worktree_cwd": None,
     }
     request = chat_service.requests[0]
     assert request.prompt == "Ship this"

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -9,6 +9,7 @@ from app.api.endpoints import websocket as websocket_endpoint
 from app.constants import (
     DEFAULT_TERMINAL_ID,
     WS_CLOSE_AUTH_FAILED,
+    WS_CLOSE_INVALID_CWD,
     WS_CLOSE_SANDBOX_NOT_FOUND,
     WS_MSG_AUTH,
     WS_MSG_DETACH,
@@ -94,6 +95,7 @@ class FakeTerminalRegistry:
         user_id: str,
         sandbox_id: str,
         terminal_id: str,
+        cwd: str,
         provider_type: SandboxProviderType,
         workspace_path: str | None,
     ) -> FakeTerminalSession:
@@ -102,6 +104,7 @@ class FakeTerminalRegistry:
                 "user_id": user_id,
                 "sandbox_id": sandbox_id,
                 "terminal_id": terminal_id,
+                "cwd": cwd,
                 "provider_type": provider_type,
                 "workspace_path": workspace_path,
             }
@@ -142,6 +145,30 @@ async def test_terminal_websocket_rejects_unowned_sandbox(
     assert websocket.close_reason == "Sandbox not found"
 
 
+async def test_terminal_websocket_rejects_escaping_cwd(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="ws-badcwd@example.com",
+        username="wsbadcwd",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    websocket = FakeWebSocket(
+        [{"text": json.dumps({"type": WS_MSG_AUTH, "token": token})}],
+        query_params={"cwd": "../outside"},
+    )
+
+    await run_terminal_websocket(websocket, workspace.sandbox_id)
+
+    assert websocket.close_code == WS_CLOSE_INVALID_CWD
+    assert websocket.close_reason == "Invalid terminal cwd"
+
+
 async def test_terminal_websocket_handles_control_frames(
     db_session: AsyncSession,
     create_user: UserFactory,
@@ -168,7 +195,7 @@ async def test_terminal_websocket_handles_control_frames(
             {"text": json.dumps({"type": WS_MSG_RESIZE, "rows": 50, "cols": 140})},
             {"text": json.dumps({"type": WS_MSG_DETACH})},
         ],
-        query_params={"terminalId": "term-a"},
+        query_params={"terminalId": "term-a", "cwd": ".worktrees/abc12345"},
     )
 
     await run_terminal_websocket(websocket, workspace.sandbox_id)
@@ -178,6 +205,7 @@ async def test_terminal_websocket_handles_control_frames(
             "user_id": str(user.id),
             "sandbox_id": workspace.sandbox_id,
             "terminal_id": "term-a",
+            "cwd": ".worktrees/abc12345",
             "provider_type": SandboxProviderType.HOST,
             "workspace_path": workspace.workspace_path,
         }

--- a/frontend/src/components/sandbox/terminal/Container.tsx
+++ b/frontend/src/components/sandbox/terminal/Container.tsx
@@ -9,6 +9,7 @@ import { terminalStorageKey } from '@/utils/terminal';
 export interface ContainerProps {
   sandboxId?: string;
   chatId?: string;
+  worktreeCwd?: string;
   isVisible: boolean;
   panelKey: string;
 }
@@ -18,7 +19,13 @@ interface TerminalInstance {
   label: string;
 }
 
-export const Container: FC<ContainerProps> = ({ sandboxId, chatId, isVisible, panelKey }) => {
+export const Container: FC<ContainerProps> = ({
+  sandboxId,
+  chatId,
+  worktreeCwd,
+  isVisible,
+  panelKey,
+}) => {
   const defaultTerminalId = `terminal-${panelKey}-1`;
   const storageKey = chatId ? terminalStorageKey(chatId, panelKey) : null;
   const [terminals, setTerminals] = useState<TerminalInstance[]>([
@@ -182,6 +189,7 @@ export const Container: FC<ContainerProps> = ({ sandboxId, chatId, isVisible, pa
               isVisible={isVisible && activeTerminalId === terminal.id}
               sandboxId={sandboxId}
               terminalId={terminal.id}
+              cwd={worktreeCwd}
               shouldClose={closingTerminalIds.has(terminal.id)}
               onClosed={() => finalizeCloseTerminal(terminal.id)}
             />

--- a/frontend/src/components/sandbox/terminal/TerminalTab.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab.tsx
@@ -17,6 +17,8 @@ export interface TerminalTabProps {
   isVisible: boolean;
   sandboxId?: string;
   terminalId?: string;
+  // Workspace-relative shell start dir (the chat's worktree); root when unset.
+  cwd?: string;
   shouldClose?: boolean;
   onClosed?: () => void;
 }
@@ -28,11 +30,13 @@ const encoder = new TextEncoder();
 // Mirrors backend WS_CLOSE_* codes in app/constants.py
 const WS_CLOSE_AUTH_FAILED = 4001;
 const WS_CLOSE_SANDBOX_NOT_FOUND = 4004;
+const WS_CLOSE_INVALID_CWD = 4005;
 
 export const TerminalTab: FC<TerminalTabProps> = ({
   isVisible,
   sandboxId,
   terminalId,
+  cwd,
   shouldClose = false,
   onClosed,
 }) => {
@@ -103,8 +107,11 @@ export const TerminalTab: FC<TerminalTabProps> = ({
     const { baseUrl, token } = resolveSandboxWs(sandboxId);
     if (!token) return;
 
-    const terminalParam = terminalId ? `?terminalId=${encodeURIComponent(terminalId)}` : '';
-    const wsUrl = `${baseUrl}/${sandboxId}/terminal${terminalParam}`;
+    const params = new URLSearchParams();
+    if (terminalId) params.set('terminalId', terminalId);
+    if (cwd) params.set('cwd', cwd);
+    const query = params.toString();
+    const wsUrl = `${baseUrl}/${sandboxId}/terminal${query ? `?${query}` : ''}`;
 
     setSessionState('connecting');
     setCloseReason(null);
@@ -174,7 +181,11 @@ export const TerminalTab: FC<TerminalTabProps> = ({
       // The server closes with WS_CLOSE_AUTH_FAILED / WS_CLOSE_SANDBOX_NOT_FOUND
       // and a human-readable reason. Surface both so the overlay can tell the
       // user why the connection dropped instead of showing a generic message.
-      if (event.code === WS_CLOSE_AUTH_FAILED || event.code === WS_CLOSE_SANDBOX_NOT_FOUND) {
+      if (
+        event.code === WS_CLOSE_AUTH_FAILED ||
+        event.code === WS_CLOSE_SANDBOX_NOT_FOUND ||
+        event.code === WS_CLOSE_INVALID_CWD
+      ) {
         setCloseReason(event.reason || null);
         setSessionState('error');
         return;
@@ -211,7 +222,7 @@ export const TerminalTab: FC<TerminalTabProps> = ({
       resetWsRefs();
       setSessionState('idle');
     };
-  }, [sandboxId, terminalId, isReady, connectAttempt, fitTerminal, terminalRef, resetWsRefs]);
+  }, [sandboxId, terminalId, cwd, isReady, connectAttempt, fitTerminal, terminalRef, resetWsRefs]);
 
   useEffect(() => {
     if (!shouldClose || isClosingRef.current) {

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -178,14 +178,15 @@ export async function applyCreatedChat(queryClient: QueryClient, newChat: Chat):
   queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
 }
 
-// Optimistically clears the unread flag in every cache the chat appears in,
-// then stamps the server-side read marker. Best-effort fire-and-forget: it
-// never rejects — a failed stamp just resurfaces the dot on the next refetch.
-export async function markChatViewed(queryClient: QueryClient, chatId: string): Promise<void> {
-  queryClient.setQueryData<Chat>(queryKeys.chat(chatId), (prev) =>
-    prev ? { ...prev, unread: false } : prev,
-  );
-
+// Canonical "patch one chat everywhere" — applies the same updater to the
+// single-chat query and every infinite chats list, so callers can't update
+// one cache and silently miss the other.
+export function patchChatInCache(
+  queryClient: QueryClient,
+  chatId: string,
+  patch: (chat: Chat) => Chat,
+) {
+  queryClient.setQueryData<Chat>(queryKeys.chat(chatId), (prev) => (prev ? patch(prev) : prev));
   queryClient.setQueriesData<InfiniteData<PaginatedChats>>(
     { queryKey: [queryKeys.chats, 'infinite'] },
     (oldData) => {
@@ -194,12 +195,19 @@ export async function markChatViewed(queryClient: QueryClient, chatId: string): 
         ...oldData,
         pages: oldData.pages.map((page) => ({
           ...page,
-          items: page.items.map((chat) =>
-            chat.id === chatId && chat.unread ? { ...chat, unread: false } : chat,
-          ),
+          items: page.items.map((chat) => (chat.id === chatId ? patch(chat) : chat)),
         })),
       };
     },
+  );
+}
+
+// Optimistically clears the unread flag in every cache the chat appears in,
+// then stamps the server-side read marker. Best-effort fire-and-forget: it
+// never rejects — a failed stamp just resurfaces the dot on the next refetch.
+export async function markChatViewed(queryClient: QueryClient, chatId: string): Promise<void> {
+  patchChatInCache(queryClient, chatId, (chat) =>
+    chat.unread ? { ...chat, unread: false } : chat,
   );
 
   try {

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -5,10 +5,9 @@ import toast from 'react-hot-toast';
 import { StreamContentBuffer, type ContentRenderSnapshot } from '@/utils/stream';
 import { notifyStreamComplete } from '@/utils/notifications';
 import { queryKeys } from '@/hooks/queries/queryKeys';
-import { markChatViewed } from '@/hooks/queries/useChatQueries';
+import { markChatViewed, patchChatInCache } from '@/hooks/queries/useChatQueries';
 import { invalidateGitState } from '@/hooks/queries/useSandboxQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
-import type { InfiniteData } from '@tanstack/react-query';
 import type {
   AssistantStreamEvent,
   Chat,
@@ -16,7 +15,6 @@ import type {
   Message,
   PermissionRequest,
 } from '@/types/chat.types';
-import type { PaginatedChats } from '@/types/api.types';
 import type { ToolEventPayload } from '@/types/tools.types';
 import {
   StreamProcessingError,
@@ -59,6 +57,12 @@ function updateMessageInCacheForChat(
         })),
       };
     },
+  );
+}
+
+function patchChatWorktreeCwd(queryClient: QueryClient, chatId: string, worktreeCwd: string) {
+  patchChatInCache(queryClient, chatId, (chat) =>
+    chat.worktree_cwd !== worktreeCwd ? { ...chat, worktree_cwd: worktreeCwd } : chat,
   );
 }
 
@@ -498,25 +502,7 @@ export function useStreamCallbacks({
         const worktreeCwd =
           typeof nestedData?.worktree_cwd === 'string' ? nestedData.worktree_cwd : undefined;
         if (worktreeCwd && chatId) {
-          const patchChat = (chat: Chat) =>
-            chat.worktree_cwd !== worktreeCwd ? { ...chat, worktree_cwd: worktreeCwd } : chat;
-
-          queryClient.setQueryData<Chat>(queryKeys.chat(chatId), (prev) =>
-            prev ? patchChat(prev) : prev,
-          );
-          queryClient.setQueriesData<InfiniteData<PaginatedChats>>(
-            { queryKey: [queryKeys.chats, 'infinite'] },
-            (oldData) => {
-              if (!oldData) return oldData;
-              return {
-                ...oldData,
-                pages: oldData.pages.map((page) => ({
-                  ...page,
-                  items: page.items.map((chat) => (chat.id === chatId ? patchChat(chat) : chat)),
-                })),
-              };
-            },
-          );
+          patchChatWorktreeCwd(queryClient, chatId, worktreeCwd);
         }
 
         return;
@@ -861,8 +847,8 @@ export function useStreamCallbacks({
   );
 
   // Stash the latest callbacks in a ref so startStream/replayStream — which are
-  // intentionally stable (empty deps) to avoid re-registering the EventSource —
-  // always dispatch through the freshest closures.
+  // intentionally stable (only the stable queryClient in deps) to avoid
+  // re-registering the EventSource — always dispatch through the freshest closures.
   useEffect(() => {
     optionsRef.current = chatId
       ? { chatId, onEnvelope, onComplete, onError, onQueueProcess }
@@ -873,7 +859,7 @@ export function useStreamCallbacks({
     async (
       request: StreamOptions['request'],
       signal?: AbortSignal,
-    ): Promise<{ messageId: string; checkpointId: string | null }> => {
+    ): Promise<{ messageId: string; checkpointId: string | null; worktreeCwd: string | null }> => {
       const currentOptions = optionsRef.current;
       if (!currentOptions) {
         throw new Error('Stream options not available');
@@ -889,9 +875,16 @@ export function useStreamCallbacks({
         onQueueProcess: currentOptions.onQueueProcess,
       };
 
-      return streamService.startStream(streamOptions);
+      const result = await streamService.startStream(streamOptions);
+      // A first worktree turn creates the worktree during the send request —
+      // patch the cache now so branch/terminal/editor UI switches immediately
+      // instead of waiting for the stream config event.
+      if (result.worktreeCwd) {
+        patchChatWorktreeCwd(queryClient, currentOptions.chatId, result.worktreeCwd);
+      }
+      return result;
     },
-    [],
+    [queryClient],
   );
 
   const replayStream = useCallback(

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -271,6 +271,11 @@ export function ChatPage() {
         ? (secondaryQuery.data?.sandbox_id ?? undefined)
         : currentChat?.sandbox_id;
       const terminalChatId = isSecondary ? (secondaryChatId ?? undefined) : currentChat?.id;
+      // Worktree chats get their shell spawned inside the worktree so the
+      // terminal matches what the agent/editor/diff views operate on.
+      const terminalWorktreeCwd = isSecondary
+        ? (secondaryQuery.data?.worktree_cwd ?? undefined)
+        : (currentChat?.worktree_cwd ?? undefined);
       return (
         <div
           className="relative flex h-full w-full"
@@ -283,6 +288,7 @@ export function ChatPage() {
               <TerminalContainer
                 sandboxId={terminalSandboxId}
                 chatId={terminalChatId}
+                worktreeCwd={terminalWorktreeCwd}
                 // Only fit/focus the terminal when its tile is actually on screen —
                 // a background tab is mounted but hidden (zero-size container).
                 isVisible={isTerminal && isVisible}
@@ -296,7 +302,13 @@ export function ChatPage() {
         </div>
       );
     },
-    [currentChat, renderNonTerminalView, secondaryChatId, secondaryQuery.data?.sandbox_id],
+    [
+      currentChat,
+      renderNonTerminalView,
+      secondaryChatId,
+      secondaryQuery.data?.sandbox_id,
+      secondaryQuery.data?.worktree_cwd,
+    ],
   );
 
   if (!chatId) return <Navigate to="/" />;

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -61,6 +61,7 @@ async function createCompletion(
         message_id: string;
         last_seq?: number;
         checkpoint_id: string | null;
+        worktree_cwd: string | null;
       }>('/chat/chat', formData, signal);
 
       const payload = ensureResponse(taskResponse, 'Failed to start chat completion');
@@ -70,6 +71,7 @@ async function createCompletion(
         source: eventSource,
         messageId: payload.message_id,
         checkpointId: payload.checkpoint_id,
+        worktreeCwd: payload.worktree_cwd,
       };
     },
     { signal },

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -260,11 +260,11 @@ class StreamService {
 
   async startStream(
     options: StreamOptions,
-  ): Promise<Pick<ApiStreamResponse, 'messageId' | 'checkpointId'>> {
+  ): Promise<Pick<ApiStreamResponse, 'messageId' | 'checkpointId' | 'worktreeCwd'>> {
     const streamId = crypto.randomUUID();
 
     try {
-      const { source, messageId, checkpointId } = await chatService.createCompletion(
+      const { source, messageId, checkpointId, worktreeCwd } = await chatService.createCompletion(
         options.request,
         options.signal,
       );
@@ -288,7 +288,7 @@ class StreamService {
       useStreamStore.getState().addStream(activeStream);
       this.attachStreamHandlers(streamId, messageId);
 
-      return { messageId, checkpointId };
+      return { messageId, checkpointId, worktreeCwd };
     } catch (error) {
       useStreamStore.getState().removeStream(streamId);
       throw error;

--- a/frontend/src/types/stream.types.ts
+++ b/frontend/src/types/stream.types.ts
@@ -40,6 +40,9 @@ export interface ApiStreamResponse {
   source: EventSource;
   messageId: string;
   checkpointId: string | null;
+  // Set when this turn bound the chat to a worktree — created server-side
+  // during the send request, before any stream event arrives.
+  worktreeCwd: string | null;
 }
 
 export interface ActiveStream {


### PR DESCRIPTION
## Summary
- Terminal sessions always started in the shared workspace root, so a worktree-backed chat's terminal landed outside the worktree the agent/editor/diff views were actually operating on
- Thread the chat's `worktree_cwd` through the send response → terminal websocket → sandbox providers, so the shell starts inside the worktree
- Validate the `cwd` query param against path escape and close the websocket with a new `WS_CLOSE_INVALID_CWD` code if invalid
- Give worktree terminals their own tmux session name (keyed by cwd) so reattaching doesn't land the user back at the workspace root
- Extract `patchChatInCache` in `useChatQueries.ts` to share cache-patching logic between `markChatViewed` and the new worktree cwd patch

## Test plan
- [ ] Start a chat that creates a worktree, open its terminal, confirm the shell starts in the worktree directory
- [ ] Confirm a non-worktree chat's terminal still starts at the workspace root
- [ ] `backend/tests/test_websocket.py` and `backend/tests/test_chat.py` cover the new cwd validation and response field