### PR TITLE
chore: fix frontend/CLAUDE.md prettier formatting

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -3,12 +3,15 @@
 ## Component Architecture
 
 ### React Version
+
 - React 19 — use `use()` instead of `useContext()`; pass `ref` as a regular prop instead of `forwardRef`
 
 ### UI Primitives
+
 - Never use raw HTML interactive elements (`<button>`, `<input>`, `<select>`, `<a>`) when a primitive exists in `components/ui/primitives/` — use `Button`, `Input`, etc.; for fully custom styling use `variant="unstyled"` (keeps focus-visible and disabled styles); don't duplicate those built-in styles in `className`
 
 ### Composition Patterns
+
 - Avoid boolean prop proliferation (`isX`, `showX`, `hideX`) — use composition instead
 - When a component exceeds ~10 props or has 3+ boolean flags, refactor to a context provider + compound components
 - Use the `state / actions` context interface pattern: `{ state: StateType; actions: ActionsType }`
@@ -17,21 +20,25 @@
 - Provider values must be `useMemo`'d to prevent unnecessary re-renders
 
 ### Provider Pattern for Complex Components
+
 - When a component has extensive internal hook logic (file handling, suggestions, mutations), lift it into a `*Provider.tsx` that wraps children with context
 - Outer component keeps its prop-based API; internally wrap `<Provider {...props}><Layout /></Provider>`
 - Sub-components read from context via `use*Context()` hooks
 - References: `InputProvider.tsx`, `ChatSessionProvider`, `FileTreeProvider`
 
 ### No Fallback Patterns in Context Interfaces
+
 - Context interface fields must not be optional (`?`) when the provider always supplies them
 - Don't add nullability guards (`value && doSomething()`) on context values guaranteed by the provider
 - Don't add `?? null` / `?? false` / `?? []` coercions unless the upstream genuinely returns `undefined`
 
 ### State Ownership
+
 - Don't write computed defaults into persisted stores (Zustand `persist`/localStorage) while their inputs (queries, message history) are still resolving — a persisted guess permanently wins over the later-derived value
 - Shared presentational components must not write to stores or commit defaults — defaulting/validation belongs to the single state-owner hook or provider; components take `value`/`onChange` only
 
 ### Existing Context Hierarchy
+
 - `ChatProvider` (`contexts/ChatContext.tsx`) — static chat metadata: `chatId`, `sandboxId`, `fileStructure`, `customAgents`, `customSlashCommands`, `customPrompts`
 - `ChatSessionProvider` (`contexts/ChatSessionContext.tsx`) — dynamic chat session state: messages, streaming, loading, permissions, input message, model selection
 - `InputProvider` (`components/chat/message-input/InputProvider.tsx`) — input internals: file handling, drag-and-drop, suggestions, enhancement, submit logic
@@ -39,17 +46,21 @@
 - `FileTreeProvider` (`components/editor/file-tree/FileTreeProvider.tsx`) — file tree selection/expansion state
 
 ### Responsive Awareness
+
 - Before removing a UI element, check whether it serves a responsive/functional role beyond its visual purpose — icons often double as compact-mode fallbacks (`compactOnMobile`); labels may be the only visible element at some breakpoints
 
 ### File Placement
+
 - When extracting non-component code (contexts, utils, hooks) from a component file, place it in the canonical folder (`contexts/`, `utils/`, `hooks/`)
 - `components/chat/tools/` is exclusively for tool components (one per tool type) — helper modals/dialogs/detail views belong in `components/chat/` or a relevant feature folder
 - Shared UI used by 2+ feature areas belongs in `components/ui/shared/`
 
 ### Event Handler Signatures
+
 - Never pass a callback directly to `onClick` (or similar) when it expects domain-typed args — wrap in an arrow: `onClick={() => handler(value)}`, not `onClick={handler}` (React passes the event as the first arg)
 
 ### useEffect Discipline
