### PR TITLE
feat: unify chat status indicators (dot/spinner)

### DIFF
--- a/frontend/src/components/layout/ChatTabs.tsx
+++ b/frontend/src/components/layout/ChatTabs.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useMatch, useNavigate } from 'react-router-dom';
-import { AlertCircle, Check, Loader2, Plus, X, type LucideIcon } from 'lucide-react';
+import { Plus, X } from 'lucide-react';
+import { AsciiSpinner } from '@/components/ui/AsciiSpinner';
+import { ChatStatusDot, type ChatStatusTone } from '@/components/ui/ChatStatusDot';
 import { Button } from '@/components/ui/primitives/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
@@ -20,14 +22,6 @@ const STATUS_LABELS: Record<ChatTabStatus, string> = {
   blocked: 'Needs you',
   streaming: 'Running',
   completed: 'Done',
-};
-
-// Same status language as the sidebar, in its icon-only compact form (like
-// sub-thread rows): pulsing amber = needs you, spinner = running, check = done.
-const STATUS_ICON: Record<ChatTabStatus, { Icon: LucideIcon; className: string }> = {
-  blocked: { Icon: AlertCircle, className: 'animate-pulse text-warning-500' },
-  streaming: { Icon: Loader2, className: 'animate-spin text-warning-500' },
-  completed: { Icon: Check, className: 'text-success-600 dark:text-success-400' },
 };
 
 interface ChatTabProps {
@@ -50,7 +44,9 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
   }, [isChatGone, chatId]);
 
   const title = chatQuery.data?.title ? stripMarkdownTitle(chatQuery.data.title) : '…';
