### PR TITLE
test: expand backend endpoint coverage to 88% and fix surfaced bugs

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -88,9 +88,9 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip install -r backend/requirements.txt pytest pytest-asyncio
+          pip install -r backend/requirements.txt pytest pytest-asyncio pytest-cov
 
       - name: Run backend tests
         run: |
           cd backend
-          pytest tests
+          pytest tests --cov=app --cov-report=term-missing:skip-covered --cov-fail-under=85

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ storage/
 .git/
 .claude/
 !.claude/plans/
-.github/
 .docker/
 .ruff_cache/
 .pytest_cache/

--- a/backend/app/admin/views.py
+++ b/backend/app/admin/views.py
@@ -6,7 +6,7 @@ from sqladmin import ModelView
 from sqladmin.helpers import get_object_identifier
 from app.models.db_models.chat import Chat, Message, MessageAttachment
 from app.models.db_models.user import User, UserSettings
-from wtforms import PasswordField, SelectField
+from wtforms import Form, PasswordField, SelectField
 from app.models.db_models.enums import (
     MessageRole,
     MessageStreamStatus,
@@ -60,7 +60,13 @@ class UserAdmin(ModelView, model=User):
 
     form_excluded_columns = ["chats", "settings", "hashed_password"]
 
-    form_extra_fields = {"password": PasswordField("Password")}
+    async def scaffold_form(self, rules: list[str] | None = None) -> type[Form]:
+        # This sqladmin version has no form_extra_fields support, so graft the
+        # password field onto the scaffolded form — without it, creating a user
+        # fails on the NOT NULL hashed_password column.
+        form: type[Form] = await super().scaffold_form(rules)
+        form.password = PasswordField("Password")
+        return form
 
     def _url_for_delete(self, request: Request, obj: Any) -> str:
         # SQLAdmin renders absolute delete URLs; proxied admin pages need

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -1,14 +1,14 @@
 import logging
 import time
 import uuid
-from collections.abc import Callable
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse
+from starlette.datastructures import Headers, MutableHeaders
 from starlette.exceptions import HTTPException as StarletteHTTPException
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.core.config import get_settings
 from app.services.exceptions import ServiceException
@@ -17,61 +17,87 @@ settings = get_settings()
 logger = logging.getLogger(__name__)
 
 
-class RequestIdMiddleware(BaseHTTPMiddleware):
-    async def dispatch(
-        self, request: Request, call_next: Callable[[Request], Response]
-    ) -> Response:
-        request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
-        request.state.request_id = request_id
+class _RequestIdSend:
+    def __init__(self, send: Send, scope: Scope, request_id: str) -> None:
+        self.send = send
+        self.scope = scope
+        self.request_id = request_id
+        self.start_time = time.perf_counter()
 
-        start_time = time.perf_counter()
+    async def __call__(self, message: Message) -> None:
+        # Stamp headers and log at response start — SSE responses never
+        # complete, so waiting for the response end would never log them.
+        if message["type"] == "http.response.start":
+            process_time = time.perf_counter() - self.start_time
+            headers = MutableHeaders(scope=message)
+            headers["X-Request-ID"] = self.request_id
+            headers["X-Process-Time"] = f"{process_time:.4f}"
+            client = self.scope.get("client")
+            logger.info(
+                "request_completed",
+                extra={
+                    "request_id": self.request_id,
+                    "method": self.scope["method"],
+                    "path": self.scope["path"],
+                    "status_code": message["status"],
+                    "process_time_ms": round(process_time * 1000, 2),
+                    "client_ip": client[0] if client else None,
+                },
+            )
+        await self.send(message)
 
-        response = await call_next(request)
 
-        process_time = time.perf_counter() - start_time
+class RequestIdMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
 
-        response.headers["X-Request-ID"] = request_id
-        response.headers["X-Process-Time"] = f"{process_time:.4f}"
-
-        logger.info(
-            "request_completed",
-            extra={
-                "request_id": request_id,
-                "method": request.method,
-                "path": request.url.path,
-                "status_code": response.status_code,
-                "process_time_ms": round(process_time * 1000, 2),
-                "client_ip": request.client.host if request.client else None,
-            },
-        )
-
-        return response
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Pure ASGI on purpose: BaseHTTPMiddleware buffers streaming responses
+        # and deadlocks never-ending EventSourceResponse (SSE) bodies.
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        request_id = Headers(scope=scope).get("X-Request-ID") or str(uuid.uuid4())
+        # Request.state is backed by scope["state"], so handlers and exception
+        # handlers keep reading request.state.request_id unchanged.
+        scope.setdefault("state", {})["request_id"] = request_id
+        await self.app(scope, receive, _RequestIdSend(send, scope, request_id))
 
 
-class SecurityHeadersMiddleware(BaseHTTPMiddleware):
-    async def dispatch(
-        self, request: Request, call_next: Callable[[Request], Response]
-    ) -> Response:
-        response = await call_next(request)
+class _SecurityHeadersSend:
+    def __init__(self, send: Send) -> None:
+        self.send = send
 
-        if not settings.ENABLE_SECURITY_HEADERS:
-            return response
+    async def __call__(self, message: Message) -> None:
+        if message["type"] == "http.response.start":
+            headers = MutableHeaders(scope=message)
+            headers["X-Content-Type-Options"] = settings.CONTENT_TYPE_OPTIONS
+            headers["X-Frame-Options"] = settings.FRAME_OPTIONS
+            headers["X-XSS-Protection"] = settings.XSS_PROTECTION
+            headers["Referrer-Policy"] = settings.REFERRER_POLICY
+            headers["Permissions-Policy"] = settings.PERMISSIONS_POLICY
 
-        response.headers["X-Content-Type-Options"] = settings.CONTENT_TYPE_OPTIONS
-        response.headers["X-Frame-Options"] = settings.FRAME_OPTIONS
-        response.headers["X-XSS-Protection"] = settings.XSS_PROTECTION
-        response.headers["Referrer-Policy"] = settings.REFERRER_POLICY
-        response.headers["Permissions-Policy"] = settings.PERMISSIONS_POLICY
+            if settings.ENVIRONMENT == "production":
+                hsts_value = f"max-age={settings.HSTS_MAX_AGE}"
+                if settings.HSTS_INCLUDE_SUBDOMAINS:
+                    hsts_value += "; includeSubDomains"
+                if settings.HSTS_PRELOAD:
+                    hsts_value += "; preload"
+                headers["Strict-Transport-Security"] = hsts_value
+        await self.send(message)
 
-        if settings.ENVIRONMENT == "production":
-            hsts_value = f"max-age={settings.HSTS_MAX_AGE}"
-            if settings.HSTS_INCLUDE_SUBDOMAINS:
-                hsts_value += "; includeSubDomains"
-            if settings.HSTS_PRELOAD:
-                hsts_value += "; preload"
-            response.headers["Strict-Transport-Security"] = hsts_value
 
-        return response
+class SecurityHeadersMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Pure ASGI on purpose: BaseHTTPMiddleware buffers streaming responses
+        # and deadlocks never-ending EventSourceResponse (SSE) bodies.
+        if scope["type"] != "http" or not settings.ENABLE_SECURITY_HEADERS:
+            await self.app(scope, receive, send)
+            return
+        await self.app(scope, receive, _SecurityHeadersSend(send))
 
 
 async def _service_exception_handler(

--- a/backend/app/db/types.py
+++ b/backend/app/db/types.py
@@ -1,11 +1,10 @@
-import json
 import uuid as uuid_module
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
 from cryptography.fernet import InvalidToken
-from sqlalchemy import CHAR, DateTime, String, Text
+from sqlalchemy import CHAR, DateTime, String
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.types import TypeDecorator
 
@@ -81,40 +80,3 @@ class EncryptedString(TypeDecorator[str]):
             return decrypt_value(value)
         except InvalidToken:
             return value
-
-
-class EncryptedJSON(TypeDecorator[Any]):
-    impl = Text
-    cache_ok = True
-
-    def process_bind_param(self, value: Any, _dialect: Dialect) -> Any:
-        from app.core.security import encrypt_value
-
-        if value is None:
-            return None
-        if isinstance(value, str):
-            serialized = value
-        else:
-            serialized = json.dumps(value, separators=(",", ":"), ensure_ascii=True)
-        return encrypt_value(serialized)
-
-    def process_result_value(self, value: Any, _dialect: Dialect) -> Any:
-        from app.core.security import decrypt_value
-
-        if value is None:
-            return None
-        if isinstance(value, (list, dict)):
-            return value
-        if isinstance(value, str):
-            try:
-                decrypted = decrypt_value(value)
-            except InvalidToken:
-                try:
-                    return json.loads(value)
-                except json.JSONDecodeError:
-                    return value
-            try:
-                return json.loads(decrypted)
-            except json.JSONDecodeError:
-                return decrypted
-        return value

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -281,7 +281,9 @@ class AcpClientHandler:
         terminal_id: str,
         **kwargs: Any,
     ) -> TerminalOutputResponse:
-        return TerminalOutputResponse(output="")
+        # truncated is required by the ACP schema — omitting it makes the
+        # response fail validation and aborts the agent's whole turn.
+        return TerminalOutputResponse(output="", truncated=False)
 
     async def release_terminal(
         self,

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -66,16 +66,18 @@ class SkillService:
 
         # Claude plugins can also bundle skills.
         result[AgentKind.CLAUDE.value].extend(
-            SkillService._get_claude_plugin_skill_paths()
+            SkillService._get_claude_plugin_skill_paths(base)
         )
 
         return result, readonly_paths
 
     @staticmethod
-    def _get_claude_plugin_skill_paths() -> list[Path]:
-        # Claude-specific: cross-reference ~/.claude/settings.json (enabled flags)
-        # with installed_plugins.json (install paths) to discover plugin-bundled skills.
-        claude_dir = Path.home() / ".claude"
+    def _get_claude_plugin_skill_paths(base: Path) -> list[Path]:
+        # Claude-specific: cross-reference .claude/settings.json (enabled flags)
+        # with installed_plugins.json (install paths) to discover plugin-bundled
+        # skills. Uses the mode-dependent base — reading the server's own home
+        # dir in server mode would leak its plugin config into every user.
+        claude_dir = base / ".claude"
         settings_path = claude_dir / "settings.json"
         installed_path = claude_dir / "plugins" / "installed_plugins.json"
         if not settings_path.is_file() or not installed_path.is_file():

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -29,7 +29,6 @@ class StorageService:
         file: UploadFile,
         agent_kind: AgentKind,
         sandbox_id: str | None = None,
-        attachment_id: str | None = None,
         user_id: str | None = None,
     ) -> MessageAttachmentDict:
         if file.content_type not in settings.ALLOWED_FILE_TYPES:
@@ -66,23 +65,16 @@ class StorageService:
 
         unique_filename = f"{uuid4()}{ext}"
 
-        if attachment_id:
-            relative_file_path = f"{folder}/{unique_filename}"
-            physical_file_path = self.storage_path / relative_file_path
-        else:
-            if not user_id:
-                raise StorageException("user_id is required for temp attachments")
+        if not user_id:
+            raise StorageException("user_id is required for temp attachments")
 
-            relative_file_path = f"temp/{user_id}/{folder}/{unique_filename}"
-            physical_file_path = self.storage_path / relative_file_path
-            physical_file_path.parent.mkdir(parents=True, exist_ok=True)
+        relative_file_path = f"temp/{user_id}/{folder}/{unique_filename}"
+        physical_file_path = self.storage_path / relative_file_path
+        physical_file_path.parent.mkdir(parents=True, exist_ok=True)
 
         physical_file_path.write_bytes(contents)
 
-        if attachment_id:
-            file_url = AttachmentURL.build_preview_url(attachment_id)
-        else:
-            file_url = AttachmentURL.build_temp_preview_url(relative_file_path)
+        file_url = AttachmentURL.build_temp_preview_url(relative_file_path)
 
         if sandbox_id and file_type not in NATIVE_FILE_TYPES[agent_kind]:
             # Attachments are advertised to the agent as readable from the

--- a/backend/tests/fake_acp_agent.py
+++ b/backend/tests/fake_acp_agent.py
@@ -1,0 +1,738 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Any
+
+from acp.agent.connection import AgentSideConnection
+from acp.schema import (
+    AgentCapabilities,
+    AgentMessageChunk,
+    AgentPlanUpdate,
+    AgentThoughtChunk,
+    ContentToolCallContent,
+    CreateTerminalResponse,
+    CurrentModeUpdate,
+    Cost,
+    FileEditToolCallContent,
+    ImageContentBlock,
+    InitializeResponse,
+    KillTerminalResponse,
+    ListSessionsResponse,
+    LoadSessionResponse,
+    NewSessionResponse,
+    PermissionOption,
+    PlanEntry,
+    PromptResponse,
+    ReadTextFileResponse,
+    ReleaseTerminalResponse,
+    SessionInfoUpdate,
+    SetSessionConfigOptionResponse,
+    SetSessionModeResponse,
+    SetSessionModelResponse,
+    TerminalOutputResponse,
+    TextContentBlock,
+    ToolCallProgress,
+    ToolCallStart,
+    ToolCallUpdate,
+    UsageUpdate,
+    UserMessageChunk,
+    WaitForTerminalExitResponse,
+    WriteTextFileResponse,
+)
+from acp.stdio import stdio_streams
+
+# Session-lifecycle behavior, selected once at process start (mirrors how a real
+# agent binary would fail deterministically at handshake/session-setup time).
+SCENARIO = os.environ.get("FAKE_ACP_SCENARIO", "normal")
+LOG_PATH = os.environ.get("FAKE_ACP_LOG")
+NEW_SESSION_ID = "fake-acp-session-1"
+
+# Per-turn behavior is picked by looking for one of these markers inside the
+# prompt text the real client sent — lets one fake binary cover every branch
+# in client.py/session.py without spawning a different process per case.
+MARKER_TOOL_DIFF = "MARKER_TOOL_DIFF"
+MARKER_TOOL_TEXT_RESULT = "MARKER_TOOL_TEXT_RESULT"
+MARKER_TOOL_CODEX_ERROR = "MARKER_TOOL_CODEX_ERROR"
+MARKER_TOOL_STRING_ERROR = "MARKER_TOOL_STRING_ERROR"
+MARKER_TOOL_TEXT_ERROR = "MARKER_TOOL_TEXT_ERROR"
+MARKER_TOOL_PROGRESS_ORPHAN = "MARKER_TOOL_PROGRESS_ORPHAN"
+MARKER_TOOL_PROGRESS_NEW = "MARKER_TOOL_PROGRESS_NEW"
+MARKER_RAW_INPUT_STRING = "MARKER_RAW_INPUT_STRING"
+MARKER_RAW_INPUT_INVALID = "MARKER_RAW_INPUT_INVALID"
+MARKER_PERMISSION = "MARKER_PERMISSION"
+MARKER_CANCEL = "MARKER_CANCEL"
+MARKER_CRASH_MID_PROMPT = "MARKER_CRASH_MID_PROMPT"
+MARKER_TOOL_LEFT_OPEN = "MARKER_TOOL_LEFT_OPEN"
+MARKER_FS_TERMINAL_STUBS = "MARKER_FS_TERMINAL_STUBS"
+MARKER_IMAGE_CONTENT = "MARKER_IMAGE_CONTENT"
+MARKER_TOOL_EMPTY_RESULT = "MARKER_TOOL_EMPTY_RESULT"
+MARKER_TOOL_UNKNOWN_DICT_ERROR = "MARKER_TOOL_UNKNOWN_DICT_ERROR"
+MARKER_ENTER_PLAN_MODE = "MARKER_ENTER_PLAN_MODE"
+# 1x1 transparent PNG, reused wherever the protocol needs inline image bytes.
+TINY_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+
+
+def log_event(record: dict[str, Any]) -> None:
+    # Best-effort JSONL audit trail so tests can assert on exactly what the
+    # real client sent (mcp servers, session ids, model ids, ...).
+    if not LOG_PATH:
+        return
+    with open(LOG_PATH, "a") as handle:
+        handle.write(json.dumps(record, default=str) + "\n")
+
+
+def text_block(text: str) -> TextContentBlock:
+    return TextContentBlock(type="text", text=text)
+
+
+class FakeAgent:
+    def __init__(self) -> None:
+        self._client: AgentSideConnection | None = None
+        self._cancel_events: dict[str, asyncio.Event] = {}
+
+    def on_connect(self, conn: AgentSideConnection) -> None:
+        self._client = conn
+
+    async def initialize(
+        self,
+        protocol_version: int,
+        client_capabilities: Any = None,
+        client_info: Any = None,
+        **kwargs: Any,
+    ) -> InitializeResponse:
+        if SCENARIO == "crash_initialize":
+            raise RuntimeError("simulated initialize failure")
+        return InitializeResponse(
+            protocol_version=protocol_version,
+            agent_capabilities=AgentCapabilities(load_session=True),
+        )
+
+    async def new_session(
+        self,
+        cwd: str,
+        mcp_servers: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> NewSessionResponse:
+        log_event(
+            {
+                "event": "new_session",
+                "cwd": cwd,
+                "mcp_servers": [
+                    server.model_dump(mode="json", by_alias=True)
+                    for server in (mcp_servers or [])
+                ],
+            }
+        )
+        if SCENARIO == "crash_new_session":
+            raise RuntimeError("simulated new_session failure")
+        return NewSessionResponse(session_id=NEW_SESSION_ID)
+
+    async def load_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> LoadSessionResponse:
+        log_event({"event": "load_session", "cwd": cwd, "session_id": session_id})
+        if SCENARIO == "crash_load_session":
+            raise RuntimeError("simulated load_session failure")
+        if SCENARIO == "load_session_replay" and self._client is not None:
+            # Simulates an agent that replays prior history on resume — the
+            # real client must mute these via handler.muted during load_session.
+            await self._client.session_update(
+                session_id=session_id,
+                update=AgentMessageChunk(
+                    session_update="agent_message_chunk",
+                    content=text_block("REPLAYED_HISTORY_SHOULD_BE_MUTED"),
+                ),
+            )
+        return LoadSessionResponse()
+
+    async def list_sessions(
+        self, cursor: str | None = None, cwd: str | None = None, **kwargs: Any
+    ) -> ListSessionsResponse:
+        return ListSessionsResponse(sessions=[])
+
+    async def set_session_mode(
+        self, mode_id: str, session_id: str, **kwargs: Any
+    ) -> SetSessionModeResponse:
+        log_event({"event": "set_session_mode", "mode_id": mode_id})
+        if SCENARIO == "config_error":
+            raise RuntimeError("simulated set_session_mode failure")
+        return SetSessionModeResponse()
+
+    async def set_session_model(
+        self, model_id: str, session_id: str, **kwargs: Any
+    ) -> SetSessionModelResponse:
+        log_event({"event": "set_session_model", "model_id": model_id})
+        if SCENARIO == "config_error":
+            raise RuntimeError("simulated set_session_model failure")
+        return SetSessionModelResponse()
+
+    async def set_config_option(
+        self, config_id: str, session_id: str, value: str | bool, **kwargs: Any
+    ) -> SetSessionConfigOptionResponse:
+        log_event(
+            {"event": "set_config_option", "config_id": config_id, "value": value}
+        )
+        if SCENARIO == "config_error":
+            raise RuntimeError("simulated set_config_option failure")
+        return SetSessionConfigOptionResponse(config_options=[])
+
+    async def authenticate(self, method_id: str, **kwargs: Any) -> None:
+        return None
+
+    async def fork_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        raise NotImplementedError
+
+    async def resume_session(
+        self,
+        cwd: str,
+        session_id: str,
+        mcp_servers: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        raise NotImplementedError
+
+    async def close_session(self, session_id: str, **kwargs: Any) -> None:
+        return None
+
+    async def cancel(self, session_id: str, **kwargs: Any) -> None:
+        # session/cancel is a notification — the pending prompt() request below
+        # is what actually unblocks the client's send_prompt() call.
+        self._cancel_events.setdefault(session_id, asyncio.Event()).set()
+
+    async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+    async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
+        return None
+
+    async def prompt(
+        self,
+        prompt: list[Any],
+        session_id: str,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> PromptResponse:
+        assert self._client is not None
+        text = "".join(
+            block.text for block in prompt if getattr(block, "type", None) == "text"
+        )
+        block_types = [getattr(block, "type", None) for block in prompt]
+        log_event(
+            {
+                "event": "prompt",
+                "session_id": session_id,
+                "text": text,
+                "block_types": block_types,
+            }
+        )
+
+        if MARKER_CRASH_MID_PROMPT in text:
+            # A hard os._exit() here would leave the client's pending prompt()
+            # request unresolved forever (the ACP SDK's receive loop doesn't
+            # reject in-flight requests on a clean EOF) — a real agent crash
+            # would wedge the turn. Erroring the request instead exercises the
+            # same finish(prompt_completed=False) path deterministically.
+            await self._emit_tool_started(session_id, "tool-crash", "Doing risky work")
+            raise RuntimeError("simulated mid-prompt agent failure")
+        if MARKER_CANCEL in text:
+            return await self._run_cancel_turn(session_id)
+        if MARKER_PERMISSION in text:
+            return await self._run_permission_turn(session_id)
+        if MARKER_FS_TERMINAL_STUBS in text:
+            await self._call_fs_terminal_stubs(session_id)
+        if MARKER_ENTER_PLAN_MODE in text:
+            return await self._run_enter_plan_mode_turn(session_id)
+
+        return await self._run_default_turn(session_id, text)
+
+    async def _call_fs_terminal_stubs(self, session_id: str) -> None:
+        # Exercises every ACP client-side stub in client.py — real agents call
+        # these for file/terminal access; ours never needs to, so drive them
+        # directly to prove the no-op implementations satisfy the protocol.
+        assert self._client is not None
+        client = self._client
+        try:
+            read: ReadTextFileResponse = await client.read_text_file(
+                path="app.py", session_id=session_id
+            )
+            log_event({"event": "debug", "step": "read_text_file", "ok": True})
+        except Exception as exc:
+            log_event({"event": "debug", "step": "read_text_file", "error": repr(exc)})
+            raise
+        assert read.content == ""
+        try:
+            write: WriteTextFileResponse | None = await client.write_text_file(
+                content="x", path="app.py", session_id=session_id
+            )
+            log_event({"event": "debug", "step": "write_text_file", "ok": True})
+        except Exception as exc:
+            log_event({"event": "debug", "step": "write_text_file", "error": repr(exc)})
+            raise
+        assert write is not None
+        try:
+            terminal: CreateTerminalResponse = await client.create_terminal(
+                command="echo hi", session_id=session_id
+            )
+            log_event({"event": "debug", "step": "create_terminal", "ok": True})
+        except Exception as exc:
+            log_event({"event": "debug", "step": "create_terminal", "error": repr(exc)})
+            raise
+        try:
+            output: TerminalOutputResponse = await client.terminal_output(
+                session_id=session_id, terminal_id=terminal.terminal_id
+            )
+            log_event({"event": "debug", "step": "terminal_output", "ok": True})
+        except Exception as exc:
+            log_event({"event": "debug", "step": "terminal_output", "error": repr(exc)})
+            raise
+        assert output.output == ""
+        try:
+            release: ReleaseTerminalResponse | None = await client.release_terminal(
+                session_id=session_id, terminal_id=terminal.terminal_id
+            )
+            log_event({"event": "debug", "step": "release_terminal", "ok": True})
+        except Exception as exc:
+            log_event(
+                {"event": "debug", "step": "release_terminal", "error": repr(exc)}
+            )
+            raise
+        assert release is not None
+        try:
+            wait_result: WaitForTerminalExitResponse = (
+                await client.wait_for_terminal_exit(
+                    session_id=session_id, terminal_id=terminal.terminal_id
+                )
+            )
+            log_event({"event": "debug", "step": "wait_for_terminal_exit", "ok": True})
+        except Exception as exc:
+            log_event(
+                {"event": "debug", "step": "wait_for_terminal_exit", "error": repr(exc)}
+            )
+            raise
+        assert wait_result.exit_code == 0
+        try:
+            kill: KillTerminalResponse | None = await client.kill_terminal(
+                session_id=session_id, terminal_id=terminal.terminal_id
+            )
+            log_event({"event": "debug", "step": "kill_terminal", "ok": True})
+        except Exception as exc:
+            log_event({"event": "debug", "step": "kill_terminal", "error": repr(exc)})
+            raise
+        assert kill is not None
+        try:
+            ext_result = await client.ext_method("agentrove.debug", {"probe": True})
+            log_event({"event": "debug", "step": "ext_method", "ok": True})
+        except Exception as exc:
+            log_event({"event": "debug", "step": "ext_method", "error": repr(exc)})
+            raise
+        assert ext_result == {}
+        await client.ext_notification("agentrove.debug_note", {"probe": True})
+
+    async def _run_enter_plan_mode_turn(self, session_id: str) -> PromptResponse:
+        # AgentService._get_plan_mode_transition() only fires on a completed
+        # tool literally named EnterPlanMode — reachable only through the
+        # adapter's map_session_mode(), which Claude's build_session_config()
+        # never calls directly (it passes permission_mode straight through).
+        assert self._client is not None
+        await self._client.session_update(
+            session_id=session_id,
+            update=ToolCallStart(
+                session_update="tool_call",
+                tool_call_id="tool-enter-plan",
+                title="Entering plan mode",
+                field_meta={"claudeCode": {"toolName": "EnterPlanMode"}},
+            ),
+        )
+        await self._client.session_update(
+            session_id=session_id,
+            update=ToolCallProgress(
+                session_update="tool_call_update",
+                tool_call_id="tool-enter-plan",
+                status="completed",
+                field_meta={"claudeCode": {"toolName": "EnterPlanMode"}},
+            ),
+        )
+        await asyncio.sleep(0.05)
+        return PromptResponse(stop_reason="end_turn")
+
+    async def _emit_tool_started(
+        self,
+        session_id: str,
+        tool_call_id: str,
+        title: str,
+        *,
+        field_meta: dict[str, Any] | None = None,
+        raw_input: Any = None,
+        kind: str = "execute",
+    ) -> None:
+        assert self._client is not None
+        await self._client.session_update(
+            session_id=session_id,
+            update=ToolCallStart(
+                session_update="tool_call",
+                tool_call_id=tool_call_id,
+                title=title,
+                kind=kind,
+                raw_input=raw_input,
+                field_meta=field_meta,
+            ),
+        )
+
+    async def _run_cancel_turn(self, session_id: str) -> PromptResponse:
+        await self._emit_tool_started(
+            session_id, "tool-cancel", "Working before cancel"
+        )
+        event = self._cancel_events.setdefault(session_id, asyncio.Event())
+        try:
+            await asyncio.wait_for(event.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            self._cancel_events.pop(session_id, None)
+        # Let already-scheduled notification-processing tasks land before
+        # the response resolves the client's pending prompt() future — the
+        # ACP SDK dispatches notifications as fire-and-forget tasks, so a
+        # response arriving right behind them can race ahead undelivered.
+        await asyncio.sleep(0.05)
+        return PromptResponse(stop_reason="cancelled")
+
+    async def _run_permission_turn(self, session_id: str) -> PromptResponse:
+        assert self._client is not None
+        tool_call_id = "tool-permission"
+        await self._emit_tool_started(session_id, tool_call_id, "Editing a file")
+
+        options = [
+            PermissionOption(
+                kind="allow_once", name="Accept Edits", option_id="acceptEdits"
+            ),
+            PermissionOption(
+                kind="reject_once", name="Reject", option_id="reject-once"
+            ),
+            # A resolvable mode (unlike reject-once) that the "user" can still
+            # pick and have the underlying command go on to fail — covers
+            # tool_failed with a *resolved* permission_mode in client.py.
+            PermissionOption(kind="allow_always", name="Plan", option_id="plan"),
+        ]
+        response = await self._client.request_permission(
+            options=options,
+            session_id=session_id,
+            tool_call=ToolCallUpdate(tool_call_id=tool_call_id, status="pending"),
+        )
+        outcome = response.outcome
+        selected_option_id = getattr(outcome, "option_id", None)
+
+        if selected_option_id == "plan":
+            await self._client.session_update(
+                session_id=session_id,
+                update=ToolCallProgress(
+                    session_update="tool_call_update",
+                    tool_call_id=tool_call_id,
+                    status="failed",
+                    raw_output="Command failed even though a mode was approved",
+                ),
+            )
+        elif selected_option_id:
+            await self._client.session_update(
+                session_id=session_id,
+                update=ToolCallProgress(
+                    session_update="tool_call_update",
+                    tool_call_id=tool_call_id,
+                    status="completed",
+                    raw_output={"decision": selected_option_id},
+                ),
+            )
+        else:
+            await self._client.session_update(
+                session_id=session_id,
+                update=ToolCallProgress(
+                    session_update="tool_call_update",
+                    tool_call_id=tool_call_id,
+                    status="failed",
+                    raw_output="Permission denied by user",
+                ),
+            )
+        await asyncio.sleep(0.05)
+        return PromptResponse(stop_reason="end_turn")
+
+    async def _run_default_turn(self, session_id: str, text: str) -> PromptResponse:
+        assert self._client is not None
+        client = self._client
+
+        await client.session_update(
+            session_id=session_id,
+            update=AgentThoughtChunk(
+                session_update="agent_thought_chunk",
+                content=text_block("Thinking it over..."),
+            ),
+        )
+        await client.session_update(
+            session_id=session_id,
+            update=AgentMessageChunk(
+                session_update="agent_message_chunk", content=text_block("Hello from ")
+            ),
+        )
+        await client.session_update(
+            session_id=session_id,
+            update=AgentMessageChunk(
+                session_update="agent_message_chunk",
+                content=text_block("the fake agent."),
+            ),
+        )
+        await client.session_update(
+            session_id=session_id,
+            update=UserMessageChunk(
+                session_update="user_message_chunk",
+                content=text_block("(echoed user note)"),
+            ),
+        )
+        if MARKER_IMAGE_CONTENT in text:
+            # Non-text content on these three chunk kinds maps to None in
+            # client.py (_map_agent_message/_map_agent_thought/_map_user_message)
+            # — no event should reach the frontend for any of them.
+            image_block = ImageContentBlock(
+                type="image", data=TINY_PNG_BASE64, mimeType="image/png"
+            )
+            await client.session_update(
+                session_id=session_id,
+                update=AgentMessageChunk(
+                    session_update="agent_message_chunk", content=image_block
+                ),
+            )
+            await client.session_update(
+                session_id=session_id,
+                update=AgentThoughtChunk(
+                    session_update="agent_thought_chunk", content=image_block
+                ),
+            )
+            await client.session_update(
+                session_id=session_id,
+                update=UserMessageChunk(
+                    session_update="user_message_chunk", content=image_block
+                ),
+            )
+        # Not part of the client's mapped update union — exercises the
+        # "Unhandled ACP update type" fallthrough in client.py.
+        await client.session_update(
+            session_id=session_id,
+            update=CurrentModeUpdate(
+                session_update="current_mode_update", current_mode_id="agent"
+            ),
+        )
+        await client.session_update(
+            session_id=session_id,
+            update=SessionInfoUpdate(
+                session_update="session_info_update", title="Fake session title"
+            ),
+        )
+
+        raw_input: Any = {"path": "app.py"}
+        if MARKER_RAW_INPUT_STRING in text:
+            raw_input = json.dumps({"path": "encoded.py"})
+        elif MARKER_RAW_INPUT_INVALID in text:
+            raw_input = "not-json{{"
+
+        await self._emit_tool_started(
+            session_id,
+            "tool-primary",
+            "Reading a file",
+            field_meta={
+                "claudeCode": {"toolName": "Read", "parentToolUseId": "parent-1"}
+            },
+            raw_input=raw_input,
+        )
+        # Title-only update with no status — re-emitted as tool_started so the
+        # UI can refresh the loading title before the tool finishes.
+        await client.session_update(
+            session_id=session_id,
+            update=ToolCallProgress(
+                session_update="tool_call_update",
+                tool_call_id="tool-primary",
+                title="Reading app.py",
+            ),
+        )
+        if MARKER_RAW_INPUT_STRING not in text and MARKER_RAW_INPUT_INVALID not in text:
+            # A later raw_input change (as opposed to the one on the initial
+            # ToolCallStart) is a distinct client.py code path in
+            # _map_tool_call_progress — cover it whenever the raw-input-on-start
+            # variants above aren't the thing being asserted on.
+            await client.session_update(
+                session_id=session_id,
+                update=ToolCallProgress(
+                    session_update="tool_call_update",
+                    tool_call_id="tool-primary",
+                    raw_input={"path": "app.py", "revised": True},
+                ),
+            )
+        await self._complete_primary_tool(session_id, text)
+
+        if MARKER_TOOL_PROGRESS_ORPHAN in text:
+            # No matching active tool and no status — must be a silent no-op.
+            await client.session_update(
+                session_id=session_id,
+                update=ToolCallProgress(
+                    session_update="tool_call_update", tool_call_id="tool-orphan"
+                ),
+            )
+        if MARKER_TOOL_PROGRESS_NEW in text:
+            # Never preceded by a ToolCallStart — client must synthesize one.
+            await client.session_update(
+                session_id=session_id,
+                update=ToolCallProgress(
+                    session_update="tool_call_update",
+                    tool_call_id="tool-new",
+                    status="completed",
+                    raw_output="synthesized result",
+                ),
+            )
+
+        await self._emit_tool_started(session_id, "tool-secondary", "Running a command")
+        if MARKER_TOOL_LEFT_OPEN in text:
+            # Never sent a terminal update for tool-secondary — it's still
+            # "active" when finish(prompt_completed=True) runs below, exercising
+            # the leftover-tool auto-complete branch in client.py.
+            pass
+        elif MARKER_TOOL_TEXT_ERROR in text:
+            await client.session_update(
+                session_id=session_id,
+                update=ToolCallProgress(
+                    session_update="tool_call_update",
+                    tool_call_id="tool-secondary",
+                    status="failed",
+                    content=[
+                        ContentToolCallContent(
+                            type="content",
+                            content=text_block("command failed: no output"),
+                        )
+                    ],
+                ),
+            )
+        else:
+            secondary_output: Any = {"error": "boom opencode"}
+            if MARKER_TOOL_CODEX_ERROR in text:
+                secondary_output = {"formatted_output": "boom codex"}
+            elif MARKER_TOOL_STRING_ERROR in text:
+                secondary_output = "boom plain string"
+            elif MARKER_TOOL_UNKNOWN_DICT_ERROR in text:
+                secondary_output = {"unexpected_key": "value"}
+            await client.session_update(
+                session_id=session_id,
+                update=ToolCallProgress(
+                    session_update="tool_call_update",
+                    tool_call_id="tool-secondary",
+                    status="failed",
+                    raw_output=secondary_output,
+                ),
+            )
+
+        await client.session_update(
+            session_id=session_id,
+            update=UsageUpdate(
+                session_update="usage_update",
+                used=1234,
+                size=100000,
+                cost=Cost(amount=0.05, currency="USD"),
+            ),
+        )
+        await client.session_update(
+            session_id=session_id,
+            update=AgentPlanUpdate(
+                session_update="plan",
+                entries=[
+                    PlanEntry(
+                        content="Investigate", status="completed", priority="high"
+                    ),
+                    PlanEntry(
+                        content="Fix it", status="in_progress", priority="medium"
+                    ),
+                ],
+            ),
+        )
+
+        await asyncio.sleep(0.05)
+        return PromptResponse(stop_reason="end_turn")
+
+    async def _complete_primary_tool(self, session_id: str, text: str) -> None:
+        assert self._client is not None
+        if MARKER_TOOL_DIFF in text:
+            await self._client.session_update(
+                session_id=session_id,
+                update=ToolCallProgress(
+                    session_update="tool_call_update",
+                    tool_call_id="tool-primary",
+                    status="completed",
+                    content=[
+                        FileEditToolCallContent(
+                            type="diff",
+                            path="app.py",
+                            old_text="old",
+                            new_text="new",
+                        )
+                    ],
+                ),
+            )
+            return
+        if MARKER_TOOL_TEXT_RESULT in text:
+            await self._client.session_update(
+                session_id=session_id,
+                update=ToolCallProgress(
+                    session_update="tool_call_update",
+                    tool_call_id="tool-primary",
+                    status="completed",
+                    content=[
+                        ContentToolCallContent(
+                            type="content", content=text_block("plain text result")
+                        )
+                    ],
+                ),
+            )
+            return
+        if MARKER_TOOL_EMPTY_RESULT in text:
+            # No raw_output, no diff/text content — _extract_tool_result falls
+            # all the way through to its empty-content "return None" fallback.
+            await self._client.session_update(
+                session_id=session_id,
+                update=ToolCallProgress(
+                    session_update="tool_call_update",
+                    tool_call_id="tool-primary",
+                    status="completed",
+                ),
+            )
+            return
+        await self._client.session_update(
+            session_id=session_id,
+            update=ToolCallProgress(
+                session_update="tool_call_update",
+                tool_call_id="tool-primary",
+                status="completed",
+                field_meta={"claudeCode": {"toolResponse": {"lines": 42}}},
+            ),
+        )
+
+
+async def main() -> None:
+    reader, writer = await stdio_streams()
+    agent = FakeAgent()
+    # listening=False + explicit listen() below — the constructor's default
+    # (listening=True) would start its own receive-loop task, racing this one
+    # for the same stdin reader ("readuntil() called while another coroutine
+    # is already waiting for incoming data").
+    conn = AgentSideConnection(
+        agent, writer, reader, listening=False, use_unstable_protocol=True
+    )
+    await conn.listen()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -1,0 +1,1009 @@
+import asyncio
+import json
+import os
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.models.db_models.workspace import Workspace
+from app.services.session_registry import session_registry
+from tests.conftest import LoginClient, UserFactory
+from tests.fake_acp_agent import (
+    MARKER_CANCEL,
+    MARKER_CRASH_MID_PROMPT,
+    MARKER_ENTER_PLAN_MODE,
+    MARKER_FS_TERMINAL_STUBS,
+    MARKER_IMAGE_CONTENT,
+    MARKER_PERMISSION,
+    MARKER_RAW_INPUT_INVALID,
+    MARKER_RAW_INPUT_STRING,
+    MARKER_TOOL_CODEX_ERROR,
+    MARKER_TOOL_DIFF,
+    MARKER_TOOL_EMPTY_RESULT,
+    MARKER_TOOL_LEFT_OPEN,
+    MARKER_TOOL_PROGRESS_NEW,
+    MARKER_TOOL_PROGRESS_ORPHAN,
+    MARKER_TOOL_STRING_ERROR,
+    MARKER_TOOL_TEXT_ERROR,
+    MARKER_TOOL_TEXT_RESULT,
+    MARKER_TOOL_UNKNOWN_DICT_ERROR,
+    NEW_SESSION_ID,
+)
+from tests.helpers import EndpointCache, create_authenticated_workspace
+
+pytestmark = pytest.mark.anyio
+
+FAKE_AGENT_SCRIPT = Path(__file__).resolve().parent / "fake_acp_agent.py"
+BINARY_NAMES = ["claude-agent-acp", "codex-acp", "copilot", "cursor-agent", "opencode"]
+
+DEFAULT_TURN_TEXT = "Hello from the fake agent."
+
+# Minimal-but-valid-enough bytes for upload endpoints that only branch on
+# content_type, not on parsing the file itself.
+PNG_BYTES = bytes.fromhex("89504e470d0a1a0a0000000d49484452")
+PDF_BYTES = b"%PDF-1.4\n%fake\n"
+
+
+@pytest.fixture(scope="session")
+def acp_bin_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    # Wrapper executables named after each real agent binary so the real
+    # AcpSession._spawn_host() PATH lookup resolves to our fake ACP agent
+    # regardless of which adapter/model a test exercises.
+    bin_dir = tmp_path_factory.mktemp("acp-fake-bin")
+    launcher = (
+        f"#!{sys.executable}\n"
+        "import runpy\n"
+        f"runpy.run_path({str(FAKE_AGENT_SCRIPT)!r}, run_name='__main__')\n"
+    )
+    for name in BINARY_NAMES:
+        target = bin_dir / name
+        target.write_text(launcher)
+        target.chmod(0o755)
+    return bin_dir
+
+
+class FakeAgentHandle:
+    def __init__(self, log_path: Path) -> None:
+        self.log_path = log_path
+
+    def events(self) -> list[dict[str, Any]]:
+        if not self.log_path.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in self.log_path.read_text().splitlines()
+            if line.strip()
+        ]
+
+    def events_of(self, event: str) -> list[dict[str, Any]]:
+        return [e for e in self.events() if e.get("event") == event]
+
+    def main_turn_prompts(self) -> list[dict[str, Any]]:
+        # A chat's first turn also triggers background title generation, an
+        # independent ACP session/prompt through this same fake agent binary
+        # — filter its "Generate a title..." prompt out when a test wants the
+        # actual chat turn's prompt event.
+        return [
+            e
+            for e in self.events_of("prompt")
+            if not e["text"].startswith("Generate a title for this message:")
+        ]
+
+
+@pytest.fixture
+def fake_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, acp_bin_dir: Path
+) -> FakeAgentHandle:
+    log_path = tmp_path / "fake-acp.jsonl"
+    monkeypatch.setenv("FAKE_ACP_LOG", str(log_path))
+    monkeypatch.setenv("FAKE_ACP_SCENARIO", "normal")
+    monkeypatch.setenv(
+        "PATH", str(acp_bin_dir) + os.pathsep + os.environ.get("PATH", "")
+    )
+    return FakeAgentHandle(log_path=log_path)
+
+
+@pytest.fixture(autouse=True)
+def pin_ambient_settings() -> Iterator[None]:
+    # A developer's own shell/.env can export real AGENTROVE_MCP_* creds and
+    # DESKTOP_MODE=true for the desktop app; Settings() picks those up
+    # regardless of bootstrap.py, so pin a deterministic web-mode baseline
+    # here. The tests that care about MCP/desktop-mode override explicitly.
+    settings = get_settings()
+    original = (
+        settings.AGENTROVE_MCP_ENABLED,
+        settings.AGENTROVE_MCP_EMAIL,
+        settings.AGENTROVE_MCP_PASSWORD,
+        settings.DESKTOP_MODE,
+    )
+    settings.AGENTROVE_MCP_ENABLED = False
+    settings.AGENTROVE_MCP_EMAIL = None
+    settings.AGENTROVE_MCP_PASSWORD = None
+    settings.DESKTOP_MODE = False
+    try:
+        yield
+    finally:
+        (
+            settings.AGENTROVE_MCP_ENABLED,
+            settings.AGENTROVE_MCP_EMAIL,
+            settings.AGENTROVE_MCP_PASSWORD,
+            settings.DESKTOP_MODE,
+        ) = original
+
+
+@pytest.fixture
+def acp_cache(monkeypatch: pytest.MonkeyPatch) -> EndpointCache:
+    # Redis isn't available in tests — every module that touches cache_connection
+    # for the chat-streaming path needs the in-memory fake wired in.
+    from app.api.endpoints import chat as chat_endpoint
+    from app.services import chat as chat_service_module
+    from app.services.streaming import runtime as runtime_module
+
+    cache = EndpointCache()
+    monkeypatch.setattr(chat_endpoint, "cache_connection", cache.connect)
+    monkeypatch.setattr(chat_service_module, "cache_connection", cache.connect)
+    monkeypatch.setattr(runtime_module, "cache_connection", cache.connect)
+    return cache
+
+
+@pytest_asyncio.fixture
+async def auth_workspace(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> tuple[dict[str, str], Workspace]:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    # AcpSession._spawn_host() uses this as the subprocess cwd — it must exist
+    # on disk for both the fake agent spawn and the (best-effort, no-op here)
+    # git checkpoint probe.
+    Path(workspace.workspace_path).mkdir(parents=True, exist_ok=True)
+    return headers, workspace
+
+
+async def enhance_prompt(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    *,
+    prompt: str,
+    model_id: str,
+) -> httpx.Response:
+    return await client.post(
+        "/api/v1/chat/enhance-prompt",
+        data={"prompt": prompt, "model_id": model_id},
+        headers=headers,
+    )
+
+
+async def create_chat(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    workspace: Workspace,
+    *,
+    model_id: str,
+    title: str = "ACP Test Chat",
+) -> dict[str, Any]:
+    response = await client.post(
+        "/api/v1/chat/chats",
+        json={"title": title, "model_id": model_id, "workspace_id": str(workspace.id)},
+        headers=headers,
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+async def send_message(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    *,
+    chat_id: str,
+    model_id: str,
+    prompt: str,
+    permission_mode: str = "default",
+    attached_files: list[tuple[str, tuple[str, bytes, str]]] | None = None,
+) -> httpx.Response:
+    data = {
+        "prompt": prompt,
+        "chat_id": chat_id,
+        "model_id": model_id,
+        "permission_mode": permission_mode,
+    }
+    return await client.post(
+        "/api/v1/chat/chat",
+        data=data,
+        files=attached_files or [],
+        headers=headers,
+    )
+
+
+async def wait_for_message(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    *,
+    chat_id: str,
+    message_id: str,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = await client.get(
+            f"/api/v1/chat/chats/{chat_id}/messages",
+            headers=headers,
+            params={"limit": 50},
+        )
+        assert response.status_code == 200, response.text
+        for item in response.json()["items"]:
+            if item["id"] == message_id and item["stream_status"] != "in_progress":
+                await _settle_background_chat_work()
+                return item
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"message {message_id} did not leave in_progress in time")
+
+
+async def _settle_background_chat_work(timeout: float = 5.0) -> None:
+    # A chat's first turn kicks off background title generation — a second,
+    # independent ACP round trip through the same fake agent — as a detached
+    # asyncio task the API doesn't expose a "done" signal for. Left running,
+    # it can still be spawning/writing after the test returns, racing the next
+    # test's autouse database fixture (which drops all tables). Everything
+    # runs in-process on this same event loop (ASGITransport, no real
+    # network), so waiting out whatever tasks are still pending is exact.
+    pending = [
+        t
+        for t in asyncio.all_tasks()
+        if not t.done() and t.get_coro().__qualname__.endswith("_generate_title")
+    ]
+    if pending:
+        await asyncio.wait(pending, timeout=timeout)
+
+
+async def wait_for_message_event(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    *,
+    message_id: str,
+    event_type: str,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = await client.get(
+            f"/api/v1/chat/messages/{message_id}/events", headers=headers
+        )
+        assert response.status_code == 200, response.text
+        for event in response.json():
+            if event["event_type"] == event_type:
+                return event
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"event {event_type} for message {message_id} never arrived")
+
+
+def tool_events(
+    message: dict[str, Any], *, kinds: tuple[str, ...] | None = None
+) -> list[dict[str, Any]]:
+    kinds = kinds or ("tool_started", "tool_completed", "tool_failed")
+    return [e for e in message["content_render"]["events"] if e["type"] in kinds]
+
+
+def last_tool(message: dict[str, Any], tool_id: str) -> dict[str, Any]:
+    matches = [e["tool"] for e in tool_events(message) if e["tool"]["id"] == tool_id]
+    assert matches, f"no tool events for id={tool_id} in {message['content_render']}"
+    return matches[-1]
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "sonnet",
+        "opus",
+        "gpt-5.6-sol",
+        "gpt-5.6-luna",
+        "gpt-5.4",
+        "copilot:gpt-5.4",
+        "cursor:auto",
+        "opencode:opencode/gpt-5-nano",
+    ],
+)
+async def test_enhance_prompt_round_trips_through_real_acp_session(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_agent: FakeAgentHandle,
+    model_id: str,
+) -> None:
+    # Drives client.py + session.py + adapters.py for real: spawns the fake
+    # agent over stdio, does the ACP handshake, creates a session, streams a
+    # full turn back, and tears the process down — once per adapter kind.
+    headers, _user, _workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email=f"{model_id.replace(':', '-')}@example.com",
+    )
+
+    response = await enhance_prompt(client, headers, prompt="say hi", model_id=model_id)
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"enhanced_prompt": DEFAULT_TURN_TEXT}
+
+    new_sessions = fake_agent.events_of("new_session")
+    assert new_sessions
+    assert new_sessions[-1]["mcp_servers"] == []
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    ["crash_initialize", "crash_new_session"],
+)
+async def test_enhance_prompt_surfaces_session_creation_failure(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_agent: FakeAgentHandle,
+    monkeypatch: pytest.MonkeyPatch,
+    scenario: str,
+) -> None:
+    headers, _user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login, email=f"{scenario}@example.com"
+    )
+    monkeypatch.setenv("FAKE_ACP_SCENARIO", scenario)
+
+    response = await enhance_prompt(client, headers, prompt="hi", model_id="sonnet")
+
+    assert response.status_code == 400, response.text
+    assert "Failed to create ACP session" in response.json()["detail"]
+
+
+async def test_enhance_prompt_surfaces_mid_prompt_crash(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_agent: FakeAgentHandle,
+) -> None:
+    headers, _user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login, email="mid-prompt-crash@example.com"
+    )
+
+    response = await enhance_prompt(
+        client, headers, prompt=f"{MARKER_CRASH_MID_PROMPT} do work", model_id="sonnet"
+    )
+
+    assert response.status_code == 400, response.text
+    assert "ACP call failed" in response.json()["detail"]
+
+
+async def test_enhance_prompt_survives_config_option_failures(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_agent: FakeAgentHandle,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Claude sets its reasoning effort via set_config_option right after the
+    # handshake; session.py must swallow a failure there and still run the turn.
+    headers, _user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login, email="config-error@example.com"
+    )
+    monkeypatch.setenv("FAKE_ACP_SCENARIO", "config_error")
+
+    response = await enhance_prompt(client, headers, prompt="hi", model_id="opus")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"enhanced_prompt": DEFAULT_TURN_TEXT}
+
+
+@pytest.mark.parametrize(
+    "marker,tool_id,field,expected",
+    [
+        (
+            MARKER_TOOL_DIFF,
+            "tool-primary",
+            "result",
+            {"diffs": [{"path": "app.py", "oldText": "old", "newText": "new"}]},
+        ),
+        (MARKER_TOOL_TEXT_RESULT, "tool-primary", "result", "plain text result"),
+        (MARKER_TOOL_CODEX_ERROR, "tool-secondary", "error", "boom codex"),
+        (MARKER_TOOL_STRING_ERROR, "tool-secondary", "error", "boom plain string"),
+        (
+            MARKER_TOOL_TEXT_ERROR,
+            "tool-secondary",
+            "error",
+            "command failed: no output",
+        ),
+        (MARKER_TOOL_PROGRESS_NEW, "tool-new", "result", "synthesized result"),
+        (MARKER_RAW_INPUT_STRING, "tool-primary", "input", {"path": "encoded.py"}),
+        (MARKER_RAW_INPUT_INVALID, "tool-primary", "input", {"raw": "not-json{{"}),
+        (MARKER_TOOL_EMPTY_RESULT, "tool-primary", "result", None),
+        (
+            MARKER_TOOL_UNKNOWN_DICT_ERROR,
+            "tool-secondary",
+            "error",
+            str({"unexpected_key": "value"}),
+        ),
+    ],
+)
+async def test_chat_tool_call_extraction_variants(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+    marker: str,
+    tool_id: str,
+    field: str,
+    expected: Any,
+) -> None:
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+    send_response = await send_message(
+        client, headers, chat_id=chat["id"], model_id="sonnet", prompt=f"{marker} go"
+    )
+    assert send_response.status_code == 200, send_response.text
+    message_id = send_response.json()["message_id"]
+
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    assert message["stream_status"] == "completed"
+
+    tool = last_tool(message, tool_id)
+    assert tool[field] == expected
+
+    # tool-orphan and Claude's plan suppression are exercised on every turn.
+    assert not any(e["tool"]["id"] == "tool-orphan" for e in tool_events(message))
+    assert not any(e["type"] == "plan" for e in message["content_render"]["events"])
+    assert any(e["type"] == "system" for e in message["content_render"]["events"])
+
+
+async def test_chat_tool_progress_orphan_update_is_a_no_op(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+) -> None:
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+    send_response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="sonnet",
+        prompt=f"{MARKER_TOOL_PROGRESS_ORPHAN} go",
+    )
+    message_id = send_response.json()["message_id"]
+
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    assert message["stream_status"] == "completed"
+    assert not any(e["tool"]["id"] == "tool-orphan" for e in tool_events(message))
+
+
+async def test_chat_tool_left_active_is_auto_completed_on_finish(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+) -> None:
+    # A tool that never receives a terminal update but whose turn otherwise
+    # ends normally exercises AcpClientHandler.finish(prompt_completed=True)'s
+    # leftover-active-tool auto-close, distinct from the prompt-failure path.
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+    send_response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="sonnet",
+        prompt=f"{MARKER_TOOL_LEFT_OPEN} go",
+    )
+    message_id = send_response.json()["message_id"]
+
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    assert message["stream_status"] == "completed"
+    tool = last_tool(message, "tool-secondary")
+    assert tool["status"] == "completed"
+    assert "result" not in tool
+    assert "error" not in tool
+
+
+async def test_chat_agent_calls_fs_and_terminal_stubs_without_error(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+) -> None:
+    # The client implements ACP's fs/terminal methods as no-op stubs (the
+    # sandbox handles file/terminal I/O directly) — drive every one of them
+    # from the agent side and confirm the turn still completes cleanly.
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+    send_response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="sonnet",
+        prompt=f"{MARKER_FS_TERMINAL_STUBS} go",
+    )
+    message_id = send_response.json()["message_id"]
+
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    assert message["stream_status"] == "completed"
+
+
+async def test_chat_non_text_content_chunks_produce_no_events(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+) -> None:
+    # AgentMessageChunk/AgentThoughtChunk/UserMessageChunk all map to None in
+    # client.py when their content block isn't text — image content must not
+    # add any extra assistant_text/assistant_thinking events.
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+    send_response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="sonnet",
+        prompt=f"{MARKER_IMAGE_CONTENT} go",
+    )
+    message_id = send_response.json()["message_id"]
+
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    assert message["stream_status"] == "completed"
+    events = message["content_render"]["events"]
+    assert len([e for e in events if e["type"] == "assistant_text"]) == 2
+    assert len([e for e in events if e["type"] == "assistant_thinking"]) == 1
+
+
+async def test_chat_enter_plan_mode_tool_triggers_mid_stream_mode_switch(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+) -> None:
+    # AgentService._get_plan_mode_transition() reacts to a completed
+    # "EnterPlanMode" tool by calling adapter.map_session_mode() and
+    # session.set_mode() mid-turn — the only caller of Claude's
+    # map_session_mode() passthrough (build_session_config never uses it).
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+    send_response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="sonnet",
+        prompt=f"{MARKER_ENTER_PLAN_MODE} go",
+    )
+    message_id = send_response.json()["message_id"]
+
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    assert message["stream_status"] == "completed"
+    set_modes = fake_agent.events_of("set_session_mode")
+    assert set_modes
+    assert set_modes[-1]["mode_id"] == "plan"
+
+
+@pytest.mark.parametrize(
+    "model_id,agent_permission_mode,expect_raises,expect_mapped_mode",
+    [
+        ("gpt-5.4", "bypassPermissions", True, None),
+        (
+            "copilot:gpt-5.4",
+            "bypassPermissions",
+            False,
+            "https://agentclientprotocol.com/protocol/session-modes#agent",
+        ),
+        ("cursor:auto", "bypassPermissions", False, "agent"),
+        ("opencode:opencode/gpt-5-nano", "bypassPermissions", False, "plan"),
+    ],
+)
+async def test_chat_permission_mode_unsupported_by_adapter(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+    model_id: str,
+    agent_permission_mode: str,
+    expect_raises: bool,
+    expect_mapped_mode: str | None,
+) -> None:
+    # "bypassPermissions" is a globally valid PermissionMode literal but isn't
+    # in every adapter's own session-mode set: Codex raises (a caller bug must
+    # fail loudly), Copilot/Cursor/OpenCode fall back to their normal mode so
+    # an agent switch never silently widens permissions.
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id=model_id)
+
+    send_response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id=model_id,
+        prompt="hello",
+        permission_mode=agent_permission_mode,
+    )
+    assert send_response.status_code == 200, send_response.text
+    message_id = send_response.json()["message_id"]
+
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    if expect_raises:
+        assert message["stream_status"] == "failed"
+        return
+    assert message["stream_status"] == "completed"
+    set_modes = fake_agent.events_of("set_session_mode")
+    assert set_modes
+    # First mode-set belongs to the chat session — background title generation
+    # opens a second session afterwards (opencode's uses a persona mode).
+    assert set_modes[0]["mode_id"] == expect_mapped_mode
+
+
+async def test_chat_attachments_with_only_native_files_skip_the_note(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+) -> None:
+    # _build_attachment_note() returns "" when every attachment is natively
+    # embeddable — no sandbox-path note is needed. Codex only treats images
+    # as native, so a single image-only upload exercises that empty branch.
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="gpt-5.4")
+
+    response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="gpt-5.4",
+        prompt="look at this photo",
+        permission_mode="auto",
+        attached_files=[("attached_files", ("photo.png", PNG_BYTES, "image/png"))],
+    )
+    assert response.status_code == 200, response.text
+    message_id = response.json()["message_id"]
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    assert message["stream_status"] == "completed"
+
+    prompts = fake_agent.main_turn_prompts()
+    assert prompts
+    last_prompt = prompts[-1]
+    assert "image" in last_prompt["block_types"]
+    assert "is available at" not in last_prompt["text"]
+
+
+async def test_chat_native_pdf_attachment_is_embedded_not_noted(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+) -> None:
+    # Claude treats pdf as natively embeddable (unlike Codex) — this drives
+    # _build_attachment_blocks()'s EmbeddedResourceContentBlock/BlobResourceContents
+    # branch instead of the sandbox-note path.
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+    response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="sonnet",
+        prompt="look at this doc",
+        attached_files=[("attached_files", ("doc.pdf", PDF_BYTES, "application/pdf"))],
+    )
+    assert response.status_code == 200, response.text
+    message_id = response.json()["message_id"]
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    assert message["stream_status"] == "completed"
+
+    prompts = fake_agent.main_turn_prompts()
+    assert prompts
+    last_prompt = prompts[-1]
+    assert "resource" in last_prompt["block_types"]
+    assert "is available at" not in last_prompt["text"]
+
+
+@pytest.mark.parametrize(
+    "option_id,expect_permission_mode,expect_status",
+    [
+        ("acceptEdits", "acceptEdits", "tool_completed"),
+        ("reject-once", None, "tool_completed"),
+        ("plan", "plan", "tool_failed"),
+        ("", None, "tool_failed"),
+    ],
+)
+async def test_chat_permission_response_flow(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+    option_id: str,
+    expect_permission_mode: str | None,
+    expect_status: str,
+) -> None:
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+    send_response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="sonnet",
+        prompt=f"{MARKER_PERMISSION} edit it",
+    )
+    message_id = send_response.json()["message_id"]
+
+    permission_event = await wait_for_message_event(
+        client, headers, message_id=message_id, event_type="permission_request"
+    )
+    payload = permission_event["render_payload"]
+    request_id = payload["request_id"]
+    option_ids = {opt["option_id"] for opt in payload["data"]["options"]}
+    assert option_ids == {"acceptEdits", "reject-once", "plan"}
+
+    respond = await client.post(
+        f"/api/v1/chat/chats/{chat['id']}/permissions/{request_id}/respond",
+        data={"option_id": option_id},
+        headers=headers,
+    )
+    assert respond.status_code == 200, respond.text
+    assert respond.json() == {"success": True}
+
+    # Responding twice must fail cleanly (no pending future left to resolve).
+    respond_again = await client.post(
+        f"/api/v1/chat/chats/{chat['id']}/permissions/{request_id}/respond",
+        data={"option_id": option_id},
+        headers=headers,
+    )
+    assert respond_again.status_code == 404
+
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    assert message["stream_status"] == "completed"
+
+    tool = last_tool(message, "tool-permission")
+    assert tool["status"] == expect_status.removeprefix("tool_")
+    assert tool.get("permission_mode") == expect_permission_mode
+
+
+async def test_chat_cancel_marks_message_interrupted(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+) -> None:
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+    send_response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="sonnet",
+        prompt=f"{MARKER_CANCEL} run long task",
+    )
+    message_id = send_response.json()["message_id"]
+
+    # Wait until the fake agent is actually blocked mid-turn (tool_started
+    # observed) so the cancel request can't race ahead of turn start.
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        response = await client.get(
+            f"/api/v1/chat/messages/{message_id}/events", headers=headers
+        )
+        if any(e["event_type"] == "tool_started" for e in response.json()):
+            break
+        await asyncio.sleep(0.05)
+    else:
+        raise AssertionError("fake agent never reached the blocking tool call")
+
+    cancel_response = await client.delete(
+        f"/api/v1/chat/chats/{chat['id']}/stream", headers=headers
+    )
+    assert cancel_response.status_code == 204
+
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    assert message["stream_status"] == "interrupted"
+
+
+async def test_chat_resume_after_session_eviction_mutes_replayed_history(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+    first = await send_message(
+        client, headers, chat_id=chat["id"], model_id="sonnet", prompt="first turn"
+    )
+    first_message_id = first.json()["message_id"]
+    first_result = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=first_message_id
+    )
+    assert first_result["stream_status"] == "completed"
+
+    chat_detail = await client.get(f"/api/v1/chat/chats/{chat['id']}", headers=headers)
+    assert chat_detail.status_code == 200
+    assert chat_detail.json()["session_agent_kind"] == "claude"
+    # session_id isn't exposed on the Chat API schema — the fake agent always
+    # hands back the same fixed id, which load_session() below must be handed.
+    session_id = NEW_SESSION_ID
+
+    # Simulate the in-process session being evicted (idle timeout / restart) —
+    # the next turn must go through AcpSession.create() with resume_session_id
+    # set, exercising the real load_session() path instead of session reuse.
+    await session_registry.terminate(chat["id"])
+    monkeypatch.setenv("FAKE_ACP_SCENARIO", "load_session_replay")
+
+    second = await send_message(
+        client, headers, chat_id=chat["id"], model_id="sonnet", prompt="second turn"
+    )
+    second_message_id = second.json()["message_id"]
+    second_result = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=second_message_id
+    )
+    assert second_result["stream_status"] == "completed"
+
+    load_sessions = fake_agent.events_of("load_session")
+    assert load_sessions
+    assert load_sessions[-1]["session_id"] == session_id
+
+    all_text = "".join(
+        e.get("text", "")
+        for e in second_result["content_render"]["events"]
+        if e["type"] == "assistant_text"
+    )
+    assert "REPLAYED_HISTORY_SHOULD_BE_MUTED" not in all_text
+    assert DEFAULT_TURN_TEXT in all_text
+
+
+async def test_chat_mid_session_model_and_mode_switch_survives_config_errors(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Codex's env doesn't vary by model, so the in-process session is reused
+    # across a model/permission_mode change — the only way to reach
+    # AcpSession.set_model()/set_mode() (as opposed to the create()-time calls).
+    monkeypatch.setenv("FAKE_ACP_SCENARIO", "config_error")
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="gpt-5.4")
+
+    first = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="gpt-5.4",
+        prompt="first turn",
+        permission_mode="auto",
+    )
+    assert first.status_code == 200, first.text
+    first_message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=first.json()["message_id"]
+    )
+    assert first_message["stream_status"] == "completed"
+    assert any(e["type"] == "plan" for e in first_message["content_render"]["events"])
+
+    second = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="gpt-5.6-luna",
+        prompt="second turn",
+        permission_mode="read-only",
+    )
+    assert second.status_code == 200, second.text
+    second_message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=second.json()["message_id"]
+    )
+    assert second_message["stream_status"] == "completed"
+
+    set_models = fake_agent.events_of("set_session_model")
+    assert len(set_models) >= 2
+    assert set_models[-1]["model_id"] == "gpt-5.6-luna[medium]"
+
+    set_modes = fake_agent.events_of("set_session_mode")
+    assert set_modes
+    assert set_modes[-1]["mode_id"] == "read-only"
+
+
+async def test_chat_attachments_and_mcp_servers_reach_the_agent(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+) -> None:
+    settings = get_settings()
+    original = (
+        settings.AGENTROVE_MCP_ENABLED,
+        settings.AGENTROVE_MCP_EMAIL,
+        settings.AGENTROVE_MCP_PASSWORD,
+    )
+    settings.AGENTROVE_MCP_ENABLED = True
+    settings.AGENTROVE_MCP_EMAIL = "mcp@example.com"
+    settings.AGENTROVE_MCP_PASSWORD = "mcp-password"
+    try:
+        headers, workspace = auth_workspace
+        # Codex only treats "image" as natively embeddable — the pdf forces
+        # the sandbox-note branch of session.py's attachment handling.
+        chat = await create_chat(client, headers, workspace, model_id="gpt-5.4")
+
+        response = await send_message(
+            client,
+            headers,
+            chat_id=chat["id"],
+            model_id="gpt-5.4",
+            prompt="look at these files",
+            permission_mode="auto",
+            attached_files=[
+                ("attached_files", ("photo.png", PNG_BYTES, "image/png")),
+                ("attached_files", ("doc.pdf", PDF_BYTES, "application/pdf")),
+            ],
+        )
+        assert response.status_code == 200, response.text
+        message_id = response.json()["message_id"]
+        message = await wait_for_message(
+            client, headers, chat_id=chat["id"], message_id=message_id
+        )
+        assert message["stream_status"] == "completed"
+    finally:
+        (
+            settings.AGENTROVE_MCP_ENABLED,
+            settings.AGENTROVE_MCP_EMAIL,
+            settings.AGENTROVE_MCP_PASSWORD,
+        ) = original
+
+    new_sessions = fake_agent.events_of("new_session")
+    assert new_sessions
+    mcp_servers = new_sessions[-1]["mcp_servers"]
+    assert len(mcp_servers) == 1
+    assert mcp_servers[0]["name"] == "agentrove"
+    assert mcp_servers[0]["command"] == sys.executable
+
+    prompts = fake_agent.main_turn_prompts()
+    assert prompts
+    last_prompt = prompts[-1]
+    assert "image" in last_prompt["block_types"]
+    assert "doc.pdf is available at" in last_prompt["text"]

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -1,17 +1,29 @@
+from collections.abc import AsyncIterator
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
+from fastapi import FastAPI
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import tests.bootstrap
+from app.constants import MODELS
+from app.core.deps import get_queue_service
 from app.models.db_models.chat import Chat, Message, MessageAttachment
 from app.models.db_models.enums import AttachmentType, MessageRole, MessageStreamStatus
 from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