+
 - Never place hooks (`useState`, `useCallback`, `useMemo`, `useEffect`) after conditional early returns
 - Never call `useEffect` directly for mount-only effects — use `useMountEffect()` from `hooks/useMountEffect.ts`
 - Never use `useEffect` to derive state from other state/props — use inline computation or `useMemo`; `useEffect(() => setX(f(y)), [y])` causes an extra render cycle
@@ -61,19 +72,23 @@
 - When local state overrides an ambient value that resolves asynchronously, derive the effective value (`local || ambient`) instead of seeding state from the prop at mount and patching it later
 
 ### Component Variants
+
 - Create explicit variant components instead of one with many boolean modes (e.g., `ThreadComposer`, `EditComposer` instead of `<Composer isThread isEditing />`)
 - Use `children` for composing static structure; render props only when the parent needs data back from the child
 
 ### Action Gating
+
 - When a React Query uses `placeholderData` / `keepPreviousData`, gate destructive actions derived from that data on `!isPlaceholderData`
 - Gate action buttons on backend capability, not UI rendering state — hide only the affordances that genuinely require rendered rows
 
 ## Types
+
 - When a Pydantic response model field has a default, the corresponding frontend TypeScript type must mark it required
 - Don't introduce a new frontend type when an existing one has the same shape — reuse directly across modules
 - When spreading a caller-provided options object into a builder, use `Omit<>` to exclude keys the factory controls — prevents silent shadowing at the type level
 
 ## Cross-cutting gotchas
+
 - When extracting a shared utility from multiple callers with slightly different semantics, verify equivalence for every edge-case input (`null`, `undefined`, `0`, `""`)
 - Don't extract a shared React hook when callers must add `useCallback`/`useMemo` wrappers that the inline version didn't need
 - In JSX conditionals with numeric values, use explicit checks (`value != null && value > 0`) — `0` renders as text in React
@@ -88,6 +103,7 @@
 ## Performance Conventions
 
 ### Bundle Size
+
 - No barrel/index.ts files — import directly from the source (e.g., `from '@/components/layout/Layout'`)
 - Heavy libraries must use dynamic `import()`, never static: `xlsx`, `jszip`, `xterm`, `@monaco-editor/react`, `react-vnc`, `qrcode`, `dompurify`, `mermaid`
 - Heavy React components: `React.lazy()` + `<Suspense>` (e.g., Monaco in dialogs, VncScreen)
@@ -95,10 +111,12 @@
 - Audit `package.json` periodically for unused deps
 
 ### Async-to-Sync Migration Safety
+
 - When converting sync (useMemo/inline) to async (useEffect + useState with dynamic imports), clear the previous state at the top of the effect before async work
 - Pattern: `useEffect(() => { setState(initial); if (!input) return; let cancelled = false; (async () => { ... })(); return () => { cancelled = true; }; }, [input])`
 
 ### Re-render Optimization
+
 - Zustand action selectors used only in callbacks: use `useStore.getState().action()` at the call site — don't subscribe via `useStore((s) => s.action)`
 - Don't wrap Zustand `set(...)` in `startTransition` inside store definitions — use synchronous `set`; `startTransition` belongs in components/hooks
 - Zustand selectors must return stable references — never create new objects/arrays/`Set`/`Map` inside the selector; derive with `useMemo`
@@ -113,6 +131,7 @@
 - When invalidating a React Query key built from an identifier, verify the format matches consumers' — cwd-relative vs workspace-root-relative paths miss each other; when formats can diverge, invalidate a prefix key (e.g., `fileContentAll`)
 
 ### Async Patterns
+
 - Use `Promise.all()` for independent async ops (e.g., multiple `queryClient.invalidateQueries()` calls)
 - When dynamically importing multiple libraries in the same function, parallelize: `Promise.all([import('a'), import('b')])`
 - When discarding a promise with `void`, attach `.catch()` — `void fn().catch(err => console.error(err))`
@@ -120,11 +139,13 @@
 ## UI/UX Guidelines
 
 ### Design Philosophy