-  const statusIcon = status ? STATUS_ICON[status] : null;
+  // Streaming renders the braille spinner separately; blocked/completed are
+  // already ChatStatusTone values, so they map straight to a dot.
+  const statusDotTone: ChatStatusTone | null = status && status !== 'streaming' ? status : null;
   const agentKind = useChatAgentKind(chatId, chatQuery.data?.session_agent_kind);
 
   return (
@@ -81,10 +77,16 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
           aria-current={isCurrent ? 'page' : undefined}
           className="flex w-full min-w-0 items-center gap-1.5 text-left text-2xs font-medium"
         >
-          {/* The status icon claims the icon slot while a status is live; at rest
+          {/* The status glyph claims the icon slot while a status is live; at rest
               the chat's provider glyph (Claude, Codex…) matches the sidebar. */}
-          {statusIcon ? (
-            <statusIcon.Icon className={cn('h-3 w-3 flex-shrink-0', statusIcon.className)} />
+          {status === 'streaming' ? (
+            <AsciiSpinner className="w-3 flex-shrink-0 text-center text-sm leading-none" />
+          ) : statusDotTone ? (
+            // h-3 w-3 box centers the 8px dot in the provider icon's footprint
+            <ChatStatusDot
+              tone={statusDotTone}
+              className="h-3 w-3 flex-shrink-0 items-center justify-center"
+            />
           ) : (
             agentKind && <ProviderIcon agentKind={agentKind} className="h-3 w-3 flex-shrink-0" />
           )}

--- a/frontend/src/components/layout/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/SidebarChatItem.tsx
@@ -1,5 +1,7 @@
-import { memo } from 'react';
-import { Check, ChevronRight, Cloud, CornerDownRight, Loader2, MoreHorizontal } from 'lucide-react';
+import { memo, useEffect, useRef } from 'react';
+import { ChevronRight, Cloud, CornerDownRight, MoreHorizontal } from 'lucide-react';
+import { AsciiSpinner } from '@/components/ui/AsciiSpinner';
+import { ChatStatusDot, chatStatusTone, type ChatStatusTone } from '@/components/ui/ChatStatusDot';
 import { Button } from '@/components/ui/primitives/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
@@ -9,6 +11,15 @@ import { stripMarkdownTitle } from '@/utils/format';
 import { getRelativeTime } from '@/utils/date';
 import type { Chat } from '@/types/chat.types';
 import type { WorkspaceBadge } from '@/hooks/queries/useSidebarChatLists';
+
+// The `status` discriminant (derived per-row below) drives the leading glyph, its
+// dot tone, and its tooltip word — precedence: needs-you > running > done > unread.
+const STATUS_LABEL: Record<ChatStatusTone, string> = {
+  blocked: 'Needs you',
+  running: 'Running',
+  completed: 'Done',
+  unread: 'Unread',
+};
 
 interface SidebarChatItemProps {
   chat: Chat;
@@ -51,14 +62,92 @@ export const SidebarChatItem = memo(function SidebarChatItem({
 }: SidebarChatItemProps) {
   // onToggleSubThreads is only set when sub_thread_count > 0
   const hasSubThreads = onToggleSubThreads != null;
+  // Keep the active chat visible when navigation lands on an off-screen row
+  const rowRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (isActive) rowRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [isActive]);
   // The open chat is being read — no unread signal for it
   const isUnread = !isActive && chat.unread;
-  const hasStatusBadge = isChatBlocked || isChatStreaming || isChatCompleted || isUnread;
   const agentKind = useChatAgentKind(chat.id, chat.session_agent_kind);
+  // Persistent status on the leading icon (visible even on hover), mirroring the
+  // sidebar precedence. Running shows the spinner; the other three show a dot.
+  const status = chatStatusTone({
+    blocked: isChatBlocked,
+    streaming: isChatStreaming,
+    completed: isChatCompleted,
+    unread: isUnread,
+  });
+  const showSpinner = status === 'running';
+  // The main slot shows the spinner for 'running', so it takes no dot there; every
+  // other status renders its tone directly.
+  const statusTone: ChatStatusTone | null = showSpinner ? null : status;
+  const statusLabel = status ? STATUS_LABEL[status] : null;
   // Mirrors the leading-slot render below — the workspace line indents to stay flush with the title
-  const hasLeadingSlot = hasSubThreads || agentKind != null;
+  const hasLeadingSlot = hasSubThreads || agentKind != null || status != null;
+  const statusSlot = hasLeadingSlot ? (
+    // Running swaps to a spinner; blocked/done/unread show a colored dot on the
+    // icon corner (or centered when there's no provider icon to anchor it).
+    <span className="relative flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center">
+      {showSpinner ? (
+        <AsciiSpinner className="text-lg leading-none" />
+      ) : agentKind ? (
+        <ProviderIcon
+          agentKind={agentKind}
+          className="h-3.5 w-3.5 text-text-tertiary dark:text-text-dark-tertiary"
+        />
+      ) : null}
+      {statusTone && (
+        <ChatStatusDot
+          tone={statusTone}
+          // Corner-overlay only when there's a provider icon to anchor to;
+          // otherwise the dot centers in the reserved box.
+          className={cn(agentKind && 'absolute -right-0.5 -top-0.5')}
+          ringClassName="ring-1 ring-surface-secondary dark:ring-surface-dark-secondary"
+        />
+      )}
+    </span>
+  ) : null;
+  // On sub-threaded rows the caret takes the slot on hover/expand — overlay the
+  // status dot on it (running shows as an amber dot, since there's no spinner here)
+  // so the persistent status never vanishes while sub-threads are open.
+  const showCaret = hasSubThreads && (isHovered || isSubThreadsExpanded);
+  const leadingIcon = showCaret ? (
+    <Button
+      onClick={() => onToggleSubThreads(chat.id)}
+      aria-expanded={isSubThreadsExpanded}
+      aria-label={`${isSubThreadsExpanded ? 'Collapse' : 'Expand'} ${chat.sub_thread_count} sub-threads`}
+      variant="unstyled"
+      // -m-1/p-1 keeps a large thumb target without shifting the row
+      className="-m-1 flex-shrink-0 p-1 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
+    >
+      <span className="relative flex h-3.5 w-3.5 items-center justify-center">
+        <ChevronRight
+          className={cn(
+            'h-3.5 w-3.5 transition-transform duration-200',
+            isSubThreadsExpanded && 'rotate-90',
+          )}
+        />
+        {status && (
+          <ChatStatusDot
+            tone={status}
+            className="absolute -right-0.5 -top-0.5"
+            ringClassName="ring-1 ring-surface-secondary dark:ring-surface-dark-secondary"
+          />
+        )}
+      </span>
+    </Button>
+  ) : statusLabel ? (
+    // Wordless dot/spinner carries status; the word lives in a tooltip
+    <FloatingTooltip content={statusLabel} className="flex flex-shrink-0 items-center">
+      {statusSlot}
+    </FloatingTooltip>
+  ) : (
+    statusSlot
+  );
   return (
     <div
+      ref={rowRef}
       className={cn(
         'group relative -mx-2 flex items-center gap-2 rounded-lg px-2 py-[7px] transition-colors duration-200',
         isActive
@@ -68,62 +157,42 @@ export const SidebarChatItem = memo(function SidebarChatItem({
       onMouseEnter={() => onMouseEnter(chat.id)}
       onMouseLeave={onMouseLeave}
     >
-      {/* Wider right padding when a status badge shows reserves room for it so
-          long titles truncate before reaching it. */}
-      <FloatingTooltip
-        content={onOpenInSplit ? `${chat.title} (Shift-click to open in split)` : chat.title}
-        className={cn('flex min-w-0 flex-1 flex-col', hasStatusBadge ? 'pr-[76px]' : 'pr-10')}
-      >
+      {/* Right padding reserves room for the timestamp/dropdown so long titles
+          truncate before reaching them. */}
+      <div className="flex min-w-0 flex-1 flex-col pr-10">
         <div className="flex min-w-0 items-center gap-1.5">
-          {/* One leading slot keeps all row titles flush: the disclosure caret
-              swaps in for the provider icon on hover/expand. */}
-          {hasSubThreads && (isHovered || isSubThreadsExpanded) ? (
-            <Button
-              onClick={() => onToggleSubThreads(chat.id)}
-              aria-expanded={isSubThreadsExpanded}
-              aria-label={`${isSubThreadsExpanded ? 'Collapse' : 'Expand'} ${chat.sub_thread_count} sub-threads`}
-              variant="unstyled"
-              // -m-1/p-1 keeps a large thumb target without shifting the row
-              className="-m-1 flex-shrink-0 p-1 text-text-tertiary hover:text-text-primary dark:text-text-dark-tertiary dark:hover:text-text-dark-primary"
-            >
-              <ChevronRight
-                className={cn(
-                  'h-3.5 w-3.5 transition-transform duration-200',
-                  isSubThreadsExpanded && 'rotate-90',
-                )}
-              />
-            </Button>
-          ) : agentKind ? (
-            <ProviderIcon
-              agentKind={agentKind}
-              className="h-3.5 w-3.5 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary"
-            />
-          ) : hasSubThreads ? (
-            // Iconless chats still reserve the slot so the title doesn't shift when the caret swaps in
-            <div className="h-3.5 w-3.5 flex-shrink-0" />
-          ) : null}
-          <Button
-            onClick={(e) => {
-              if (e.shiftKey && onOpenInSplit && !isActive) {
-                e.preventDefault();
-                onOpenInSplit(chat.id);
-                return;
-              }
-              onSelect(chat.id);
-            }}
-            aria-current={isSelected ? 'page' : undefined}
-            variant="unstyled"
-            // flex-1 keeps the whole row width as the open-chat hit target, not just the text
-            className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-[13px]"
+          {/* One leading slot keeps all row titles flush: caret on hover/expand,
+              otherwise the provider icon + a persistent status dot (or spinner). */}
+          {leadingIcon}
+          {/* Tooltip wraps only the title, not the icon — so the icon's own status
+              tooltip fires on its own hover instead of stacking with this one. */}
+          <FloatingTooltip
+            content={onOpenInSplit ? `${chat.title} (Shift-click to open in split)` : chat.title}
+            className="flex min-w-0 flex-1"
           >
-            <span className={cn('min-w-0 truncate', (isActive || isUnread) && 'font-medium')}>
-              {stripMarkdownTitle(chat.title)}
-            </span>
-            {/* Resting hint that sub-threads exist; the caret conveys it on hover/expand */}
-            {hasSubThreads && !isHovered && !isSubThreadsExpanded && (
-              <CornerDownRight className="h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
-            )}
-          </Button>
+            <Button
+              onClick={(e) => {
+                if (e.shiftKey && onOpenInSplit && !isActive) {
+                  e.preventDefault();
+                  onOpenInSplit(chat.id);
+                  return;
+                }
+                onSelect(chat.id);
+              }}
+              aria-current={isSelected ? 'page' : undefined}
+              variant="unstyled"
+              // flex-1 keeps the whole row width as the open-chat hit target, not just the text
+              className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-[13px]"
+            >
+              <span className={cn('min-w-0 truncate', (isActive || isUnread) && 'font-medium')}>
+                {stripMarkdownTitle(chat.title)}
+              </span>
+              {/* Resting hint that sub-threads exist; the caret conveys it on hover/expand */}
+              {hasSubThreads && !isHovered && !isSubThreadsExpanded && (
+                <CornerDownRight className="h-3 w-3 flex-shrink-0 text-text-quaternary dark:text-text-dark-quaternary" />
+              )}
+            </Button>
+          </FloatingTooltip>
         </div>
         {/* Clicking the badge opens the workspace context menu (new thread, rename,
             delete) — the flat list has no group headers to hang those actions on. */}
@@ -144,41 +213,17 @@ export const SidebarChatItem = memo(function SidebarChatItem({
             <span className="truncate">{workspaceBadge.name}</span>
           </Button>
         )}
-      </FloatingTooltip>
+      </div>
 
-      {/* One status badge by precedence: a pending request blocks the agent
-          (loudest, only pulsing element), then the live run, then done-since-
-          last-viewed, then unseen activity. Idle rows fall back to the timestamp. */}
+      {/* Right slot shows the timestamp — status now lives on the leading
+          dot/spinner. Hides on hover to reveal the dropdown. */}
       <span
         className={cn(
-          'absolute right-2 flex items-center text-[10px] transition-opacity duration-200',
+          'absolute right-2 flex items-center text-[10px] tabular-nums text-text-quaternary transition-opacity duration-200 dark:text-text-dark-quaternary',
           isHovered || isActive || isDropdownOpen ? 'opacity-0' : 'opacity-100',
         )}
       >
-        {isChatBlocked ? (
-          <span className="animate-pulse rounded-md bg-warning-100 px-1.5 py-0.5 font-medium text-warning-600 dark:bg-warning-500/10 dark:text-warning-400">
-            Needs you
-          </span>
-        ) : isChatStreaming ? (
-          // Neutral fill keeps amber exclusive to "action required" — the spinner carries the signal
-          <span className="flex items-center gap-1 rounded-md bg-surface-tertiary px-1.5 py-0.5 font-medium text-text-tertiary dark:bg-surface-dark-tertiary/50 dark:text-text-dark-tertiary">
-            <Loader2 className="h-2.5 w-2.5 animate-spin text-warning-500" />
-            Running
-          </span>
-        ) : isChatCompleted ? (
-          <span className="flex items-center gap-1 rounded-md bg-success-100 px-1.5 py-0.5 font-medium text-success-600 dark:bg-success-500/10 dark:text-success-400">
-            <Check className="h-2.5 w-2.5" />
-            Done
-          </span>
-        ) : isUnread ? (
-          <span className="rounded-md bg-surface-tertiary px-1.5 py-0.5 font-medium text-text-primary dark:bg-surface-dark-tertiary/50 dark:text-text-dark-primary">
-            Unread
-          </span>
-        ) : (
-          <span className="tabular-nums text-text-quaternary dark:text-text-dark-quaternary">
-            {getRelativeTime(chat.updated_at)}
-          </span>
-        )}
+        {getRelativeTime(chat.updated_at)}
       </span>
 
       <Button

--- a/frontend/src/components/layout/SubThreadList.tsx
+++ b/frontend/src/components/layout/SubThreadList.tsx
@@ -1,7 +1,9 @@
-import { memo, useState, useCallback } from 'react';
-import { AlertCircle, Check, Loader2, MoreHorizontal } from 'lucide-react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { MoreHorizontal } from 'lucide-react';
 import { useSubThreadsQuery } from '@/hooks/queries/useChatQueries';
 import { useChatAgentKind } from '@/hooks/useChatAgentKind';
+import { AsciiSpinner } from '@/components/ui/AsciiSpinner';
+import { ChatStatusDot, chatStatusTone, type ChatStatusTone } from '@/components/ui/ChatStatusDot';
 import { Button } from '@/components/ui/primitives/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
@@ -36,8 +38,24 @@ const SubThreadRow = memo(function SubThreadRow({
   onMouseLeave,
 }: SubThreadRowProps) {
   const agentKind = useChatAgentKind(thread.id, thread.session_agent_kind);
+  // Same status language as top-level rows: red dot = needs you, braille spinner =
+  // running, green dot = done. Persistent on the leading icon (visible on hover).
+  const status = chatStatusTone({
+    blocked: isBlocked,
+    streaming: isStreaming,
+    completed: isCompleted,
+  });
+  const showSpinner = status === 'running';
+  const statusTone: ChatStatusTone | null = showSpinner ? null : status;
+  const hasLeadingSlot = agentKind != null || status != null;
+  // Keep the active sub-thread visible when navigation lands on an off-screen row
+  const rowRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (isActive) rowRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [isActive]);
   return (
     <div
+      ref={rowRef}
       className={cn(
         'group relative flex items-center rounded-lg transition-colors duration-200',
         isActive
@@ -61,11 +79,24 @@ const SubThreadRow = memo(function SubThreadRow({
               : 'text-text-tertiary hover:text-text-secondary dark:text-text-dark-tertiary dark:hover:text-text-dark-secondary',
           )}
         >
-          {agentKind && (
-            <ProviderIcon
-              agentKind={agentKind}
-              className="h-3 w-3 flex-shrink-0 text-text-tertiary dark:text-text-dark-tertiary"
-            />
+          {hasLeadingSlot && (
+            <span className="relative flex h-3 w-3 flex-shrink-0 items-center justify-center">
+              {showSpinner ? (
+                <AsciiSpinner className="text-base leading-none" />
+              ) : agentKind ? (
+                <ProviderIcon
+                  agentKind={agentKind}
+                  className="h-3 w-3 text-text-tertiary dark:text-text-dark-tertiary"
+                />
+              ) : null}
+              {statusTone && (
+                <ChatStatusDot
+                  tone={statusTone}
+                  className={cn(agentKind && 'absolute -right-0.5 -top-0.5')}
+                  ringClassName="ring-1 ring-surface-secondary dark:ring-surface-dark-secondary"
+                />
+              )}
+            </span>
           )}
           <span className={cn('truncate text-xs', isActive && 'font-medium')}>
             {stripMarkdownTitle(thread.title)}
@@ -73,25 +104,15 @@ const SubThreadRow = memo(function SubThreadRow({
         </Button>
       </FloatingTooltip>
 
-      {/* Icon-only status — sub-thread rows are too tight for the labeled
-          badges top-level chats use. Same precedence: blocked > running > done. */}
+      {/* Status now lives on the leading icon; the right slot shows the timestamp
+          and hides on hover to reveal the dropdown. */}
       <span
         className={cn(
-          'absolute right-2 flex items-center transition-opacity duration-200',
+          'absolute right-2 flex items-center text-[10px] tabular-nums text-text-quaternary transition-opacity duration-200 dark:text-text-dark-quaternary',
           isHovered || isActive ? 'opacity-0' : 'opacity-100',
         )}
       >
-        {isBlocked ? (
-          <AlertCircle className="h-3 w-3 animate-pulse text-warning-500" />
-        ) : isStreaming ? (
-          <Loader2 className="h-3 w-3 animate-spin text-warning-500" />
-        ) : isCompleted ? (
-          <Check className="h-3 w-3 text-success-600 dark:text-success-400" />
-        ) : (
-          <span className="text-[10px] tabular-nums text-text-quaternary dark:text-text-dark-quaternary">
-            {getRelativeTime(thread.updated_at)}
-          </span>
-        )}
+        {getRelativeTime(thread.updated_at)}
       </span>
 
       <Button

--- a/frontend/src/components/ui/AsciiSpinner.tsx
+++ b/frontend/src/components/ui/AsciiSpinner.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { useMountEffect } from '@/hooks/useMountEffect';
+import { cn } from '@/utils/cn';
+
+// Braille frames give a smooth terminal-style spin — the CLI-agent aesthetic,
+// shown in place of a chat's icon while its agent is working.
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const FRAME_INTERVAL_MS = 80;
+
+export function AsciiSpinner({ className }: { className?: string }) {
+  const [frame, setFrame] = useState(0);
+  useMountEffect(() => {
+    const id = window.setInterval(() => {
+      setFrame((prev) => (prev + 1) % SPINNER_FRAMES.length);
+    }, FRAME_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  });
+  return (
+    <span aria-hidden="true" className={cn('select-none font-mono text-warning-500', className)}>
+      {SPINNER_FRAMES[frame]}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/ChatStatusDot.tsx
+++ b/frontend/src/components/ui/ChatStatusDot.tsx
@@ -1,0 +1,59 @@
+import { cn } from '@/utils/cn';
+
+export type ChatStatusTone = 'blocked' | 'running' | 'completed' | 'unread';
+
+// Precedence for a chat's status tone (shared by the sidebar rows and sub-threads):
+// needs-you > running > done > unread. Running normally renders the spinner, not a dot.
+export function chatStatusTone(flags: {
+  blocked: boolean;
+  streaming: boolean;
+  completed: boolean;
+  unread?: boolean;
+}): ChatStatusTone | null {
+  if (flags.blocked) return 'blocked';
+  if (flags.streaming) return 'running';
+  if (flags.completed) return 'completed';
+  if (flags.unread) return 'unread';
+  return null;
+}
+
+// Shared status dot for the sidebar rows and the title-bar tabs so both read the
+// same: red (pulsing) = needs you, amber = running, green = done, blue = unread.
+// (Running normally shows the braille spinner; the amber dot is its compact form.)
+const TONE_STYLE: Record<ChatStatusTone, { color: string; ping: boolean }> = {
+  blocked: { color: 'bg-error-500', ping: true },
+  running: { color: 'bg-warning-500', ping: false },
+  completed: { color: 'bg-success-500', ping: false },
+  unread: { color: 'bg-info-500', ping: false },
+};
+
+// className positions the whole dot (e.g. absolute corner overlay, or a sizing box
+// to center it); ringClassName punches it out from an icon it overlays.
+export function ChatStatusDot({
+  tone,
+  className,
+  ringClassName,
+}: {
+  tone: ChatStatusTone;
+  className?: string;
+  ringClassName?: string;
+}) {
+  const { color, ping } = TONE_STYLE[tone];
+  return (
+    <span className={cn('flex h-2 w-2', className)}>
+      {/* Inner box owns the ping's positioning context so the ring stays dot-sized
+          regardless of how the outer span is positioned. */}
+      <span className="relative flex h-2 w-2">
+        {ping && (
+          <span
+            className={cn(
+              'absolute inline-flex h-full w-full animate-ping rounded-full opacity-75',
+              color,
+            )}
+          />
+        )}
+        <span className={cn('relative inline-flex h-2 w-2 rounded-full', ringClassName, color)} />
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract `ChatStatusDot` and `AsciiSpinner` as shared UI components so the sidebar and title-bar tabs render chat status (blocked/running/completed/unread) identically.
- Sidebar: move status off the right-aligned badge (only visible at rest) onto the persistent leading icon, with the status word surfaced via tooltip and the running state shown as a braille spinner.
- Tabs: swap the `lucide-react` status icons for the same `ChatStatusDot`/`AsciiSpinner` components.
- Scroll the active sidebar row into view when navigation lands on an off-screen chat.