### PR TITLE
fix: replace nonexistent surface-primary token with valid tokens

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -149,7 +149,7 @@
 - Refer to `frontend/tailwind.config.js` for defined colors
 - Never hardcode hex or default Tailwind colors (`bg-gray-100`, `text-blue-600`, ...)
 - Every light color class must have a `dark:` counterpart, and every `dark:` class a light-mode one — never one without the other
-- Surface tokens: `surface-primary`, `surface-secondary` (most used), `surface-tertiary`, `surface-hover`, `surface-active` — dark variants `surface-dark-*`
+- Surface tokens: `surface` (base/default — there is no `surface-primary`), `surface-secondary` (most used), `surface-tertiary`, `surface-hover`, `surface-active` — dark variants `surface-dark`, `surface-dark-secondary`, etc.
 - Border tokens: `border-border` (default), `border-border-secondary`, `border-border-hover` — dark `border-border-dark-*`; prefer `border-border/50` + `dark:border-border-dark/50` for subtle borders
 - Text tokens: `text-text-primary`, `text-text-secondary`, `text-text-tertiary`, `text-text-quaternary` — dark `text-text-dark-*`
 - **Never use `brand-*` for buttons, switches, highlights, focus rings, or structural elements** — UI is fully monochrome

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -296,7 +296,7 @@ export default function App() {
 
   if (desktopError) {
     return (
-      <div className="bg-surface-primary dark:bg-surface-dark-primary flex min-h-screen flex-col text-text-primary dark:text-text-dark-primary">
+      <div className="flex min-h-screen flex-col bg-surface text-text-primary dark:bg-surface-dark dark:text-text-dark-primary">
         <DesktopDragRegion />
         <div className="flex flex-1 items-center justify-center">
           <div className="rounded-lg border border-border/50 bg-surface-secondary px-4 py-3 text-xs dark:border-border-dark/50 dark:bg-surface-dark-secondary">

--- a/frontend/src/components/chat/workspace-selector/CreateWorkspaceFooter.tsx
+++ b/frontend/src/components/chat/workspace-selector/CreateWorkspaceFooter.tsx
@@ -243,7 +243,7 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
           }}
           placeholder="Workspace name"
           autoFocus
-          className="bg-surface-primary dark:bg-surface-dark-primary h-8 w-full rounded-lg border border-border/50 px-3 text-xs text-text-primary outline-none placeholder:text-text-quaternary focus-visible:border-border-hover dark:border-border-dark/50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus-visible:border-border-dark-hover"
+          className="h-8 w-full rounded-lg border border-border/50 bg-surface-tertiary px-3 text-xs text-text-primary outline-none placeholder:text-text-quaternary focus-visible:border-border-hover dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus-visible:border-border-dark-hover"
         />
         <ProviderToggle value={sandboxProvider} onChange={setSandboxProvider} />
         <div className="flex items-center justify-end gap-2">
@@ -305,7 +305,7 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
                 onChange={(e) => setRepoSearchQuery(e.target.value)}
                 placeholder="Search repositories…"
                 autoFocus
-                className="bg-surface-primary dark:bg-surface-dark-primary h-8 w-full rounded-lg border border-border/50 pl-8 pr-3 text-xs text-text-primary outline-none placeholder:text-text-quaternary focus-visible:border-border-hover dark:border-border-dark/50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus-visible:border-border-dark-hover"
+                className="h-8 w-full rounded-lg border border-border/50 bg-surface-tertiary pl-8 pr-3 text-xs text-text-primary outline-none placeholder:text-text-quaternary focus-visible:border-border-hover dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus-visible:border-border-dark-hover"
               />
             </div>
             <div className="max-h-[12rem] overflow-y-auto">
@@ -348,7 +348,7 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
               placeholder="https://github.com/org/repo.git"
               autoFocus
               disabled={createWorkspace.isPending}
-              className="bg-surface-primary dark:bg-surface-dark-primary h-8 w-full rounded-lg border border-border/50 px-3 font-mono text-xs text-text-primary outline-none placeholder:text-text-quaternary focus-visible:border-border-hover disabled:opacity-50 dark:border-border-dark/50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus-visible:border-border-dark-hover"
+              className="h-8 w-full rounded-lg border border-border/50 bg-surface-tertiary px-3 font-mono text-xs text-text-primary outline-none placeholder:text-text-quaternary focus-visible:border-border-hover disabled:opacity-50 dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus-visible:border-border-dark-hover"
             />
             {!hasGitHubToken && (
               <p className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">

--- a/frontend/src/components/chat/workspace-selector/WorkspacePicker.tsx
+++ b/frontend/src/components/chat/workspace-selector/WorkspacePicker.tsx
@@ -88,7 +88,7 @@ export function WorkspacePicker({
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Search workspaces…"
                   autoFocus
-                  className="bg-surface-primary dark:bg-surface-dark-primary h-8 w-full rounded-lg border border-border/50 pl-8 pr-3 text-xs text-text-primary outline-none placeholder:text-text-quaternary focus-visible:border-border-hover dark:border-border-dark/50 dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus-visible:border-border-dark-hover"
+                  className="h-8 w-full rounded-lg border border-border/50 bg-surface-tertiary pl-8 pr-3 text-xs text-text-primary outline-none placeholder:text-text-quaternary focus-visible:border-border-hover dark:border-border-dark/50 dark:bg-surface-dark-secondary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary dark:focus-visible:border-border-dark-hover"
                 />
               </div>
             </div>

--- a/frontend/src/components/editor/file-preview/FilePreview.tsx
+++ b/frontend/src/components/editor/file-preview/FilePreview.tsx
@@ -88,9 +88,7 @@ export const FilePreview = memo(function FilePreview({
     }
 
     return createPortal(
-      <div className="bg-surface-primary dark:bg-surface-dark-primary fixed inset-0 z-50">
-        {previewContent}
-      </div>,
+      <div className="fixed inset-0 z-50 bg-surface dark:bg-surface-dark">{previewContent}</div>,
       document.body,
     );
   }


### PR DESCRIPTION
## Summary
- `surface-primary` and `surface-dark-primary` aren't defined in the Tailwind config, so these classes rendered as unstyled fallbacks in `App.tsx`, `FilePreview.tsx`, `CreateWorkspaceFooter.tsx`, and `WorkspacePicker.tsx`
- Replaced with valid tokens (`surface`/`surface-dark`, `surface-tertiary`/`surface-dark-secondary`) matching the surrounding UI
- Updated `frontend/CLAUDE.md` surface token docs to reflect the actual available tokens