+
 - Fully monochrome — no brand/blue accent colors in structural UI
 - Clean, minimal, refined — subtle over visually heavy
 - When multiple visual approaches are viable (connector styles, layout, color), present visual mockups for selection before implementation
 
 ### Color Palette
+
 - Refer to `frontend/tailwind.config.js` for defined colors
 - Never hardcode hex or default Tailwind colors (`bg-gray-100`, `text-blue-600`, ...)
 - Every light color class must have a `dark:` counterpart, and every `dark:` class a light-mode one — never one without the other
@@ -142,6 +163,7 @@
 - Don't use opacity below `/30` for structural lines (connectors, tree branches, dividers) — use `/50` minimum
 
 ### Typography
+
 - `text-xs` default, `text-sm` for primary inputs, `text-2xs` for meta/section headers, `text-lg` for dialog titles only — avoid `text-base`+ in dense UI
 - `font-medium` for standard emphasis; `font-semibold` only for page titles (`text-xl`) and section headers; avoid `font-bold` except special display (auth codes)
 - Form labels: `text-xs text-text-secondary` — no icons next to labels
@@ -149,12 +171,14 @@
 - `font-mono` for code, URIs, package names, env vars, file paths, technical IDs — pair with `text-xs` or `text-2xs`
 
 ### Borders & Radius
+
 - Standard border: `border border-border/50 dark:border-border-dark/50`; full opacity only for prominent dividers
 - Radius: `rounded-md` small (buttons, inputs), `rounded-lg` standard containers/cards, `rounded-xl` prominent cards/dropdowns, `rounded-2xl` overlays; button sizes follow `sm: rounded-md`, `md: rounded-lg`, `lg: rounded-xl`
 - Shadows: `shadow-sm` interactive, `shadow-medium` dropdowns/panels, `shadow-strong` modals; use `backdrop-blur-xl` + `bg-*/95` for frosted dropdowns
 - No custom shadow tokens (`shadow-soft`, `shadow-harsh`) — only `shadow-sm` / `shadow-medium` / `shadow-strong`
 
 ### Icons
+
 - Default `h-3.5 w-3.5` for toolbars/action buttons/small controls
 - `h-4 w-4` for message actions and form controls
 - `h-3 w-3` for text-adjacent icons, badges, close buttons
@@ -165,12 +189,14 @@
 - Don't generate SVG path data from memory — fetch official brand icon SVGs from authoritative sources (Simple Icons, brand asset pages)
 
 ### Panel Headers
+
 - `h-9` height with `px-3` padding
 - File paths / technical labels: `font-mono text-2xs`
 - Section labels: `text-2xs font-medium uppercase tracking-wider text-text-quaternary`
 - Icon buttons: `h-3 w-3`, no background, hover `text-text-primary`
 
 ### Animations & Transitions
+
 - Use CSS keyframe animations via Tailwind (`animate-fade-in`, `animate-fade-in-up`, `animate-dot-pulse`) — no `framer-motion` or other JS animation libs
 - `transition-colors duration-200` for hover/focus; `transition-all duration-300` for complex state changes (drag-and-drop)
 - `transition-[padding] duration-500 ease-in-out` for sidebar/layout animations
@@ -180,6 +206,7 @@
 - Delay-reveal loading indicators for data that usually resolves fast (`opacity-0` + `animationDelay` ~300ms + explicit `animationFillMode: 'forwards'`) so fast loads render nothing — an immediate spinner trades one flash for another (see `ListManagementTab`)
 
 ### Layout
+
 - Don't use absolute positioning for sibling layout — use flexbox (`flex`, `justify-between`, `gap-*`); reserve `absolute` for overlays, tooltips, dropdowns, decorative elements
 - When action buttons have variable-length or long labels, stack vertically (`flex-col`) at full width
 - When nesting child items under parents (e.g., sub-threads), always maintain visible indentation — connector lines supplement but indentation is the primary hierarchy signal


### PR DESCRIPTION
## Summary
- Add missing blank lines after markdown headings in `frontend/CLAUDE.md` to match prettier's formatting rules