### PR TITLE
fix: remount expanded file diff when content changes

### DIFF
--- a/frontend/src/components/sandbox/git/DiffFileRow.tsx
+++ b/frontend/src/components/sandbox/git/DiffFileRow.tsx
@@ -154,6 +154,7 @@ function FileStatusBadge({ type }: { type?: string }) {
 
 export const DiffFileRow = memo(function DiffFileRow({
   file,
+  contentKey,
   isExpanded,
   isReviewed,
   stats,
@@ -173,6 +174,7 @@ export const DiffFileRow = memo(function DiffFileRow({
   onCancelComment,
 }: {
   file: FileDiffMetadata;
+  contentKey: string | undefined;
   isExpanded: boolean;
   isReviewed: boolean;
   stats: FileChangeStats | undefined;
@@ -292,7 +294,11 @@ export const DiffFileRow = memo(function DiffFileRow({
         </FloatingTooltip>
       </div>
       {isExpanded && (
+        // Keyed by content hash — the library's VirtualizedFileDiff ignores a
+        // new fileDiff after hydration (`this.fileDiff ??= fileDiff`), so a
+        // refetch with changed content must remount to render fresh lines.
         <FileDiffRenderer
+          key={contentKey}
           file={file}
           options={options}
           canComment={!!chatId}

--- a/frontend/src/components/sandbox/git/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView.tsx
@@ -905,6 +905,7 @@ const DiffViewContent = memo(function DiffViewContent({ chatId, isVisible }: Dif
                   <DiffFileRow
                     key={file.name}
                     file={file}
+                    contentKey={reviewKeyByFile.get(file.name)}
                     isExpanded={!collapsedFiles.has(file.name)}
                     isReviewed={reviewedNames.has(file.name)}
                     stats={statsByFile.get(file.name)}


### PR DESCRIPTION
## Summary
- `VirtualizedFileDiff` caches its `fileDiff` on first hydration (`this.fileDiff ??= fileDiff`), so refetching a file with changed content never re-renders updated lines while a diff row stays expanded.
- Keys `FileDiffRenderer` by `reviewKeyByFile` (content hash), forcing a remount when the underlying diff content changes, instead of reusing the stale cached instance.