### PR TITLE
Unify command menu into all/chats/files/actions search

### DIFF
--- a/frontend/src/components/chat/chat-search/ChatSearchPanel.tsx
+++ b/frontend/src/components/chat/chat-search/ChatSearchPanel.tsx
@@ -1,9 +1,10 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { Loader2, Search, X } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Input } from '@/components/ui/primitives/Input';
 import { useMountEffect } from '@/hooks/useMountEffect';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useSearchChatsQuery } from '@/hooks/queries/useChatQueries';
 import type { ChatSearchResult } from '@/types/chat.types';
 import { cn } from '@/utils/cn';
@@ -42,7 +43,7 @@ export const ChatSearchPanel = memo(function ChatSearchPanel({
   inputRef,
 }: ChatSearchPanelProps) {
   const [query, setQuery] = useState('');
-  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const debouncedQuery = useDebouncedValue(query, 250);
   const localInputRef = useRef<HTMLInputElement>(null);
   const activeInputRef = inputRef ?? localInputRef;
 
@@ -50,16 +51,10 @@ export const ChatSearchPanel = memo(function ChatSearchPanel({
     activeInputRef.current?.focus();
   });
 
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedQuery(query), 250);
-    return () => clearTimeout(timer);
-  }, [query]);
-
   const { data, isFetching, error } = useSearchChatsQuery(debouncedQuery);
 
   const handleClear = useCallback(() => {
     setQuery('');
-    setDebouncedQuery('');
     activeInputRef.current?.focus();
   }, [activeInputRef]);
 

--- a/frontend/src/components/chat/workspace-selector/CreateWorkspaceFooter.tsx
+++ b/frontend/src/components/chat/workspace-selector/CreateWorkspaceFooter.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, memo } from 'react';
+import { useState, useCallback, memo } from 'react';
 import toast from 'react-hot-toast';
 import { Search, GitBranch, Plus, Box, HardDrive, Lock, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/primitives/Input';
 import { useCreateWorkspaceMutation } from '@/hooks/queries/useWorkspaceQueries';
 import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
 import { useGitHubReposQuery } from '@/hooks/queries/useGitHubQueries';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import type { GitHubRepo } from '@/types/github.types';
 import { formatRelativeTime } from '@/utils/date';
 import { cn } from '@/utils/cn';
@@ -135,13 +136,8 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
   const [gitUrl, setGitUrl] = useState('');
   const [sandboxProvider, setSandboxProvider] = useState<'docker' | 'host'>('docker');
   const [repoSearchQuery, setRepoSearchQuery] = useState('');
-  const [debouncedRepoQuery, setDebouncedRepoQuery] = useState('');
+  const debouncedRepoQuery = useDebouncedValue(repoSearchQuery, 300);
   const [showUrlInput, setShowUrlInput] = useState(false);
-
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedRepoQuery(repoSearchQuery), 300);
-    return () => clearTimeout(timer);
-  }, [repoSearchQuery]);
 
   const { data: reposData, isLoading: reposLoading } = useGitHubReposQuery(
     debouncedRepoQuery,

--- a/frontend/src/components/editor/file-search/SearchPanel.tsx
+++ b/frontend/src/components/editor/file-search/SearchPanel.tsx
@@ -1,10 +1,11 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { CaseSensitive, Loader2, Regex, Search, WholeWord, X } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { Input } from '@/components/ui/primitives/Input';
 import { useMountEffect } from '@/hooks/useMountEffect';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useSearchInFilesQuery } from '@/hooks/queries/useSandboxQueries';
 import type { SearchParams } from '@/types/sandbox.types';
 import { cn } from '@/utils/cn';