+from app.services.queue import QueueService
+from app.services.sandbox_providers.base import SandboxProvider
 
 from tests.conftest import LoginClient, UserFactory
-from tests.helpers import create_authenticated_workspace
+from tests.helpers import (
+    EndpointCache,
+    FakeProviderFactory,
+    FakeSandboxProvider,
+    create_authenticated_workspace,
+)
 
 
 pytestmark = pytest.mark.anyio
@@ -200,3 +212,264 @@ async def test_temp_attachment_preview_allows_only_current_user_temp_dir(
     assert preview_response.headers["content-disposition"].startswith("inline;")
     assert other_response.status_code == 403
     assert traversal_response.status_code == 403
+
+
+async def test_temp_attachment_preview_returns_404_for_missing_file(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        "/api/v1/attachments/temp/preview",
+        params={"path": f"temp/{user.id}/missing.txt"},
+        headers=headers,
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "File not found"
+
+
+async def test_attachment_download_returns_404_for_unknown_attachment(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/attachments/{uuid4()}/download", headers=headers
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Attachment not found"
+
+
+async def test_attachment_preview_rejects_path_escaping_storage_dir(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    attachment = await create_attachment_row(
+        db_session,
+        user,
+        workspace,
+        file_path="../outside-storage.txt",
+        filename="outside-storage.txt",
+    )
+
+    response = await client.get(
+        f"/api/v1/attachments/{attachment.id}/preview", headers=headers
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Access denied"
+
+
+class QueueServiceOverride:
+    def __init__(self) -> None:
+        self.cache = EndpointCache()
+
+    async def __call__(self) -> AsyncIterator[QueueService]:
+        async with self.cache.connect() as store:
+            yield QueueService(store)
+
+
+async def create_chat_for_queue_upload(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    *,
+    email: str,
+    username: str,
+) -> tuple[dict[str, str], FakeSandboxProvider, str]:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login, email=email, username=username
+    )
+    chat = Chat(title="Upload Chat", user_id=user.id, workspace_id=workspace.id)
+    db_session.add(chat)
+    await db_session.commit()
+    await db_session.refresh(chat)
+    provider = FakeSandboxProvider(workspace_path=workspace.workspace_path)
+    return headers, provider, str(chat.id)
+
+
+async def test_queue_message_upload_writes_sandbox_copy_for_non_native_file_type(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, provider, chat_id = await create_chat_for_queue_upload(
+        client,
+        db_session,
+        create_user,
+        login,
+        email="queue-upload-pdf@example.com",
+        username="queueuploadpdf",
+    )
+    monkeypatch.setattr(
+        SandboxProvider, "create_provider", FakeProviderFactory(provider)
+    )
+    app.dependency_overrides[get_queue_service] = QueueServiceOverride()
+    codex_model_id = next(
+        model_id
+        for model_id, info in MODELS.items()
+        if info.agent_kind.value == "codex"
+    )
+
+    response = await client.post(
+        f"/api/v1/chat/chats/{chat_id}/queue",
+        data={"content": "Look at this PDF", "model_id": codex_model_id},
+        files={"attached_files": ("doc.pdf", b"%PDF-1.4 fake", "application/pdf")},
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    queue_response = await client.get(
+        f"/api/v1/chat/chats/{chat_id}/queue", headers=headers
+    )
+    attachments = queue_response.json()[0]["attachments"]
+    assert attachments is not None
+    stored = attachments[0]
+    assert stored["file_type"] == "pdf"
+    assert stored["filename"] == "doc.pdf"
+    on_disk = tests.bootstrap.TEST_DIR / "storage" / stored["file_path"]
+    assert on_disk.read_bytes() == b"%PDF-1.4 fake"
+    # PDFs aren't in codex's NATIVE_FILE_TYPES, so a sandbox copy is required.
+    assert len(provider.writes) == 1
+    assert provider.writes[0][2] == b"%PDF-1.4 fake"
+
+
+async def test_queue_message_upload_skips_sandbox_copy_for_native_image_type(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, provider, chat_id = await create_chat_for_queue_upload(
+        client,
+        db_session,
+        create_user,
+        login,
+        email="queue-upload-image@example.com",
+        username="queueuploadimage",
+    )
+    monkeypatch.setattr(
+        SandboxProvider, "create_provider", FakeProviderFactory(provider)
+    )
+    app.dependency_overrides[get_queue_service] = QueueServiceOverride()
+    codex_model_id = next(
+        model_id
+        for model_id, info in MODELS.items()
+        if info.agent_kind.value == "codex"
+    )
+
+    response = await client.post(
+        f"/api/v1/chat/chats/{chat_id}/queue",
+        data={"content": "Look at this image", "model_id": codex_model_id},
+        files={"attached_files": ("pic.png", b"\x89PNG fake", "image/png")},
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    # Images are codex-native — the agent reads them inline, so no sandbox
+    # write should happen (the file still lands in temp storage on disk).
+    assert provider.writes == []
+    queue_response = await client.get(
+        f"/api/v1/chat/chats/{chat_id}/queue", headers=headers
+    )
+    stored = queue_response.json()[0]["attachments"][0]
+    on_disk = tests.bootstrap.TEST_DIR / "storage" / stored["file_path"]
+    assert on_disk.read_bytes() == b"\x89PNG fake"
+
+
+async def test_queue_message_upload_rejects_invalid_content_type(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, provider, chat_id = await create_chat_for_queue_upload(
+        client,
+        db_session,
+        create_user,
+        login,
+        email="queue-upload-badtype@example.com",
+        username="queueuploadbadtype",
+    )
+    monkeypatch.setattr(
+        SandboxProvider, "create_provider", FakeProviderFactory(provider)
+    )
+    app.dependency_overrides[get_queue_service] = QueueServiceOverride()
+    codex_model_id = next(
+        model_id
+        for model_id, info in MODELS.items()
+        if info.agent_kind.value == "codex"
+    )
+
+    response = await client.post(
+        f"/api/v1/chat/chats/{chat_id}/queue",
+        data={"content": "Bad file", "model_id": codex_model_id},
+        files={"attached_files": ("virus.exe", b"MZ", "application/octet-stream")},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid file type: application/octet-stream"
+
+
+async def test_queue_message_upload_rejects_oversized_file(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, provider, chat_id = await create_chat_for_queue_upload(
+        client,
+        db_session,
+        create_user,
+        login,
+        email="queue-upload-toolarge@example.com",
+        username="queueuploadtoolarge",
+    )
+    monkeypatch.setattr(
+        SandboxProvider, "create_provider", FakeProviderFactory(provider)
+    )
+    app.dependency_overrides[get_queue_service] = QueueServiceOverride()
+    codex_model_id = next(
+        model_id
+        for model_id, info in MODELS.items()
+        if info.agent_kind.value == "codex"
+    )
+    oversized_content = b"0" * (5 * 1024 * 1024 + 1)
+
+    response = await client.post(
+        f"/api/v1/chat/chats/{chat_id}/queue",
+        data={"content": "Too big", "model_id": codex_model_id},
+        files={"attached_files": ("huge.png", oversized_content, "image/png")},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert "too large" in response.json()["detail"].lower()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,14 +1,81 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from email.mime.multipart import MIMEMultipart
+
+import aiosmtplib
+import httpx
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.security import hash_refresh_token
+from app.models.db_models.refresh_token import RefreshToken
 from app.models.db_models.user import User
+from app.services.email import EmailService, email_service
 
 from tests.conftest import EmailCapture, LoginClient, SettingsOverride, UserFactory
 from tests.helpers import count_refresh_tokens, get_user_by_email, get_user_settings
 
 
 pytestmark = pytest.mark.anyio
+
+
+def extract_html_body(message: MIMEMultipart) -> str:
+    # The service attaches a single "html" MIMEText part — decode it to
+    # assert on the rendered template output (link, token).
+    payload = message.get_payload()[0].get_payload(decode=True)
+    assert isinstance(payload, bytes)
+    return payload.decode()
+
+
+@dataclass
+class FakeHttpxResponse:
+    status_code: int
+    text: str
+
+
+@dataclass
+class FakeDisposableDomainsClient:
+    fetch: "DisposableDomainsFetch"
+
+    async def __aenter__(self) -> "FakeDisposableDomainsClient":
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        return None
+
+    async def get(self, _url: str) -> FakeHttpxResponse:
+        self.fetch.call_count += 1
+        if self.fetch.raises is not None:
+            raise self.fetch.raises("simulated network failure")
+        return FakeHttpxResponse(self.fetch.status_code, self.fetch.text)
+
+
+@dataclass
+class DisposableDomainsFetch:
+    # Stands in for `httpx.AsyncClient` itself (the real code does
+    # `httpx.AsyncClient(timeout=10.0)`), so this must be callable.
+    status_code: int = 200
+    text: str = "mailinator.com\n"
+    raises: type[Exception] | None = None
+    call_count: int = 0
+
+    def __call__(self, *, timeout: float | None = None) -> FakeDisposableDomainsClient:
+        return FakeDisposableDomainsClient(self)
+
+
+@dataclass
+class SmtpSendCapture:
+    calls: list[MIMEMultipart] = field(default_factory=list)
+    raises: type[Exception] | None = None
+
+    async def send(
+        self, message: MIMEMultipart, **_kwargs: object
+    ) -> tuple[dict[str, str], str]:
+        self.calls.append(message)
+        if self.raises is not None:
+            raise self.raises("simulated smtp failure")
+        return {}, "OK"
 
 
 async def test_register_creates_user_and_settings(
@@ -412,3 +479,268 @@ async def test_verify_rejects_invalid_token(client: AsyncClient) -> None:
     response = await client.post("/api/v1/auth/verify", json={"token": "bad-token"})
 
     assert response.status_code == 400
+
+
+@pytest.mark.parametrize(
+    ("username", "expected_message"),
+    [
+        ("", "Username is required"),
+        ("ab", "Username must be at least 3 characters long"),
+        ("a" * 31, "Username must be less than 30 characters long"),
+        ("bad!name", "Username can only contain letters, numbers, and underscores"),
+    ],
+)
+async def test_register_rejects_invalid_username_variants(
+    client: AsyncClient,
+    email_capture: EmailCapture,
+    username: str,
+    expected_message: str,
+) -> None:
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "invalid-variant@example.com",
+            "username": username,
+            "password": "password123",
+        },
+    )
+
+    assert response.status_code == 422
+    errors = response.json()["detail"]
+    assert any(expected_message in str(err.get("msg", "")) for err in errors)
+
+
+async def test_refresh_rejects_expired_token(
+    client: AsyncClient,
+    create_user: UserFactory,
+    db_session: AsyncSession,
+) -> None:
+    user = await create_user(email="expired@example.com", username="expireduser")
+    raw_token = "already-expired-raw-token"
+    # Naive datetime on purpose — exercises UTCDateTime's naive-bind branch
+    # in addition to the service's expiry check.
+    db_session.add(
+        RefreshToken(
+            token_hash=hash_refresh_token(raw_token),
+            user_id=user.id,
+            expires_at=datetime(2000, 1, 1),
+        )
+    )
+    await db_session.commit()
+
+    response = await client.post(
+        "/api/v1/auth/jwt/refresh",
+        json={"refresh_token": raw_token},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid or expired refresh token"
+
+
+async def test_refresh_rejects_token_for_deactivated_user(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    db_session: AsyncSession,
+) -> None:
+    user = await create_user(
+        email="deactivated@example.com", username="deactivateduser"
+    )
+    tokens = await login(email="deactivated@example.com")
+    user.is_active = False
+    db_session.add(user)
+    await db_session.commit()
+
+    response = await client.post(
+        "/api/v1/auth/jwt/refresh",
+        json={"refresh_token": tokens["refresh_token"]},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid or expired refresh token"
+
+
+async def test_logout_with_unknown_token_still_succeeds(client: AsyncClient) -> None:
+    # Exercises RefreshTokenService.revoke_token's "not found" branch — the
+    # endpoint doesn't surface the boolean result either way.
+    response = await client.post(
+        "/api/v1/auth/jwt/logout",
+        json={"refresh_token": "token-that-was-never-issued"},
+    )
+
+    assert response.status_code == 204
+
+
+async def test_register_blocks_disposable_email_via_live_domain_fetch(
+    client: AsyncClient,
+    settings_override: SettingsOverride,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(EmailService, "_disposable_domains_cache", set())
+    monkeypatch.setattr(EmailService, "_disposable_domains_cache_time", None)
+    fetch = DisposableDomainsFetch(text="mailinator.com\n")
+    monkeypatch.setattr("app.services.email.httpx.AsyncClient", fetch)
+    settings_override(BLOCK_DISPOSABLE_EMAILS=True)
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "spammer@mailinator.com",
+            "username": "spammer",
+            "password": "password123",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "Disposable email" in response.json()["detail"]
+    assert fetch.call_count == 1
+
+    second = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "spammer2@mailinator.com",
+            "username": "spammertwo",
+            "password": "password123",
+        },
+    )
+
+    assert second.status_code == 400
+    # Within the cache TTL, the domain list isn't re-fetched.
+    assert fetch.call_count == 1
+
+
+async def test_register_blocks_disposable_email_using_stale_cache_when_refetch_fails(
+    client: AsyncClient,
+    settings_override: SettingsOverride,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Pre-populate the cache but with a timestamp older than the TTL, so a
+    # refetch is attempted; when it fails, the stale (still non-empty) cache
+    # is served instead of an empty set.
+    monkeypatch.setattr(EmailService, "_disposable_domains_cache", {"mailinator.com"})
+    monkeypatch.setattr(
+        EmailService,
+        "_disposable_domains_cache_time",
+        datetime(2000, 1, 1, tzinfo=timezone.utc),
+    )
+    fetch = DisposableDomainsFetch(raises=httpx.ConnectError)
+    monkeypatch.setattr("app.services.email.httpx.AsyncClient", fetch)
+    settings_override(BLOCK_DISPOSABLE_EMAILS=True)
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "stale@mailinator.com",
+            "username": "staleuser",
+            "password": "password123",
+        },
+    )
+
+    assert response.status_code == 400
+    assert fetch.call_count == 1
+
+
+async def test_register_allows_email_when_domain_fetch_fails(
+    client: AsyncClient,
+    settings_override: SettingsOverride,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(EmailService, "_disposable_domains_cache", set())
+    monkeypatch.setattr(EmailService, "_disposable_domains_cache_time", None)
+    fetch = DisposableDomainsFetch(raises=httpx.ConnectError)
+    monkeypatch.setattr("app.services.email.httpx.AsyncClient", fetch)
+    settings_override(BLOCK_DISPOSABLE_EMAILS=True)
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "user@example.com",
+            "username": "networkfail",
+            "password": "password123",
+        },
+    )
+
+    assert response.status_code == 201
+    assert fetch.call_count == 1
+
+
+async def test_forgot_password_sends_real_smtp_message(
+    client: AsyncClient,
+    create_user: UserFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await create_user(email="smtp-reset@example.com", username="smtpreset")
+    monkeypatch.setattr(email_service, "smtp_password", "app-password")
+    capture = SmtpSendCapture()
+    monkeypatch.setattr("app.services.email.aiosmtplib.send", capture.send)
+
+    response = await client.post(
+        "/api/v1/auth/forgot-password",
+        json={"email": "smtp-reset@example.com"},
+    )
+
+    assert response.status_code == 202
+    assert len(capture.calls) == 1
+    message = capture.calls[0]
+    assert message["Subject"] == "Reset your Agentrove password"
+    assert message["To"] == "smtp-reset@example.com"
+    assert "reset-password?token=" in extract_html_body(message)
+
+
+async def test_request_verify_token_sends_real_smtp_message(
+    client: AsyncClient,
+    create_user: UserFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await create_user(
+        email="smtp-verify@example.com", username="smtpverify", is_verified=False
+    )
+    monkeypatch.setattr(email_service, "smtp_password", "app-password")
+    capture = SmtpSendCapture()
+    monkeypatch.setattr("app.services.email.aiosmtplib.send", capture.send)
+
+    response = await client.post(
+        "/api/v1/auth/request-verify-token",
+        json={"email": "smtp-verify@example.com"},
+    )
+
+    assert response.status_code == 202
+    assert len(capture.calls) == 1
+    message = capture.calls[0]
+    assert message["Subject"] == "Verify your Agentrove account"
+    assert "verify-email?token=" in extract_html_body(message)
+
+
+async def test_forgot_password_swallows_smtp_send_failure(
+    client: AsyncClient,
+    create_user: UserFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await create_user(email="smtp-fail@example.com", username="smtpfail")
+    monkeypatch.setattr(email_service, "smtp_password", "app-password")
+    capture = SmtpSendCapture(raises=aiosmtplib.SMTPException)
+    monkeypatch.setattr("app.services.email.aiosmtplib.send", capture.send)
+
+    response = await client.post(
+        "/api/v1/auth/forgot-password",
+        json={"email": "smtp-fail@example.com"},
+    )
+
+    assert response.status_code == 202
+    assert len(capture.calls) == 1
+
+
+async def test_forgot_password_returns_false_without_smtp_configured(
+    client: AsyncClient,
+    create_user: UserFactory,
+) -> None:
+    # No email_capture fixture and no smtp_password configured (bootstrap
+    # sets MAIL_PASSWORD="") — exercises _send_email's early-return branch.
+    await create_user(email="no-smtp@example.com", username="nosmtp")
+
+    response = await client.post(
+        "/api/v1/auth/forgot-password",
+        json={"email": "no-smtp@example.com"},
+    )
+
+    assert response.status_code == 202

--- a/backend/tests/test_automations.py
+++ b/backend/tests/test_automations.py
@@ -1,0 +1,573 @@
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_automation_service
+from app.models.db_models.chat import Chat
+from app.models.db_models.user import User
+from app.models.schemas.chat import ChatCreate, ChatRequest
+from app.services.automation import AutomationService
+from app.services.exceptions import ChatException
+
+from tests.conftest import LoginClient, UserFactory
+from tests.helpers import create_authenticated_workspace
+
+
+pytestmark = pytest.mark.anyio
+
+
+TEST_MODEL_ID = "opencode:google-vertex-anthropic/claude-sonnet-4-5@20250929"
+
+
+class FakeChatService:
+    def __init__(self) -> None:
+        self.created_chats: list[ChatCreate] = []
+        self.completions: list[tuple[ChatRequest, User]] = []
+        self.completion_error: ChatException | None = None
+
+    async def create_chat(self, user: User, chat_data: ChatCreate) -> Chat:
+        self.created_chats.append(chat_data)
+        return Chat(
+            id=uuid4(),
+            title=chat_data.title,
+            user_id=user.id,
+            workspace_id=chat_data.workspace_id,
+        )
+
+    async def initiate_chat_completion(self, request: ChatRequest, user: User) -> None:
+        if self.completion_error:
+            raise self.completion_error
+        self.completions.append((request, user))
+
+
+class AutomationServiceOverride:
+    def __init__(self, chat_service: FakeChatService) -> None:
+        self.chat_service = chat_service
+
+    def __call__(self) -> AutomationService:
+        return AutomationService(self.chat_service)
+
+
+def automation_payload(workspace_id: UUID, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "name": "Nightly digest",
+        "prompt": "Summarize today's changes",
+        "model_id": TEST_MODEL_ID,
+        "cron_expression": "0 9 * * *",
+        "timezone": "UTC",
+        "workspace_id": str(workspace_id),
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def test_create_automation_persists_and_computes_next_run(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id),
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["name"] == "Nightly digest"
+    assert body["workspace_id"] == str(workspace.id)
+    assert body["cron_expression"] == "0 9 * * *"
+    assert body["enabled"] is True
+    assert body["last_run_at"] is None
+    next_run_at = datetime.fromisoformat(body["next_run_at"])
+    assert next_run_at > datetime.now(timezone.utc)
+
+
+async def test_create_automation_rejects_unknown_model(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id, model_id="not-a-real-model"),
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unknown model"
+
+
+async def test_create_automation_rejects_workspace_not_owned(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    _owner_headers, _owner, other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="owner-workspace@example.com",
+        username="ownerworkspace",
+    )
+    (
+        intruder_headers,
+        _intruder,
+        _intruder_workspace,
+    ) = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="intruder@example.com",
+        username="intruder",
+    )
+
+    response = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(other_workspace.id),
+        headers=intruder_headers,
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Workspace not found"
+
+
+async def test_create_automation_rejects_invalid_cron_expression(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id, cron_expression="not a cron"),
+        headers=headers,
+    )
+
+    assert response.status_code == 422
+
+
+async def test_create_automation_rejects_invalid_timezone(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id, timezone="Not/AZone"),
+        headers=headers,
+    )
+
+    assert response.status_code == 422
+
+
+async def test_automations_reject_missing_token(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/automations")
+
+    assert response.status_code == 401
+
+
+async def test_list_automations_scoped_to_owner(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    owner_headers, _owner, owner_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="list-owner@example.com",
+        username="listowner",
+    )
+    other_headers, _other, _other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="list-other@example.com",
+        username="listother",
+    )
+    create_response = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(owner_workspace.id),
+        headers=owner_headers,
+    )
+    assert create_response.status_code == 201
+
+    owner_list = await client.get("/api/v1/automations", headers=owner_headers)
+    other_list = await client.get("/api/v1/automations", headers=other_headers)
+
+    assert owner_list.status_code == 200
+    assert len(owner_list.json()) == 1
+    assert owner_list.json()[0]["name"] == "Nightly digest"
+    assert other_list.status_code == 200
+    assert other_list.json() == []
+
+
+async def test_update_automation_recomputes_next_run_on_cron_change(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id),
+        headers=headers,
+    )
+    automation_id = created.json()["id"]
+    original_next_run = created.json()["next_run_at"]
+
+    response = await client.patch(
+        f"/api/v1/automations/{automation_id}",
+        json={"cron_expression": "30 4 * * *"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["cron_expression"] == "30 4 * * *"
+    assert body["next_run_at"] != original_next_run
+
+
+async def test_update_automation_preserves_next_run_for_non_schedule_field(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id),
+        headers=headers,
+    )
+    automation_id = created.json()["id"]
+    original_next_run = created.json()["next_run_at"]
+
+    response = await client.patch(
+        f"/api/v1/automations/{automation_id}",
+        json={"name": "Renamed digest"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "Renamed digest"
+    assert body["next_run_at"] == original_next_run
+
+
+async def test_update_automation_rejects_invalid_timezone(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id),
+        headers=headers,
+    )
+    automation_id = created.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/automations/{automation_id}",
+        json={"timezone": "Not/AZone"},
+        headers=headers,
+    )
+
+    assert response.status_code == 422
+
+
+async def test_update_automation_rejects_unknown_model(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id),
+        headers=headers,
+    )
+    automation_id = created.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/automations/{automation_id}",
+        json={"model_id": "not-a-real-model"},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unknown model"
+
+
+async def test_update_automation_rejects_workspace_not_owned(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="update-owner@example.com",
+        username="updateowner",
+    )
+    _other_headers, _other, other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="update-other@example.com",
+        username="updateother",
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id),
+        headers=headers,
+    )
+    automation_id = created.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/automations/{automation_id}",
+        json={"workspace_id": str(other_workspace.id)},
+        headers=headers,
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Workspace not found"
+
+
+async def test_update_automation_rejects_other_users_automation(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    owner_headers, _owner, owner_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="patch-owner@example.com",
+        username="patchowner",
+    )
+    (
+        intruder_headers,
+        _intruder,
+        _intruder_workspace,
+    ) = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="patch-intruder@example.com",
+        username="patchintruder",
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(owner_workspace.id),
+        headers=owner_headers,
+    )
+    automation_id = created.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/automations/{automation_id}",
+        json={"name": "Hijacked"},
+        headers=intruder_headers,
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Automation not found"
+
+
+async def test_delete_automation_removes_row_and_rejects_other_users(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    owner_headers, _owner, owner_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="delete-owner@example.com",
+        username="deleteowner",
+    )
+    (
+        intruder_headers,
+        _intruder,
+        _intruder_workspace,
+    ) = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="delete-intruder@example.com",
+        username="deleteintruder",
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(owner_workspace.id),
+        headers=owner_headers,
+    )
+    automation_id = created.json()["id"]
+
+    intruder_delete = await client.delete(
+        f"/api/v1/automations/{automation_id}", headers=intruder_headers
+    )
+    owner_delete = await client.delete(
+        f"/api/v1/automations/{automation_id}", headers=owner_headers
+    )
+    owner_list_after = await client.get("/api/v1/automations", headers=owner_headers)
+
+    assert intruder_delete.status_code == 404
+    assert owner_delete.status_code == 204
+    assert owner_list_after.json() == []
+
+
+async def test_run_automation_creates_chat_and_updates_last_run_at(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    fake_chat_service = FakeChatService()
+    app.dependency_overrides[get_automation_service] = AutomationServiceOverride(
+        fake_chat_service
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id),
+        headers=headers,
+    )
+    automation_id = created.json()["id"]
+    assert created.json()["last_run_at"] is None
+
+    response = await client.post(
+        f"/api/v1/automations/{automation_id}/run", headers=headers
+    )
+
+    assert response.status_code == 200
+    assert UUID(response.json()["chat_id"])
+    assert len(fake_chat_service.created_chats) == 1
+    assert fake_chat_service.created_chats[0].workspace_id == workspace.id
+    assert fake_chat_service.created_chats[0].model_id == TEST_MODEL_ID
+    assert len(fake_chat_service.completions) == 1
+    assert fake_chat_service.completions[0][0].prompt == "Summarize today's changes"
+
+    list_after = await client.get("/api/v1/automations", headers=headers)
+    assert list_after.json()[0]["last_run_at"] is not None
+
+
+async def test_run_automation_rejects_other_users_automation(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    fake_chat_service = FakeChatService()
+    app.dependency_overrides[get_automation_service] = AutomationServiceOverride(
+        fake_chat_service
+    )
+    owner_headers, _owner, owner_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="run-owner@example.com",
+        username="runowner",
+    )
+    (
+        intruder_headers,
+        _intruder,
+        _intruder_workspace,
+    ) = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="run-intruder@example.com",
+        username="runintruder",
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(owner_workspace.id),
+        headers=owner_headers,
+    )
+    automation_id = created.json()["id"]
+
+    response = await client.post(
+        f"/api/v1/automations/{automation_id}/run", headers=intruder_headers
+    )
+
+    assert response.status_code == 404
+    assert fake_chat_service.created_chats == []
+
+
+async def test_run_automation_translates_chat_completion_error(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    fake_chat_service = FakeChatService()
+    fake_chat_service.completion_error = ChatException(
+        "Provider unavailable", status_code=503
+    )
+    app.dependency_overrides[get_automation_service] = AutomationServiceOverride(
+        fake_chat_service
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id),
+        headers=headers,
+    )
+    automation_id = created.json()["id"]
+
+    response = await client.post(
+        f"/api/v1/automations/{automation_id}/run", headers=headers
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Provider unavailable"

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -4,6 +4,7 @@ from uuid import UUID, uuid4
 import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.endpoints import chat as chat_endpoint
@@ -13,13 +14,19 @@ from app.models.db_models.chat import Chat, ChatCheckpoint, Message, MessageEven
 from app.models.db_models.enums import MessageRole, MessageStreamStatus
 from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
-from app.models.schemas.chat import ChatRequest
+from app.models.schemas.chat import (
+    ChatCreate,
+    ChatRequest,
+    ChatSearchResponse,
+    ChatUpdate,
+)
+from app.services import chat as chat_service_module
 from app.services.db import SessionFactoryType
-from app.services.exceptions import AgentException, ChatException
+from app.services.exceptions import AgentException, ChatException, SandboxException
 from app.services.queue import QueueService
 from app.services.sandbox_providers.base import SandboxProvider
 from app.services.streaming.runtime import ChatStreamRuntime
-from app.utils.cache import MemoryStore
+from app.utils.cache import CacheError, MemoryStore
 
 from tests.conftest import LoginClient, UserFactory
 from tests.helpers import (
@@ -52,6 +59,21 @@ class SendNowCapture:
     ) -> bool:
         self.chat_ids.append(chat_id)
         return True
+
+
+class ProcessSendNowIdleFailure:
+    async def process_send_now_idle(
+        self, chat_id: str, _session_factory: SessionFactoryType
+    ) -> bool:
+        raise RuntimeError("idle send-now boom")
+
+
+class CancelGenerationCapture:
+    def __init__(self) -> None:
+        self.chat_ids: list[str] = []
+
+    async def __call__(self, chat_id: str) -> None:
+        self.chat_ids.append(chat_id)
 
 
 class PermissionResolver:
@@ -98,7 +120,9 @@ class AgentServiceOverride:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, User]] = []
         self.ask_code_calls: list[tuple[str, str, str, str, User, Chat]] = []
+        self.title_calls: list[tuple[str, str, User, Chat | None]] = []
         self.fail = False
+        self.next_title: str | None = "Generated Title"
 
     def __call__(self) -> "AgentServiceOverride":
         return self
@@ -125,6 +149,82 @@ class AgentServiceOverride:
         if self.fail:
             raise AgentException("Ask failed", status_code=503)
         return "Answer: " + question
+
+    async def generate_title(
+        self, prompt: str, model_id: str, user: User, chat: Chat | None = None
+    ) -> str | None:
+        self.title_calls.append((prompt, model_id, user, chat))
+        return self.next_title
+
+
+class RaisingChatService:
+    def __init__(self, exc: Exception) -> None:
+        self.exc = exc
+
+    async def __call__(self) -> AsyncIterator["RaisingChatService"]:
+        yield self
+
+    async def create_chat(self, user: User, chat_data: ChatCreate) -> Chat:
+        raise self.exc
+
+    async def search_messages(
+        self, user: User, query: str, *, limit: int = 50, per_chat_limit: int = 5
+    ) -> ChatSearchResponse:
+        raise self.exc
+
+    async def get_sub_threads(self, chat_id: UUID, user: User) -> list[Chat]:
+        raise self.exc
+
+    async def get_chat(self, chat_id: UUID, user: User) -> Chat:
+        raise self.exc
+
+    async def update_chat(
+        self, chat_id: UUID, chat_update: ChatUpdate, user: User
+    ) -> Chat:
+        raise self.exc
+
+
+class RaisingMessageService:
+    def __init__(self, exc: Exception) -> None:
+        self.exc = exc
+
+    async def get_in_progress_assistant_message(self, chat_id: UUID) -> Message:
+        raise self.exc
+
+
+class StreamStatusServiceOverride:
+    # Wraps a real Chat row (so get_chat succeeds) while forcing the
+    # in-progress-message lookup to fail, isolating the endpoint's
+    # SQLAlchemyError branch from the ChatException branch.
+    def __init__(self, chat: Chat, exc: Exception) -> None:
+        self._chat = chat
+        self.message_service = RaisingMessageService(exc)
+
+    async def __call__(self) -> AsyncIterator["StreamStatusServiceOverride"]:
+        yield self
+
+    async def get_chat(self, chat_id: UUID, user: User) -> Chat:
+        return self._chat
+
+
+class WriteFailingSandboxProvider(FakeSandboxProvider):
+    async def write_file(
+        self, sandbox_id: str, path: str, content: str | bytes
+    ) -> None:
+        raise SandboxException("disk full", status_code=400)
+
+
+class RaisingCacheConnection:
+    # Stands in for app.services.chat.cache_connection so the best-effort
+    # chat-event publish hits its CacheError branch without a real Redis.
+    def __call__(self) -> "RaisingCacheConnection":
+        return self
+
+    async def __aenter__(self) -> None:
+        raise CacheError("cache unavailable")
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        return None
 
 
 @pytest.fixture
@@ -209,12 +309,13 @@ async def create_checkpoint_row(
     *,
     cwd: str | None = None,
     pre_run_diff: str = "",
+    base_head: str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 ) -> ChatCheckpoint:
     checkpoint = ChatCheckpoint(
         chat_id=chat.id,
         assistant_message_id=assistant_message.id,
         cwd=cwd,
-        base_head="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        base_head=base_head,
         pre_run_diff=pre_run_diff,
     )
     db_session.add(checkpoint)
@@ -1180,3 +1281,861 @@ async def test_chats_reject_missing_token(client: AsyncClient) -> None:
     assert list_response.status_code == 401
     assert create_response.status_code == 401
     assert detail_response.status_code == 401
+
+
+async def test_create_chat_publishes_best_effort_and_swallows_cache_errors(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    monkeypatch.setattr(
+        chat_service_module, "cache_connection", RaisingCacheConnection()
+    )
+
+    response = await client.post(
+        "/api/v1/chat/chats",
+        json={
+            "title": "Best Effort",
+            "model_id": TEST_MODEL_ID,
+            "workspace_id": str(workspace.id),
+        },
+        headers=headers,
+    )
+
+    # The chat_created broadcast is best-effort — a cache outage must not
+    # block chat creation.
+    assert response.status_code == 201
+    assert response.json()["title"] == "Best Effort"
+
+
+async def test_create_chat_endpoint_translates_database_and_cache_errors(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    payload = {
+        "title": "New Chat",
+        "model_id": TEST_MODEL_ID,
+        "workspace_id": str(workspace.id),
+    }
+
+    app.dependency_overrides[get_chat_service] = RaisingChatService(
+        SQLAlchemyError("db down")
+    )
+    db_error_response = await client.post(
+        "/api/v1/chat/chats", json=payload, headers=headers
+    )
+
+    app.dependency_overrides[get_chat_service] = RaisingChatService(
+        CacheError("redis down")
+    )
+    cache_error_response = await client.post(
+        "/api/v1/chat/chats", json=payload, headers=headers
+    )
+
+    assert db_error_response.status_code == 500
+    assert db_error_response.json()["detail"] == "Database error while creating chat"
+    assert cache_error_response.status_code == 503
+    assert cache_error_response.json()["detail"] == "Service temporarily unavailable"
+
+
+async def test_generate_chat_title_endpoint_covers_success_and_failure_paths(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    agent_service = AgentServiceOverride()
+    app.dependency_overrides[get_agent_service] = agent_service
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    empty_chat = await create_chat_row(db_session, user, workspace, title="Empty")
+
+    no_messages_response = await client.post(
+        f"/api/v1/chat/chats/{empty_chat.id}/generate-title", headers=headers
+    )
+
+    chat = await create_chat_row(db_session, user, workspace, title="With Messages")
+    await create_message_row(db_session, chat, content="Ship the release notes")
+    await create_message_row(
+        db_session,
+        chat,
+        content="",
+        role=MessageRole.ASSISTANT,
+        model_id=TEST_MODEL_ID,
+    )
+
+    success_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/generate-title", headers=headers
+    )
+
+    agent_service.next_title = None
+    failure_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/generate-title", headers=headers
+    )
+
+    assert no_messages_response.status_code == 400
+    assert (
+        no_messages_response.json()["detail"]
+        == "Chat has no messages to generate a title from"
+    )
+    assert success_response.status_code == 200
+    assert success_response.json() == {"title": "Generated Title"}
+    assert failure_response.status_code == 503
+    assert failure_response.json()["detail"] == "Title generation failed"
+    [prompt, model_id, stored_user, stored_chat] = agent_service.title_calls[0]
+    assert prompt == "Ship the release notes"
+    assert model_id == TEST_MODEL_ID
+    assert stored_user.id == user.id
+    assert stored_chat is not None
+    assert stored_chat.id == chat.id
+
+
+async def test_search_chats_endpoint_translates_database_error(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    app.dependency_overrides[get_chat_service] = RaisingChatService(
+        SQLAlchemyError("db down")
+    )
+
+    response = await client.get("/api/v1/chat/chats/search?q=needle", headers=headers)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Database error while searching chats"
+
+
+async def test_get_active_streams_returns_empty_and_populated_results(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    monkeypatch.setattr(ChatStreamRuntime, "active_chat_ids", lambda: set())
+    empty_response = await client.get(
+        "/api/v1/chat/chats/active-streams", headers=headers
+    )
+
+    stream_id = uuid4()
+    message = await create_message_row(
+        db_session,
+        chat,
+        content="Streaming",
+        role=MessageRole.ASSISTANT,
+        stream_status=MessageStreamStatus.IN_PROGRESS,
+        active_stream_id=stream_id,
+        last_seq=3,
+    )
+    monkeypatch.setattr(ChatStreamRuntime, "active_chat_ids", lambda: {str(chat.id)})
+    populated_response = await client.get(
+        "/api/v1/chat/chats/active-streams", headers=headers
+    )
+
+    assert empty_response.status_code == 200
+    assert empty_response.json() == []
+    assert populated_response.status_code == 200
+    [status_entry] = populated_response.json()
+    assert status_entry["chat_id"] == str(chat.id)
+    assert status_entry["message_id"] == str(message.id)
+    assert status_entry["stream_id"] == str(stream_id)
+    assert status_entry["last_seq"] == 3
+
+
+async def test_get_sub_threads_endpoint_handles_missing_chat_and_database_error(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    missing_response = await client.get(
+        f"/api/v1/chat/chats/{uuid4()}/sub-threads", headers=headers
+    )
+
+    app.dependency_overrides[get_chat_service] = RaisingChatService(
+        SQLAlchemyError("db down")
+    )
+    db_error_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/sub-threads", headers=headers
+    )
+
+    assert missing_response.status_code == 404
+    assert missing_response.json()["detail"] == "Chat not found"
+    assert db_error_response.status_code == 500
+    assert (
+        db_error_response.json()["detail"]
+        == "Database error while retrieving sub-threads"
+    )
+
+
+async def test_get_chat_detail_endpoint_translates_database_error(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    app.dependency_overrides[get_chat_service] = RaisingChatService(
+        SQLAlchemyError("db down")
+    )
+
+    response = await client.get(f"/api/v1/chat/chats/{uuid4()}", headers=headers)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Database error while retrieving chat"
+
+
+async def test_update_chat_endpoint_rejects_missing_chat_and_translates_database_error(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    missing_response = await client.patch(
+        f"/api/v1/chat/chats/{uuid4()}",
+        json={"title": "Ghost"},
+        headers=headers,
+    )
+
+    app.dependency_overrides[get_chat_service] = RaisingChatService(
+        SQLAlchemyError("db down")
+    )
+    db_error_response = await client.patch(
+        f"/api/v1/chat/chats/{uuid4()}",
+        json={"title": "Ghost"},
+        headers=headers,
+    )
+
+    assert missing_response.status_code == 404
+    assert (
+        missing_response.json()["detail"]
+        == "Chat not found or you don't have permission to update it"
+    )
+    assert db_error_response.status_code == 500
+    assert db_error_response.json()["detail"] == "Database error while updating chat"
+
+
+async def test_mark_chat_viewed_and_update_preserve_read_state_across_bumps(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    viewed_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/viewed", headers=headers
+    )
+    updated_response = await client.patch(
+        f"/api/v1/chat/chats/{chat.id}",
+        json={"title": "Renamed after viewing"},
+        headers=headers,
+    )
+
+    assert viewed_response.status_code == 204
+    assert updated_response.status_code == 200
+    updated = updated_response.json()
+    assert updated["title"] == "Renamed after viewing"
+    # Marking viewed then updating shouldn't flip the chat back to unread —
+    # confirms the read-state carry-through in ChatService.update_chat.
+    assert updated["unread"] is False
+
+
+async def test_get_chats_filters_by_workspace_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    other_workspace = Workspace(
+        name="Second Workspace",
+        user_id=user.id,
+        sandbox_id="sandbox-second",
+        sandbox_provider="host",
+        workspace_path="/tmp/agentrove-test-second",
+        source_type="empty",
+        source_url=None,
+    )
+    db_session.add(other_workspace)
+    await db_session.commit()
+    await db_session.refresh(other_workspace)
+
+    chat_in_workspace = await create_chat_row(
+        db_session, user, workspace, title="In Workspace"
+    )
+    await create_chat_row(db_session, user, other_workspace, title="Other Workspace")
+
+    response = await client.get(
+        f"/api/v1/chat/chats?workspace_id={workspace.id}", headers=headers
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item["id"] for item in body["items"]] == [str(chat_in_workspace.id)]
+
+
+async def test_search_messages_reports_truncation_from_chat_cap_and_per_chat_limits(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    # chat_cap truncation: 3 distinct matching chats but limit=1 caps the
+    # lookahead at chat_cap=2, so the loop breaks mid-iteration.
+    for index in range(3):
+        cap_chat = await create_chat_row(
+            db_session, user, workspace, title=f"Cap Chat {index}"
+        )
+        await create_message_row(
+            db_session, cap_chat, content=f"contains cap-needle-{index}"
+        )
+    cap_response = await client.get(
+        "/api/v1/chat/chats/search?q=cap-needle&limit=1&per_chat_limit=5",
+        headers=headers,
+    )
+
+    # per-chat truncation: one chat with 2 matches but per_chat_limit=1.
+    per_chat = await create_chat_row(
+        db_session, user, workspace, title="Per Chat Limit"
+    )
+    await create_message_row(
+        db_session, per_chat, content="first perchat-needle mention"
+    )
+    await create_message_row(
+        db_session, per_chat, content="second perchat-needle mention"
+    )
+    per_chat_response = await client.get(
+        "/api/v1/chat/chats/search?q=perchat-needle&limit=5&per_chat_limit=1",
+        headers=headers,
+    )
+
+    # post-loop truncation: exactly limit+1 distinct chats so the loop
+    # exhausts all rows without ever hitting the mid-loop break.
+    for index in range(2):
+        tail_chat = await create_chat_row(
+            db_session, user, workspace, title=f"Tail Chat {index}"
+        )
+        await create_message_row(
+            db_session, tail_chat, content=f"contains tail-needle-{index}"
+        )
+    tail_response = await client.get(
+        "/api/v1/chat/chats/search?q=tail-needle&limit=1&per_chat_limit=5",
+        headers=headers,
+    )
+
+    assert cap_response.status_code == 200
+    cap_body = cap_response.json()
+    assert cap_body["truncated"] is True
+    assert len(cap_body["results"]) == 1
+
+    assert per_chat_response.status_code == 200
+    per_chat_body = per_chat_response.json()
+    assert per_chat_body["truncated"] is True
+    assert per_chat_body["results"][0]["match_count"] == 2
+    assert len(per_chat_body["results"][0]["matches"]) == 1
+
+    assert tail_response.status_code == 200
+    tail_body = tail_response.json()
+    assert tail_body["truncated"] is True
+    assert len(tail_body["results"]) == 1
+
+
+async def test_create_sub_thread_rejects_missing_parent_and_preserves_read_state(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    parent = await create_chat_row(db_session, user, workspace, title="Parent")
+
+    missing_parent_response = await client.post(
+        "/api/v1/chat/chats",
+        json={
+            "title": "Orphan",
+            "model_id": TEST_MODEL_ID,
+            "workspace_id": str(workspace.id),
+            "parent_chat_id": str(uuid4()),
+        },
+        headers=headers,
+    )
+
+    await client.post(f"/api/v1/chat/chats/{parent.id}/viewed", headers=headers)
+
+    sub_thread_response = await client.post(
+        "/api/v1/chat/chats",
+        json={
+            "title": "Sub-thread",
+            "model_id": TEST_MODEL_ID,
+            "workspace_id": str(workspace.id),
+            "parent_chat_id": str(parent.id),
+        },
+        headers=headers,
+    )
+    parent_detail = await client.get(f"/api/v1/chat/chats/{parent.id}", headers=headers)
+
+    assert missing_parent_response.status_code == 404
+    assert missing_parent_response.json()["detail"] == "Parent chat not found"
+    assert sub_thread_response.status_code == 201
+    assert parent_detail.status_code == 200
+    # Sub-thread creation bumps the parent's ordering timestamp but should
+    # carry the already-read state across it rather than flipping unread.
+    assert parent_detail.json()["unread"] is False
+
+
+async def test_create_chat_rejects_missing_or_foreign_workspace(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        "/api/v1/chat/chats",
+        json={
+            "title": "No Workspace",
+            "model_id": TEST_MODEL_ID,
+            "workspace_id": str(uuid4()),
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Workspace not found"
+
+
+async def test_delete_chat_rejects_missing_chat_and_cascades_sub_threads_and_workspace(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(SandboxProvider, "create_provider", FakeProviderFactory())
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    missing_response = await client.delete(
+        f"/api/v1/chat/chats/{uuid4()}", headers=headers
+    )
+
+    parent = await create_chat_row(db_session, user, workspace, title="Parent")
+    sub_create = await client.post(
+        "/api/v1/chat/chats",
+        json={
+            "title": "Sub-thread",
+            "model_id": TEST_MODEL_ID,
+            "workspace_id": str(workspace.id),
+            "parent_chat_id": str(parent.id),
+        },
+        headers=headers,
+    )
+    sub_thread_id = sub_create.json()["id"]
+
+    delete_response = await client.delete(
+        f"/api/v1/chat/chats/{parent.id}", headers=headers
+    )
+    sub_thread_detail = await client.get(
+        f"/api/v1/chat/chats/{sub_thread_id}", headers=headers
+    )
+
+    assert missing_response.status_code == 404
+    assert sub_create.status_code == 201
+    assert delete_response.status_code == 204
+    # Deleting the parent must cascade-delete its sub-thread too.
+    assert sub_thread_detail.status_code == 404
+
+
+async def test_restore_message_checkpoint_translates_sandbox_and_value_errors(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    invalid_message = await create_message_row(
+        db_session, chat, content="Invalid checkpoint", role=MessageRole.ASSISTANT
+    )
+    await create_checkpoint_row(
+        db_session, chat, invalid_message, base_head="not-a-valid-hash"
+    )
+    monkeypatch.setattr(SandboxProvider, "create_provider", FakeProviderFactory())
+    value_error_response = await client.post(
+        f"/api/v1/chat/messages/{invalid_message.id}/checkpoint/restore-all",
+        headers=headers,
+    )
+
+    write_failing_message = await create_message_row(
+        db_session, chat, content="Write failure", role=MessageRole.ASSISTANT
+    )
+    await create_checkpoint_row(
+        db_session,
+        chat,
+        write_failing_message,
+        pre_run_diff="diff --git a/app.py b/app.py\n",
+    )
+    monkeypatch.setattr(
+        SandboxProvider,
+        "create_provider",
+        FakeProviderFactory(provider=WriteFailingSandboxProvider()),
+    )
+    sandbox_error_response = await client.post(
+        f"/api/v1/chat/messages/{write_failing_message.id}/checkpoint/restore-all",
+        headers=headers,
+    )
+
+    assert value_error_response.status_code == 400
+    assert value_error_response.json()["detail"] == "Invalid checkpoint commit"
+    assert sandbox_error_response.status_code == 400
+    assert sandbox_error_response.json()["detail"] == "disk full"
+
+
+async def test_cancel_stream_endpoint_only_cancels_when_active_or_pending(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    idle_chat = await create_chat_row(db_session, user, workspace, title="Idle")
+    pending_chat = await create_chat_row(db_session, user, workspace, title="Pending")
+    await create_message_row(
+        db_session,
+        pending_chat,
+        content="",
+        role=MessageRole.ASSISTANT,
+        stream_status=MessageStreamStatus.IN_PROGRESS,
+    )
+    active_chat = await create_chat_row(db_session, user, workspace, title="Active")
+
+    capture = CancelGenerationCapture()
+    monkeypatch.setattr(chat_endpoint.session_registry, "cancel_generation", capture)
+    monkeypatch.setattr(
+        ChatStreamRuntime,
+        "has_active_chat",
+        lambda chat_id: chat_id == str(active_chat.id),
+    )
+
+    idle_response = await client.delete(
+        f"/api/v1/chat/chats/{idle_chat.id}/stream", headers=headers
+    )
+    pending_response = await client.delete(
+        f"/api/v1/chat/chats/{pending_chat.id}/stream", headers=headers
+    )
+    active_response = await client.delete(
+        f"/api/v1/chat/chats/{active_chat.id}/stream", headers=headers
+    )
+
+    assert idle_response.status_code == 204
+    assert pending_response.status_code == 204
+    assert active_response.status_code == 204
+    # Idle+no-pending-start must not cancel; pending-start and active-runtime
+    # chats both should, even though only one has an active runtime task.
+    assert capture.chat_ids == [str(pending_chat.id), str(active_chat.id)]
+
+
+async def test_queue_message_with_attachments_saves_to_sandbox(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = FakeSandboxProvider()
+    monkeypatch.setattr(
+        SandboxProvider, "create_provider", FakeProviderFactory(provider=provider)
+    )
+    app.dependency_overrides[get_queue_service] = QueueServiceOverride()
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    create_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Review this", "model_id": TEST_MODEL_ID},
+        files={"attached_files": ("report.pdf", b"%PDF-1.4", "application/pdf")},
+        headers=headers,
+    )
+    list_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/queue", headers=headers
+    )
+
+    assert create_response.status_code == 201
+    assert list_response.status_code == 200
+    queued = list_response.json()
+    assert len(queued) == 1
+    [attachment] = queued[0]["attachments"]
+    assert attachment["filename"] == "report.pdf"
+    assert attachment["file_type"] == "pdf"
+    assert attachment["file_url"].startswith("/api/v1/attachments/temp/preview?path=")
+    assert len(provider.writes) == 1
+    sandbox_id, path, _content = provider.writes[0]
+    assert sandbox_id == workspace.sandbox_id
+    assert path.endswith(".pdf")
+
+
+async def test_send_now_queued_message_cancels_active_stream_and_handles_idle_failure(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app.dependency_overrides[get_queue_service] = QueueServiceOverride()
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    first_create = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "First", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    first_id = first_create.json()["id"]
+
+    capture = CancelGenerationCapture()
+    monkeypatch.setattr(chat_endpoint.session_registry, "cancel_generation", capture)
+    monkeypatch.setattr(ChatStreamRuntime, "has_active_chat", lambda _chat_id: True)
+
+    active_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{first_id}/send-now", headers=headers
+    )
+
+    second_create = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Second", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    second_id = second_create.json()["id"]
+
+    monkeypatch.setattr(ChatStreamRuntime, "has_active_chat", lambda _chat_id: False)
+    monkeypatch.setattr(
+        ChatStreamRuntime,
+        "process_send_now_idle",
+        staticmethod(ProcessSendNowIdleFailure().process_send_now_idle),
+    )
+
+    idle_failure_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{second_id}/send-now", headers=headers
+    )
+
+    assert active_response.status_code == 204
+    assert capture.chat_ids == [str(chat.id)]
+    assert idle_failure_response.status_code == 503
+    assert (
+        idle_failure_response.json()["detail"] == "Failed to start send-now execution"
+    )
+
+
+async def test_get_message_events_returns_404_for_missing_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/chat/messages/{uuid4()}/events", headers=headers
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Message not found"
+
+
+async def test_get_stream_status_handles_access_denied_and_missing_active_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner_headers, owner, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="stream-status-owner@example.com",
+        username="streamstatusowner",
+    )
+    chat = await create_chat_row(db_session, owner, workspace)
+    other_headers, _other_user, _other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="stream-status-other@example.com",
+        username="streamstatusother",
+    )
+
+    monkeypatch.setattr(ChatStreamRuntime, "has_active_chat", lambda _chat_id: True)
+
+    denied_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/status", headers=other_headers
+    )
+    no_message_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/status", headers=owner_headers
+    )
+
+    assert denied_response.status_code == 404
+    assert denied_response.json()["detail"] == "Chat not found or access denied"
+    assert no_message_response.status_code == 200
+    assert no_message_response.json() == {
+        "has_active_task": False,
+        "message_id": None,
+        "stream_id": None,
+        "last_seq": 0,
+    }
+
+
+async def test_get_stream_status_translates_database_error(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+    monkeypatch.setattr(ChatStreamRuntime, "has_active_chat", lambda _chat_id: True)
+    app.dependency_overrides[get_chat_service] = StreamStatusServiceOverride(
+        chat, SQLAlchemyError("db down")
+    )
+
+    response = await client.get(f"/api/v1/chat/chats/{chat.id}/status", headers=headers)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Database error while checking chat status"
+
+
+async def test_chat_messages_pagination_cursor_round_trip_and_rejects_invalid_cursor(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+    older = await create_message_row(db_session, chat, content="Older message")
+    newer = await create_message_row(db_session, chat, content="Newer message")
+
+    first_page = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages?limit=1", headers=headers
+    )
+    first_body = first_page.json()
+    next_cursor = first_body["next_cursor"]
+
+    second_page = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages?limit=1&cursor={next_cursor}",
+        headers=headers,
+    )
+
+    invalid_cursor_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages?cursor=not-valid-base64!!",
+        headers=headers,
+    )
+
+    assert first_page.status_code == 200
+    assert first_body["has_more"] is True
+    assert next_cursor is not None
+    assert first_body["items"][0]["id"] == str(newer.id)
+    assert second_page.status_code == 200
+    second_body = second_page.json()
+    assert second_body["has_more"] is False
+    assert second_body["items"][0]["id"] == str(older.id)
+    assert invalid_cursor_response.status_code == 400
+    assert invalid_cursor_response.json()["detail"] == "Invalid pagination cursor"
+
+
+async def test_context_usage_for_chat_without_assistant_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    chat_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/context-usage", headers=headers
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "tokens_used": 0,
+        "context_window": 0,
+        "percentage": 0.0,
+    }

--- a/backend/tests/test_github.py
+++ b/backend/tests/test_github.py
@@ -1,6 +1,10 @@
+from collections.abc import Callable
+
+import httpx
 import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_agent_service, get_github_service
 from app.models.db_models.user import User
@@ -16,6 +20,7 @@ from app.models.schemas.github import (
 from app.services.exceptions import AgentException, GitHubException
 
 from tests.conftest import LoginClient, UserFactory
+from tests.helpers import get_user_settings
 
 
 pytestmark = pytest.mark.anyio
@@ -137,6 +142,99 @@ async def create_auth_headers(
     await create_user(email="github-user@example.com", username="githubuser")
     tokens = await login(email="github-user@example.com")
     return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+class GitHubTransport:
+    # Scripted HTTP boundary for app.services.github.GitHubService, keyed by
+    # (method, path) so the real service's httpx calls run unmocked end to end.
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+        self._responses: dict[tuple[str, str], httpx.Response | Exception] = {}
+
+    def script(
+        self, method: str, path: str, response: httpx.Response | Exception
+    ) -> None:
+        self._responses[(method, path)] = response
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        outcome = self._responses[(request.method, request.url.path)]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class ScriptedAsyncClient(httpx.AsyncClient):
+    # Handler is set per-test by install_github_transport rather than captured
+    # in a closure, so this class stays a plain module-level definition.
+    transport_handler: Callable[[httpx.Request], httpx.Response] | None = None
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        if ScriptedAsyncClient.transport_handler is not None:
+            kwargs["transport"] = httpx.MockTransport(
+                ScriptedAsyncClient.transport_handler
+            )
+        super().__init__(*args, **kwargs)
+
+
+def install_github_transport(
+    monkeypatch: pytest.MonkeyPatch, transport: GitHubTransport
+) -> None:
+    # GitHubService instantiates httpx.AsyncClient() itself, so route every
+    # instantiation through our scripted transport for the test's duration.
+    monkeypatch.setattr(ScriptedAsyncClient, "transport_handler", transport.handler)
+    monkeypatch.setattr(httpx, "AsyncClient", ScriptedAsyncClient)
+
+
+async def create_headers_with_github_pat(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    *,
+    email: str,
+    username: str,
+    token: str = "ghp_scripted_token",
+) -> dict[str, str]:
+    user = await create_user(email=email, username=username)
+    tokens = await login(email=email)
+    settings = await get_user_settings(db_session, user.id)
+    assert settings is not None
+    settings.github_personal_access_token = token
+    await db_session.commit()
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+def github_repo_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "name": "app",
+        "full_name": "owner/app",
+        "description": "desc",
+        "language": "Python",
+        "html_url": "https://github.com/owner/app",
+        "clone_url": "https://github.com/owner/app.git",
+        "private": False,
+        "pushed_at": "2026-01-01T00:00:00Z",
+        "stargazers_count": 3,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def github_pr_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "number": 42,
+        "title": "Add feature",
+        "body": "Details",
+        "state": "open",
+        "html_url": "https://github.com/owner/agentrove/pull/42",
+        "head": {"ref": "feature", "repo": {"full_name": "owner/agentrove"}},
+        "base": {"ref": "main"},
+        "user": {"login": "octocat", "avatar_url": "https://example.com/a.png"},
+        "draft": False,
+        "review_comments": 1,
+    }
+    payload.update(overrides)
+    return payload
 
 
 async def test_github_service_routes_call_dependency(
@@ -267,6 +365,31 @@ async def test_github_generation_routes_translate_agent_errors(
     assert response.json()["detail"] == "Model unavailable"
 
 
+async def test_github_generate_pr_description_translates_agent_errors(
+    app: FastAPI,
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    agent = FakeAgentService()
+    agent.error = AgentException("Model unavailable", status_code=503)
+    app.dependency_overrides[get_agent_service] = agent
+    headers = await create_auth_headers(create_user, login)
+
+    response = await client.post(
+        "/api/v1/github/generate-pr-description",
+        json={
+            "title": "Add tests",
+            "diff": "diff --git a/app.py b/app.py",
+            "model_id": TEST_MODEL_ID,
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Model unavailable"
+
+
 async def test_github_routes_reject_missing_token(client: AsyncClient) -> None:
     repos_response = await client.get("/api/v1/github/repositories")
     create_pr_response = await client.post(
@@ -301,3 +424,586 @@ async def test_github_service_routes_reject_authenticated_user_without_pat(
 
     assert response.status_code == 400
     assert response.json()["detail"] == "GitHub personal access token not configured"
+
+
+async def test_github_service_lists_repositories_with_search_query(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-search@example.com",
+        username="ghsearch",
+        token="ghp_search_token",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "GET",
+        "/search/repositories",
+        httpx.Response(200, json={"items": [github_repo_payload()]}),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.get(
+        "/api/v1/github/repositories?q=agent&page=2&per_page=1",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"][0]["full_name"] == "owner/app"
+    assert body["has_more"] is True
+    request = transport.requests[0]
+    params = dict(request.url.params)
+    assert params["q"] == "agent"
+    assert params["page"] == "2"
+    assert request.headers["authorization"] == "Bearer ghp_search_token"
+
+
+async def test_github_service_lists_repositories_default_via_user_repos(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-default@example.com",
+        username="ghdefault",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "GET",
+        "/user/repos",
+        httpx.Response(
+            200, json=[github_repo_payload(name="app2", full_name="owner/app2")]
+        ),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.get("/api/v1/github/repositories", headers=headers)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"][0]["full_name"] == "owner/app2"
+    assert body["has_more"] is False
+    params = dict(transport.requests[0].url.params)
+    assert params["affiliation"] == "owner,collaborator,organization_member"
+
+
+async def test_github_service_lists_repositories_translates_generic_error(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-error@example.com",
+        username="gherror",
+    )
+    transport = GitHubTransport()
+    transport.script("GET", "/user/repos", httpx.Response(500, text="upstream failure"))
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.get("/api/v1/github/repositories", headers=headers)
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "GitHub API request failed"
+
+
+async def test_github_service_lists_pull_requests_maps_fields(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-prs@example.com",
+        username="ghprs",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "GET",
+        "/repos/owner/agentrove/pulls",
+        httpx.Response(
+            200,
+            json=[
+                github_pr_payload(),
+                github_pr_payload(
+                    number=43,
+                    head={"ref": "deleted-fork", "repo": None},
+                ),
+            ],
+        ),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.get(
+        "/api/v1/github/pulls?owner=owner&repo=agentrove", headers=headers
+    )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert items[0]["number"] == 42
+    assert items[0]["head"]["repo"]["full_name"] == "owner/agentrove"
+    assert items[1]["number"] == 43
+    assert items[1]["head"]["repo"]["full_name"] == ""
+
+
+async def test_github_service_lists_pull_requests_translates_invalid_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-badtoken@example.com",
+        username="ghbadtoken",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "GET", "/repos/owner/agentrove/pulls", httpx.Response(401, json={})
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.get(
+        "/api/v1/github/pulls?owner=owner&repo=agentrove", headers=headers
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "GitHub token is invalid or expired"
+
+
+async def test_github_service_creates_pull_request_without_reviewers(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-create-pr@example.com",
+        username="ghcreatepr",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "POST",
+        "/repos/owner/agentrove/pulls",
+        httpx.Response(
+            201,
+            json={
+                "number": 7,
+                "html_url": "https://github.com/owner/agentrove/pull/7",
+                "title": "Ship tests",
+            },
+        ),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.post(
+        "/api/v1/github/pulls",
+        json={
+            "owner": "owner",
+            "repo": "agentrove",
+            "title": "Ship tests",
+            "body": "Adds coverage",
+            "head": "feature",
+            "base": "main",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["number"] == 7
+    assert body["reviewer_warning"] is None
+    assert len(transport.requests) == 1
+
+
+async def test_github_service_creates_pull_request_assigns_reviewers(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-reviewers-ok@example.com",
+        username="ghreviewersok",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "POST",
+        "/repos/owner/agentrove/pulls",
+        httpx.Response(
+            201,
+            json={
+                "number": 8,
+                "html_url": "https://github.com/owner/agentrove/pull/8",
+                "title": "Ship tests",
+            },
+        ),
+    )
+    transport.script(
+        "POST",
+        "/repos/owner/agentrove/pulls/8/requested_reviewers",
+        httpx.Response(201, json={}),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.post(
+        "/api/v1/github/pulls",
+        json={
+            "owner": "owner",
+            "repo": "agentrove",
+            "title": "Ship tests",
+            "body": "Adds coverage",
+            "head": "feature",
+            "base": "main",
+            "reviewers": ["reviewer"],
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["reviewer_warning"] is None
+    assert len(transport.requests) == 2
+
+
+async def test_github_service_creates_pull_request_reviewer_failure_sets_warning(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-reviewers-fail@example.com",
+        username="ghreviewersfail",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "POST",
+        "/repos/owner/agentrove/pulls",
+        httpx.Response(
+            201,
+            json={
+                "number": 9,
+                "html_url": "https://github.com/owner/agentrove/pull/9",
+                "title": "Ship tests",
+            },
+        ),
+    )
+    transport.script(
+        "POST",
+        "/repos/owner/agentrove/pulls/9/requested_reviewers",
+        httpx.Response(422, json={"message": "not a collaborator"}),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.post(
+        "/api/v1/github/pulls",
+        json={
+            "owner": "owner",
+            "repo": "agentrove",
+            "title": "Ship tests",
+            "body": "Adds coverage",
+            "head": "feature",
+            "base": "main",
+            "reviewers": ["reviewer"],
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["reviewer_warning"] == "Failed to assign reviewers"
+
+
+async def test_github_service_creates_pull_request_reviewer_network_error_sets_warning(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-reviewers-network@example.com",
+        username="ghreviewersnetwork",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "POST",
+        "/repos/owner/agentrove/pulls",
+        httpx.Response(
+            201,
+            json={
+                "number": 10,
+                "html_url": "https://github.com/owner/agentrove/pull/10",
+                "title": "Ship tests",
+            },
+        ),
+    )
+    transport.script(
+        "POST",
+        "/repos/owner/agentrove/pulls/10/requested_reviewers",
+        httpx.ConnectError("boom"),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.post(
+        "/api/v1/github/pulls",
+        json={
+            "owner": "owner",
+            "repo": "agentrove",
+            "title": "Ship tests",
+            "body": "Adds coverage",
+            "head": "feature",
+            "base": "main",
+            "reviewers": ["reviewer"],
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["reviewer_warning"] == "Failed to assign reviewers"
+
+
+async def test_github_service_creates_pull_request_translates_json_error_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-create-fail-json@example.com",
+        username="ghcreatefailjson",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "POST",
+        "/repos/owner/agentrove/pulls",
+        httpx.Response(422, json={"message": "Validation failed"}),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.post(
+        "/api/v1/github/pulls",
+        json={
+            "owner": "owner",
+            "repo": "agentrove",
+            "title": "Ship tests",
+            "body": "Adds coverage",
+            "head": "feature",
+            "base": "main",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Validation failed"
+
+
+async def test_github_service_creates_pull_request_translates_non_json_error_body(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-create-fail-text@example.com",
+        username="ghcreatefailtext",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "POST",
+        "/repos/owner/agentrove/pulls",
+        httpx.Response(500, text="Internal Server Error"),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.post(
+        "/api/v1/github/pulls",
+        json={
+            "owner": "owner",
+            "repo": "agentrove",
+            "title": "Ship tests",
+            "body": "Adds coverage",
+            "head": "feature",
+            "base": "main",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Failed to create pull request"
+
+
+async def test_github_service_creates_pull_request_translates_invalid_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-create-badtoken@example.com",
+        username="ghcreatebadtoken",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "POST", "/repos/owner/agentrove/pulls", httpx.Response(401, json={})
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.post(
+        "/api/v1/github/pulls",
+        json={
+            "owner": "owner",
+            "repo": "agentrove",
+            "title": "Ship tests",
+            "body": "Adds coverage",
+            "head": "feature",
+            "base": "main",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "GitHub token is invalid or expired"
+
+
+async def test_github_service_lists_collaborators_returns_data(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-collaborators@example.com",
+        username="ghcollaborators",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "GET",
+        "/repos/owner/agentrove/collaborators",
+        httpx.Response(
+            200, json=[{"login": "reviewer", "avatar_url": "https://example.com/r"}]
+        ),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.get(
+        "/api/v1/github/collaborators?owner=owner&repo=agentrove", headers=headers
+    )
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {"login": "reviewer", "avatar_url": "https://example.com/r"}
+    ]
+
+
+async def test_github_service_collaborators_returns_empty_when_forbidden(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-collaborators-403@example.com",
+        username="ghcollaborators403",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "GET",
+        "/repos/owner/agentrove/collaborators",
+        httpx.Response(403, json={"message": "Forbidden"}),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.get(
+        "/api/v1/github/collaborators?owner=owner&repo=agentrove", headers=headers
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_github_service_lists_collaborators_translates_generic_error(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers = await create_headers_with_github_pat(
+        db_session,
+        create_user,
+        login,
+        email="gh-collaborators-error@example.com",
+        username="ghcollaboratorserror",
+    )
+    transport = GitHubTransport()
+    transport.script(
+        "GET",
+        "/repos/owner/agentrove/collaborators",
+        httpx.Response(500, text="upstream failure"),
+    )
+    install_github_transport(monkeypatch, transport)
+
+    response = await client.get(
+        "/api/v1/github/collaborators?owner=owner&repo=agentrove", headers=headers
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Failed to load collaborators"

--- a/backend/tests/test_infra.py
+++ b/backend/tests/test_infra.py
@@ -1,0 +1,297 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.main as main_module
+from app.core.config import get_settings
+from app.core.security import get_password_hash, verify_password
+from app.main import create_application
+from app.models.db_models.user import User
+
+from tests.conftest import UserFactory
+
+
+pytestmark = pytest.mark.anyio
+
+
+class FakePingStore:
+    def __init__(self, *, healthy: bool) -> None:
+        self.healthy = healthy
+
+    async def ping(self) -> bool:
+        return self.healthy
+
+
+@asynccontextmanager
+async def healthy_cache_connection() -> AsyncIterator[FakePingStore]:
+    yield FakePingStore(healthy=True)
+
+
+@asynccontextmanager
+async def ping_false_cache_connection() -> AsyncIterator[FakePingStore]:
+    yield FakePingStore(healthy=False)
+
+
+@asynccontextmanager
+async def failing_cache_connection() -> AsyncIterator[FakePingStore]:
+    # Raising before the yield propagates out of `async with cache_connection()`,
+    # exercising _check_redis_ready's broad except branch.
+    raise RuntimeError("redis connection refused")
+    yield  # unreachable — present only so asynccontextmanager sees a generator
+
+
+async def test_health_check_returns_healthy(client: AsyncClient) -> None:
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
+async def test_openapi_schema_includes_bearer_auth_and_is_cached(
+    client: AsyncClient,
+) -> None:
+    # Two calls: first builds+caches the schema, second returns the cached copy.
+    first = await client.get("/api/v1/openapi.json")
+    second = await client.get("/api/v1/openapi.json")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    schema = first.json()
+    assert schema["components"]["securitySchemes"]["bearerAuth"] == {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+    }
+    assert schema["security"] == [{"bearerAuth": []}]
+    assert first.json() == second.json()
+
+
+async def test_readyz_skips_redis_check_in_desktop_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", True)
+    application = create_application()
+    transport = httpx.ASGITransport(app=application, client=("testclient", 50000))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as test_client:
+        response = await test_client.get("/api/v1/readyz")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ready"
+    assert body["checks"]["database"]["ok"] is True
+    assert "redis" not in body["checks"]
+
+
+async def test_readyz_reports_ready_when_redis_reachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    monkeypatch.setattr(main_module, "cache_connection", healthy_cache_connection)
+    application = create_application()
+    transport = httpx.ASGITransport(app=application, client=("testclient", 50000))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as test_client:
+        response = await test_client.get("/api/v1/readyz")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ready"
+    assert body["checks"]["redis"]["ok"] is True
+
+
+async def test_readyz_reports_not_ready_when_redis_ping_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    monkeypatch.setattr(main_module, "cache_connection", ping_false_cache_connection)
+    application = create_application()
+    transport = httpx.ASGITransport(app=application, client=("testclient", 50000))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as test_client:
+        response = await test_client.get("/api/v1/readyz")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "not_ready"
+    assert body["checks"]["redis"]["ok"] is False
+    assert body["checks"]["redis"]["error"] == "Redis ping returned false"
+
+
+async def test_readyz_reports_not_ready_when_redis_connection_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    monkeypatch.setattr(main_module, "cache_connection", failing_cache_connection)
+    application = create_application()
+    transport = httpx.ASGITransport(app=application, client=("testclient", 50000))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as test_client:
+        response = await test_client.get("/api/v1/readyz")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "not_ready"
+    assert body["checks"]["redis"]["ok"] is False
+    assert "redis connection refused" in body["checks"]["redis"]["error"]
+
+
+async def test_admin_login_page_renders_when_desktop_mode_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    application = create_application()
+    transport = httpx.ASGITransport(app=application, client=("testclient", 50000))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as test_client:
+        response = await test_client.get("/admin/login")
+
+    assert response.status_code == 200
+
+
+async def test_admin_login_rejects_non_superuser(
+    monkeypatch: pytest.MonkeyPatch,
+    create_user: UserFactory,
+) -> None:
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    await create_user(
+        email="regular-admin@example.com",
+        username="regularadmin",
+        password="password123",
+    )
+
+    application = create_application()
+    transport = httpx.ASGITransport(app=application, client=("testclient", 50000))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as test_client:
+        login_response = await test_client.post(
+            "/admin/login",
+            data={"username": "regular-admin@example.com", "password": "password123"},
+        )
+        dashboard_response = await test_client.get(
+            "/admin/user/list", follow_redirects=False
+        )
+
+    assert login_response.status_code == 400
+    assert dashboard_response.status_code == 302
+    assert dashboard_response.headers["location"].endswith("/admin/login")
+
+
+async def test_admin_login_rejects_wrong_password(
+    monkeypatch: pytest.MonkeyPatch,
+    create_user: UserFactory,
+) -> None:
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    await create_user(email="wrongpass-admin@example.com", username="wrongpassadmin")
+
+    application = create_application()
+    transport = httpx.ASGITransport(app=application, client=("testclient", 50000))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as test_client:
+        response = await test_client.post(
+            "/admin/login",
+            data={"username": "wrongpass-admin@example.com", "password": "wrongpass"},
+        )
+
+    assert response.status_code == 400
+
+
+async def test_admin_login_authenticates_superuser_and_lists_users(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
+) -> None:
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    admin_user = User(
+        email="admin@example.com",
+        username="adminuser",
+        hashed_password=get_password_hash("adminpass123"),
+        is_active=True,
+        is_verified=True,
+        is_superuser=True,
+    )
+    db_session.add(admin_user)
+    await db_session.commit()
+
+    application = create_application()
+    transport = httpx.ASGITransport(app=application, client=("testclient", 50000))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as test_client:
+        login_response = await test_client.post(
+            "/admin/login",
+            data={"username": "admin@example.com", "password": "adminpass123"},
+            follow_redirects=False,
+        )
+        list_response = await test_client.get("/admin/user/list")
+        logout_response = await test_client.get("/admin/logout", follow_redirects=False)
+        post_logout_response = await test_client.get(
+            "/admin/user/list", follow_redirects=False
+        )
+
+    assert login_response.status_code == 302
+    assert list_response.status_code == 200
+    assert "admin@example.com" in list_response.text
+    assert logout_response.status_code == 302
+    assert post_logout_response.status_code == 302
+
+
+async def test_admin_create_user_hashes_grafted_password_field(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
+) -> None:
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    admin_user = User(
+        email="creator-admin@example.com",
+        username="creatoradmin",
+        hashed_password=get_password_hash("adminpass123"),
+        is_active=True,
+        is_verified=True,
+        is_superuser=True,
+    )
+    db_session.add(admin_user)
+    await db_session.commit()
+
+    application = create_application()
+    transport = httpx.ASGITransport(app=application, client=("testclient", 50000))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as test_client:
+        await test_client.post(
+            "/admin/login",
+            data={"username": "creator-admin@example.com", "password": "adminpass123"},
+            follow_redirects=False,
+        )
+        form_response = await test_client.get("/admin/user/create")
+        create_response = await test_client.post(
+            "/admin/user/create",
+            data={
+                "email": "made-in-admin@example.com",
+                "username": "madeinadmin",
+                "password": "freshpass123",
+                "is_active": "on",
+                "is_verified": "on",
+            },
+            follow_redirects=False,
+        )
+
+    assert form_response.status_code == 200
+    assert 'name="password"' in form_response.text
+    assert create_response.status_code == 302, create_response.text
+
+    result = await db_session.execute(
+        select(User).where(User.email == "made-in-admin@example.com")
+    )
+    created = result.scalar_one()
+    assert verify_password("freshpass123", created.hashed_password)

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -1,21 +1,130 @@
+import base64
 import io
+import shlex
+import subprocess
 import zipfile
+from pathlib import Path
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import get_settings
+from app.models.db_models.workspace import Workspace
+from app.services.exceptions import SandboxException
+from app.services.git import (
+    GIT_CHECKOUT_FROM_REMOTE_TEMPLATE,
+    GIT_CHECKOUT_TEMPLATE,
+    GIT_CREATE_BRANCH_FROM_REMOTE_TEMPLATE,
+    GIT_CURRENT_BRANCH_CMD,
+    GIT_IS_REPO_CMD,
+    GIT_PULL_CMD,
+    GIT_PUSH_CMD,
+    GIT_SHOW_HEAD_TEMPLATE,
+    GIT_STATUS_PORCELAIN_CMD,
+    RESTORE_ALL_CMD,
+)
 from app.services.sandbox_providers.base import SandboxProvider
+from app.services.sandbox_providers.types import (
+    CommandResult,
+    FileContent,
+    FileMetadata,
+)
 
 from tests.conftest import LoginClient, UserFactory
 from tests.helpers import (
     FakeProviderFactory,
     FakeSandboxProvider,
     create_authenticated_workspace,
+    get_user_settings,
 )
 
 
 pytestmark = pytest.mark.anyio
+
+
+class ScriptedSandboxProvider(FakeSandboxProvider):
+    # Extends FakeSandboxProvider with per-test scripted command responses and
+    # optional forced exceptions — helpers.py can't be edited, so error-path
+    # coverage (git/search failures, provider errors) lives here instead.
+    def __init__(self) -> None:
+        super().__init__()
+        self.command_overrides: list[tuple[str, CommandResult]] = []
+        self.list_files_error: SandboxException | None = None
+        self.read_file_error: SandboxException | None = None
+        self.write_file_error: SandboxException | None = None
+
+    def script(self, substring: str, result: CommandResult) -> None:
+        self.command_overrides.append((substring, result))
+
+    async def execute_command(
+        self,
+        sandbox_id: str,
+        command: str,
+        envs: dict[str, str] | None = None,
+        timeout: int = 120,
+    ) -> CommandResult:
+        for substring, result in self.command_overrides:
+            if substring in command:
+                self.commands.append((sandbox_id, command, envs))
+                return result
+        return await super().execute_command(sandbox_id, command, envs, timeout)
+
+    async def list_files(self, sandbox_id: str, path: str = "") -> list[FileMetadata]:
+        if self.list_files_error:
+            raise self.list_files_error
+        return await super().list_files(sandbox_id, path)
+
+    async def read_file(self, sandbox_id: str, path: str) -> FileContent:
+        if self.read_file_error:
+            raise self.read_file_error
+        return await super().read_file(sandbox_id, path)
+
+    async def write_file(
+        self, sandbox_id: str, path: str, content: str | bytes
+    ) -> None:
+        if self.write_file_error:
+            raise self.write_file_error
+        await super().write_file(sandbox_id, path, content)
+
+
+def install_scripted_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> ScriptedSandboxProvider:
+    provider = ScriptedSandboxProvider()
+    monkeypatch.setattr(
+        SandboxProvider, "create_provider", FakeProviderFactory(provider=provider)
+    )
+    return provider
+
+
+async def create_host_workspace(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_dir: Path,
+    *,
+    email: str = "host-user@example.com",
+    username: str = "hostuser",
+) -> tuple[dict[str, str], Workspace]:
+    # Mirrors create_authenticated_workspace but points workspace_path at a
+    # real on-disk temp dir so the real LocalHostProvider runs, not a fake.
+    user = await create_user(email=email, username=username)
+    tokens = await login(email=email)
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+    workspace = Workspace(
+        name="Host Workspace",
+        user_id=user.id,
+        sandbox_id=f"sandbox-{username}",
+        sandbox_provider="host",
+        workspace_path=str(workspace_dir),
+        source_type="empty",
+        source_url=None,
+    )
+    db_session.add(workspace)
+    await db_session.commit()
+    await db_session.refresh(workspace)
+    return headers, workspace
 
 
 @pytest.fixture
@@ -366,3 +475,1122 @@ async def test_search_endpoint_propagates_filters(
         "cd 'src' && rg --json -n --max-count=100 --max-columns=500 "
         "-w -g '*.py' -g '!vendor/*' -- needle ."
     ]
+
+
+async def test_get_files_metadata_rejects_invalid_cwd(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/metadata?cwd=../escape",
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+
+
+async def test_get_files_metadata_propagates_provider_status_code(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.list_files_error = SandboxException("listing failed", status_code=502)
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/metadata",
+        headers=headers,
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "listing failed"
+
+
+async def test_get_file_content_rejects_invalid_path_and_missing_file(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    invalid_path_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/content/weird'file.py",
+        headers=headers,
+    )
+    missing_file_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/content/missing.py",
+        headers=headers,
+    )
+
+    assert invalid_path_response.status_code == 400
+    assert missing_file_response.status_code == 404
+
+
+async def test_update_file_propagates_provider_error(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.write_file_error = SandboxException("disk full")
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.put(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files",
+        json={"file_path": "a.py", "content": "x"},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "disk full"
+
+
+async def test_download_zip_propagates_provider_error(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.list_files_error = SandboxException("zip listing failed")
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/download-zip",
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "zip listing failed"
+
+
+async def test_git_diff_not_a_repo(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.script(GIT_IS_REPO_CMD, CommandResult(stdout="", stderr="", exit_code=128))
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff", headers=headers
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "diff": "",
+        "has_changes": False,
+        "is_git_repo": False,
+        "error": None,
+    }
+
+
+async def test_git_diff_unstaged_and_branch_success_modes(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    default_mode_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff", headers=headers
+    )
+    unstaged_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff?mode=unstaged",
+        headers=headers,
+    )
+    branch_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff?mode=branch",
+        headers=headers,
+    )
+
+    assert default_mode_response.status_code == 200
+    assert default_mode_response.json()["is_git_repo"] is True
+    assert unstaged_response.status_code == 200
+    assert unstaged_response.json()["is_git_repo"] is True
+    assert branch_response.status_code == 200
+    assert branch_response.json()["is_git_repo"] is True
+
+
+async def test_git_diff_branch_mode_reports_unknown_base(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.script("git merge-base", CommandResult(stdout="", stderr="", exit_code=2))
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff?mode=branch", headers=headers
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "diff": "",
+        "has_changes": False,
+        "is_git_repo": True,
+        "error": "Could not determine base branch",
+    }
+
+
+async def test_git_changed_paths(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.script(
+        GIT_STATUS_PORCELAIN_CMD,
+        CommandResult(stdout="\n M app.py\0?? new_file.py\0", stderr="", exit_code=0),
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/changed-paths", headers=headers
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "paths": ["app.py", "new_file.py"],
+        "is_git_repo": True,
+    }
+
+
+async def test_git_changed_paths_rebases_to_cwd_prefix(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.script(
+        GIT_STATUS_PORCELAIN_CMD,
+        CommandResult(
+            stdout="packages/api/\n M packages/api/app.py\0?? other/file.py\0",
+            stderr="",
+            exit_code=0,
+        ),
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/changed-paths?cwd=packages/api",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"paths": ["app.py"], "is_git_repo": True}
+
+
+async def test_git_changed_paths_not_a_repo(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.script(
+        GIT_STATUS_PORCELAIN_CMD, CommandResult(stdout="", stderr="", exit_code=2)
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/changed-paths", headers=headers
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"paths": [], "is_git_repo": False}
+
+
+async def test_git_file_baseline_variants(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.script(
+        GIT_SHOW_HEAD_TEMPLATE.substitute(spec=shlex.quote("HEAD:./not-a-repo.py")),
+        CommandResult(stdout="", stderr="", exit_code=2),
+    )
+    provider.script(
+        GIT_SHOW_HEAD_TEMPLATE.substitute(spec=shlex.quote("HEAD:./new-file.py")),
+        CommandResult(stdout="", stderr="fatal: path not in HEAD", exit_code=128),
+    )
+    provider.script(
+        GIT_SHOW_HEAD_TEMPLATE.substitute(spec=shlex.quote("HEAD:./tracked.py")),
+        CommandResult(stdout="print('baseline')\n", stderr="", exit_code=0),
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    not_repo_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/file-baseline?path=not-a-repo.py",
+        headers=headers,
+    )
+    new_file_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/file-baseline?path=new-file.py",
+        headers=headers,
+    )
+    tracked_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/file-baseline?path=tracked.py",
+        headers=headers,
+    )
+
+    assert not_repo_response.json() == {
+        "path": "not-a-repo.py",
+        "content": "",
+        "is_git_repo": False,
+    }
+    assert new_file_response.json() == {
+        "path": "new-file.py",
+        "content": "",
+        "is_git_repo": True,
+    }
+    assert tracked_response.json() == {
+        "path": "tracked.py",
+        "content": "print('baseline')\n",
+        "is_git_repo": True,
+    }
+
+
+async def test_git_file_baseline_rejects_invalid_path(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/file-baseline?path=-rf",
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+
+
+async def test_git_branches_not_a_repo_and_malformed_output(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.script(
+        "git for-each-ref", CommandResult(stdout="", stderr="", exit_code=2)
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    not_repo_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/branches", headers=headers
+    )
+
+    assert not_repo_response.json() == {
+        "branches": [],
+        "current_branch": "",
+        "is_git_repo": False,
+    }
+
+    other_provider = install_scripted_provider(monkeypatch)
+    other_provider.script(
+        "git for-each-ref", CommandResult(stdout="main\n", stderr="", exit_code=0)
+    )
+    other_headers, _other_user, other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="branches-malformed@example.com",
+        username="branchesmalformed",
+    )
+
+    malformed_response = await client.get(
+        f"/api/v1/sandbox/{other_workspace.sandbox_id}/git/branches",
+        headers=other_headers,
+    )
+
+    assert malformed_response.status_code == 400
+    assert malformed_response.json()["detail"] == "Failed to parse git branches output"
+
+
+async def test_git_checkout_remote_fallback_success(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    branch = "feature-remote"
+    provider.script(
+        GIT_CHECKOUT_TEMPLATE.substitute(branch=branch),
+        CommandResult(stdout="", stderr="error: pathspec", exit_code=1),
+    )
+    provider.script(
+        GIT_CHECKOUT_FROM_REMOTE_TEMPLATE.substitute(branch=branch),
+        CommandResult(stdout="", stderr="", exit_code=0),
+    )
+    provider.script(
+        GIT_CURRENT_BRANCH_CMD,
+        CommandResult(stdout=f"{branch}\n", stderr="", exit_code=0),
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/checkout",
+        json={"branch": branch},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": True,
+        "current_branch": branch,
+        "error": None,
+    }
+
+
+async def test_git_checkout_fails_when_both_attempts_fail(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    branch = "feature-missing"
+    provider.script(
+        GIT_CHECKOUT_TEMPLATE.substitute(branch=branch),
+        CommandResult(stdout="local fail\n", stderr="", exit_code=1),
+    )
+    provider.script(
+        GIT_CHECKOUT_FROM_REMOTE_TEMPLATE.substitute(branch=branch),
+        CommandResult(stdout="remote fail\n", stderr="", exit_code=1),
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/checkout",
+        json={"branch": branch},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": False,
+        "current_branch": "",
+        "error": "remote fail",
+    }
+
+
+async def test_git_checkout_reverts_detached_head(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    branch = "v1.0.0"
+    provider.script(
+        GIT_CHECKOUT_TEMPLATE.substitute(branch=branch),
+        CommandResult(stdout="", stderr="", exit_code=0),
+    )
+    provider.script(
+        GIT_CURRENT_BRANCH_CMD, CommandResult(stdout="HEAD\n", stderr="", exit_code=0)
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/checkout",
+        json={"branch": branch},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": False,
+        "current_branch": "",
+        "error": "Cannot checkout: would result in detached HEAD",
+    }
+    assert any(
+        "git checkout - 2>/dev/null" in command
+        for _sid, command, _envs in provider.commands
+    )
+
+
+async def test_git_checkout_rejects_invalid_branch_name(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/checkout",
+        json={"branch": "-bad"},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+
+
+async def test_git_create_branch_remote_fallback_success(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    name = "new-feature"
+    base_branch = "develop"
+    primary_base = f" '{base_branch}'"
+    provider.script(
+        f"git checkout -b '{name}'{primary_base} 2>&1",
+        CommandResult(stdout="fatal\n", stderr="", exit_code=1),
+    )
+    provider.script(
+        GIT_CREATE_BRANCH_FROM_REMOTE_TEMPLATE.substitute(name=name, base=base_branch),
+        CommandResult(stdout="", stderr="", exit_code=0),
+    )
+    provider.script(
+        GIT_CURRENT_BRANCH_CMD,
+        CommandResult(stdout=f"{name}\n", stderr="", exit_code=0),
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/create-branch",
+        json={"name": name, "base_branch": base_branch},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"success": True, "current_branch": name, "error": None}
+
+
+async def test_git_create_branch_rejects_invalid_names(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    invalid_name_response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/create-branch",
+        json={"name": "bad name"},
+        headers=headers,
+    )
+    invalid_base_response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/create-branch",
+        json={"name": "ok-name", "base_branch": "bad base"},
+        headers=headers,
+    )
+
+    assert invalid_name_response.status_code == 400
+    assert invalid_base_response.status_code == 400
+
+
+async def test_git_create_branch_fails_without_base_branch(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No base_branch means create_branch never attempts the remote-fallback
+    # retry, so a failed primary checkout must surface directly.
+    provider = install_scripted_provider(monkeypatch)
+    provider.script(
+        "git checkout -b 'taken' 2>&1",
+        CommandResult(
+            stdout="fatal: A branch named 'taken' already exists\n",
+            stderr="",
+            exit_code=1,
+        ),
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/create-branch",
+        json={"name": "taken"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": False,
+        "current_branch": "",
+        "error": "fatal: A branch named 'taken' already exists",
+    }
+
+
+async def test_git_push_and_pull_endpoints(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.script(
+        f"{GIT_PUSH_CMD} 2>&1",
+        CommandResult(stdout="", stderr="fatal: no upstream", exit_code=1),
+    )
+    provider.script(
+        f"{GIT_PULL_CMD} 2>&1",
+        CommandResult(stdout="Already up to date.\n", stderr="", exit_code=0),
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    push_response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/push", headers=headers
+    )
+    pull_response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/pull", headers=headers
+    )
+
+    assert push_response.status_code == 200
+    assert push_response.json() == {
+        "success": False,
+        "output": "",
+        "error": "fatal: no upstream",
+    }
+    assert pull_response.status_code == 200
+    assert pull_response.json() == {
+        "success": True,
+        "output": "Already up to date.",
+        "error": None,
+    }
+
+
+async def test_git_restore_all_endpoint(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.script(RESTORE_ALL_CMD, CommandResult(stdout="", stderr="", exit_code=0))
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/restore-all", headers=headers
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"success": True, "output": "", "error": None}
+
+
+async def test_git_restore_file_without_rename(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    # No old_path means this is a plain restore (not a rename), which takes
+    # the RESTORE_FILE_TEMPLATE branch rather than RESTORE_RENAME_TEMPLATE.
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/restore-file",
+        json={"file_path": "app.py"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+
+async def test_git_restore_file_rejects_invalid_paths(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    invalid_file_path_response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/restore-file",
+        json={"file_path": "../escape.py"},
+        headers=headers,
+    )
+    invalid_old_path_response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/restore-file",
+        json={"file_path": "ok.py", "old_path": "-bad"},
+        headers=headers,
+    )
+
+    assert invalid_file_path_response.status_code == 400
+    assert invalid_old_path_response.status_code == 400
+
+
+async def test_git_remote_url_error_paths(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.script(
+        "git remote get-url origin", CommandResult(stdout="", stderr="", exit_code=1)
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    no_remote_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/remote-url", headers=headers
+    )
+
+    assert no_remote_response.status_code == 400
+    assert no_remote_response.json()["detail"] == "No git remote origin found"
+
+    other_provider = install_scripted_provider(monkeypatch)
+    other_provider.script(
+        "git remote get-url origin",
+        CommandResult(stdout="git@gitlab.com:foo/bar.git\n", stderr="", exit_code=0),
+    )
+    other_headers, _other_user, other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="non-github-remote@example.com",
+        username="nongithubremote",
+    )
+
+    non_github_response = await client.get(
+        f"/api/v1/sandbox/{other_workspace.sandbox_id}/git/remote-url",
+        headers=other_headers,
+    )
+
+    assert non_github_response.status_code == 400
+    assert "GitHub" in non_github_response.json()["detail"]
+
+
+async def test_git_endpoints_reject_invalid_cwd(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    sandbox_id = workspace.sandbox_id
+    bad_cwd = "../escape"
+
+    responses = [
+        await client.get(
+            f"/api/v1/sandbox/{sandbox_id}/git/diff?cwd={bad_cwd}", headers=headers
+        ),
+        await client.get(
+            f"/api/v1/sandbox/{sandbox_id}/git/changed-paths?cwd={bad_cwd}",
+            headers=headers,
+        ),
+        await client.get(
+            f"/api/v1/sandbox/{sandbox_id}/git/file-baseline?path=a.py&cwd={bad_cwd}",
+            headers=headers,
+        ),
+        await client.get(
+            f"/api/v1/sandbox/{sandbox_id}/git/branches?cwd={bad_cwd}", headers=headers
+        ),
+        await client.post(
+            f"/api/v1/sandbox/{sandbox_id}/git/checkout",
+            json={"branch": "main", "cwd": "../escape"},
+            headers=headers,
+        ),
+        await client.post(
+            f"/api/v1/sandbox/{sandbox_id}/git/commit",
+            json={"message": "msg", "cwd": "../escape"},
+            headers=headers,
+        ),
+        await client.post(
+            f"/api/v1/sandbox/{sandbox_id}/git/push?cwd={bad_cwd}", headers=headers
+        ),
+        await client.post(
+            f"/api/v1/sandbox/{sandbox_id}/git/pull?cwd={bad_cwd}", headers=headers
+        ),
+        await client.post(
+            f"/api/v1/sandbox/{sandbox_id}/git/restore-all?cwd={bad_cwd}",
+            headers=headers,
+        ),
+        await client.post(
+            f"/api/v1/sandbox/{sandbox_id}/git/create-branch",
+            json={"name": "main", "cwd": "../escape"},
+            headers=headers,
+        ),
+        await client.get(
+            f"/api/v1/sandbox/{sandbox_id}/git/remote-url?cwd={bad_cwd}",
+            headers=headers,
+        ),
+        await client.get(
+            f"/api/v1/sandbox/{sandbox_id}/search?q=x&cwd={bad_cwd}", headers=headers
+        ),
+    ]
+
+    assert all(response.status_code == 400 for response in responses)
+
+
+async def test_search_provider_failure_returns_400(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.script(
+        "rg --json",
+        CommandResult(stdout="", stderr="regex parse error", exit_code=2),
+    )
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/search?q=needle", headers=headers
+    )
+
+    assert response.status_code == 400
+    assert "regex parse error" in response.json()["detail"]
+
+
+async def test_host_provider_serves_real_files_from_disk(
+    tmp_path: Path,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    # Exercises the real LocalHostProvider (no fake) against real files on
+    # disk inside the pytest tmp dir — file read/write, os.walk fallback for
+    # non-git dirs, WALK_SKIP_DIRS pruning, and the symlink-escape guard.
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    (workspace_dir / "README.md").write_text("real readme")
+    (workspace_dir / "src").mkdir()
+    (workspace_dir / "src" / "app.py").write_text("print('hi')")
+    node_modules = workspace_dir / "node_modules" / "pkg"
+    node_modules.mkdir(parents=True)
+    (node_modules / "index.js").write_text("module.exports = {}")
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("secret")
+    (workspace_dir / "escape-link").symlink_to(outside_file)
+    (workspace_dir / "logo.zip").write_bytes(b"PK\x03\x04binarydata")
+
+    headers, workspace = await create_host_workspace(
+        db_session, create_user, login, workspace_dir
+    )
+
+    metadata_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/metadata", headers=headers
+    )
+    content_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/content/README.md",
+        headers=headers,
+    )
+    binary_content_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/content/logo.zip",
+        headers=headers,
+    )
+    write_response = await client.put(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files",
+        json={"file_path": "src/nested/new.py", "content": "print('new')"},
+        headers=headers,
+    )
+    escape_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/content/escape-link",
+        headers=headers,
+    )
+    missing_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/content/does-not-exist.py",
+        headers=headers,
+    )
+
+    assert metadata_response.status_code == 200
+    paths = {f["path"] for f in metadata_response.json()["files"]}
+    assert "README.md" in paths
+    assert "src/app.py" in paths
+    assert not any(p.startswith("node_modules") for p in paths)
+    assert content_response.status_code == 200
+    assert content_response.json()["content"] == "real readme"
+    assert binary_content_response.status_code == 200
+    binary_body = binary_content_response.json()
+    assert binary_body["is_binary"] is True
+    assert base64.b64decode(binary_body["content"]) == b"PK\x03\x04binarydata"
+    assert write_response.status_code == 200
+    assert (workspace_dir / "src" / "nested" / "new.py").read_text() == "print('new')"
+    assert escape_response.status_code == 404
+    assert missing_response.status_code == 404
+
+
+async def test_host_provider_runs_real_git_commands(
+    tmp_path: Path,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    # Runs real `git`/`bash` subprocesses via LocalHostProvider.execute_command
+    # against a real repo in a temp dir — no fakes involved.
+    workspace_dir = tmp_path / "git-workspace"
+    workspace_dir.mkdir()
+    subprocess.run(
+        ["git", "-c", "init.defaultBranch=main", "init", "-q"],
+        cwd=workspace_dir,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=workspace_dir,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=workspace_dir, check=True
+    )
+    (workspace_dir / "app.py").write_text("print('v1')\n")
+    # Two nested tracked files under the same dir so `git ls-files` output
+    # exercises both the parent-directory synthesis and the seen_dirs dedup
+    # branch in SandboxProvider.parse_git_ls_files.
+    (workspace_dir / "src").mkdir()
+    (workspace_dir / "src" / "nested.py").write_text("print('nested')\n")
+    (workspace_dir / "src" / "other.py").write_text("print('other')\n")
+    subprocess.run(["git", "add", "."], cwd=workspace_dir, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "initial"], cwd=workspace_dir, check=True
+    )
+    (workspace_dir / "app.py").write_text("print('v2')\n")
+
+    headers, workspace = await create_host_workspace(
+        db_session,
+        create_user,
+        login,
+        workspace_dir,
+        email="hostgit@example.com",
+        username="hostgit",
+    )
+
+    # A custom secret forces SandboxService to pass non-empty envs into
+    # execute_command, exercising the process_env.update(envs) merge path.
+    secret_response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/secrets",
+        json={"key": "MY_VAR", "value": "hello"},
+        headers=headers,
+    )
+    branches_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/branches", headers=headers
+    )
+    diff_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff?mode=unstaged",
+        headers=headers,
+    )
+    remote_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/remote-url", headers=headers
+    )
+    commit_response = await client.post(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/commit",
+        json={"message": "v2"},
+        headers=headers,
+    )
+    # After the commit the tree is clean, so `git ls-files` succeeds and
+    # list_files takes the git-tracked-files branch instead of the os.walk
+    # fallback exercised by test_host_provider_serves_real_files_from_disk.
+    metadata_response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/files/metadata", headers=headers
+    )
+
+    assert secret_response.status_code == 200
+    assert branches_response.status_code == 200
+    assert branches_response.json()["current_branch"] == "main"
+    assert branches_response.json()["is_git_repo"] is True
+    assert diff_response.status_code == 200
+    assert diff_response.json()["is_git_repo"] is True
+    assert "print('v2')" in diff_response.json()["diff"]
+    assert remote_response.status_code == 400
+    assert remote_response.json()["detail"] == "No git remote origin found"
+    assert commit_response.status_code == 200
+    assert commit_response.json()["success"] is True
+    assert metadata_response.status_code == 200
+    metadata_files = metadata_response.json()["files"]
+    assert {"path": "app.py", "type": "file", "is_binary": False} in metadata_files
+    assert {"path": "src", "type": "directory", "is_binary": False} in metadata_files
+    assert {
+        "path": "src/nested.py",
+        "type": "file",
+        "is_binary": False,
+    } in metadata_files
+
+
+async def test_git_endpoint_injects_github_token_env(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    fake_provider: FakeSandboxProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # SandboxService.build_env_vars only injects GITHUB_TOKEN/GIT_ASKPASS when
+    # a github_personal_access_token is configured AND DESKTOP_MODE is off —
+    # seed both directly (no endpoint here sets a token) then confirm the
+    # env reaches the provider exec call. Mirrors conftest's SettingsOverride
+    # pattern for toggling settings outside the HTTP boundary.
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    user_settings = await get_user_settings(db_session, user.id)
+    assert user_settings is not None
+    user_settings.github_personal_access_token = "ghp_test_token"
+    await db_session.commit()
+
+    # git/branches deliberately bypasses env injection (see GitService.get_branches),
+    # so use git/diff instead, which routes through SandboxService.execute_command.
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff", headers=headers
+    )
+
+    assert response.status_code == 200
+    envs_used = [envs for _sid, _cmd, envs in fake_provider.commands if envs]
+    assert envs_used
+    assert envs_used[0]["GITHUB_TOKEN"] == "ghp_test_token"
+    assert "GIT_ASKPASS" in envs_used[0]
+
+
+async def test_download_zip_includes_binary_files(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    # write_file always stores is_binary=False on FakeSandboxProvider — set
+    # the FileContent directly with is_binary=True so list_files/
+    # generate_zip_download take the base64-decode branch.
+    provider.files["logo.zip"] = FileContent(
+        path="logo.zip",
+        content=base64.b64encode(b"binary-bytes").decode(),
+        type="file",
+        is_binary=True,
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/download-zip", headers=headers
+    )
+
+    assert response.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(response.content)) as archive:
+        assert archive.read("logo.zip") == b"binary-bytes"
+
+
+async def test_download_zip_skips_files_that_fail_to_read(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = install_scripted_provider(monkeypatch)
+    provider.read_file_error = SandboxException("read failed")
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/download-zip", headers=headers
+    )
+
+    assert response.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(response.content)) as archive:
+        assert archive.namelist() == []

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,7 +1,10 @@
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import delete, text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.endpoints import settings as settings_endpoint
+from app.models.db_models.user import UserSettings
 
 from tests.conftest import LoginClient, UserFactory
 from tests.helpers import EndpointCache
@@ -110,3 +113,99 @@ async def test_settings_rejects_missing_token(client: AsyncClient) -> None:
 
     assert get_response.status_code == 401
     assert patch_response.status_code == 401
+
+
+async def test_patch_settings_rejects_non_list_non_string_json_field(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    await create_user(email="bad-json-field@example.com", username="badjsonfield")
+    tokens = await login(email="bad-json-field@example.com")
+
+    response = await client.patch(
+        "/api/v1/settings/",
+        json={"custom_env_vars": 123},
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+
+    assert response.status_code == 422
+
+
+async def test_get_settings_returns_404_when_settings_row_missing(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    db_session: AsyncSession,
+    settings_cache: EndpointCache,
+) -> None:
+    user = await create_user(
+        email="missing-settings@example.com", username="missingsettings"
+    )
+    tokens = await login(email="missing-settings@example.com")
+    await db_session.execute(
+        delete(UserSettings).where(UserSettings.user_id == user.id)
+    )
+    await db_session.commit()
+
+    response = await client.get(
+        "/api/v1/settings/",
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+
+    assert response.status_code == 404
+
+
+async def test_patch_settings_returns_404_when_settings_row_missing(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    db_session: AsyncSession,
+    settings_cache: EndpointCache,
+) -> None:
+    user = await create_user(
+        email="missing-settings-patch@example.com", username="missingpatch"
+    )
+    tokens = await login(email="missing-settings-patch@example.com")
+    await db_session.execute(
+        delete(UserSettings).where(UserSettings.user_id == user.id)
+    )
+    await db_session.commit()
+
+    response = await client.patch(
+        "/api/v1/settings/",
+        json={"custom_instructions": "test"},
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+
+    assert response.status_code == 404
+
+
+async def test_get_settings_returns_legacy_plaintext_github_token(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    db_session: AsyncSession,
+    settings_cache: EndpointCache,
+) -> None:
+    user = await create_user(email="legacy-token@example.com", username="legacytoken")
+    tokens = await login(email="legacy-token@example.com")
+    # Raw SQL bypasses the EncryptedString bind, simulating a pre-encryption
+    # legacy row so decrypt_value raises InvalidToken and the type falls
+    # back to returning the stored value as-is.
+    await db_session.execute(
+        text(
+            "UPDATE user_settings SET github_personal_access_token = :token "
+            "WHERE user_id = :user_id"
+        ),
+        {"token": "legacy-plaintext-token", "user_id": user.id.hex},
+    )
+    await db_session.commit()
+
+    response = await client.get(
+        "/api/v1/settings/",
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["github_personal_access_token"] == "legacy-plaintext-token"

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -1,12 +1,21 @@
+import base64
+import json
+import os
+from pathlib import Path
+from uuid import uuid4
+
 import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
 
+from app.core.config import get_settings
 from app.core.deps import get_skill_service
 from app.models.schemas.skills import SkillFileEntry
 from app.models.types import CustomSkillDict
+from app.services.sandbox_providers.base import SandboxProvider
 
 from tests.conftest import LoginClient, UserFactory
+from tests.helpers import FakeProviderFactory
 
 
 pytestmark = pytest.mark.anyio
@@ -81,6 +90,53 @@ async def auth_headers(
     await create_user(email="skills@example.com", username="skillsuser")
     tokens = await login(email="skills@example.com")
     return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+@pytest.fixture
+def real_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(SandboxProvider, "create_provider", FakeProviderFactory())
+
+
+@pytest.fixture
+def real_skill_service(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The autouse fake_skill_service fixture above overrides get_skill_service
+    # for every test in this module. Real SkillService also branches on
+    # DESKTOP_MODE — force server mode so the global skill dir resolves under
+    # STORAGE_PATH regardless of DESKTOP_MODE leaking from the host shell env.
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    del app.dependency_overrides[get_skill_service]
+
+
+async def create_real_workspace(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    *,
+    email: str,
+    username: str,
+) -> tuple[dict[str, str], str, str]:
+    await create_user(email=email, username=username)
+    tokens = await login(email=email)
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+    response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "Skill Workspace",
+            "source_type": "empty",
+            "sandbox_provider": "host",
+        },
+        headers=headers,
+    )
+    assert response.status_code == 201
+    body = response.json()
+    return headers, body["id"], body["workspace_path"]
+
+
+def write_skill_md(skill_dir: Path, description: str, body: str = "Body text") -> None:
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\ndescription: {description}\n---\n{body}\n", encoding="utf-8"
+    )
 
 
 async def test_list_skills_returns_available_skills(
@@ -207,3 +263,495 @@ async def test_skills_reject_missing_token(
     assert list_response.status_code == 401
     assert files_response.status_code == 401
     assert update_response.status_code == 401
+
+
+async def test_real_skill_service_lists_reads_and_updates_files_on_disk(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    real_sandbox: None,
+    real_skill_service: None,
+) -> None:
+    headers, workspace_id, workspace_path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill@example.com",
+        username="realskill",
+    )
+    skill_dir = Path(workspace_path) / ".claude" / "skills" / "myskill"
+    write_skill_md(skill_dir, "Reviews code changes")
+    (skill_dir / "reference.md").write_text("See also", encoding="utf-8")
+    png_bytes = b"\x89PNG\r\n\x1a\n" + bytes(range(10))
+    (skill_dir / "assets").mkdir()
+    (skill_dir / "assets" / "logo.png").write_bytes(png_bytes)
+
+    list_response = await client.get(
+        "/api/v1/skills", params={"workspace_id": workspace_id}, headers=headers
+    )
+    files_response = await client.get(
+        "/api/v1/skills/claude/myskill/files",
+        params={"workspace_id": workspace_id},
+        headers=headers,
+    )
+
+    assert list_response.status_code == 200
+    entries = {item["name"]: item for item in list_response.json()}
+    assert entries["myskill"]["description"] == "Reviews code changes"
+    # OpenCode's namespace list also cross-reads `.claude/skills`, so the same
+    # on-disk dir surfaces under both sources (see SkillService._build_paths_by_source).
+    assert entries["myskill"]["sources"] == ["claude", "opencode"]
+    assert entries["myskill"]["read_only"] is False
+    assert entries["myskill"]["file_count"] == 3
+
+    assert files_response.status_code == 200
+    files_by_path = {f["path"]: f for f in files_response.json()["files"]}
+    assert files_by_path["SKILL.md"]["is_binary"] is False
+    assert "Reviews code changes" in files_by_path["SKILL.md"]["content"]
+    logo_entry = files_by_path["assets/logo.png"]
+    assert logo_entry["is_binary"] is True
+    assert base64.b64decode(logo_entry["content"]) == png_bytes
+
+    update_response = await client.put(
+        "/api/v1/skills/claude/myskill",
+        json={
+            "files": [
+                {
+                    "path": "SKILL.md",
+                    "content": "---\ndescription: Updated description\n---\nNew body\n",
+                    "is_binary": False,
+                }
+            ]
+        },
+        params={"workspace_id": workspace_id},
+        headers=headers,
+    )
+
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["description"] == "Updated description"
+    assert updated["file_count"] == 1
+    assert updated["sources"] == ["claude"]
+    # update() replaces the whole skill dir, so files not resubmitted are gone.
+    assert not (skill_dir / "reference.md").exists()
+    assert not (skill_dir / "assets").exists()
+    assert "Updated description" in (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+
+
+async def test_real_skill_service_skips_dangling_symlinks_and_binary_frontmatter(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    real_sandbox: None,
+    real_skill_service: None,
+) -> None:
+    headers, workspace_id, workspace_path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-edge@example.com",
+        username="realskilledge",
+    )
+    skills_root = Path(workspace_path) / ".claude" / "skills"
+    good_skill = skills_root / "goodskill"
+    write_skill_md(good_skill, "Good skill")
+    # A dangling symlink makes Path.stat() raise FileNotFoundError (an OSError
+    # subclass) during _compute_dir_stats's rglob walk — must be skipped, not raised.
+    os.symlink(good_skill / "missing-target", good_skill / "broken-link")
+
+    unreadable_skill = skills_root / "unreadableskill"
+    unreadable_skill.mkdir(parents=True)
+    # Invalid UTF-8 bytes make SKILL.md unreadable as text — list_all should
+    # skip the skill instead of raising UnicodeDecodeError.
+    (unreadable_skill / "SKILL.md").write_bytes(b"---\ndescription: \xff\xfe\n---\n")
+
+    response = await client.get(
+        "/api/v1/skills", params={"workspace_id": workspace_id}, headers=headers
+    )
+
+    assert response.status_code == 200
+    names = {item["name"] for item in response.json()}
+    assert "goodskill" in names
+    assert "unreadableskill" not in names
+
+
+async def test_real_skill_service_returns_404_for_unknown_skill(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    real_sandbox: None,
+    real_skill_service: None,
+) -> None:
+    headers, workspace_id, _path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-missing@example.com",
+        username="realskillmissing",
+    )
+
+    files_response = await client.get(
+        "/api/v1/skills/claude/does-not-exist/files",
+        params={"workspace_id": workspace_id},
+        headers=headers,
+    )
+    update_response = await client.put(
+        "/api/v1/skills/claude/does-not-exist",
+        json={"files": []},
+        params={"workspace_id": workspace_id},
+        headers=headers,
+    )
+
+    assert files_response.status_code == 404
+    assert files_response.json()["detail"] == "Skill 'does-not-exist' not found"
+    assert update_response.status_code == 404
+    assert update_response.json()["detail"] == "Skill 'does-not-exist' not found"
+
+
+async def test_real_skill_service_rejects_readonly_cursor_builtin_update(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    real_sandbox: None,
+    real_skill_service: None,
+) -> None:
+    headers, workspace_id, _path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-readonly@example.com",
+        username="realskillro",
+    )
+    settings = get_settings()
+    skill_name = f"builtin-{uuid4().hex[:8]}"
+    builtin_dir = Path(settings.STORAGE_PATH) / ".cursor" / "skills-cursor" / skill_name
+    write_skill_md(builtin_dir, "Cursor built-in skill")
+
+    response = await client.put(
+        f"/api/v1/skills/cursor/{skill_name}",
+        json={
+            "files": [
+                {
+                    "path": "SKILL.md",
+                    "content": "---\ndescription: Hijacked\n---\nBody\n",
+                    "is_binary": False,
+                }
+            ]
+        },
+        params={"workspace_id": workspace_id},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        f"Skill '{skill_name}' is read-only and cannot be edited"
+    )
+
+
+async def test_real_skill_service_update_rejects_path_traversal(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    real_sandbox: None,
+    real_skill_service: None,
+) -> None:
+    headers, workspace_id, workspace_path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-traversal@example.com",
+        username="realskilltraversal",
+    )
+    skill_dir = Path(workspace_path) / ".claude" / "skills" / "traversal"
+    write_skill_md(skill_dir, "Traversal target")
+
+    response = await client.put(
+        "/api/v1/skills/claude/traversal",
+        json={
+            "files": [{"path": "../escaped.txt", "content": "x", "is_binary": False}]
+        },
+        params={"workspace_id": workspace_id},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid file path: ../escaped.txt"
+
+
+async def test_real_skill_service_update_writes_binary_files(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    real_sandbox: None,
+    real_skill_service: None,
+) -> None:
+    headers, workspace_id, workspace_path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-binary@example.com",
+        username="realskillbinary",
+    )
+    skill_dir = Path(workspace_path) / ".claude" / "skills" / "binaryskill"
+    write_skill_md(skill_dir, "Binary asset skill")
+    payload_bytes = b"\x00\x01binary-content"
+
+    response = await client.put(
+        "/api/v1/skills/claude/binaryskill",
+        json={
+            "files": [
+                {
+                    "path": "SKILL.md",
+                    "content": "---\ndescription: Binary asset skill\n---\nBody\n",
+                    "is_binary": False,
+                },
+                {
+                    "path": "assets/data.bin",
+                    "content": base64.b64encode(payload_bytes).decode("ascii"),
+                    "is_binary": True,
+                },
+            ]
+        },
+        params={"workspace_id": workspace_id},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["file_count"] == 2
+    assert (skill_dir / "assets" / "data.bin").read_bytes() == payload_bytes
+
+
+async def test_real_skill_service_update_rejects_invalid_frontmatter(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    real_sandbox: None,
+    real_skill_service: None,
+) -> None:
+    headers, workspace_id, workspace_path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-badyaml@example.com",
+        username="realskillbadyaml",
+    )
+    skill_dir = Path(workspace_path) / ".claude" / "skills" / "badyaml"
+    write_skill_md(skill_dir, "Bad yaml target")
+
+    no_frontmatter_response = await client.put(
+        "/api/v1/skills/claude/badyaml",
+        json={
+            "files": [
+                {
+                    "path": "SKILL.md",
+                    "content": "No frontmatter here",
+                    "is_binary": False,
+                }
+            ]
+        },
+        params={"workspace_id": workspace_id},
+        headers=headers,
+    )
+    unterminated_response = await client.put(
+        "/api/v1/skills/claude/badyaml",
+        json={
+            "files": [
+                {
+                    "path": "SKILL.md",
+                    "content": "---\ndescription: no closing marker\n",
+                    "is_binary": False,
+                }
+            ]
+        },
+        params={"workspace_id": workspace_id},
+        headers=headers,
+    )
+    non_dict_response = await client.put(
+        "/api/v1/skills/claude/badyaml",
+        json={
+            "files": [
+                {
+                    "path": "SKILL.md",
+                    "content": "---\njust a plain string\n---\nBody\n",
+                    "is_binary": False,
+                }
+            ]
+        },
+        params={"workspace_id": workspace_id},
+        headers=headers,
+    )
+
+    assert no_frontmatter_response.status_code == 400
+    assert no_frontmatter_response.json()["detail"] == (
+        "Content must start with YAML frontmatter (---)"
+    )
+    assert unterminated_response.status_code == 400
+    assert unterminated_response.json()["detail"] == (
+        "YAML frontmatter must end with ---"
+    )
+    assert non_dict_response.status_code == 400
+    assert non_dict_response.json()["detail"] == (
+        "YAML frontmatter must be a dictionary"
+    )
+
+
+async def test_real_skill_service_discovers_enabled_claude_plugin_skills(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    real_sandbox: None,
+    real_skill_service: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Server mode resolves the plugin config under STORAGE_PATH, not the
+    # process home dir — point it at the per-test tmp dir.
+    monkeypatch.setattr(get_settings(), "STORAGE_PATH", str(tmp_path))
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True)
+    enabled_install = tmp_path / "enabled-install"
+    write_skill_md(enabled_install / "skills" / "pluginskill", "Plugin skill")
+    disabled_install = tmp_path / "disabled-install"
+    write_skill_md(disabled_install / "skills" / "otherskill", "Disabled skill")
+    (claude_dir / "settings.json").write_text(
+        json.dumps(
+            {"enabledPlugins": {"enabled@market": True, "disabled@market": False}}
+        ),
+        encoding="utf-8",
+    )
+    plugins_dir = claude_dir / "plugins"
+    plugins_dir.mkdir()
+    (plugins_dir / "installed_plugins.json").write_text(
+        json.dumps(
+            {
+                "plugins": {
+                    "enabled@market": [
+                        {"installPath": str(enabled_install)},
+                        {},
+                    ],
+                    "disabled@market": [{"installPath": str(disabled_install)}],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    headers, workspace_id, _path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-plugin@example.com",
+        username="realskillplugin",
+    )
+
+    response = await client.get(
+        "/api/v1/skills", params={"workspace_id": workspace_id}, headers=headers
+    )
+
+    assert response.status_code == 200
+    names = {item["name"] for item in response.json()}
+    assert "pluginskill" in names
+    assert "otherskill" not in names
+
+
+async def test_real_skill_service_returns_no_plugin_skills_without_settings_files(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    real_sandbox: None,
+    real_skill_service: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Server mode resolves the plugin config under STORAGE_PATH, not the
+    # process home dir — point it at the per-test tmp dir.
+    monkeypatch.setattr(get_settings(), "STORAGE_PATH", str(tmp_path))
+
+    headers, workspace_id, _path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-nohome@example.com",
+        username="realskillnohome",
+    )
+
+    response = await client.get(
+        "/api/v1/skills", params={"workspace_id": workspace_id}, headers=headers
+    )
+
+    assert response.status_code == 200
+    # STORAGE_PATH is shared across the test session, so only assert this
+    # workspace's own (nonexistent) skill is absent rather than the full list.
+    assert "myskill" not in {item["name"] for item in response.json()}
+
+
+async def test_real_skill_service_skips_malformed_plugin_settings_json(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    real_sandbox: None,
+    real_skill_service: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Server mode resolves the plugin config under STORAGE_PATH, not the
+    # process home dir — point it at the per-test tmp dir.
+    monkeypatch.setattr(get_settings(), "STORAGE_PATH", str(tmp_path))
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "settings.json").write_text("{not valid json", encoding="utf-8")
+    plugins_dir = claude_dir / "plugins"
+    plugins_dir.mkdir()
+    (plugins_dir / "installed_plugins.json").write_text("{}", encoding="utf-8")
+
+    headers, workspace_id, _path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-badjson@example.com",
+        username="realskillbadjson",
+    )
+
+    response = await client.get(
+        "/api/v1/skills", params={"workspace_id": workspace_id}, headers=headers
+    )
+
+    assert response.status_code == 200
+
+
+async def test_real_skill_service_skips_plugin_discovery_without_enabled_plugins(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    real_sandbox: None,
+    real_skill_service: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Server mode resolves the plugin config under STORAGE_PATH, not the
+    # process home dir — point it at the per-test tmp dir.
+    monkeypatch.setattr(get_settings(), "STORAGE_PATH", str(tmp_path))
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "settings.json").write_text(
+        json.dumps({"enabledPlugins": {}}), encoding="utf-8"
+    )
+    plugins_dir = claude_dir / "plugins"
+    plugins_dir.mkdir()
+    (plugins_dir / "installed_plugins.json").write_text(
+        json.dumps({"plugins": {}}), encoding="utf-8"
+    )
+
+    headers, workspace_id, _path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-noenabled@example.com",
+        username="realskillnoenabled",
+    )
+
+    response = await client.get(
+        "/api/v1/skills", params={"workspace_id": workspace_id}, headers=headers
+    )
+
+    assert response.status_code == 200

--- a/backend/tests/test_streaming.py
+++ b/backend/tests/test_streaming.py
@@ -1,0 +1,1166 @@
+import asyncio
+import json
+import time
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import pytest_asyncio
+import uvicorn
+from acp.schema import PermissionOption, ToolCallUpdate
+from fastapi import FastAPI
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.endpoints import chat as chat_endpoint
+from app.core import deps
+from app.constants import MODELS, REDIS_KEY_CHAT_STREAM_LIVE
+from app.models.db_models.chat import Chat
+from app.models.db_models.enums import MessageStreamStatus
+from app.models.db_models.user import User
+from app.models.db_models.workspace import Workspace
+from app.services.acp.client import AcpClientHandler
+from app.services.acp.session import AcpSession, AcpSessionConfig
+from app.services.session_registry import session_registry
+from app.services import chat as chat_service_module
+from app.services.sandbox_providers.base import SandboxProvider
+from app.services.streaming import runtime as runtime_module
+from app.services.streaming.runtime import ChatStreamRuntime
+from app.services.streaming.types import StreamEnvelope, StreamEvent
+
+from tests.conftest import LoginClient, UserFactory
+from tests.helpers import (
+    EndpointCache,
+    FakeProviderFactory,
+    create_authenticated_workspace,
+)
+
+
+TEST_MODEL_ID = "opencode:google-vertex-anthropic/claude-sonnet-4-5@20250929"
+TEST_CONTEXT_WINDOW = MODELS[TEST_MODEL_ID].context_window
+
+pytestmark = pytest.mark.anyio
+
+# Sentinel script step: makes the fake ACP session block forever on this
+# prompt (until the runtime cancels it), simulating a long-running turn.
+BLOCK_FOREVER = object()
+
+
+@dataclass
+class PermissionStep:
+    # Mirrors AcpClientHandler.request_permission's inputs — pushed onto the
+    # queue for real via the handler so respond_to_permission can resolve it.
+    options: list[tuple[str, str, str]]
+    tool_call_id: str
+    on_response: dict[str, list[StreamEvent]]
+
+
+class FakeAcpSession:
+    # Duck-types AcpSession's public surface (session.py) so AgentService and
+    # SessionRegistry drive it exactly like a real ACP subprocess session,
+    # without ever spawning one.
+    def __init__(
+        self,
+        scripts: list[list[Any]],
+        *,
+        usage: dict[str, int] | None = None,
+        total_cost_usd: float = 0.0,
+        session_id: str = "acp-session-1",
+    ) -> None:
+        self.handler: AcpClientHandler | None = None
+        self.configs: list[AcpSessionConfig] = []
+        self.acp_session_id = session_id
+        self._scripts = scripts
+        self._call_index = 0
+        self.usage = usage
+        self.total_cost_usd = total_cost_usd
+        self.alive = True
+        self.cancel_calls = 0
+        self.set_mode_calls: list[str] = []
+        self.set_model_calls: list[tuple[str, str | None]] = []
+        self.close_calls = 0
+        self.prompt_calls: list[str] = []
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+    async def send_prompt(
+        self,
+        content: str,
+        attachments: list[dict[str, Any]] | None = None,
+        agent_kind: Any = None,
+    ) -> None:
+        assert self.handler is not None
+        self.prompt_calls.append(content)
+        self.handler.prepare_for_prompt()
+        prompt_completed = False
+        try:
+            script = self._scripts[self._call_index]
+            self._call_index += 1
+            for step in script:
+                if isinstance(step, PermissionStep):
+                    await self._run_permission_step(step)
+                elif step is BLOCK_FOREVER:
+                    await asyncio.Event().wait()
+                elif isinstance(step, BaseException):
+                    raise step
+                else:
+                    self.handler.event_queue.put_nowait(step)
+            prompt_completed = True
+        finally:
+            if self.usage is not None:
+                self.handler.usage = self.usage
+            self.handler.total_cost_usd = self.total_cost_usd
+            self.handler.finish(prompt_completed=prompt_completed)
+
+    async def _run_permission_step(self, step: PermissionStep) -> None:
+        assert self.handler is not None
+        options = [
+            PermissionOption(kind="allow_once", name=name, option_id=option_id)
+            for _kind, name, option_id in step.options
+        ]
+        tool_call = ToolCallUpdate(tool_call_id=step.tool_call_id)
+        response = await self.handler.request_permission(
+            options=options, session_id=self.acp_session_id, tool_call=tool_call
+        )
+        outcome = response.outcome
+        option_id = getattr(outcome, "option_id", "")
+        for event in step.on_response.get(option_id, []):
+            self.handler.event_queue.put_nowait(event)
+
+    async def cancel(self) -> None:
+        self.cancel_calls += 1
+
+    async def set_model(
+        self, model_id: str, reasoning_effort: str | None = None
+    ) -> None:
+        self.set_model_calls.append((model_id, reasoning_effort))
+
+    async def set_mode(self, mode_id: str) -> None:
+        self.set_mode_calls.append(mode_id)
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.alive = False
+
+
+class FakeAcpSessionFactory:
+    def __init__(self) -> None:
+        self.pending: list[FakeAcpSession] = []
+        self.created: list[FakeAcpSession] = []
+
+    def queue(self, session: FakeAcpSession) -> None:
+        self.pending.append(session)
+
+    async def create(self, config: AcpSessionConfig) -> FakeAcpSession:
+        session = self.pending.pop(0)
+        session.handler = AcpClientHandler(agent_kind=config.agent_kind)
+        session.configs.append(config)
+        if config.resume_session_id:
+            session.acp_session_id = config.resume_session_id
+        self.created.append(session)
+        return session
+
+
+@pytest.fixture(autouse=True)
+def streaming_runtime_state_reset() -> Iterator[None]:
+    # Both registries are process-wide singletons/class state — reset around
+    # every test so a task or session left by one test can't leak into the next.
+    ChatStreamRuntime._background_task_chat_ids.clear()
+    session_registry._sessions.clear()
+    session_registry._pending_cancels.clear()
+    yield
+    ChatStreamRuntime._background_task_chat_ids.clear()
+    session_registry._sessions.clear()
+    session_registry._pending_cancels.clear()
+
+
+@pytest.fixture(autouse=True)
+def fake_sandbox_provider(monkeypatch: pytest.MonkeyPatch) -> FakeProviderFactory:
+    factory = FakeProviderFactory()
+    monkeypatch.setattr(SandboxProvider, "create_provider", factory)
+    return factory
+
+
+@pytest.fixture
+def acp_factory(monkeypatch: pytest.MonkeyPatch) -> FakeAcpSessionFactory:
+    factory = FakeAcpSessionFactory()
+    monkeypatch.setattr(AcpSession, "create", factory.create)
+    return factory
+
+
+@pytest.fixture
+def streaming_cache(monkeypatch: pytest.MonkeyPatch) -> EndpointCache:
+    cache = EndpointCache()
+    # cache_connection is imported by value into each of these modules, so the
+    # global patch in utils.cache doesn't reach them — patch every call site
+    # that the send/stream/queue pipeline actually uses.
+    monkeypatch.setattr(chat_endpoint, "cache_connection", cache.connect)
+    monkeypatch.setattr(deps, "cache_connection", cache.connect)
+    monkeypatch.setattr(chat_service_module, "cache_connection", cache.connect)
+    monkeypatch.setattr(runtime_module, "cache_connection", cache.connect)
+    return cache
+
+
+async def create_chat_row(
+    db_session: AsyncSession,
+    user: User,
+    workspace: Workspace,
+    *,
+    title: str = "Streaming Chat",
+    session_id: str | None = None,
+) -> Chat:
+    chat = Chat(
+        title=title,
+        user_id=user.id,
+        workspace_id=workspace.id,
+        session_id=session_id,
+    )
+    db_session.add(chat)
+    await db_session.commit()
+    await db_session.refresh(chat)
+    return chat
+
+
+def find_background_task(chat_id: UUID) -> "asyncio.Task[str]":
+    for task, chat_id_str in ChatStreamRuntime._background_task_chat_ids.items():
+        if chat_id_str == str(chat_id) and not task.done():
+            return task
+    raise AssertionError(f"no running background task for chat {chat_id}")
+
+
+async def run_background_task(chat_id: UUID, *, timeout: float = 5.0) -> str:
+    task = find_background_task(chat_id)
+    result = await asyncio.wait_for(task, timeout=timeout)
+    # Done-callbacks (registry pruning) run via call_soon — give them a turn.
+    await asyncio.sleep(0)
+    return result
+
+
+async def wait_for_message_event_type(
+    client: AsyncClient,
+    headers: dict[str, str],
+    message_id: str,
+    event_type: str,
+    *,
+    timeout: float = 2.0,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = await client.get(
+            f"/api/v1/chat/messages/{message_id}/events", headers=headers
+        )
+        assert response.status_code == 200
+        for event in response.json():
+            if event["event_type"] == event_type:
+                return event
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"event type {event_type!r} not observed for {message_id}")
+
+
+async def send_message(
+    client: AsyncClient,
+    headers: dict[str, str],
+    chat: Chat,
+    *,
+    prompt: str = "Hello agent",
+    permission_mode: str = "bypassPermissions",
+) -> dict[str, Any]:
+    response = await client.post(
+        "/api/v1/chat/chat",
+        data={
+            "prompt": prompt,
+            "chat_id": str(chat.id),
+            "model_id": TEST_MODEL_ID,
+            "permission_mode": permission_mode,
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200
+    return dict(response.json())
+
+
+async def test_send_message_streams_full_turn_and_persists_final_snapshot(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    # session_id pre-set so this turn isn't treated as "new chat" — keeps the
+    # test focused on the main-turn pipeline instead of also needing a second
+    # scripted session for background title generation.
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-1")
+
+    tool_payload = {
+        "id": "tool-1",
+        "name": "Read",
+        "title": "Read file",
+        "status": "completed",
+        "parent_id": None,
+        "input": {"path": "README.md"},
+        "result": "file contents",
+    }
+    script = [
+        StreamEvent(type="assistant_text", text="Hello "),
+        StreamEvent(type="assistant_text", text="world"),
+        StreamEvent(type="tool_started", tool={**tool_payload, "status": "started"}),
+        StreamEvent(type="tool_completed", tool=tool_payload),
+        StreamEvent(
+            type="usage",
+            data={"input_tokens": 1500, "context_window": TEST_CONTEXT_WINDOW},
+        ),
+    ]
+    acp_factory.queue(FakeAcpSession([script], session_id="resumed-1"))
+
+    result = await send_message(client, headers, chat)
+    message_id = result["message_id"]
+
+    await run_background_task(chat.id)
+
+    messages_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+    assert messages_response.status_code == 200
+    items = messages_response.json()["items"]
+    assistant_item = next(item for item in items if item["id"] == message_id)
+    assert assistant_item["stream_status"] == MessageStreamStatus.COMPLETED.value
+    assert assistant_item["content_text"] == "Hello world"
+    events = assistant_item["content_render"]["events"]
+    assert [e["type"] for e in events] == [
+        "assistant_text",
+        "assistant_text",
+        "tool_started",
+        "tool_completed",
+    ]
+    assert events[3]["tool"]["status"] == "completed"
+
+    status_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/status", headers=headers
+    )
+    assert status_response.status_code == 200
+    assert status_response.json()["has_active_task"] is False
+
+    # Terminal-event persistence: the pre-completion buffered events are wiped
+    # by the final snapshot, but the "complete" control event is emitted after
+    # that cleanup, so exactly one row should remain.
+    terminal_events_response = await client.get(
+        f"/api/v1/chat/messages/{message_id}/events", headers=headers
+    )
+    assert terminal_events_response.status_code == 200
+    terminal_events = terminal_events_response.json()
+    assert [e["event_type"] for e in terminal_events] == ["complete"]
+
+    context_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/context-usage", headers=headers
+    )
+    assert context_response.status_code == 200
+    assert context_response.json() == {
+        "tokens_used": 1500,
+        "context_window": TEST_CONTEXT_WINDOW,
+        "percentage": (1500 / TEST_CONTEXT_WINDOW) * 100,
+    }
+
+
+async def test_send_message_new_chat_generates_title_in_background(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id=None)
+
+    main_script = [StreamEvent(type="assistant_text", text="Hi there")]
+    title_script = [StreamEvent(type="assistant_text", text="Greeting Chat")]
+    acp_factory.queue(FakeAcpSession([main_script], session_id="new-session-1"))
+    acp_factory.queue(FakeAcpSession([title_script], session_id="title-session"))
+
+    await send_message(client, headers, chat)
+    await run_background_task(chat.id)
+
+    # Title generation runs as an untracked fire-and-forget task (no handle to
+    # await), so poll the chat detail endpoint until it lands.
+    deadline = time.monotonic() + 2.0
+    title = None
+    while time.monotonic() < deadline:
+        detail_response = await client.get(
+            f"/api/v1/chat/chats/{chat.id}", headers=headers
+        )
+        assert detail_response.status_code == 200
+        title = detail_response.json()["title"]
+        if title == "Generated Title" or title == "Greeting Chat":
+            break
+        await asyncio.sleep(0.01)
+
+    assert title == "Greeting Chat"
+    await db_session.refresh(chat)
+    assert chat.session_id == "new-session-1"
+
+
+async def test_send_message_extracts_and_strips_prompt_suggestions(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-2")
+
+    script = [
+        StreamEvent(
+            type="assistant_text",
+            text=(
+                'Done.\n<prompt_suggestions>["Add tests", "Update docs"]'
+                "</prompt_suggestions>"
+            ),
+        ),
+    ]
+    acp_factory.queue(FakeAcpSession([script], session_id="resumed-2"))
+
+    result = await send_message(client, headers, chat)
+    await run_background_task(chat.id)
+
+    messages_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+    items = messages_response.json()["items"]
+    assistant_item = next(item for item in items if item["id"] == result["message_id"])
+    assert assistant_item["content_text"] == "Done."
+    events = assistant_item["content_render"]["events"]
+    assert events[-1] == {
+        "type": "prompt_suggestions",
+        "suggestions": ["Add tests", "Update docs"],
+    }
+
+
+async def test_permission_request_respond_allows_and_denies_then_stream_completes(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-3")
+
+    allow_step = PermissionStep(
+        options=[("allow_once", "Allow", "allow"), ("reject_once", "Reject", "reject")],
+        tool_call_id="tool-allow",
+        on_response={
+            "allow": [StreamEvent(type="assistant_text", text="Wrote file. ")]
+        },
+    )
+    deny_step = PermissionStep(
+        options=[("allow_once", "Allow", "allow")],
+        tool_call_id="tool-deny",
+        on_response={"": [StreamEvent(type="assistant_text", text="Skipped action.")]},
+    )
+    script = [allow_step, deny_step]
+    acp_factory.queue(FakeAcpSession([script], session_id="resumed-3"))
+
+    result = await send_message(client, headers, chat)
+    message_id = result["message_id"]
+
+    allow_event = await wait_for_message_event_type(
+        client, headers, message_id, "permission_request"
+    )
+    assert allow_event["render_payload"]["request_id"] == "tool-allow"
+
+    allow_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/permissions/tool-allow/respond",
+        data={"option_id": "allow"},
+        headers=headers,
+    )
+    assert allow_response.status_code == 200
+    assert allow_response.json() == {"success": True}
+
+    deny_event = await wait_for_message_event_type(
+        client, headers, message_id, "permission_request"
+    )
+    # After the first respond, a second (different) permission_request must
+    # have been persisted for the deny step — same event_type, new request_id.
+    deadline = time.monotonic() + 2.0
+    while deny_event["render_payload"]["request_id"] != "tool-deny":
+        if time.monotonic() > deadline:
+            raise AssertionError("second permission_request never observed")
+        events_response = await client.get(
+            f"/api/v1/chat/messages/{message_id}/events", headers=headers
+        )
+        matches = [
+            e
+            for e in events_response.json()
+            if e["event_type"] == "permission_request"
+            and e["render_payload"]["request_id"] == "tool-deny"
+        ]
+        if matches:
+            deny_event = matches[0]
+            break
+        await asyncio.sleep(0.01)
+
+    deny_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/permissions/tool-deny/respond",
+        headers=headers,
+    )
+    assert deny_response.status_code == 200
+
+    await run_background_task(chat.id)
+
+    messages_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+    items = messages_response.json()["items"]
+    assistant_item = next(item for item in items if item["id"] == message_id)
+    assert assistant_item["stream_status"] == MessageStreamStatus.COMPLETED.value
+    assert assistant_item["content_text"] == "Wrote file. Skipped action."
+
+
+async def test_respond_to_permission_returns_404_for_unknown_request(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-x")
+
+    response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/permissions/unknown-request/respond",
+        data={"option_id": "allow"},
+        headers=headers,
+    )
+    assert response.status_code == 404
+
+
+async def test_cancel_stream_marks_message_interrupted(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-4")
+
+    script = [StreamEvent(type="assistant_text", text="Working..."), BLOCK_FOREVER]
+    acp_factory.queue(FakeAcpSession([script], session_id="resumed-4"))
+
+    result = await send_message(client, headers, chat)
+    message_id = result["message_id"]
+
+    await wait_for_message_event_type(client, headers, message_id, "stream_started")
+
+    cancel_response = await client.delete(
+        f"/api/v1/chat/chats/{chat.id}/stream", headers=headers
+    )
+    assert cancel_response.status_code == 204
+
+    await run_background_task(chat.id)
+
+    messages_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+    items = messages_response.json()["items"]
+    assistant_item = next(item for item in items if item["id"] == message_id)
+    assert assistant_item["stream_status"] == MessageStreamStatus.INTERRUPTED.value
+
+    terminal_events_response = await client.get(
+        f"/api/v1/chat/messages/{message_id}/events", headers=headers
+    )
+    assert [e["event_type"] for e in terminal_events_response.json()] == ["cancelled"]
+
+
+async def test_cancel_stream_is_a_noop_when_nothing_is_running(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-idle")
+
+    response = await client.delete(
+        f"/api/v1/chat/chats/{chat.id}/stream", headers=headers
+    )
+    assert response.status_code == 204
+
+
+async def test_stream_failure_marks_message_failed_and_emits_bootstrap_error(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-5")
+
+    script = [RuntimeError("boom")]
+    acp_factory.queue(FakeAcpSession([script], session_id="resumed-5"))
+
+    result = await send_message(client, headers, chat)
+    message_id = result["message_id"]
+
+    task = find_background_task(chat.id)
+    with pytest.raises(RuntimeError, match="boom"):
+        await asyncio.wait_for(task, timeout=5.0)
+    await asyncio.sleep(0)
+
+    messages_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+    items = messages_response.json()["items"]
+    assistant_item = next(item for item in items if item["id"] == message_id)
+    assert assistant_item["stream_status"] == MessageStreamStatus.FAILED.value
+    events = assistant_item["content_render"]["events"]
+    assert events[-1]["type"] == "assistant_text"
+    assert "Error: boom" in events[-1]["text"]
+
+    # emit_bootstrap_error's own terminal snapshot save deletes the "error"
+    # MessageEvent row it just inserted (same terminal-cleanup path as any
+    # other stream_status transition), so no rows survive for a reconnect —
+    # only the content_render text carries the error after completion.
+    error_events_response = await client.get(
+        f"/api/v1/chat/messages/{message_id}/events", headers=headers
+    )
+    assert error_events_response.json() == []
+
+
+async def test_queued_message_is_processed_automatically_after_stream_completes(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-6")
+
+    # Two scripts on the SAME fake session: the fingerprint (model, mode,
+    # persona, system prompt) is identical across both turns, so the runtime
+    # reuses the one ACP session instead of creating a second one.
+    first_script = [StreamEvent(type="assistant_text", text="First turn done")]
+    second_script = [StreamEvent(type="assistant_text", text="Second turn done")]
+    acp_factory.queue(
+        FakeAcpSession([first_script, second_script], session_id="resumed-6")
+    )
+
+    queue_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Follow-up prompt", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    assert queue_response.status_code == 201
+
+    first_result = await send_message(client, headers, chat, prompt="First prompt")
+    first_message_id = first_result["message_id"]
+
+    await run_background_task(chat.id)
+    # Draining the queue starts a second background task in the same chain —
+    # give the loop a moment to register it before searching again.
+    await asyncio.sleep(0)
+    await run_background_task(chat.id)
+
+    queue_list_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/queue", headers=headers
+    )
+    assert queue_list_response.json() == []
+
+    messages_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+    items = messages_response.json()["items"]
+    assert len(items) == 4
+
+    first_assistant = next(item for item in items if item["id"] == first_message_id)
+    assert first_assistant["stream_status"] == MessageStreamStatus.COMPLETED.value
+
+    second_assistant = next(
+        item
+        for item in items
+        if item["role"] == "assistant" and item["id"] != first_message_id
+    )
+    assert second_assistant["stream_status"] == MessageStreamStatus.COMPLETED.value
+    assert second_assistant["content_text"] == "Second turn done"
+
+    second_user = next(
+        item
+        for item in items
+        if item["role"] == "user" and item["content_text"] == "Follow-up prompt"
+    )
+    assert second_user is not None
+
+    # The handoff event on the first message survives (it's emitted after the
+    # terminal-snapshot cleanup) and no "complete" event fires for turn one —
+    # completion is deferred to the drained follow-up turn.
+    first_events_response = await client.get(
+        f"/api/v1/chat/messages/{first_message_id}/events", headers=headers
+    )
+    first_events = first_events_response.json()
+    assert [e["event_type"] for e in first_events] == ["queue_processing"]
+    assert first_events[0]["render_payload"]["content"] == "Follow-up prompt"
+
+
+async def test_send_now_cancels_active_generation_and_starts_queued_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-7")
+
+    first_script = [StreamEvent(type="assistant_text", text="Working"), BLOCK_FOREVER]
+    second_script = [StreamEvent(type="assistant_text", text="Send-now turn done")]
+    acp_factory.queue(
+        FakeAcpSession([first_script, second_script], session_id="resumed-7")
+    )
+
+    queue_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Urgent follow-up", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    assert queue_response.status_code == 201
+    queued_id = queue_response.json()["id"]
+
+    first_result = await send_message(client, headers, chat, prompt="First prompt")
+    first_message_id = first_result["message_id"]
+    await wait_for_message_event_type(
+        client, headers, first_message_id, "stream_started"
+    )
+
+    send_now_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued_id}/send-now", headers=headers
+    )
+    assert send_now_response.status_code == 204
+
+    await run_background_task(chat.id)
+    await asyncio.sleep(0)
+    await run_background_task(chat.id)
+
+    messages_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+    items = messages_response.json()["items"]
+    first_assistant = next(item for item in items if item["id"] == first_message_id)
+    assert first_assistant["stream_status"] == MessageStreamStatus.INTERRUPTED.value
+
+    second_assistant = next(
+        item
+        for item in items
+        if item["role"] == "assistant" and item["id"] != first_message_id
+    )
+    assert second_assistant["content_text"] == "Send-now turn done"
+    assert second_assistant["stream_status"] == MessageStreamStatus.COMPLETED.value
+
+    queue_list_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/queue", headers=headers
+    )
+    assert queue_list_response.json() == []
+
+
+async def test_send_now_starts_immediately_when_chat_is_idle(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-8")
+
+    script = [StreamEvent(type="assistant_text", text="Idle send-now turn")]
+    acp_factory.queue(FakeAcpSession([script], session_id="resumed-8"))
+
+    queue_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Idle follow-up", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    queued_id = queue_response.json()["id"]
+
+    assert ChatStreamRuntime.has_active_chat(str(chat.id)) is False
+
+    send_now_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued_id}/send-now", headers=headers
+    )
+    assert send_now_response.status_code == 204
+
+    await run_background_task(chat.id)
+
+    messages_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+    items = messages_response.json()["items"]
+    assert len(items) == 2
+    assistant_item = next(item for item in items if item["role"] == "assistant")
+    assert assistant_item["content_text"] == "Idle send-now turn"
+    assert assistant_item["stream_status"] == MessageStreamStatus.COMPLETED.value
+
+    queue_list_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/queue", headers=headers
+    )
+    assert queue_list_response.json() == []
+
+
+async def test_send_now_returns_404_for_unknown_queued_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-9")
+    missing_id = UUID("00000000-0000-0000-0000-000000000042")
+
+    response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{missing_id}/send-now", headers=headers
+    )
+    assert response.status_code == 404
+
+
+async def test_active_streams_and_status_reflect_running_background_task(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-10")
+
+    script = [BLOCK_FOREVER]
+    acp_factory.queue(FakeAcpSession([script], session_id="resumed-10"))
+
+    result = await send_message(client, headers, chat)
+    message_id = result["message_id"]
+
+    active_streams_response = await client.get(
+        "/api/v1/chat/chats/active-streams", headers=headers
+    )
+    assert active_streams_response.status_code == 200
+    active_streams = active_streams_response.json()
+    assert len(active_streams) == 1
+    assert active_streams[0]["chat_id"] == str(chat.id)
+    assert active_streams[0]["message_id"] == message_id
+
+    status_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/status", headers=headers
+    )
+    assert status_response.status_code == 200
+    status_body = status_response.json()
+    assert status_body["has_active_task"] is True
+    assert status_body["message_id"] == message_id
+
+    # Clean up the still-running background task so it doesn't leak past
+    # this test (the reset fixture only clears the registry, not live tasks).
+    await wait_for_message_event_type(client, headers, message_id, "stream_started")
+    cancel_response = await client.delete(
+        f"/api/v1/chat/chats/{chat.id}/stream", headers=headers
+    )
+    assert cancel_response.status_code == 204
+    await run_background_task(chat.id)
+
+
+async def test_active_streams_is_empty_when_user_has_no_running_chats(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, _workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.get("/api/v1/chat/chats/active-streams", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_message_events_endpoint_rejects_non_owner_and_unknown_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-12")
+    other_headers, _other_user, _other_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="streaming-other@example.com",
+        username="streamingother",
+    )
+
+    script = [StreamEvent(type="assistant_text", text="Owner only")]
+    acp_factory.queue(FakeAcpSession([script], session_id="resumed-12"))
+    result = await send_message(client, headers, chat)
+    message_id = result["message_id"]
+    await run_background_task(chat.id)
+
+    owner_response = await client.get(
+        f"/api/v1/chat/messages/{message_id}/events", headers=headers
+    )
+    assert owner_response.status_code == 200
+
+    other_response = await client.get(
+        f"/api/v1/chat/messages/{message_id}/events", headers=other_headers
+    )
+    assert other_response.status_code == 404
+
+    missing_response = await client.get(
+        f"/api/v1/chat/messages/{UUID('00000000-0000-0000-0000-000000000099')}/events",
+        headers=headers,
+    )
+    assert missing_response.status_code == 404
+
+
+async def test_stream_with_no_events_raises_and_marks_message_failed(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-13")
+
+    # An empty script finishes the ACP prompt without emitting a single
+    # stream event — the runtime must treat that as a hard failure rather
+    # than silently completing.
+    acp_factory.queue(FakeAcpSession([[]], session_id="resumed-13"))
+
+    result = await send_message(client, headers, chat)
+    message_id = result["message_id"]
+
+    task = find_background_task(chat.id)
+    with pytest.raises(Exception, match="Stream completed without any events"):
+        await asyncio.wait_for(task, timeout=5.0)
+    await asyncio.sleep(0)
+
+    messages_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+    items = messages_response.json()["items"]
+    assistant_item = next(item for item in items if item["id"] == message_id)
+    assert assistant_item["stream_status"] == MessageStreamStatus.FAILED.value
+
+
+async def test_mid_stream_system_event_updates_chat_session_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-14")
+
+    script = [
+        StreamEvent(type="system", data={"session_id": "pivoted-session"}),
+        StreamEvent(type="assistant_text", text="Pivoted"),
+    ]
+    # acp_session_id stays "resumed-14" (the resumed id) — the pivot is
+    # signalled purely through the mid-stream "system" event payload, as a
+    # provider would when it hands off to a new underlying session.
+    acp_factory.queue(FakeAcpSession([script], session_id="resumed-14"))
+
+    await send_message(client, headers, chat)
+    await run_background_task(chat.id)
+
+    deadline = time.monotonic() + 2.0
+    session_id = None
+    while time.monotonic() < deadline:
+        await db_session.refresh(chat)
+        session_id = chat.session_id
+        if session_id == "pivoted-session":
+            break
+        await asyncio.sleep(0.01)
+
+    assert session_id == "pivoted-session"
+
+
+async def test_send_message_with_worktree_persists_cwd_and_emits_system_event(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-15")
+
+    script = [StreamEvent(type="assistant_text", text="Working in worktree")]
+    acp_factory.queue(FakeAcpSession([script], session_id="resumed-15"))
+
+    response = await client.post(
+        "/api/v1/chat/chat",
+        data={
+            "prompt": "Do it in a worktree",
+            "chat_id": str(chat.id),
+            "model_id": TEST_MODEL_ID,
+            "permission_mode": "bypassPermissions",
+            "worktree": "true",
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200
+    # AgentService.ensure_worktree_cwd resolves the cwd (and persists it)
+    # before the background stream even starts, so this is already set by
+    # the time initiate_chat_completion responds.
+    assert response.json()["worktree_cwd"] is not None
+
+    await run_background_task(chat.id)
+
+    await db_session.refresh(chat)
+    assert chat.worktree_cwd == response.json()["worktree_cwd"]
+
+    detail_response = await client.get(f"/api/v1/chat/chats/{chat.id}", headers=headers)
+    assert detail_response.status_code == 200
+    assert detail_response.json()["worktree_cwd"] == response.json()["worktree_cwd"]
+
+
+@pytest_asyncio.fixture
+async def live_server_url(app: FastAPI) -> AsyncIterator[str]:
+    # httpx's ASGITransport buffers the whole response before returning, so an
+    # unbounded SSE body can never be read through it — live-stream tests need
+    # a real socket server.
+    config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error")
+    server = uvicorn.Server(config)
+    serve_task = asyncio.create_task(server.serve())
+    deadline = time.monotonic() + 10.0
+    while not server.started:
+        assert time.monotonic() < deadline, "uvicorn did not start in time"
+        await asyncio.sleep(0.01)
+    port = server.servers[0].sockets[0].getsockname()[1]
+    yield f"http://127.0.0.1:{port}"
+    server.should_exit = True
+    await serve_task
+
+
+async def test_stream_sse_replays_backlog_then_delivers_live_events(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+    live_server_url: str,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-sse")
+    acp_factory.queue(
+        FakeAcpSession(
+            [[StreamEvent(type="assistant_text", text="hi")]],
+            session_id="resumed-sse",
+        )
+    )
+    result = await send_message(client, headers, chat)
+    await run_background_task(chat.id)
+
+    # asyncio.timeout turns an SSE regression into a test failure instead of a
+    # hung test run.
+    async with asyncio.timeout(15):
+        sse_client = httpx.AsyncClient(base_url=live_server_url, timeout=10.0)
+        async with (
+            sse_client,
+            sse_client.stream(
+                "GET", f"/api/v1/chat/chats/{chat.id}/stream", headers=headers
+            ) as response,
+        ):
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("text/event-stream")
+
+            envelopes: list[dict[str, Any]] = []
+            lines = response.aiter_lines()
+            async for line in lines:
+                if line.startswith("data:"):
+                    envelopes.append(json.loads(line.removeprefix("data:").strip()))
+                    break
+
+            backlog = envelopes[0]
+            assert backlog["kind"] == "complete"
+            assert backlog["chatId"] == str(chat.id)
+            assert backlog["messageId"] == result["message_id"]
+
+            # The generator only subscribes before the backlog replay, so
+            # publishing after the first read can't race the subscription.
+            live_envelope = StreamEnvelope.serialize(
+                chat_id=chat.id,
+                message_id=UUID(result["message_id"]),
+                stream_id=uuid4(),
+                seq=backlog["seq"] + 1,
+                kind="complete",
+                payload={},
+            )
+            await streaming_cache.store.publish(
+                REDIS_KEY_CHAT_STREAM_LIVE.format(chat_id=chat.id), live_envelope
+            )
+
+            # A terminal live event must close the stream server-side, ending
+            # this iteration instead of hanging on a never-finished response.
+            async for line in lines:
+                if line.startswith("data:"):
+                    envelopes.append(json.loads(line.removeprefix("data:").strip()))
+
+    assert [e["seq"] for e in envelopes] == [backlog["seq"], backlog["seq"] + 1]

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -1,28 +1,221 @@
+import asyncio
+import errno
 import json
-from typing import Any, cast
+import shlex
+from collections.abc import AsyncIterator
+from typing import Any, Callable, cast
 
 import pytest
+import pytest_asyncio
 from fastapi import WebSocket
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.websockets import WebSocketDisconnect
 
 from app.api.endpoints import websocket as websocket_endpoint
 from app.constants import (
     DEFAULT_TERMINAL_ID,
+    PTY_OUTPUT_QUEUE_SIZE,
     WS_CLOSE_AUTH_FAILED,
     WS_CLOSE_INVALID_CWD,
     WS_CLOSE_SANDBOX_NOT_FOUND,
     WS_MSG_AUTH,
+    WS_MSG_CLOSE,
     WS_MSG_DETACH,
     WS_MSG_INIT,
     WS_MSG_RESIZE,
 )
 from app.services.sandbox_providers import SandboxProviderType
+from app.services.sandbox_providers.base import SandboxProvider
+from app.services.sandbox_providers.types import (
+    CommandResult,
+    PtyDataCallbackType,
+    PtySize,
+)
 
 from tests.conftest import LoginClient, UserFactory
 from tests.helpers import create_authenticated_workspace
 
 
 pytestmark = pytest.mark.anyio
+
+
+async def wait_until(predicate: Callable[[], bool], timeout: float = 2.0) -> None:
+    # Generic polling helper for asserting on background-task side effects
+    # (PTY provider calls, forwarded websocket frames) without a fixed sleep.
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() >= deadline:
+            raise TimeoutError("condition not met before timeout")
+        await asyncio.sleep(0.01)
+
+
+class LiveFakeWebSocket:
+    # Unlike FakeWebSocket (a static frame list), this queues frames so a
+    # test can push auth/control/input frames while the endpoint coroutine
+    # is already running as a background task — needed to interleave PTY
+    # output arriving mid-connection with client frames.
+    def __init__(
+        self,
+        query_params: dict[str, str] | None = None,
+        close_error: OSError | None = None,
+    ) -> None:
+        self.query_params = query_params or {}
+        self.accepted = False
+        self.sent_text: list[str] = []
+        self.close_code: int | None = None
+        self.close_reason: str | None = None
+        self._frames: "asyncio.Queue[dict[str, Any]]" = asyncio.Queue()
+        self._close_error = close_error
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive(self) -> dict[str, Any]:
+        frame = await self._frames.get()
+        if "__disconnect__" in frame:
+            raise WebSocketDisconnect()
+        return frame
+
+    async def send_text(self, payload: str) -> None:
+        self.sent_text.append(payload)
+
+    async def close(self, code: int = 1000, reason: str | None = None) -> None:
+        self.close_code = code
+        self.close_reason = reason
+        if self._close_error is not None:
+            raise self._close_error
+
+    def push_text(self, payload: str) -> None:
+        self._frames.put_nowait({"text": payload})
+
+    def push_bytes(self, data: bytes) -> None:
+        self._frames.put_nowait({"bytes": data})
+
+    def push_raw(self, frame: dict[str, Any]) -> None:
+        self._frames.put_nowait(frame)
+
+    def push_disconnect(self) -> None:
+        self._frames.put_nowait({"__disconnect__": True})
+
+
+class FakePtySandboxProvider(SandboxProvider):
+    # Real TerminalSessionRegistry/TerminalSessionRecord run against this —
+    # unlike FakeSandboxProvider (static pty-1 id, no on_data callback
+    # tracking), this records every pty lifecycle call and lets tests drive
+    # PTY output by invoking the registered on_data callback directly.
+    def __init__(self) -> None:
+        self._workspace_root = "/tmp/agentrove-pty-test"
+        self._pty_sessions: dict[str, dict[str, Any]] = {}
+        self.on_data_callbacks: dict[str, PtyDataCallbackType] = {}
+        self.created_ptys: list[tuple[str, str, int, int, str, str]] = []
+        self.sent_inputs: list[tuple[str, str, bytes]] = []
+        self.resizes: list[tuple[str, str, PtySize]] = []
+        self.killed: list[tuple[str, str]] = []
+        self.executed_commands: list[tuple[str, str]] = []
+        self._counter = 0
+
+    @property
+    def workspace_root(self) -> str:
+        return self._workspace_root
+
+    async def create_sandbox(self, workspace_path: str | None = None) -> str:
+        return "sandbox-1"
+
+    async def delete_sandbox(self, sandbox_id: str) -> None:
+        return None
+
+    async def create_pty(
+        self,
+        sandbox_id: str,
+        rows: int,
+        cols: int,
+        tmux_session: str,
+        cwd: str,
+        on_data: PtyDataCallbackType,
+    ) -> str:
+        self._counter += 1
+        pty_id = f"pty-{self._counter}"
+        self.on_data_callbacks[pty_id] = on_data
+        self.created_ptys.append((pty_id, sandbox_id, rows, cols, tmux_session, cwd))
+        self.register_pty_session(sandbox_id, pty_id, {})
+        return pty_id
+
+    async def send_pty_input(self, sandbox_id: str, pty_id: str, data: bytes) -> None:
+        self.sent_inputs.append((sandbox_id, pty_id, data))
+
+    async def resize_pty(self, sandbox_id: str, pty_id: str, size: PtySize) -> None:
+        self.resizes.append((sandbox_id, pty_id, size))
+
+    async def kill_pty(self, sandbox_id: str, pty_id: str) -> None:
+        self.killed.append((sandbox_id, pty_id))
+        self.cleanup_pty_session_tracking(sandbox_id, pty_id)
+
+    async def execute_command(
+        self,
+        sandbox_id: str,
+        command: str,
+        envs: dict[str, str] | None = None,
+        timeout: int = 120,
+    ) -> CommandResult:
+        self.executed_commands.append((sandbox_id, command))
+        return CommandResult(stdout="", stderr="", exit_code=0)
+
+
+class FailingPtySandboxProvider(FakePtySandboxProvider):
+    # Exercises SandboxService's own error handling (send_pty_input /
+    # resize_pty_session / cleanup_pty_session) — every pty operation is
+    # attempted (recorded) and then raises, so the terminal session must
+    # keep running instead of crashing the websocket connection.
+    async def send_pty_input(self, sandbox_id: str, pty_id: str, data: bytes) -> None:
+        self.sent_inputs.append((sandbox_id, pty_id, data))
+        raise RuntimeError("send failed")
+
+    async def resize_pty(self, sandbox_id: str, pty_id: str, size: PtySize) -> None:
+        self.resizes.append((sandbox_id, pty_id, size))
+        raise RuntimeError("resize failed")
+
+    async def kill_pty(self, sandbox_id: str, pty_id: str) -> None:
+        self.killed.append((sandbox_id, pty_id))
+        raise OSError("kill failed")
+
+
+class FakePtyProviderFactory:
+    def __init__(self, provider: SandboxProvider) -> None:
+        self.provider = provider
+
+    def __call__(
+        self,
+        provider_type: SandboxProviderType | str,
+        workspace_path: str | None = None,
+    ) -> SandboxProvider:
+        return self.provider
+
+
+@pytest_asyncio.fixture
+async def pty_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[FakePtySandboxProvider]:
+    provider = FakePtySandboxProvider()
+    monkeypatch.setattr(
+        SandboxProvider, "create_provider", FakePtyProviderFactory(provider)
+    )
+    yield provider
+    # Real TerminalSessionRecord tasks are bound to this test's event loop —
+    # tear them all down so a lingering task doesn't leak into the next test.
+    await websocket_endpoint.terminal_session_registry.terminate_all()
+
+
+@pytest_asyncio.fixture
+async def failing_pty_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[FailingPtySandboxProvider]:
+    provider = FailingPtySandboxProvider()
+    monkeypatch.setattr(
+        SandboxProvider, "create_provider", FakePtyProviderFactory(provider)
+    )
+    yield provider
+    await websocket_endpoint.terminal_session_registry.terminate_all()
 
 
 class FakeWebSocket:
@@ -253,3 +446,433 @@ async def test_terminal_websocket_uses_default_terminal_id(
     await run_terminal_websocket(websocket, workspace.sandbox_id)
 
     assert registry.calls[0]["terminal_id"] == DEFAULT_TERMINAL_ID
+
+
+async def test_terminal_websocket_real_session_lifecycle(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    # Runs the real TerminalSessionRegistry/TerminalSessionRecord against
+    # FakePtySandboxProvider — attach, input queueing, resize, PTY output
+    # forwarding, and terminate (pty kill + tmux kill-session).
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-lifecycle@example.com",
+        username="ptylifecycle",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    websocket = LiveFakeWebSocket(query_params={"terminalId": "term-live"})
+    task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, websocket), workspace.sandbox_id
+        )
+    )
+
+    websocket.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    websocket.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 30, "cols": 100}))
+    await wait_until(lambda: len(websocket.sent_text) >= 1)
+
+    init_payload = json.loads(websocket.sent_text[0])
+    assert init_payload["type"] == WS_MSG_INIT
+    pty_id = init_payload["id"]
+    assert len(pty_provider.created_ptys) == 1
+    _pty_id, _sandbox_id, rows, cols, tmux_session, cwd = pty_provider.created_ptys[0]
+    assert (rows, cols, cwd) == (30, 100, "")
+    expected_tmux = f"agentrove_{workspace.sandbox_id.replace('-', '_')}_term_live"
+    assert tmux_session == expected_tmux
+
+    websocket.push_bytes(b"echo hi\n")
+    await wait_until(lambda: len(pty_provider.sent_inputs) >= 1)
+    assert pty_provider.sent_inputs == [(workspace.sandbox_id, pty_id, b"echo hi\n")]
+
+    websocket.push_text(json.dumps({"type": WS_MSG_RESIZE, "rows": 40, "cols": 120}))
+    await wait_until(lambda: len(pty_provider.resizes) >= 1)
+    assert pty_provider.resizes == [
+        (workspace.sandbox_id, pty_id, PtySize(rows=40, cols=120))
+    ]
+
+    await pty_provider.on_data_callbacks[pty_id](b"hello from pty")
+    await wait_until(lambda: len(websocket.sent_text) >= 2)
+    assert json.loads(websocket.sent_text[1]) == {
+        "type": "stdout",
+        "data": "hello from pty",
+    }
+
+    websocket.push_text(json.dumps({"type": WS_MSG_CLOSE}))
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert pty_provider.killed == [(workspace.sandbox_id, pty_id)]
+    assert any(
+        f"tmux kill-session -t {shlex.quote(expected_tmux)}" in cmd
+        for _sid, cmd in pty_provider.executed_commands
+    )
+    assert websocket.close_code == 1000
+
+
+async def test_terminal_websocket_buffered_output_replays_on_reconnect(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-reconnect@example.com",
+        username="ptyreconnect",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+
+    first_ws = LiveFakeWebSocket(query_params={"terminalId": "term-r"})
+    first_task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, first_ws), workspace.sandbox_id
+        )
+    )
+    first_ws.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    first_ws.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(first_ws.sent_text) >= 1)
+    pty_id = json.loads(first_ws.sent_text[0])["id"]
+
+    first_ws.push_text(json.dumps({"type": WS_MSG_DETACH}))
+    await asyncio.wait_for(first_task, timeout=2.0)
+
+    # Output arrives while nobody is attached — it must be buffered, not
+    # dropped, and replayed as one batched frame on the next attach.
+    await pty_provider.on_data_callbacks[pty_id](b"buffered-1 ")
+    await pty_provider.on_data_callbacks[pty_id](b"buffered-2")
+
+    second_ws = LiveFakeWebSocket(query_params={"terminalId": "term-r"})
+    second_task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, second_ws), workspace.sandbox_id
+        )
+    )
+    second_ws.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    second_ws.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(second_ws.sent_text) >= 2)
+
+    assert json.loads(second_ws.sent_text[0])["id"] == pty_id
+    assert json.loads(second_ws.sent_text[1]) == {
+        "type": "stdout",
+        "data": "buffered-1 buffered-2",
+    }
+    assert len(pty_provider.created_ptys) == 1
+    # Reattaching an already-started session (is_reattach) repaints via tmux.
+    assert any(
+        "tmux refresh-client" in cmd for _sid, cmd in pty_provider.executed_commands
+    )
+
+    second_ws.push_text(json.dumps({"type": WS_MSG_CLOSE}))
+    await asyncio.wait_for(second_task, timeout=2.0)
+
+
+async def test_terminal_websocket_input_and_resize_before_init_are_noops(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-noop@example.com",
+        username="ptynoop",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    websocket = LiveFakeWebSocket(query_params={"terminalId": "term-noop"})
+    task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, websocket), workspace.sandbox_id
+        )
+    )
+
+    websocket.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    # Bytes and resize arrive before INIT — the session record exists (via
+    # get_or_create) but has no pty yet, so both must be silently dropped.
+    websocket.push_bytes(b"too-early")
+    websocket.push_text(json.dumps({"type": WS_MSG_RESIZE, "rows": 10, "cols": 10}))
+    websocket.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(websocket.sent_text) >= 1)
+
+    assert pty_provider.sent_inputs == []
+    assert pty_provider.resizes == []
+    assert len(pty_provider.created_ptys) == 1
+
+    websocket.push_text(json.dumps({"type": WS_MSG_CLOSE}))
+    await asyncio.wait_for(task, timeout=2.0)
+
+
+async def test_terminal_registry_scopes_sessions_by_cwd(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-cwd@example.com",
+        username="ptycwd",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+
+    root_ws = LiveFakeWebSocket(query_params={"terminalId": "term-shared"})
+    root_task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, root_ws), workspace.sandbox_id
+        )
+    )
+    root_ws.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    root_ws.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(root_ws.sent_text) >= 1)
+    root_pty_id = json.loads(root_ws.sent_text[0])["id"]
+    root_ws.push_text(json.dumps({"type": WS_MSG_DETACH}))
+    await asyncio.wait_for(root_task, timeout=2.0)
+
+    worktree_ws = LiveFakeWebSocket(
+        query_params={"terminalId": "term-shared", "cwd": ".worktrees/abc12345"}
+    )
+    worktree_task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, worktree_ws), workspace.sandbox_id
+        )
+    )
+    worktree_ws.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    worktree_ws.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(worktree_ws.sent_text) >= 1)
+    worktree_ws.push_text(json.dumps({"type": WS_MSG_CLOSE}))
+    await asyncio.wait_for(worktree_task, timeout=2.0)
+
+    # Same terminal_id, different cwd — must be a distinct pty/tmux session.
+    assert len(pty_provider.created_ptys) == 2
+    root_tmux = pty_provider.created_ptys[0][4]
+    worktree_tmux = pty_provider.created_ptys[1][4]
+    assert root_tmux != worktree_tmux
+    assert worktree_tmux == (
+        f"agentrove_{workspace.sandbox_id.replace('-', '_')}_term_shared"
+        "__worktrees_abc12345"
+    )
+
+    root_ws2 = LiveFakeWebSocket(query_params={"terminalId": "term-shared"})
+    root_task2 = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, root_ws2), workspace.sandbox_id
+        )
+    )
+    root_ws2.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    root_ws2.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(root_ws2.sent_text) >= 1)
+
+    # Reattaching to the root-cwd terminal reuses the original pty — no
+    # third pty gets created.
+    assert json.loads(root_ws2.sent_text[0])["id"] == root_pty_id
+    assert len(pty_provider.created_ptys) == 2
+
+    root_ws2.push_text(json.dumps({"type": WS_MSG_CLOSE}))
+    await asyncio.wait_for(root_task2, timeout=2.0)
+
+
+async def test_terminal_websocket_new_attach_closes_stale_websocket(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-steal@example.com",
+        username="ptysteal",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+
+    first_ws = LiveFakeWebSocket(query_params={"terminalId": "term-steal"})
+    first_task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, first_ws), workspace.sandbox_id
+        )
+    )
+    first_ws.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    first_ws.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(first_ws.sent_text) >= 1)
+
+    second_ws = LiveFakeWebSocket(query_params={"terminalId": "term-steal"})
+    second_task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, second_ws), workspace.sandbox_id
+        )
+    )
+    second_ws.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    second_ws.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: first_ws.close_code is not None)
+
+    # attach() force-closes the previous connection's websocket when a new
+    # one attaches to the same session without a clean detach first.
+    assert first_ws.close_code == 1000
+    assert len(pty_provider.created_ptys) == 1
+
+    # The first task's own receive loop is still parked on `receive()` since
+    # our fake doesn't simulate a real disconnect — detach it manually so
+    # the test ends deterministically instead of waiting for the ping timeout.
+    first_ws.push_text(json.dumps({"type": WS_MSG_DETACH}))
+    await asyncio.wait_for(first_task, timeout=2.0)
+
+    second_ws.push_text(json.dumps({"type": WS_MSG_CLOSE}))
+    await asyncio.wait_for(second_task, timeout=2.0)
+
+
+async def test_terminal_websocket_output_queue_drops_oldest_when_full(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-overflow@example.com",
+        username="ptyoverflow",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+
+    websocket = LiveFakeWebSocket(query_params={"terminalId": "term-overflow"})
+    task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, websocket), workspace.sandbox_id
+        )
+    )
+    websocket.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    websocket.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(websocket.sent_text) >= 1)
+    pty_id = json.loads(websocket.sent_text[0])["id"]
+
+    websocket.push_text(json.dumps({"type": WS_MSG_DETACH}))
+    await asyncio.wait_for(task, timeout=2.0)
+
+    # Fill the output queue (PTY_OUTPUT_QUEUE_SIZE) well past capacity while
+    # nobody is attached to drain it — must drop the oldest entries rather
+    # than block or grow unbounded.
+    on_data = pty_provider.on_data_callbacks[pty_id]
+    for i in range(PTY_OUTPUT_QUEUE_SIZE + 20):
+        await on_data(f"{i}\n".encode())
+
+    reconnect_ws = LiveFakeWebSocket(query_params={"terminalId": "term-overflow"})
+    reconnect_task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, reconnect_ws), workspace.sandbox_id
+        )
+    )
+    reconnect_ws.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    reconnect_ws.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(reconnect_ws.sent_text) >= 2)
+
+    replayed = json.loads(reconnect_ws.sent_text[1])["data"]
+    replayed_numbers = replayed.strip().split("\n")
+    assert "0" not in replayed_numbers
+    assert str(PTY_OUTPUT_QUEUE_SIZE + 19) in replayed_numbers
+
+    reconnect_ws.push_text(json.dumps({"type": WS_MSG_CLOSE}))
+    await asyncio.wait_for(reconnect_task, timeout=2.0)
+
+
+async def test_terminal_websocket_survives_provider_pty_errors(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    failing_pty_provider: FailingPtySandboxProvider,
+) -> None:
+    # SandboxService.send_pty_input/resize_pty_session/cleanup_pty_session
+    # each catch provider errors and log rather than propagate — the
+    # terminal connection must keep working through input, resize, and a
+    # clean close even when every underlying pty call fails.
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-errors@example.com",
+        username="ptyerrors",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    websocket = LiveFakeWebSocket(query_params={"terminalId": "term-errors"})
+    task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, websocket), workspace.sandbox_id
+        )
+    )
+
+    websocket.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    websocket.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(websocket.sent_text) >= 1)
+
+    websocket.push_bytes(b"echo hi\n")
+    await wait_until(lambda: len(failing_pty_provider.sent_inputs) >= 1)
+    # send_pty_input's failure path calls cleanup_pty_session -> kill_pty.
+    await wait_until(lambda: len(failing_pty_provider.killed) >= 1)
+
+    websocket.push_text(json.dumps({"type": WS_MSG_RESIZE, "rows": 40, "cols": 100}))
+    await wait_until(lambda: len(failing_pty_provider.resizes) >= 1)
+
+    websocket.push_text(json.dumps({"type": WS_MSG_CLOSE}))
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert websocket.close_code == 1000
+    # terminate()'s own cleanup_pty_session call means kill_pty was attempted
+    # at least twice (once from the input failure, once from close()).
+    assert len(failing_pty_provider.killed) >= 2
+
+
+async def test_terminal_websocket_ignores_malformed_frames_and_handles_disconnect(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    # Malformed control frames (no text/bytes key, non-dict JSON, dict with
+    # no "type") must be silently skipped, and an abrupt client disconnect
+    # (WebSocketDisconnect from receive()) must be handled gracefully rather
+    # than propagating out of the endpoint — including a close() that itself
+    # raises a non-EPIPE OSError during the best-effort final close.
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-malformed@example.com",
+        username="ptymalformed",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    websocket = LiveFakeWebSocket(
+        query_params={"terminalId": "term-malformed"},
+        close_error=OSError(errno.ECONNRESET, "connection reset"),
+    )
+    task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, websocket), workspace.sandbox_id
+        )
+    )
+
+    websocket.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    websocket.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(websocket.sent_text) >= 1)
+
+    websocket.push_raw({})
+    websocket.push_raw({"text": "[1, 2, 3]"})
+    websocket.push_raw({"text": json.dumps({"no_type": "here"})})
+    websocket.push_disconnect()
+
+    await asyncio.wait_for(task, timeout=2.0)
+
+    # Session stayed alive through the junk frames — only one pty, never
+    # torn down by a bad frame — and the final close was attempted despite
+    # raising.
+    assert len(pty_provider.created_ptys) == 1
+    assert websocket.close_code == 1000

--- a/backend/tests/test_workspace.py
+++ b/backend/tests/test_workspace.py
@@ -1,14 +1,20 @@
+import asyncio
 from pathlib import Path
 from typing import Any
 from uuid import UUID
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import get_settings
+from app.models.db_models.chat import Chat, Message
+from app.models.db_models.enums import MessageRole, MessageStreamStatus
+from app.services import workspace as workspace_module
 from app.services.sandbox_providers.base import SandboxProvider
 
 from tests.conftest import LoginClient, UserFactory
-from tests.helpers import FakeProviderFactory
+from tests.helpers import FakeProviderFactory, get_user_by_email, get_user_settings
 
 
 pytestmark = pytest.mark.anyio
@@ -17,6 +23,56 @@ pytestmark = pytest.mark.anyio
 @pytest.fixture
 def workspace_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(SandboxProvider, "create_provider", FakeProviderFactory())
+
+
+class FakeGitProcess:
+    def __init__(
+        self, returncode: int, stdout: bytes, stderr: bytes, *, hang: bool = False
+    ) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._hang = hang
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        # `hang` simulates a clone that never finishes so the caller's
+        # asyncio.wait_for(...) deadline (patched short in tests) fires first.
+        if self._hang:
+            await asyncio.sleep(1)
+        return self._stdout, self._stderr
+
+    def kill(self) -> None:
+        return None
+
+    async def wait(self) -> None:
+        return None
+
+
+class FakeGitClone:
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        stderr: bytes = b"",
+        hang: bool = False,
+    ) -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.hang = hang
+        self.calls: list[tuple[tuple[str, ...], dict[str, str] | None]] = []
+
+    async def __call__(
+        self,
+        *args: str,
+        stdout: int,
+        stderr: int,
+        env: dict[str, str] | None = None,
+    ) -> FakeGitProcess:
+        self.calls.append((args, env))
+        # Real `git clone` creates the target dir; mirror that so the rest of
+        # create_workspace (which persists workspace_path) behaves realistically.
+        Path(args[-1]).mkdir(parents=True, exist_ok=True)
+        return FakeGitProcess(self.returncode, b"", self.stderr, hang=self.hang)
 
 
 async def create_authenticated_workspace(
@@ -230,3 +286,402 @@ async def test_workspaces_reject_missing_token(client: AsyncClient) -> None:
     assert list_response.status_code == 401
     assert create_response.status_code == 401
     assert get_response.status_code == 401
+
+
+async def test_create_workspace_from_local_path_succeeds(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+    tmp_path: Path,
+) -> None:
+    await create_user(email="local-workspace@example.com", username="localworkspace")
+    tokens = await login(email="local-workspace@example.com")
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "Local Workspace",
+            "source_type": "local",
+            "workspace_path": str(tmp_path),
+            "sandbox_provider": "host",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["source_type"] == "local"
+    assert body["source_url"] is None
+    assert body["workspace_path"] == str(tmp_path.resolve())
+
+
+async def test_create_workspace_local_rejects_missing_and_nonexistent_path(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+    tmp_path: Path,
+) -> None:
+    await create_user(email="local-invalid@example.com", username="localinvalid")
+    tokens = await login(email="local-invalid@example.com")
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    missing_response = await client.post(
+        "/api/v1/workspaces",
+        json={"name": "No Path", "source_type": "local", "sandbox_provider": "host"},
+        headers=headers,
+    )
+    nonexistent_response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "Bad Path",
+            "source_type": "local",
+            "workspace_path": str(tmp_path / "does-not-exist"),
+            "sandbox_provider": "host",
+        },
+        headers=headers,
+    )
+
+    assert missing_response.status_code == 400
+    assert (
+        missing_response.json()["detail"]
+        == "workspace_path is required for local workspace"
+    )
+    assert nonexistent_response.status_code == 400
+    assert (
+        nonexistent_response.json()["detail"]
+        == "workspace_path must be an existing directory"
+    )
+
+
+async def test_create_workspace_clones_https_repo_with_github_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Desktop mode ignores the stored PAT and uses host git credentials instead —
+    # force server mode so this test exercises the GIT_ASKPASS token path
+    # regardless of the DESKTOP_MODE value inherited from the host shell.
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    await create_user(email="git-https@example.com", username="githttps")
+    tokens = await login(email="git-https@example.com")
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    user = await get_user_by_email(db_session, "git-https@example.com")
+    assert user is not None
+    user_settings = await get_user_settings(db_session, user.id)
+    assert user_settings is not None
+    user_settings.github_personal_access_token = "super-secret-token"
+    await db_session.commit()
+
+    fake_clone = FakeGitClone()
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_clone)
+
+    response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "Https Clone",
+            "source_type": "git",
+            "git_url": "https://github.com/agentrove/app.git",
+            "sandbox_provider": "host",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["source_type"] == "git"
+    assert body["source_url"] == "https://github.com/agentrove/app.git"
+    assert Path(body["workspace_path"]).name.startswith("app-")
+
+    assert len(fake_clone.calls) == 1
+    args, env = fake_clone.calls[0]
+    assert args[:6] == (
+        "git",
+        "clone",
+        "--depth",
+        "1",
+        "--no-single-branch",
+        "https://github.com/agentrove/app.git",
+    )
+    assert env is not None
+    assert env["GIT_PASSWORD"] == "super-secret-token"
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    askpass_path = env["GIT_ASKPASS"]
+    # The askpass helper script is a one-shot temp file — cleaned up in the
+    # `finally` block once the clone finishes.
+    assert not Path(askpass_path).exists()
+
+
+async def test_create_workspace_clones_ssh_repo_without_token(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await create_user(email="git-ssh@example.com", username="gitssh")
+    tokens = await login(email="git-ssh@example.com")
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    fake_clone = FakeGitClone()
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_clone)
+
+    response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "Ssh Clone",
+            "source_type": "git",
+            "git_url": "git@github.com:agentrove/app.git",
+            "sandbox_provider": "host",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["source_url"] == "git@github.com:agentrove/app.git"
+    assert Path(body["workspace_path"]).name.startswith("app-")
+    _args, env = fake_clone.calls[0]
+    assert env is None
+
+
+async def test_create_workspace_git_clone_timeout_returns_400(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await create_user(email="git-timeout@example.com", username="gittimeout")
+    tokens = await login(email="git-timeout@example.com")
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    monkeypatch.setattr(workspace_module, "GIT_CLONE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", FakeGitClone(hang=True))
+
+    response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "Timeout Clone",
+            "source_type": "git",
+            "git_url": "https://github.com/agentrove/app.git",
+            "sandbox_provider": "host",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Git clone timed out"
+
+
+async def test_create_workspace_git_clone_failure_masks_token_in_error(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    await create_user(email="git-failure@example.com", username="gitfailure")
+    tokens = await login(email="git-failure@example.com")
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    user = await get_user_by_email(db_session, "git-failure@example.com")
+    assert user is not None
+    user_settings = await get_user_settings(db_session, user.id)
+    assert user_settings is not None
+    user_settings.github_personal_access_token = "leaky-token"
+    await db_session.commit()
+
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        FakeGitClone(
+            returncode=128,
+            stderr=b"fatal: authentication failed for leaky-token\n",
+        ),
+    )
+
+    response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "Failed Clone",
+            "source_type": "git",
+            "git_url": "https://github.com/agentrove/app.git",
+            "sandbox_provider": "host",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "leaky-token" not in detail
+    assert "***" in detail
+
+
+async def test_create_workspace_rejects_invalid_git_url_shapes(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+) -> None:
+    await create_user(email="git-invalid@example.com", username="gitinvalid")
+    tokens = await login(email="git-invalid@example.com")
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    blank_response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "Blank Url",
+            "source_type": "git",
+            "git_url": "   ",
+            "sandbox_provider": "host",
+        },
+        headers=headers,
+    )
+    non_https_response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "Ftp Url",
+            "source_type": "git",
+            "git_url": "ftp://example.com/repo.git",
+            "sandbox_provider": "host",
+        },
+        headers=headers,
+    )
+    embedded_creds_response = await client.post(
+        "/api/v1/workspaces",
+        json={
+            "name": "Creds Url",
+            "source_type": "git",
+            "git_url": "https://user:pass@github.com/agentrove/app.git",
+            "sandbox_provider": "host",
+        },
+        headers=headers,
+    )
+
+    assert blank_response.status_code == 400
+    assert blank_response.json()["detail"] == "git_url is required for git workspace"
+    assert non_https_response.status_code == 400
+    assert (
+        non_https_response.json()["detail"]
+        == "git_url must be an HTTPS or git@... SSH URL"
+    )
+    assert embedded_creds_response.status_code == 400
+    assert (
+        embedded_creds_response.json()["detail"]
+        == "git_url must not contain embedded credentials"
+    )
+
+
+async def test_delete_workspace_soft_deletes_its_chats_and_messages(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+) -> None:
+    headers, workspace = await create_authenticated_workspace(
+        client,
+        create_user,
+        login,
+        email="delete-with-chats@example.com",
+        username="deletewithchats",
+    )
+    user = await get_user_by_email(db_session, "delete-with-chats@example.com")
+    assert user is not None
+    workspace_id = workspace["id"]
+
+    chat = Chat(title="Doomed Chat", user_id=user.id, workspace_id=UUID(workspace_id))
+    db_session.add(chat)
+    await db_session.flush()
+    message = Message(
+        chat_id=chat.id,
+        content_text="Hello",
+        content_render={"events": [{"type": "user_text", "text": "Hello"}]},
+        role=MessageRole.USER,
+        stream_status=MessageStreamStatus.COMPLETED,
+    )
+    db_session.add(message)
+    await db_session.commit()
+    await db_session.refresh(chat)
+    await db_session.refresh(message)
+
+    response = await client.delete(
+        f"/api/v1/workspaces/{workspace_id}", headers=headers
+    )
+
+    assert response.status_code == 204
+    await db_session.refresh(chat)
+    await db_session.refresh(message)
+    assert chat.deleted_at is not None
+    assert message.deleted_at is not None
+
+
+async def test_update_workspace_rejects_missing_or_foreign_workspace(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+) -> None:
+    owner_headers, workspace = await create_authenticated_workspace(
+        client,
+        create_user,
+        login,
+        email="update-owner@example.com",
+        username="updateowner",
+    )
+    await create_user(email="update-other@example.com", username="updateother")
+    other_tokens = await login(email="update-other@example.com")
+    other_headers = {"Authorization": f"Bearer {other_tokens['access_token']}"}
+    missing_id = UUID("00000000-0000-0000-0000-000000000002")
+
+    missing_response = await client.patch(
+        f"/api/v1/workspaces/{missing_id}",
+        json={"name": "New Name"},
+        headers=owner_headers,
+    )
+    foreign_response = await client.patch(
+        f"/api/v1/workspaces/{workspace['id']}",
+        json={"name": "New Name"},
+        headers=other_headers,
+    )
+
+    assert missing_response.status_code == 404
+    assert foreign_response.status_code == 404
+
+
+async def test_delete_workspace_rejects_missing_or_foreign_workspace(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+) -> None:
+    owner_headers, workspace = await create_authenticated_workspace(
+        client,
+        create_user,
+        login,
+        email="delete-owner@example.com",
+        username="deleteowner",
+    )
+    await create_user(email="delete-other@example.com", username="deleteother")
+    other_tokens = await login(email="delete-other@example.com")
+    other_headers = {"Authorization": f"Bearer {other_tokens['access_token']}"}
+    missing_id = UUID("00000000-0000-0000-0000-000000000003")
+
+    missing_response = await client.delete(
+        f"/api/v1/workspaces/{missing_id}", headers=owner_headers
+    )
+    foreign_response = await client.delete(
+        f"/api/v1/workspaces/{workspace['id']}", headers=other_headers
+    )
+
+    assert missing_response.status_code == 404
+    assert foreign_response.status_code == 404


### PR DESCRIPTION
## Summary
- Grow the backend suite from 86 tests / 55% coverage to **300 tests / 88% coverage**, all behavior-driven through real HTTP/WebSocket/SSE routes against the real app and an isolated test DB — zero `unittest.mock`; hand-written fakes exist only at true external boundaries (a scripted stdio ACP agent the real client spawns, a scripted GitHub HTTP transport, SMTP capture, fake sandbox providers, in-memory cache instead of Redis).
- New test files: `test_acp.py` + `fake_acp_agent.py` (real ACP client/session/adapters over a fake agent binary), `test_streaming.py` (SSE pipeline, permissions, cancel, queue drain), `test_automations.py`, `test_infra.py` (app wiring, admin, maintenance); substantial extensions to the existing chat/github/auth/settings/sandbox/websocket/workspace/skills/attachments tests.

## Bugs fixed (each caught by a new test)
- **ACP `terminal/output` stub** (`acp/client.py`): response omitted the schema-required `truncated` field, so any agent calling it had its whole turn aborted with "Invalid params".
- **SSE disconnect leak** (`core/middleware.py`): `BaseHTTPMiddleware` never propagates `http.disconnect` to `EventSourceResponse`, so every disconnected SSE client left its stream generator (and DB session) running forever. Both custom middlewares are now pure ASGI. Verified by a new end-to-end test that boots a real uvicorn server (httpx `ASGITransport` buffers whole responses and can't read unbounded SSE bodies), replays the backlog, receives a live pub/sub event, and observes the stream close on the terminal event.
- **Admin user creation broken**: the installed sqladmin ignores `form_extra_fields`, so the create-user form rendered without a password field and 500'd on `NOT NULL hashed_password`. The field is now grafted in a `scaffold_form` override; a test creates a user through `/admin/user/create` and verifies the stored hash.
- **Skill plugin discovery leaked server state**: `_get_claude_plugin_skill_paths` always read the server process's own `~/.claude`, injecting the host's plugin config into every user's skill list in server mode. It now uses the same mode-dependent base dir as the rest of skill discovery.

## Dead code removed
- `EncryptedJSON` column type (`db/types.py`) — unused anywhere.
- `StorageService.save_file`'s `attachment_id` parameter and both its branches — no caller ever passed it.

## Remaining uncovered (~12%), by design
`docker_provider.py` needs a live Docker daemon (covering it would mean faking the entire aiodocker API), host-provider pty/tmux paths, Redis-connected cache internals, and defensive teardown branches in the streaming/ACP session layer — all only reachable by mocking internal collaborators, which this suite deliberately avoids.

## Verification
- `pytest tests` → 300 passed, twice consecutively (deterministic, ~2 min)
- `ruff check` / `ruff format --check` / `mypy app/` clean with CI's pinned versions