### PR TITLE
feat(fe): enable diff and terminal views on the landing page

### DIFF
--- a/frontend/src/components/layout/TitleBar/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar/TitleBar.tsx
@@ -4,15 +4,11 @@ import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
 import { Button } from '@/components/ui/primitives/Button/Button';
 import { ToggleButton } from '@/components/ui/ToggleButton/ToggleButton';
-import { ViewSwitcher, type SwitchableView } from '@/components/layout/ViewSwitcher/ViewSwitcher';
+import { ViewSwitcher } from '@/components/layout/ViewSwitcher/ViewSwitcher';
 import { ChatTabs } from '@/components/layout/ChatTabs/ChatTabs';
 import clsx from 'clsx';
 import { IS_MAC_PLATFORM, isDesktopApp } from '@/utils/platform';
 import styles from './TitleBar.module.scss';
-
-// The landing page's renderView only supports these two non-agent views —
-// diff/terminal need a chat, so their switcher buttons would open blank panes.
-const LANDING_VIEWS: SwitchableView[] = ['editor', 'secrets'];
 
 async function getTauriWindow() {
   const { getCurrentWindow } = await import('@tauri-apps/api/window');
@@ -181,10 +177,9 @@ export function TitleBar() {
           {isAuthenticated && (isChatPage || isLandingPage) && <ChatTabs />}
         </div>
         {/* Views have no tabs — the switcher is the only affordance to open and
-            close them, so landing (which can show an editor/secrets pane) needs
-            it too, just restricted to the views it can render. */}
-        {isChatPage && <ViewSwitcher />}
-        {isLandingPage && <ViewSwitcher views={LANDING_VIEWS} />}
+            close them, so landing (which renders every view against the selected
+            workspace's sandbox) needs it too. */}
+        {(isChatPage || isLandingPage) && <ViewSwitcher />}
       </div>
     </div>
   );

--- a/frontend/src/components/layout/ViewSwitcher/ViewSwitcher.tsx
+++ b/frontend/src/components/layout/ViewSwitcher/ViewSwitcher.tsx
@@ -13,7 +13,7 @@ import {
 import type { ViewType } from '@/types/ui.types';
 import styles from './ViewSwitcher.module.scss';
 
-export type SwitchableView = Exclude<ViewType, 'agent'>;
+type SwitchableView = Exclude<ViewType, 'agent'>;
 
 // Non-agent secondary views, in the order Cursor lays them out: diff (git),
 // editor (file), terminal, secrets.
@@ -33,7 +33,7 @@ function viewTooltip(view: SwitchableView): string {
   return `${label} · ⇧-click or right-click to split`;
 }
 
-export function ViewSwitcher({ views = SWITCHABLE_VIEWS }: { views?: SwitchableView[] }) {
+export function ViewSwitcher() {
   const activeAgentTile = useUIStore((s) => s.activeAgentTile);
   const secondaryChatId = useUIStore((s) => s.secondaryChatId);
   const visibleLayout = useUIStore((s) => s.visibleLayout);
@@ -48,7 +48,7 @@ export function ViewSwitcher({ views = SWITCHABLE_VIEWS }: { views?: SwitchableV
 
   return (
     <div className={styles['view-switcher']}>
-      {views.map((view) => {
+      {SWITCHABLE_VIEWS.map((view) => {
         const Icon = VIEW_ICONS[view];
         const isActive = visibleSet.has(viewTypeToTileId(view, secondary));
         return (

--- a/frontend/src/components/sandbox/git/DiffView/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView/DiffView.tsx
@@ -48,6 +48,9 @@ interface DiffViewProps {
   // The chat this tile renders — resolves the sandbox/cwd it diffs and binds it
   // to jumps so the primary and secondary diff tiles never consume each other's.
   chatId: string | undefined;
+  // Chat-less contexts (the landing page) supply the sandbox directly — diffs run
+  // at the workspace root and review comments are disabled (they need a chat).
+  sandboxId?: string;
   // Whether this tile is currently on screen — background tiles stay mounted, so
   // visibility is how we know the user just switched to the diff view.
   isVisible: boolean;
@@ -63,10 +66,14 @@ export const DiffView = memo(function DiffView(props: DiffViewProps) {
   return <DiffViewContent {...props} />;
 });
 
-const DiffViewContent = memo(function DiffViewContent({ chatId, isVisible }: DiffViewProps) {
+const DiffViewContent = memo(function DiffViewContent({
+  chatId,
+  sandboxId: workspaceSandboxId,
+  isVisible,
+}: DiffViewProps) {
   const theme = useResolvedTheme();
   const { data: chat } = useChatQuery(chatId);
-  const sandboxId = chat?.sandbox_id ?? undefined;
+  const sandboxId = chat?.sandbox_id ?? workspaceSandboxId;
   const cwd = chat?.worktree_cwd ?? undefined;
   // Files render expanded by default (continuous review scroll) — track the
   // exceptions the user collapsed instead of the ones they opened.

--- a/frontend/src/components/ui/command-menu/commandRegistry.ts
+++ b/frontend/src/components/ui/command-menu/commandRegistry.ts
@@ -89,22 +89,8 @@ export type MenuListItem =
 const VIEW_COMMANDS: ViewCommandItem[] = [
   { type: 'view', id: 'agent', label: 'Agent', icon: MessagesSquare, shortcut: 'a' },
   { type: 'view', id: 'editor', label: 'Editor', icon: CodeXml, shortcut: 'e' },
-  {
-    type: 'view',
-    id: 'terminal',
-    label: 'Terminal',
-    icon: Terminal,
-    shortcut: 't',
-    requiresChat: true,
-  },
-  {
-    type: 'view',
-    id: 'diff',
-    label: 'Diff',
-    icon: GitBranch,
-    shortcut: 'd',
-    requiresChat: true,
-  },
+  { type: 'view', id: 'terminal', label: 'Terminal', icon: Terminal, shortcut: 't' },
+  { type: 'view', id: 'diff', label: 'Diff', icon: GitBranch, shortcut: 'd' },
   { type: 'view', id: 'secrets', label: 'Secrets', icon: Lock, shortcut: 's' },
 ];
 

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -56,6 +56,11 @@ const SecretsView = lazyNamed(
   () => import('@/components/sandbox/secrets/SecretsView/SecretsView'),
   'SecretsView',
 );
+const DiffView = lazyNamed(() => import('@/components/sandbox/git/DiffView/DiffView'), 'DiffView');
+const TerminalContainer = lazyNamed(
+  () => import('@/components/sandbox/terminal/Container/Container'),
+  'Container',
+);
 
 const EXAMPLE_PROMPTS = [
   'Build a REST API with authentication',
@@ -351,7 +356,7 @@ export function LandingPage() {
   useLayoutSidebar(sidebarContent);
 
   const renderView = useCallback(
-    (tileId: TileId): ReactNode => {
+    (tileId: TileId, isVisible: boolean): ReactNode => {
       switch (tileIdToViewType(tileId)) {
         case 'agent':
           return (
@@ -426,6 +431,26 @@ export function LandingPage() {
           return (
             <Suspense fallback={viewLoadingFallback}>
               <SecretsView sandboxId={selectedSandboxId} />
+            </Suspense>
+          );
+        case 'diff':
+          // No chat yet — the sandbox comes from the selected workspace, so the
+          // diff runs at the workspace root and review comments are disabled.
+          return (
+            <Suspense fallback={viewLoadingFallback}>
+              <DiffView chatId={undefined} sandboxId={selectedSandboxId} isVisible={isVisible} />
+            </Suspense>
+          );
+        case 'terminal':
+          // No chatId — pre-chat terminal tabs aren't persisted; the shell
+          // spawns at the workspace root.
+          return (
+            <Suspense fallback={viewLoadingFallback}>
+              <TerminalContainer
+                sandboxId={selectedSandboxId}
+                isVisible={isVisible}
+                panelKey={`tile-${tileId}`}
+              />
             </Suspense>
           );
         default:


### PR DESCRIPTION
## Summary
- The landing page previously restricted its `ViewSwitcher` to `editor`/`secrets` only, since diff/terminal need a chat and would otherwise render blank panes.
- Diff and terminal now work chat-lessly on the landing page: `DiffView` accepts an optional `sandboxId` (used when there's no `chatId`, diffing at the workspace root with review comments disabled), and a new `TerminalContainer` case spawns a shell against the selected workspace's sandbox without a persisted `chatId`.
- Removed the now-unnecessary `views` prop on `ViewSwitcher` and the `requiresChat` flags on the terminal/diff command menu entries, since both views work everywhere now.

## Test plan
- [ ] On the landing page, select a workspace and open the Diff view — confirm it shows the workspace's git diff with no console errors.
- [ ] On the landing page, open the Terminal view — confirm a shell spawns at the workspace root.
- [ ] Confirm chat pages still render Diff/Terminal as before (chat-scoped sandbox/cwd, review comments enabled).
- [ ] Confirm the command menu (⌘K) can jump to Diff/Terminal from the landing page.