@@ -32,7 +33,7 @@ export const SearchPanel = memo(function SearchPanel({
   inputRef,
 }: SearchPanelProps) {
   const [query, setQuery] = useState('');
-  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const debouncedQuery = useDebouncedValue(query, 250);
   const [toggles, setToggles] = useState<Record<ToggleKey, boolean>>({
     caseSensitive: false,
     wholeWord: false,
@@ -53,11 +54,6 @@ export const SearchPanel = memo(function SearchPanel({
     },
     [onOpenResult],
   );
-
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedQuery(query), 250);
-    return () => clearTimeout(timer);
-  }, [query]);
 
   const params: SearchParams = useMemo(
     () => ({
@@ -83,7 +79,6 @@ export const SearchPanel = memo(function SearchPanel({
 
   const handleClear = useCallback(() => {
     setQuery('');
-    setDebouncedQuery('');
     activeInputRef.current?.focus();
   }, [activeInputRef]);
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useNavigate } from 'react-router-dom';
-import { Plus } from 'lucide-react';
+import { Plus, Search } from 'lucide-react';
 import toast from 'react-hot-toast';
 import type { Chat } from '@/types/chat.types';
 import type { Workspace } from '@/types/workspace.types';
@@ -431,6 +431,14 @@ export function Sidebar({
     }
   }, [navigate, isMobile]);
 
+  const handleOpenSearch = useCallback(() => {
+    useUIStore.getState().setCommandMenuOpen(true);
+    // Close the drawer on mobile so the destination isn't hidden behind it after picking a result
+    if (isMobile) {
+      useUIStore.getState().setSidebarOpen(false);
+    }
+  }, [isMobile]);
+
   const handleDropdownClick = useCallback((e: React.MouseEvent<HTMLButtonElement>, chat: Chat) => {
     e.stopPropagation();
     const rect = e.currentTarget.getBoundingClientRect();
@@ -622,14 +630,22 @@ export function Sidebar({
           sidebarOpen ? 'translate-x-0' : '-translate-x-full',
         )}
       >
-        <div className="px-4 pt-2">
+        <div className="flex flex-col gap-1 px-4 pt-2">
           <Button
             onClick={handleNewChat}
             variant="unstyled"
-            className="flex w-full items-center justify-center gap-2.5 rounded-lg bg-surface-tertiary px-2 py-2 text-[13px] font-medium text-text-secondary transition-colors duration-200 hover:bg-surface-tertiary hover:text-text-primary dark:bg-surface-dark-tertiary/50 dark:text-text-dark-secondary dark:hover:bg-surface-dark-tertiary dark:hover:text-text-dark-primary"
+            className="flex w-full items-center gap-2.5 rounded-lg bg-surface-tertiary px-3 py-2 text-[13px] font-medium text-text-primary transition-colors duration-200 hover:bg-surface-tertiary dark:bg-surface-dark-tertiary/50 dark:text-text-dark-primary dark:hover:bg-surface-dark-tertiary"
           >
             <Plus className="h-3.5 w-3.5" />
             New thread
+          </Button>
+          <Button
+            onClick={handleOpenSearch}
+            variant="unstyled"
+            className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-[13px] text-text-secondary transition-colors duration-200 hover:bg-surface-tertiary hover:text-text-primary dark:text-text-dark-secondary dark:hover:bg-surface-dark-tertiary/50 dark:hover:text-text-dark-primary"
+          >
+            <Search className="h-3.5 w-3.5" />
+            Search
           </Button>
         </div>
 

--- a/frontend/src/components/layout/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { Command } from 'lucide-react';
 import { useMatch } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
@@ -174,29 +173,13 @@ export function TitleBar() {
         {IS_MACOS_DESKTOP && <TrafficLights />}
 
         {isAuthenticated && showSidebar && (
-          <div className="ml-3 flex items-center gap-0.5">
+          <div className="ml-3 flex items-center">
             <ToggleButton
               isOpen={sidebarOpen}
               onClick={() => useUIStore.getState().setSidebarOpen(!sidebarOpen)}
               position="left"
               ariaLabel="Toggle sidebar"
             />
-            {isChatPage && (
-              <Button
-                onClick={() => useUIStore.getState().setCommandMenuOpen(true)}
-                variant="unstyled"
-                className={cn(
-                  'rounded-full p-1.5',
-                  'text-text-tertiary hover:text-text-primary',
-                  'dark:text-text-dark-quaternary dark:hover:text-text-dark-primary',
-                  'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-                  'transition-colors duration-200',
-                )}
-                aria-label="Open command menu"
-              >
-                <Command className="h-3.5 w-3.5" />
-              </Button>
-            )}
           </div>
         )}
 

--- a/frontend/src/components/ui/CommandMenu.tsx
+++ b/frontend/src/components/ui/CommandMenu.tsx
@@ -1,19 +1,23 @@
 import {
+  Fragment,
   useState,
   useEffect,
   useRef,
   useMemo,
   useCallback,
+  type ReactNode,
+  type Ref,
   type MouseEvent as ReactMouseEvent,
 } from 'react';
 import { Button } from '@/components/ui/primitives/Button';
 import { Input } from '@/components/ui/primitives/Input';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip';
 import { createPortal } from 'react-dom';
-import { GitBranch, Search, PanelRight, PanelBottom, File } from 'lucide-react';
+import { GitBranch, Search, PanelRight, PanelBottom, File, MessageSquare } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 import { useUIStore } from '@/store/uiStore';
+import { useAuthStore } from '@/store/authStore';
 import { useQueryClient } from '@tanstack/react-query';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { isSecondaryPaneActive, viewTypeToTileId } from '@/utils/tileHelpers';
@@ -21,21 +25,28 @@ import { useChatContext } from '@/hooks/useChatContext';
 import { useActiveChat } from '@/hooks/useActiveChat';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
 import { useGitBranchesQuery, useCheckoutBranchMutation } from '@/hooks/queries/useSandboxQueries';
+import { useWorkspacesList } from '@/hooks/queries/useWorkspaceQueries';
+import { useSidebarChatLists } from '@/hooks/queries/useSidebarChatLists';
+import { useSearchChatsQuery } from '@/hooks/queries/useChatQueries';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { fuzzySearch } from '@/utils/fuzzySearch';
 import { HighlightMatch } from '@/components/ui/shared/HighlightMatch';
 import { SearchPanel } from '@/components/editor/file-search/SearchPanel';
 import { ChatSearchPanel } from '@/components/chat/chat-search/ChatSearchPanel';
 import { cn } from '@/utils/cn';
 import { THEMES, type ThemeMeta } from '@/utils/theme';
+import { IS_MAC_PLATFORM } from '@/utils/platform';
 import type { ViewType, SplitDirection, Theme } from '@/types/ui.types';
 import {
   ALL_COMMANDS,
   COMMAND_TO_MODE,
+  MAIN_FILTERS,
   executeCommand,
   flattenFiles,
   formatShortcut,
   type CommandItem,
   type FlatFileItem,
+  type MainFilter,
   type MenuMode,
 } from './commandRegistry';
 
@@ -52,18 +63,102 @@ const splitButtonClass = cn(
   'transition-colors duration-200',
 );
 
+const sectionHeaderClass = cn(
+  'px-3 pb-1 pt-2 text-2xs font-medium uppercase tracking-wider',
+  'text-text-quaternary dark:text-text-dark-quaternary',
+);
+
+const FILTER_LABELS: Record<MainFilter, string> = {
+  all: 'All',
+  chats: 'Chats',
+  files: 'Files',
+  actions: 'Actions',
+};
+
+const isMainMode = (mode: MenuMode): mode is MainFilter =>
+  mode === 'all' || mode === 'chats' || mode === 'files' || mode === 'actions';
+
+// Chat rows come from two sources — loaded chat lists (instant title fuzzy match) and
+// the backend message-content search (Chats tab only) — normalized to one display shape.
+interface ChatRowItem {
+  id: string;
+  title: string;
+  workspaceName?: string;
+  matchCount?: number;
+}
+
+// One flat list drives both keyboard navigation and rendering of the sectioned
+// main-mode results, so their ordering can never diverge.
+type MenuListItem =
+  | { kind: 'chat'; chat: ChatRowItem }
+  | { kind: 'file'; file: FlatFileItem }
+  | { kind: 'command'; command: CommandItem };
+
+interface MenuRowProps {
+  id: string;
+  index: number;
+  isActive: boolean;
+  itemRef: Ref<HTMLDivElement> | undefined;
+  onActivate: (index: number, e: ReactMouseEvent) => void;
+  onSelect: () => void;
+  disabled?: boolean;
+  // Controls rendered outside the option button (shortcut hint, split buttons).
+  trailing?: ReactNode;
+  children: ReactNode;
+}
+
+// Shared row shell — active highlight, synthetic-hover guard, option semantics.
+// Only the button content (and optional trailing controls) differ per row type.
+function MenuRow({
+  id,
+  index,
+  isActive,
+  itemRef,
+  onActivate,
+  onSelect,
+  disabled,
+  trailing,
+  children,
+}: MenuRowProps) {
+  return (
+    <div
+      ref={itemRef}
+      className={cn(
+        rowClass,
+        isActive
+          ? 'bg-surface-active dark:bg-surface-dark-active'
+          : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
+      )}
+      onMouseMove={(e) => onActivate(index, e)}
+    >
+      <Button
+        variant="unstyled"
+        id={id}
+        role="option"
+        aria-selected={isActive}
+        className="flex flex-1 items-center gap-3 overflow-hidden"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onSelect}
+        disabled={disabled}
+      >
+        {children}
+      </Button>
+      {trailing}
+    </div>
+  );
+}
+
 export function CommandMenu() {
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
-  const [mode, setMode] = useState<MenuMode>('commands');
+  const [mode, setMode] = useState<MenuMode>('all');
   const inputRef = useRef<HTMLInputElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const chatSearchInputRef = useRef<HTMLInputElement>(null);
   const previousFocusRef = useRef<Element | null>(null);
   const activeItemRef = useRef<HTMLDivElement>(null);
-  const stateRef = useRef({ activeIndex: 0, mode: 'commands' as MenuMode });
-  const filteredFilesRef = useRef<FlatFileItem[]>([]);
-  const filteredCommandsRef = useRef<CommandItem[]>([]);
+  const stateRef = useRef({ activeIndex: 0, mode: 'all' as MenuMode });
+  const listItemsRef = useRef<MenuListItem[]>([]);
   const filteredBranchesRef = useRef<string[]>([]);
   const filteredThemesRef = useRef<ThemeMeta[]>([]);
   const listLengthRef = useRef(0);
@@ -75,6 +170,7 @@ export function CommandMenu() {
   const isOpen = useUIStore((state) => state.commandMenuOpen);
   const theme = useUIStore((state) => state.theme);
   const isMobile = useIsMobile();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   // On-screen tile ids (not deduped view kinds) so the active-state/split
   // affordances can distinguish a view's primary tile from its `:secondary`
   // variant. Keyed on visibility, not open membership — views have no tabs, so an
@@ -119,15 +215,98 @@ export function CommandMenu() {
 
   const canSwitchBranch = !!branchesData?.is_git_repo && branchesData.branches.length > 0;
 
+  // Chat rows reuse the sidebar's queries (cache-warm on every page the menu mounts on),
+  // gated on open + auth so the always-mounted menu doesn't fetch while closed or logged out.
+  const chatQueriesEnabled = isOpen && isAuthenticated;
+  const workspaces = useWorkspacesList({ enabled: chatQueriesEnabled });
+  const { pinnedChats, recentChats, workspaceBadgeById } = useSidebarChatLists(
+    workspaces,
+    chatQueriesEnabled,
+  );
+  const menuChats = useMemo(() => {
+    if (!isOpen) return [];
+    // Pinned and recents are disjoint; the menu is a single recency-ordered list.
+    return [...pinnedChats, ...recentChats].sort(
+      (a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at),
+    );
+  }, [isOpen, pinnedChats, recentChats]);
+
   const flatFiles = useMemo(() => flattenFiles(fileStructure), [fileStructure]);
+
+  const filteredChats = useMemo(
+    () =>
+      mode !== 'all' && mode !== 'chats'
+        ? []
+        : fuzzySearch(query, menuChats, { keys: ['title'], limit: mode === 'chats' ? 30 : 5 }),
+    [query, menuChats, mode],
+  );
+
+  // Deep search runs on the Chats tab only — the All tab stays instant/local; the
+  // "Search in chats" action remains the snippet-level browser for message matches.
+  const debouncedQuery = useDebouncedValue(query, 250);
+  const deepSearchQuery = mode === 'chats' ? debouncedQuery.trim() : '';
+  const {
+    data: chatSearchData,
+    isFetching: isSearchingChats,
+    isPlaceholderData: isStaleChatSearch,
+  } = useSearchChatsQuery(deepSearchQuery, { enabled: isOpen && deepSearchQuery.length >= 2 });
+  const trimmedQuery = query.trim();
+  // Debounce/fetch lag — content rows are hidden while the search trails the input,
+  // so show the searching hint instead of a misleading empty or settled list.
+  const isChatSearchPending =
+    mode === 'chats' &&
+    trimmedQuery.length >= 2 &&
+    (deepSearchQuery !== trimmedQuery || isSearchingChats);
+
+  const chatRows = useMemo<ChatRowItem[]>(() => {
+    const titleRows = filteredChats.map((chat) => ({
+      id: chat.id,
+      title: chat.title,
+      workspaceName: workspaceBadgeById.get(chat.workspace_id)?.name,
+    }));
+    // Stale rows are selectable, so a quick Enter could open a chat unrelated to the
+    // current input. Two windows produce them: the debounce lag (deepSearchQuery still
+    // holds the previous term) and keepPreviousData while a new request is in flight
+    // (placeholder response for the previous term). Hide content rows through both;
+    // the length gate keeps the section query-driven below the search minimum.
+    if (
+      mode !== 'chats' ||
+      deepSearchQuery.length < 2 ||
+      deepSearchQuery !== trimmedQuery ||
+      !chatSearchData ||
+      isStaleChatSearch
+    ) {
+      return titleRows;
+    }
+    // Content-only hits go below title matches, deduped by chat id.
+    const titleIds = new Set(titleRows.map((row) => row.id));
+    const contentRows = chatSearchData.results
+      .filter((result) => !titleIds.has(result.chat_id))
+      .map((result) => ({
+        id: result.chat_id,
+        title: result.chat_title,
+        workspaceName: result.workspace_name,
+        matchCount: result.match_count,
+      }));
+    return [...titleRows, ...contentRows];
+  }, [
+    filteredChats,
+    workspaceBadgeById,
+    mode,
+    deepSearchQuery,
+    trimmedQuery,
+    chatSearchData,
+    isStaleChatSearch,
+  ]);
 
   const filteredFiles = useMemo(
     () =>
-      mode !== 'files'
+      mode !== 'all' && mode !== 'files'
         ? []
-        : query.trim()
-          ? fuzzySearch(query, flatFiles, { keys: ['name', 'path'], limit: 30 })
-          : flatFiles.slice(0, 30),
+        : fuzzySearch(query, flatFiles, {
+            keys: ['name', 'path'],
+            limit: mode === 'files' ? 30 : 5,
+          }),
     [query, flatFiles, mode],
   );
 
@@ -145,10 +324,19 @@ export function CommandMenu() {
 
   const filteredCommands = useMemo(
     () =>
-      mode !== 'commands'
+      mode !== 'all' && mode !== 'actions'
         ? []
         : fuzzySearch(query, visibleCommands, { keys: ['label'], limit: 20 }),
     [query, visibleCommands, mode],
+  );
+
+  const listItems = useMemo<MenuListItem[]>(
+    () => [
+      ...chatRows.map((chat) => ({ kind: 'chat' as const, chat })),
+      ...filteredFiles.map((file) => ({ kind: 'file' as const, file })),
+      ...filteredCommands.map((command) => ({ kind: 'command' as const, command })),
+    ],
+    [chatRows, filteredFiles, filteredCommands],
   );
 
   const orderedBranches = useMemo(() => {
@@ -169,13 +357,11 @@ export function CommandMenu() {
   );
 
   const listLength =
-    mode === 'files'
-      ? filteredFiles.length
-      : mode === 'branches'
-        ? filteredBranches.length
-        : mode === 'themes'
-          ? filteredThemes.length
-          : filteredCommands.length;
+    mode === 'branches'
+      ? filteredBranches.length
+      : mode === 'themes'
+        ? filteredThemes.length
+        : listItems.length;
 
   const activateFromMouse = (index: number, e: ReactMouseEvent) => {
     const last = lastMouseRef.current;
@@ -201,12 +387,19 @@ export function CommandMenu() {
     }
   }, []);
 
+  // Tab clicks and ⌘[/⌘] keep the typed query — filters narrow the current search.
+  const switchFilter = useCallback((next: MainFilter) => {
+    lastMouseRef.current = null;
+    setMode(next);
+    setActiveIndex(0);
+  }, []);
+
   useEffect(() => {
     if (isOpen) {
       previousFocusRef.current = document.activeElement;
       // switchMode also focuses the right input for the target mode.
       const ui = useUIStore.getState();
-      switchMode(ui.pendingMenuMode ?? 'commands');
+      switchMode(ui.pendingMenuMode ?? 'all');
       ui.setPendingMenuMode(null);
     } else if (previousFocusRef.current instanceof HTMLElement) {
       previousFocusRef.current.focus();
@@ -224,6 +417,16 @@ export function CommandMenu() {
       close();
     },
     [close, queryClient, navigate, sandboxId, worktreeCwd],
+  );
+
+  // Commands either dispatch an action or switch the menu into a sub-mode/filter.
+  const runCommand = useCallback(
+    (cmd: CommandItem) => {
+      const nextMode = COMMAND_TO_MODE[cmd.id];
+      if (nextMode) switchMode(nextMode);
+      else handleSelectItem(cmd);
+    },
+    [switchMode, handleSelectItem],
   );
 
   const handleSelectFile = useCallback(
@@ -300,8 +503,7 @@ export function CommandMenu() {
 
   stateRef.current.activeIndex = activeIndex;
   stateRef.current.mode = mode;
-  filteredFilesRef.current = filteredFiles;
-  filteredCommandsRef.current = filteredCommands;
+  listItemsRef.current = listItems;
   filteredBranchesRef.current = filteredBranches;
   filteredThemesRef.current = filteredThemes;
   listLengthRef.current = listLength;
@@ -319,12 +521,23 @@ export function CommandMenu() {
 
       if (m === 'search' || m === 'chat-search') {
         // The embedded panel handles its own typing + click-to-open; don't
-        // hijack Enter/arrows here. Only wire Escape to step back to commands.
+        // hijack Enter/arrows here. Only wire Escape to step back to the main list.
         if (e.key === 'Escape') {
           e.preventDefault();
           e.stopImmediatePropagation();
-          switchMode('commands');
+          switchMode('all');
         }
+        return;
+      }
+
+      // ⌘[/⌘] cycle the main-mode filter tabs (preventDefault also blocks the
+      // browser's back/forward navigation bound to these chords).
+      if (isMainMode(m) && (e.metaKey || e.ctrlKey) && (e.key === '[' || e.key === ']')) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        const step = e.key === ']' ? 1 : -1;
+        const current = MAIN_FILTERS.indexOf(m);
+        switchFilter(MAIN_FILTERS[(current + step + MAIN_FILTERS.length) % MAIN_FILTERS.length]);
         return;
       }
 
@@ -332,8 +545,10 @@ export function CommandMenu() {
         case 'Escape':
           e.preventDefault();
           e.stopImmediatePropagation();
-          if (m === 'files' || m === 'branches' || m === 'themes') {
-            switchMode('commands');
+          if (m === 'branches' || m === 'themes') {
+            switchMode('all');
+          } else if (m !== 'all') {
+            switchFilter('all');
           } else {
             close();
           }
@@ -352,21 +567,21 @@ export function CommandMenu() {
           break;
         case 'Enter':
           e.preventDefault();
-          if (m === 'files') {
-            const file = filteredFilesRef.current[idx];
-            if (file) handleSelectFile(file);
-          } else if (m === 'branches') {
+          if (m === 'branches') {
             const branch = filteredBranchesRef.current[idx];
             if (branch) handleSelectBranch(branch);
           } else if (m === 'themes') {
             const themeItem = filteredThemesRef.current[idx];
             if (themeItem) handleSelectTheme(themeItem.value);
           } else {
-            const cmd = filteredCommandsRef.current[idx];
-            if (cmd) {
-              const nextMode = COMMAND_TO_MODE[cmd.id];
-              if (nextMode) switchMode(nextMode);
-              else handleSelectItem(cmd);
+            const item = listItemsRef.current[idx];
+            if (!item) break;
+            if (item.kind === 'chat') {
+              handleOpenChatResult(item.chat.id);
+            } else if (item.kind === 'file') {
+              handleSelectFile(item.file);
+            } else {
+              runCommand(item.command);
             }
           }
           break;
@@ -377,15 +592,137 @@ export function CommandMenu() {
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
   }, [
     isOpen,
-    handleSelectItem,
+    runCommand,
     handleSelectFile,
+    handleOpenChatResult,
     handleSelectBranch,
     handleSelectTheme,
     switchMode,
+    switchFilter,
     close,
   ]);
 
   if (!isOpen) return null;
+
+  const modKey = IS_MAC_PLATFORM ? '⌘' : 'Ctrl+';
+
+  const renderMainRow = (item: MenuListItem, index: number) => {
+    const rowProps = {
+      index,
+      isActive: index === activeIndex,
+      itemRef: index === activeIndex ? activeItemRef : undefined,
+      onActivate: activateFromMouse,
+      id: `menu-item-${index}`,
+    };
+    // Sections are contiguous by kind, so a header renders on each kind transition.
+    const prevKind = listItems[index - 1]?.kind;
+    const showHeader = mode === 'all' && prevKind !== item.kind;
+
+    if (item.kind === 'chat') {
+      const { chat } = item;
+      return (
+        <Fragment key={`chat-${chat.id}`}>
+          {showHeader && (
+            <p className={sectionHeaderClass}>{trimmedQuery ? 'Chats' : 'Recent chats'}</p>
+          )}
+          <MenuRow {...rowProps} onSelect={() => handleOpenChatResult(chat.id)}>
+            <MessageSquare className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
+            <HighlightMatch
+              text={chat.title}
+              searchQuery={query}
+              className="flex-1 truncate text-left font-medium"
+            />
+            {/* Content hits show the match count — it explains why a title
+                that doesn't match the query is listed. */}
+            {(chat.matchCount != null || chat.workspaceName) && (
+              <span className="shrink-0 text-text-quaternary dark:text-text-dark-quaternary">
+                {chat.matchCount != null
+                  ? `${chat.matchCount} ${chat.matchCount === 1 ? 'match' : 'matches'}`
+                  : chat.workspaceName}
+              </span>
+            )}
+          </MenuRow>
+        </Fragment>
+      );
+    }
+
+    if (item.kind === 'file') {
+      const { file } = item;
+      return (
+        <Fragment key={`file-${file.path}`}>
+          {showHeader && <p className={sectionHeaderClass}>Files</p>}
+          <MenuRow {...rowProps} onSelect={() => handleSelectFile(file)}>
+            <File className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
+            <span className="truncate">
+              <HighlightMatch text={file.name} searchQuery={query} className="font-medium" />
+              <span className="ml-2 text-text-quaternary dark:text-text-dark-quaternary">
+                {file.path}
+              </span>
+            </span>
+          </MenuRow>
+        </Fragment>
+      );
+    }
+
+    const cmd = item.command;
+    const Icon = cmd.icon;
+    // Active/split state is scoped to the pane the user is in: the view counts as
+    // active only if the active pane's target tile (e.g. editor:secondary) is
+    // already on screen, so the split buttons stay available to surface it beside
+    // the other panes.
+    const isViewActive =
+      cmd.type === 'view' && leafTileIds.has(viewTypeToTileId(cmd.id, useSecondary));
+    return (
+      <Fragment key={`command-${cmd.id}`}>
+        {showHeader && <p className={sectionHeaderClass}>Actions</p>}
+        <MenuRow
+          {...rowProps}
+          onSelect={() => runCommand(cmd)}
+          trailing={
+            <>
+              {!isMobile && cmd.shortcut && (
+                <kbd className="ml-auto shrink-0 font-mono text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                  {formatShortcut(cmd.shortcut)}
+                </kbd>
+              )}
+              {cmd.type === 'view' && !isMobile && !isViewActive && (
+                <div className="flex items-center gap-0.5">
+                  <FloatingTooltip content="Split right" className="flex">
+                    <Button
+                      variant="unstyled"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => handleSplit(cmd.id, 'row')}
+                      className={splitButtonClass}
+                      aria-label="Split right"
+                    >
+                      <PanelRight className="h-3 w-3" />
+                    </Button>
+                  </FloatingTooltip>
+                  <FloatingTooltip content="Split down" className="flex">
+                    <Button
+                      variant="unstyled"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => handleSplit(cmd.id, 'column')}
+                      className={splitButtonClass}
+                      aria-label="Split down"
+                    >
+                      <PanelBottom className="h-3 w-3" />
+                    </Button>
+                  </FloatingTooltip>
+                </div>
+              )}
+            </>
+          }
+        >
+          <Icon className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
+          <HighlightMatch text={cmd.label} searchQuery={query} className="flex-1 text-left" />
+          {isViewActive && (
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-text-primary dark:bg-text-dark-primary" />
+          )}
+        </MenuRow>
+      </Fragment>
+    );
+  };
 
   return createPortal(
     <div
@@ -397,10 +734,7 @@ export function CommandMenu() {
     >
       <div
         className={cn(
-          'mt-20 h-fit w-full',
-          // Widen for search mode so code snippets don't wrap; keep the compact
-          // dialog for every other mode.
-          mode === 'search' || mode === 'chat-search' ? 'max-w-2xl' : 'max-w-md',
+          'mt-20 h-fit w-full max-w-2xl',
           'rounded-xl border border-border/50 shadow-strong dark:border-border-dark/50',
           'bg-surface/95 backdrop-blur-xl dark:bg-surface-dark/95',
           'animate-fade-in',
@@ -414,7 +748,7 @@ export function CommandMenu() {
               <Button
                 variant="unstyled"
                 onMouseDown={(e) => e.preventDefault()}
-                onClick={() => switchMode('commands')}
+                onClick={() => switchMode('all')}
                 className="shrink-0 rounded-md bg-surface-hover px-1.5 py-0.5 text-2xs font-medium text-text-secondary dark:bg-surface-dark-hover dark:text-text-dark-secondary"
               >
                 Search in files
@@ -438,7 +772,7 @@ export function CommandMenu() {
               <Button
                 variant="unstyled"
                 onMouseDown={(e) => e.preventDefault()}
-                onClick={() => switchMode('commands')}
+                onClick={() => switchMode('all')}
                 className="shrink-0 rounded-md bg-surface-hover px-1.5 py-0.5 text-2xs font-medium text-text-secondary dark:bg-surface-dark-hover dark:text-text-dark-secondary"
               >
                 Search in chats
@@ -454,14 +788,14 @@ export function CommandMenu() {
         ) : (
           <>
             <div className="flex items-center gap-2 border-b border-border/50 px-3 dark:border-border-dark/50">
-              {(mode === 'files' || mode === 'branches' || mode === 'themes') && (
+              {(mode === 'branches' || mode === 'themes') && (
                 <Button
                   variant="unstyled"
                   onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => switchMode('commands')}
+                  onClick={() => switchMode('all')}
                   className="shrink-0 rounded-md bg-surface-hover px-1.5 py-0.5 text-2xs font-medium text-text-secondary dark:bg-surface-dark-hover dark:text-text-dark-secondary"
                 >
-                  {mode === 'files' ? 'Files' : mode === 'branches' ? 'Branches' : 'Themes'}
+                  {mode === 'branches' ? 'Branches' : 'Themes'}
                 </Button>
               )}
               <Search className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
@@ -474,121 +808,84 @@ export function CommandMenu() {
                   setActiveIndex(0);
                 }}
                 placeholder={
-                  mode === 'files'
-                    ? 'Search files...'
-                    : mode === 'branches'
-                      ? 'Search branches...'
-                      : mode === 'themes'
-                        ? 'Search themes...'
-                        : 'Search...'
+                  mode === 'branches'
+                    ? 'Search branches...'
+                    : mode === 'themes'
+                      ? 'Search themes...'
+                      : mode === 'chats'
+                        ? 'Search chats and messages...'
+                        : mode === 'files'
+                          ? 'Search files...'
+                          : mode === 'actions'
+                            ? 'Search actions...'
+                            : 'Search chats, files, actions...'
                 }
                 className="h-10 w-full bg-transparent text-sm text-text-primary outline-none placeholder:text-text-quaternary dark:text-text-dark-primary dark:placeholder:text-text-dark-quaternary"
                 role="combobox"
                 aria-expanded="true"
                 aria-controls={listId}
                 aria-activedescendant={
-                  mode === 'files'
-                    ? filteredFiles[activeIndex]
-                      ? `file-item-${activeIndex}`
+                  mode === 'branches'
+                    ? filteredBranches[activeIndex]
+                      ? `branch-item-${activeIndex}`
                       : undefined
-                    : mode === 'branches'
-                      ? filteredBranches[activeIndex]
-                        ? `branch-item-${activeIndex}`
+                    : mode === 'themes'
+                      ? filteredThemes[activeIndex]
+                        ? `theme-item-${activeIndex}`
                         : undefined
-                      : mode === 'themes'
-                        ? filteredThemes[activeIndex]
-                          ? `theme-item-${activeIndex}`
-                          : undefined
-                        : filteredCommands[activeIndex]
-                          ? `command-item-${filteredCommands[activeIndex].id}`
-                          : undefined
+                      : listItems[activeIndex]
+                        ? `menu-item-${activeIndex}`
+                        : undefined
                 }
               />
             </div>
 
-            <div className="max-h-64 overflow-y-auto py-1" role="listbox" id={listId}>
-              {mode === 'files' ? (
+            {isMainMode(mode) && (
+              <div className="flex items-center gap-1 border-b border-border/50 px-3 py-2 dark:border-border-dark/50">
+                {MAIN_FILTERS.map((filter) => (
+                  <Button
+                    key={filter}
+                    variant="unstyled"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => switchFilter(filter)}
+                    className={cn(
+                      'rounded-md px-2.5 py-1 text-xs font-medium transition-colors duration-200',
+                      filter === mode
+                        ? 'bg-surface-active text-text-primary dark:bg-surface-dark-active dark:text-text-dark-primary'
+                        : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary dark:text-text-dark-tertiary dark:hover:bg-surface-dark-hover dark:hover:text-text-dark-primary',
+                    )}
+                  >
+                    {FILTER_LABELS[filter]}
+                  </Button>
+                ))}
+              </div>
+            )}
+
+            <div className="max-h-[24rem] overflow-y-auto py-1" role="listbox" id={listId}>
+              {mode === 'branches' ? (
                 <>
-                  {filteredFiles.map((file, index) => (
-                    <div
-                      key={file.path}
-                      ref={index === activeIndex ? activeItemRef : undefined}
-                      className={cn(
-                        rowClass,
-                        index === activeIndex
-                          ? 'bg-surface-active dark:bg-surface-dark-active'
-                          : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-                      )}
-                      onMouseMove={(e) => activateFromMouse(index, e)}
+                  {filteredBranches.map((branch, index) => (
+                    <MenuRow
+                      key={branch}
+                      id={`branch-item-${index}`}
+                      index={index}
+                      isActive={index === activeIndex}
+                      itemRef={index === activeIndex ? activeItemRef : undefined}
+                      onActivate={activateFromMouse}
+                      onSelect={() => handleSelectBranch(branch)}
+                      disabled={checkoutBranch.isPending}
                     >
-                      <Button
-                        variant="unstyled"
-                        id={`file-item-${index}`}
-                        role="option"
-                        aria-selected={index === activeIndex}
-                        className="flex flex-1 items-center gap-3 overflow-hidden"
-                        onMouseDown={(e) => e.preventDefault()}
-                        onClick={() => handleSelectFile(file)}
-                      >
-                        <File className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
-                        <span className="truncate">
-                          <HighlightMatch
-                            text={file.name}
-                            searchQuery={query}
-                            className="font-medium"
-                          />
-                          <span className="ml-2 text-text-quaternary dark:text-text-dark-quaternary">
-                            {file.path}
-                          </span>
-                        </span>
-                      </Button>
-                    </div>
+                      <GitBranch className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
+                      <HighlightMatch
+                        text={branch}
+                        searchQuery={query}
+                        className="flex-1 truncate text-left font-mono"
+                      />
+                      {branch === branchesData?.current_branch && (
+                        <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-text-primary dark:bg-text-dark-primary" />
+                      )}
+                    </MenuRow>
                   ))}
-                  {filteredFiles.length === 0 && (
-                    <p className="px-3 py-4 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
-                      No matching files
-                    </p>
-                  )}
-                </>
-              ) : mode === 'branches' ? (
-                <>
-                  {filteredBranches.map((branch, index) => {
-                    const isCurrent = branch === branchesData?.current_branch;
-                    return (
-                      <div
-                        key={branch}
-                        ref={index === activeIndex ? activeItemRef : undefined}
-                        className={cn(
-                          rowClass,
-                          index === activeIndex
-                            ? 'bg-surface-active dark:bg-surface-dark-active'
-                            : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-                        )}
-                        onMouseMove={(e) => activateFromMouse(index, e)}
-                      >
-                        <Button
-                          variant="unstyled"
-                          id={`branch-item-${index}`}
-                          role="option"
-                          aria-selected={index === activeIndex}
-                          className="flex flex-1 items-center gap-3 overflow-hidden"
-                          onMouseDown={(e) => e.preventDefault()}
-                          onClick={() => handleSelectBranch(branch)}
-                          disabled={checkoutBranch.isPending}
-                        >
-                          <GitBranch className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
-                          <HighlightMatch
-                            text={branch}
-                            searchQuery={query}
-                            className="flex-1 truncate text-left font-mono"
-                          />
-                          {isCurrent && (
-                            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-text-primary dark:bg-text-dark-primary" />
-                          )}
-                        </Button>
-                      </div>
-                    );
-                  })}
                   {filteredBranches.length === 0 && (
                     <p className="px-3 py-4 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
                       {!sandboxId
@@ -607,39 +904,26 @@ export function CommandMenu() {
                 <>
                   {filteredThemes.map((themeItem, index) => {
                     const Icon = themeItem.icon;
-                    const isActive = themeItem.value === theme;
                     return (
-                      <div
+                      <MenuRow
                         key={themeItem.value}
-                        ref={index === activeIndex ? activeItemRef : undefined}
-                        className={cn(
-                          rowClass,
-                          index === activeIndex
-                            ? 'bg-surface-active dark:bg-surface-dark-active'
-                            : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-                        )}
-                        onMouseMove={(e) => activateFromMouse(index, e)}
+                        id={`theme-item-${index}`}
+                        index={index}
+                        isActive={index === activeIndex}
+                        itemRef={index === activeIndex ? activeItemRef : undefined}
+                        onActivate={activateFromMouse}
+                        onSelect={() => handleSelectTheme(themeItem.value)}
                       >
-                        <Button
-                          variant="unstyled"
-                          id={`theme-item-${index}`}
-                          role="option"
-                          aria-selected={index === activeIndex}
-                          className="flex flex-1 items-center gap-3 overflow-hidden"
-                          onMouseDown={(e) => e.preventDefault()}
-                          onClick={() => handleSelectTheme(themeItem.value)}
-                        >
-                          <Icon className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
-                          <HighlightMatch
-                            text={themeItem.label}
-                            searchQuery={query}
-                            className="flex-1 truncate text-left"
-                          />
-                          {isActive && (
-                            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-text-primary dark:bg-text-dark-primary" />
-                          )}
-                        </Button>
-                      </div>
+                        <Icon className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
+                        <HighlightMatch
+                          text={themeItem.label}
+                          searchQuery={query}
+                          className="flex-1 truncate text-left"
+                        />
+                        {themeItem.value === theme && (
+                          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-text-primary dark:bg-text-dark-primary" />
+                        )}
+                      </MenuRow>
                     );
                   })}
                   {filteredThemes.length === 0 && (
@@ -650,89 +934,21 @@ export function CommandMenu() {
                 </>
               ) : (
                 <>
-                  {filteredCommands.map((cmd, index) => {
-                    const Icon = cmd.icon;
-                    // Active/split state is scoped to the pane the user is in: the
-                    // view counts as active only if the active pane's target tile
-                    // (e.g. editor:secondary) is already on screen, so the split
-                    // buttons stay available to surface it beside the other panes.
-                    const isActive =
-                      cmd.type === 'view' &&
-                      leafTileIds.has(viewTypeToTileId(cmd.id, useSecondary));
-
-                    return (
-                      <div
-                        key={cmd.id}
-                        ref={index === activeIndex ? activeItemRef : undefined}
-                        className={cn(
-                          rowClass,
-                          index === activeIndex
-                            ? 'bg-surface-active dark:bg-surface-dark-active'
-                            : 'hover:bg-surface-hover dark:hover:bg-surface-dark-hover',
-                        )}
-                        onMouseMove={(e) => activateFromMouse(index, e)}
-                      >
-                        <Button
-                          variant="unstyled"
-                          id={`command-item-${cmd.id}`}
-                          role="option"
-                          aria-selected={index === activeIndex}
-                          className="flex flex-1 items-center gap-3"
-                          onMouseDown={(e) => e.preventDefault()}
-                          onClick={() => {
-                            const nextMode = COMMAND_TO_MODE[cmd.id];
-                            if (nextMode) switchMode(nextMode);
-                            else handleSelectItem(cmd);
-                          }}
-                        >
-                          <Icon className="h-3.5 w-3.5 shrink-0 text-text-tertiary dark:text-text-dark-tertiary" />
-                          <HighlightMatch
-                            text={cmd.label}
-                            searchQuery={query}
-                            className="flex-1 text-left"
-                          />
-                          {isActive && (
-                            <span className="h-1.5 w-1.5 rounded-full bg-text-primary dark:bg-text-dark-primary" />
-                          )}
-                        </Button>
-                        {!isMobile && cmd.shortcut && (
-                          <kbd className="ml-auto shrink-0 font-mono text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-                            {formatShortcut(cmd.shortcut)}
-                          </kbd>
-                        )}
-                        {cmd.type === 'view' && !isMobile && !isActive && (
-                          <div className="flex items-center gap-0.5">
-                            <FloatingTooltip content="Split right" className="flex">
-                              <Button
-                                variant="unstyled"
-                                onMouseDown={(e) => e.preventDefault()}
-                                onClick={() => handleSplit(cmd.id, 'row')}
-                                className={splitButtonClass}
-                                aria-label="Split right"
-                              >
-                                <PanelRight className="h-3 w-3" />
-                              </Button>
-                            </FloatingTooltip>
-                            <FloatingTooltip content="Split down" className="flex">
-                              <Button
-                                variant="unstyled"
-                                onMouseDown={(e) => e.preventDefault()}
-                                onClick={() => handleSplit(cmd.id, 'column')}
-                                className={splitButtonClass}
-                                aria-label="Split down"
-                              >
-                                <PanelBottom className="h-3 w-3" />
-                              </Button>
-                            </FloatingTooltip>
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-
-                  {filteredCommands.length === 0 && (
+                  {listItems.map(renderMainRow)}
+                  {isChatSearchPending && (
+                    <p className="px-3 py-2 text-center text-2xs text-text-quaternary dark:text-text-dark-quaternary">
+                      Searching messages…
+                    </p>
+                  )}
+                  {listItems.length === 0 && !isChatSearchPending && (
                     <p className="px-3 py-4 text-center text-xs text-text-quaternary dark:text-text-dark-quaternary">
-                      No matching commands
+                      {mode === 'chats'
+                        ? 'No matching chats'
+                        : mode === 'files'
+                          ? 'No matching files'
+                          : mode === 'actions'
+                            ? 'No matching actions'
+                            : 'No results'}
                     </p>
                   )}
                 </>
@@ -742,13 +958,11 @@ export function CommandMenu() {
             {!isMobile && (
               <div className="flex items-center justify-between border-t border-border/50 px-3 py-2 dark:border-border-dark/50">
                 <span className="text-2xs text-text-quaternary dark:text-text-dark-quaternary">
-                  {mode === 'files'
-                    ? '↵ Open file · Esc to go back'
-                    : mode === 'branches'
-                      ? '↵ Switch branch · Esc to go back'
-                      : mode === 'themes'
-                        ? '↵ Set theme · Esc to go back'
-                        : '↵ Select · Split via icons · Shortcuts work globally · Esc to close'}
+                  {mode === 'branches'
+                    ? '↵ Switch branch · Esc to go back'
+                    : mode === 'themes'
+                      ? '↵ Set theme · Esc to go back'
+                      : `↑↓ Select · ↵ Open · ${modKey}[ or ${modKey}] change filter · Esc to close`}
                 </span>
               </div>
             )}

--- a/frontend/src/components/ui/commandRegistry.ts
+++ b/frontend/src/components/ui/commandRegistry.ts
@@ -57,7 +57,13 @@ export interface ActionCommandItem {
 
 export type CommandItem = ViewCommandItem | ActionCommandItem;
 
-export type MenuMode = 'commands' | 'files' | 'branches' | 'search' | 'chat-search' | 'themes';
+// Main-mode filter tabs share one unified list; ⌘[/⌘] cycle through them in this order.
+export type MainFilter = 'all' | 'chats' | 'files' | 'actions';
+export const MAIN_FILTERS: MainFilter[] = ['all', 'chats', 'files', 'actions'];
+
+// Sub-modes (branch picker, theme picker, embedded search panels) replace the whole
+// menu surface; main filters only narrow the unified list.
+export type MenuMode = MainFilter | 'branches' | 'search' | 'chat-search' | 'themes';
 
 export interface FlatFileItem {
   path: string;

--- a/frontend/src/hooks/queries/useCloudQueries.ts
+++ b/frontend/src/hooks/queries/useCloudQueries.ts
@@ -123,7 +123,7 @@ export const useCloudChatsTotalQuery = (enabled: boolean) => {
 // the cloud events feed (useCloudChatEvents); the poll is a safety net for
 // changes the feed doesn't carry (titles, deletes, other-device edits). Key
 // extends queryKeys.cloudChats so the LandingPage invalidation prefix-matches it.
-export const useInfiniteCloudChatsQuery = () => {
+export const useInfiniteCloudChatsQuery = (enabled: boolean = true) => {
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
   const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
   return useInfiniteQuery({
@@ -138,7 +138,7 @@ export const useInfiniteCloudChatsQuery = () => {
       return nextPage <= lastPage.pages ? nextPage : undefined;
     },
     initialPageParam: 1,
-    enabled: !!cloudUrl,
+    enabled: enabled && !!cloudUrl,
     staleTime: 10_000,
     refetchInterval: 15_000,
   });

--- a/frontend/src/hooks/queries/useSidebarChatLists.ts
+++ b/frontend/src/hooks/queries/useSidebarChatLists.ts
@@ -16,22 +16,22 @@ export interface WorkspaceBadge {
 // Sidebar chat data: local and cloud chats live on separate backends, so three
 // queries (local pinned, local unpinned, cloud) are merged client-side into the
 // Pinned and Recents lists, with one loadMore advancing both paginated sources.
-export function useSidebarChatLists(workspaces: Workspace[]) {
-  const { data: pinnedChatsData } = useInfiniteChatsQuery({ pinned: true });
+export function useSidebarChatLists(workspaces: Workspace[], enabled: boolean = true) {
+  const { data: pinnedChatsData } = useInfiniteChatsQuery({ pinned: true, enabled });
   const {
     data: localChatsData,
     hasNextPage: hasMoreLocal,
     fetchNextPage: fetchMoreLocal,
     isFetchingNextPage: isFetchingMoreLocal,
     isLoading: isLoadingLocal,
-  } = useInfiniteChatsQuery({ pinned: false });
+  } = useInfiniteChatsQuery({ pinned: false, enabled });
   const {
     data: cloudChatsData,
     hasNextPage: hasMoreCloud,
     fetchNextPage: fetchMoreCloud,
     isFetchingNextPage: isFetchingMoreCloud,
     isLoading: isLoadingCloud,
-  } = useInfiniteCloudChatsQuery();
+  } = useInfiniteCloudChatsQuery(enabled);
 
   const cloudChats = useMemo(
     () => cloudChatsData?.pages.flatMap((page) => page.items) ?? [],
@@ -72,7 +72,7 @@ export function useSidebarChatLists(workspaces: Workspace[]) {
 
   // Resolves each row's workspace badge; cloud workspaces carry the cloud icon and
   // route rename/delete to the VPS. Workspace IDs are UUIDs from separate DBs — no collisions.
-  const { data: cloudWorkspaces } = useCloudWorkspacesQuery(true);
+  const { data: cloudWorkspaces } = useCloudWorkspacesQuery(enabled);
   const workspaceBadgeById = useMemo(() => {
     const map = new Map<string, WorkspaceBadge>();
     for (const workspace of workspaces) {

--- a/frontend/src/hooks/useDebouncedValue.ts
+++ b/frontend/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react';
+
+// Debounced copy of a fast-changing string (search inputs). Empty values flush
+// immediately so clearing a search resets results without waiting out the delay.
+export function useDebouncedValue(value: string, delayMs: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    if (!value) {
+      setDebounced(value);
+      return;
+    }
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+  return debounced;
+}


### PR DESCRIPTION
## Summary
- Merge chat, file, and action results into a single filterable list in the command menu (⌘K), with All/Chats/Files/Actions tabs cycled via ⌘[ / ⌘]
- Chats tab adds deep message-content search (debounced) alongside instant title matches from the sidebar's chat lists
- Replace the title bar's command-menu shortcut button with a dedicated Search entry in the sidebar
- Extract the repeated debounce-timer effect (search panels, workspace repo search) into a shared `useDebouncedValue` hook
- Thread an `enabled` flag through `useSidebarChatLists` / `useInfiniteCloudChatsQuery` so the command menu's chat queries only fire when open and authenticated