### PR TITLE
fix: provision git askpass script lazily before push/pull

### DIFF
--- a/backend/app/services/git.py
+++ b/backend/app/services/git.py
@@ -416,9 +416,13 @@ class GitService:
         return GitCommandResponse(success=True, output=result.stdout.strip())
 
     async def push(self, sandbox_id: str, cwd: str | None = None) -> GitCommandResponse:
+        # Provision the askpass script on demand — the sandbox may predate the
+        # GitHub token or have been recreated since creation-time setup.
+        await self.sandbox_service.ensure_git_askpass_script(sandbox_id)
         return await self.run_command(sandbox_id, GIT_PUSH_CMD, cwd)
 
     async def pull(self, sandbox_id: str, cwd: str | None = None) -> GitCommandResponse:
+        await self.sandbox_service.ensure_git_askpass_script(sandbox_id)
         return await self.run_command(sandbox_id, GIT_PULL_CMD, cwd)
 
     async def commit(

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -50,25 +50,21 @@ class SandboxService:
             envs["GIT_ASKPASS"] = str(SANDBOX_GIT_ASKPASS_PATH)
         return envs
 
-    async def _setup_git_askpass_script(self, sandbox_id: str) -> None:
-        # GIT_ASKPASS is a script git calls for credentials — it just echoes the
-        # GITHUB_TOKEN env var, avoiding interactive prompts for HTTPS git operations.
+    async def ensure_git_askpass_script(self, sandbox_id: str) -> None:
+        # Lazy + idempotent: git calls GIT_ASKPASS for HTTPS credentials and the
+        # script just echoes GITHUB_TOKEN. env_vars carries GIT_ASKPASS only when
+        # a token is set outside desktop mode, so its presence is the signal to
+        # (re)provision. Re-running before remote ops self-heals the case where
+        # the sandbox was created before the token existed or its container was
+        # recreated and lost the file.
+        if "GIT_ASKPASS" not in self.env_vars:
+            return
         script_content = '#!/bin/sh\\necho "$GITHUB_TOKEN"'
         setup_cmd = (
             f"echo -e '{script_content}' > {SANDBOX_GIT_ASKPASS_PATH} && "
             f"chmod +x {SANDBOX_GIT_ASKPASS_PATH}"
         )
         await self.execute_command(sandbox_id, setup_cmd)
-
-    async def initialize_sandbox(
-        self,
-        sandbox_id: str,
-        has_github_token: bool = False,
-    ) -> None:
-        # One-time setup when a sandbox is first created — provisions
-        # credentials and scripts the container needs before first use.
-        if has_github_token and not settings.DESKTOP_MODE:
-            await self._setup_git_askpass_script(sandbox_id)
 
     async def cleanup(self) -> None:
         await self.provider.cleanup()

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -118,10 +118,7 @@ class WorkspaceService(BaseDbService[Workspace]):
             workspace_path=workspace_path,
         )
 
-        await sandbox_service.initialize_sandbox(
-            sandbox_id=sandbox_id,
-            has_github_token=bool(github_token),
-        )
+        await sandbox_service.ensure_git_askpass_script(sandbox_id)
 
         try:
             async with self._session_factory() as db:


### PR DESCRIPTION
## Summary
- Replace the one-time `initialize_sandbox` setup with `ensure_git_askpass_script`, called right before `push`/`pull` instead of only at sandbox creation.
- Self-heals sandboxes that predate the GitHub token being set, or whose container was recreated and lost the askpass script since creation-time setup.