### PR TITLE
fix: carry prior turn's duration through queue handoff

### DIFF
--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -411,7 +411,9 @@ class ChatStreamRuntime:
             # If there's a queued follow-up message, start it immediately in this
             # same background task chain — the "complete" event is deferred until
             # the entire queue is drained so the client stays in streaming mode.
-            queue_processed = await self._process_next_queued()
+            queue_processed = await self._process_next_queued(
+                prior_duration_ms=duration_ms
+            )
             if not queue_processed:
                 await self._emit_context_usage(stream_result)
                 await self.emit_event(
@@ -425,7 +427,9 @@ class ChatStreamRuntime:
             # cancelled (and its handler.finish() sentinel already fired)
             # before the new prompt begins on the same shared handler.
             await self._close_stream()
-            if await self._process_next_queued(send_now_only=True):
+            if await self._process_next_queued(
+                send_now_only=True, prior_duration_ms=duration_ms
+            ):
                 session_registry.consume_pending_cancel(self.chat_id)
                 return final_content
             await self._emit_context_usage(stream_result)
@@ -487,7 +491,9 @@ class ChatStreamRuntime:
         if exc:
             logger.error("Session update task failed: %s", exc)
 
-    async def _process_next_queued(self, *, send_now_only: bool = False) -> bool:
+    async def _process_next_queued(
+        self, *, send_now_only: bool = False, prior_duration_ms: int | None = None
+    ) -> bool:
         next_msg: dict[str, Any] | None = None
         try:
             async with cache_connection() as cache:
@@ -540,6 +546,9 @@ class ChatStreamRuntime:
                     "attachments": MessageService.serialize_attachments(
                         next_msg, user_message
                     ),
+                    # The prior turn's terminal event is suppressed during a queue
+                    # handoff, so ship its persisted duration here for the rollup.
+                    "prior_duration_ms": prior_duration_ms,
                 },
                 apply_snapshot=False,
             )

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -774,6 +774,21 @@ export function useStreamCallbacks({
         clearStreamSession(streamId);
       }
 
+      // The prior turn's complete event is suppressed during a handoff, so stamp
+      // its persisted duration here — otherwise the rollup shows plain "Worked".
+      if (data.priorDurationMs != null) {
+        const applyDuration = (message: Message): Message => ({
+          ...message,
+          duration_ms: data.priorDurationMs,
+        });
+        updateMessageInCacheForChat(queryClient, chatId, data.priorMessageId, applyDuration);
+        if (isCurrentChat) {
+          setMessages((prev) =>
+            prev.map((msg) => (msg.id === data.priorMessageId ? applyDuration(msg) : msg)),
+          );
+        }
+      }
+
       const userMessage: Message = {
         id: data.userMessageId,
         chat_id: chatId,
@@ -835,6 +850,9 @@ export function useStreamCallbacks({
 
       setMessages((prev) => [...prev, userMessage, assistantMessage]);
       setCurrentMessageId(data.assistantMessageId);
+      // Anchor the queued turn to the top like a normal send — Chat's anchor
+      // handshake keys off the pending user message id.
+      setPendingUserMessageId(data.userMessageId);
     },
     [
       flushBufferedContent,
@@ -843,6 +861,7 @@ export function useStreamCallbacks({
       queryClient,
       setMessages,
       setCurrentMessageId,
+      setPendingUserMessageId,
     ],
   );
 

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -112,6 +112,7 @@ class StreamService {
       checkpoint_id?: string | null;
       content?: string;
       model_id: string;
+      prior_duration_ms?: number | null;
       attachments?: Array<{
         id: string;
         message_id: string;
@@ -144,6 +145,11 @@ class StreamService {
         content: payload.content,
         modelId: payload.model_id,
         attachments: payload.attachments,
+        // The handoff envelope is emitted by the finishing stream, so its
+        // messageId is the prior turn's assistant message.
+        priorMessageId: envelope.messageId,
+        priorDurationMs:
+          typeof payload.prior_duration_ms === 'number' ? payload.prior_duration_ms : null,
       });
     }
   }
@@ -171,10 +177,12 @@ class StreamService {
       chatStorage.setEventId(chatId, String(seq));
     }
 
-    // Queue handoff events carry the old assistant message ID but must be processed
-    // before the messageId filter — they update the stream's messageId for subsequent events.
+    // Queue handoff events are fully owned by maybeHandleQueueEvent — routing them
+    // on to onEnvelope would clear the pending id onQueueProcess just set for the
+    // queued turn's anchor, and nothing downstream consumes this kind anyway.
     if (parsed.kind === 'queue_processing') {
       this.maybeHandleQueueEvent(parsed, chatId);
+      return;
     }
 
     const isForActiveMessage = parsed.messageId === currentStream.messageId;

--- a/frontend/src/types/stream.types.ts
+++ b/frontend/src/types/stream.types.ts
@@ -34,6 +34,10 @@ export interface QueueProcessingData {
   content: string;
   modelId: string;
   attachments?: MessageAttachment[];
+  // The handoff suppresses the prior turn's complete event, so its persisted
+  // run duration rides along here for the "Worked for X" rollup label.
+  priorMessageId: string;
+  priorDurationMs: number | null;
 }
 
 export interface ApiStreamResponse {


### PR DESCRIPTION
## Summary
- The prior turn's `complete` event is suppressed during a queue handoff, so its persisted run duration was lost and the message rollup showed a bare "Worked" instead of "Worked for Xs"
- `_process_next_queued` now accepts `prior_duration_ms` and includes it in the `queue_processing` envelope; the frontend stamps it onto the prior assistant message (query cache + in-memory state) when the handoff event arrives
- Also anchors the queued turn's pending user message id like a normal send (Chat's anchor handshake keys off it), and stops routing `queue_processing` events on to `onEnvelope` now that `maybeHandleQueueEvent` fully owns them