### PR TITLE
fix: derive GIT_ASKPASS path from sandbox provider

### DIFF
--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -151,6 +151,7 @@ async def get_sandbox_service(
     env_vars = SandboxService.build_env_vars(
         user_settings.custom_env_vars,
         user_settings.github_personal_access_token,
+        row.sandbox_provider,
     )
 
     return SandboxService(provider, env_vars=env_vars)

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -542,8 +542,9 @@ class AcpSession:
         if config.sandbox_id:
             host_base = settings.get_host_sandbox_base_dir()
             host_home = f"{host_base}/{config.sandbox_id}"
-            # Rewrite virtual sandbox paths (/home/user/...) to the real
-            # host sandbox directory so helpers like GIT_ASKPASS resolve.
+            # Rewrite virtual sandbox paths (/home/user/...) in env values to
+            # the real host sandbox directory. GIT_ASKPASS is exempt by design:
+            # in host mode it already points at a real API-filesystem path.
             for key, val in config.env.items():
                 env[key] = val.replace(SANDBOX_HOME_DIR, host_home)
             # Web mode: override HOME so the agent uses the sandbox dir.

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -9,7 +9,6 @@ from uuid import UUID
 from sqlalchemy import update
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.constants import SANDBOX_GIT_ASKPASS_PATH
 from app.core.config import get_settings
 from app.db.session import SessionLocal
 from app.models.db_models.chat import Chat
@@ -492,7 +491,7 @@ class AgentService:
         # Skip in desktop mode — host git credentials handle auth natively
         if user_settings.github_personal_access_token and not settings.DESKTOP_MODE:
             env["GITHUB_TOKEN"] = user_settings.github_personal_access_token
-            env["GIT_ASKPASS"] = SANDBOX_GIT_ASKPASS_PATH
+            env["GIT_ASKPASS"] = SandboxProvider.git_askpass_path(sandbox_provider)
         if settings.GIT_AUTHOR_NAME and settings.GIT_AUTHOR_EMAIL:
             env["GIT_AUTHOR_NAME"] = settings.GIT_AUTHOR_NAME
             env["GIT_AUTHOR_EMAIL"] = settings.GIT_AUTHOR_EMAIL

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -6,9 +6,6 @@ import logging
 import zipfile
 from typing import Any, Callable
 
-from app.constants import (
-    SANDBOX_GIT_ASKPASS_PATH,
-)
 from app.core.config import get_settings
 from app.models.types import CustomEnvVarDict
 from app.services.exceptions import SandboxException
@@ -16,6 +13,7 @@ from app.services.sandbox_providers import (
     PtyDataCallbackType,
     PtySize,
     SandboxProvider,
+    SandboxProviderType,
 )
 from app.services.sandbox_providers.types import CommandResult
 
@@ -38,37 +36,19 @@ class SandboxService:
     def build_env_vars(
         custom_env_vars: list[CustomEnvVarDict] | None,
         github_token: str | None,
+        provider_type: SandboxProviderType | str,
     ) -> dict[str, str]:
         envs: dict[str, str] = {}
         if custom_env_vars:
             for ev in custom_env_vars:
                 envs[ev["key"]] = ev["value"]
         # Desktop mode uses the host's native git credentials; only inject
-        # token-based auth inside Docker containers.
+        # token-based auth outside desktop mode. The askpass path depends on
+        # the provider — container path for Docker, API filesystem for host.
         if github_token and not settings.DESKTOP_MODE:
             envs["GITHUB_TOKEN"] = github_token
-            envs["GIT_ASKPASS"] = str(SANDBOX_GIT_ASKPASS_PATH)
+            envs["GIT_ASKPASS"] = SandboxProvider.git_askpass_path(provider_type)
         return envs
-
-    async def _setup_git_askpass_script(self, sandbox_id: str) -> None:
-        # GIT_ASKPASS is a script git calls for credentials — it just echoes the
-        # GITHUB_TOKEN env var, avoiding interactive prompts for HTTPS git operations.
-        script_content = '#!/bin/sh\\necho "$GITHUB_TOKEN"'
-        setup_cmd = (
-            f"echo -e '{script_content}' > {SANDBOX_GIT_ASKPASS_PATH} && "
-            f"chmod +x {SANDBOX_GIT_ASKPASS_PATH}"
-        )
-        await self.execute_command(sandbox_id, setup_cmd)
-
-    async def initialize_sandbox(
-        self,
-        sandbox_id: str,
-        has_github_token: bool = False,
-    ) -> None:
-        # One-time setup when a sandbox is first created — provisions
-        # credentials and scripts the container needs before first use.
-        if has_github_token and not settings.DESKTOP_MODE:
-            await self._setup_git_askpass_script(sandbox_id)
 
     async def cleanup(self) -> None:
         await self.provider.cleanup()

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -4,7 +4,7 @@ import posixpath
 from pathlib import Path
 from typing import Any
 
-from app.constants import SANDBOX_BINARY_EXTENSIONS
+from app.constants import SANDBOX_BINARY_EXTENSIONS, SANDBOX_GIT_ASKPASS_PATH
 from app.core.config import get_settings
 from app.services.sandbox_providers.types import (
     CommandResult,
@@ -40,6 +40,21 @@ class SandboxProvider:
         # to runtime that needs grounding in the provider's workspace root.
         rel = normalize_relative_path(rel_path)
         return posixpath.join(self.workspace_root, rel) if rel else self.workspace_root
+
+    @staticmethod
+    def git_askpass_path(provider_type: "SandboxProviderType | str") -> str:
+        # Docker bakes the script into the sandbox image; host mode runs git in
+        # the API process's filesystem, where /home/user doesn't exist — so
+        # provision a shared script under the storage dir on first use (the
+        # content is static, one file serves every sandbox).
+        if SandboxProviderType(provider_type) == SandboxProviderType.DOCKER:
+            return SANDBOX_GIT_ASKPASS_PATH
+        script = Path(settings.get_host_sandbox_base_dir()) / "git-askpass.sh"
+        if not script.exists():
+            script.parent.mkdir(parents=True, exist_ok=True)
+            script.write_text('#!/bin/sh\necho "$GITHUB_TOKEN"\n')
+            script.chmod(0o700)
+        return str(script)
 
     @staticmethod
     def create_provider(

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -107,6 +107,7 @@ class WorkspaceService(BaseDbService[Workspace]):
         env_vars = SandboxService.build_env_vars(
             user_settings.custom_env_vars,
             github_token,
+            data.sandbox_provider,
         )
         provider = SandboxProvider.create_provider(
             data.sandbox_provider,
@@ -116,11 +117,6 @@ class WorkspaceService(BaseDbService[Workspace]):
 
         sandbox_id = await sandbox_service.provider.create_sandbox(
             workspace_path=workspace_path,
-        )
-
-        await sandbox_service.initialize_sandbox(
-            sandbox_id=sandbox_id,
-            has_github_token=bool(github_token),
         )
 
         try:


### PR DESCRIPTION
## Summary
- `GIT_ASKPASS` was hardcoded to the Docker-only container path (`/home/user/.git-askpass.sh`), which doesn't exist when git runs in host mode against the API process's own filesystem.
- Adds `SandboxProvider.git_askpass_path()`, which returns the baked-in container path for Docker and lazily provisions a shared askpass script under the storage dir for host mode.
- Threads `sandbox_provider` through `SandboxService.build_env_vars` so the right path is chosen at env-build time, and removes the now-unused eager `initialize_sandbox` / `_setup_git_askpass_script` provisioning step.

## Test plan
- [ ] Push/pull from a chat using a Docker sandbox with a GitHub token configured
- [ ] Push/pull from a chat using a host-mode sandbox with a GitHub token configured