### PR TITLE
fix: release pooled DB connection before SSE/file responses stream

### DIFF
--- a/backend/app/api/endpoints/attachments.py
+++ b/backend/app/api/endpoints/attachments.py
@@ -18,12 +18,18 @@ router = APIRouter()
 async def preview_temp_attachment(
     path: str,
     current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
     attachment_service: AttachmentService = Depends(get_attachment_service),
 ) -> FileResponse:
     try:
-        return await attachment_service.get_temp_preview(path, current_user.id)
+        response = await attachment_service.get_temp_preview(path, current_user.id)
     except AttachmentException as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+    # The file body streams after the handler returns while yield deps stay
+    # open — release the auth chain's session so a slow download doesn't pin
+    # a pooled DB connection.
+    await db.close()
+    return response
 
 
 @router.get("/attachments/{attachment_id}/preview")
@@ -34,9 +40,14 @@ async def preview_attachment(
     attachment_service: AttachmentService = Depends(get_attachment_service),
 ) -> FileResponse:
     try:
-        return await attachment_service.get_preview(attachment_id, current_user.id, db)
+        response = await attachment_service.get_preview(
+            attachment_id, current_user.id, db
+        )
     except AttachmentException as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+    # Release before the body streams — see preview_temp_attachment.
+    await db.close()
+    return response
 
 
 @router.get("/attachments/{attachment_id}/download")
@@ -47,6 +58,11 @@ async def download_attachment(
     attachment_service: AttachmentService = Depends(get_attachment_service),
 ) -> FileResponse:
     try:
-        return await attachment_service.get_download(attachment_id, current_user.id, db)
+        response = await attachment_service.get_download(
+            attachment_id, current_user.id, db
+        )
     except AttachmentException as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+    # Release before the body streams — see preview_temp_attachment.
+    await db.close()
+    return response

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -16,6 +16,7 @@ from fastapi import (
     status,
 )
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette.sse import EventSourceResponse
 
 from app.constants import (
@@ -31,6 +32,7 @@ from app.core.deps import (
     get_queue_service,
 )
 from app.core.security import get_current_user
+from app.db.session import get_db
 from app.models.db_models.chat import Chat
 from app.models.db_models.user import User
 from app.models.types import MessageAttachmentDict, PermissionMode
@@ -286,10 +288,15 @@ async def get_active_streams(
 async def stream_user_chat_events(
     current_user: User = Depends(get_current_user),
     chat_service: ChatService = Depends(get_chat_service),
+    db: AsyncSession = Depends(get_db),
 ) -> EventSourceResponse:
     # Global per-user feed of chat lifecycle events (chats created / turns started
     # out-of-band, e.g. via MCP). Declared before /chats/{chat_id} so "events"
     # isn't parsed as a UUID.
+    # `db` is the same cached session the auth chain used; FastAPI keeps yield
+    # deps open until the response finishes, so a long-lived SSE connection would
+    # pin its pooled DB connection until disconnect. Auth is done — release it.
+    await db.close()
     return EventSourceResponse(
         chat_service.create_chat_events_stream(current_user.id),
         headers={
@@ -447,6 +454,7 @@ async def stream_events(
     request: Request,
     _chat: Chat = Depends(ensure_chat_access),
     chat_service: ChatService = Depends(get_chat_service),
+    db: AsyncSession = Depends(get_db),
 ) -> EventSourceResponse:
     # Browser EventSource reconnects send the current cursor via Last-Event-ID.
     # Keep query-param baseline support and use whichever is more advanced.
@@ -455,6 +463,10 @@ async def stream_events(
         parse_non_negative_seq(request.headers.get("Last-Event-ID")),
     )
 
+    # Access checks are done; release the request session (shared with the auth
+    # chain via the dependency cache) so this SSE stream doesn't pin a pooled DB
+    # connection for its whole lifetime — the generator opens its own sessions.
+    await db.close()
     return EventSourceResponse(
         chat_service.create_event_stream(chat_id, after_seq),
         headers={

--- a/backend/tests/test_streaming.py
+++ b/backend/tests/test_streaming.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.endpoints import chat as chat_endpoint
 from app.core import deps
 from app.constants import MODELS, REDIS_KEY_CHAT_STREAM_LIVE
+from app.db.session import engine
 from app.models.db_models.chat import Chat
 from app.models.db_models.enums import MessageStreamStatus
 from app.models.db_models.user import User
@@ -1164,3 +1165,42 @@ async def test_stream_sse_replays_backlog_then_delivers_live_events(
                     envelopes.append(json.loads(line.removeprefix("data:").strip()))
 
     assert [e["seq"] for e in envelopes] == [backlog["seq"], backlog["seq"] + 1]
+
+
+async def test_sse_endpoints_release_db_connection_while_streaming(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    streaming_cache: EndpointCache,
+    live_server_url: str,
+) -> None:
+    # Regression: FastAPI holds the get_db yield dependency open until the
+    # response completes, so an open SSE connection used to pin the auth
+    # chain's pooled DB connection for its whole lifetime — a handful of open
+    # tabs exhausted the default 5+10 pool and every request then timed out at
+    # auth. The SSE handlers must release the session before streaming starts.
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    baseline = engine.pool.checkedout()
+    async with asyncio.timeout(15):
+        sse_client = httpx.AsyncClient(base_url=live_server_url, timeout=10.0)
+        async with (
+            sse_client,
+            sse_client.stream(
+                "GET", "/api/v1/chat/chats/events", headers=headers
+            ) as events_response,
+            sse_client.stream(
+                "GET", f"/api/v1/chat/chats/{chat.id}/stream", headers=headers
+            ) as chat_stream_response,
+        ):
+            assert events_response.status_code == 200
+            assert chat_stream_response.status_code == 200
+            # The chat stream's backlog replay briefly opens its own session,
+            # so poll rather than assert instantly. Without the release fix
+            # each open stream pins a connection forever, the count never
+            # returns to baseline, and asyncio.timeout fails the test.
+            while engine.pool.checkedout() > baseline:
+                await asyncio.sleep(0.01)


### PR DESCRIPTION
## Summary
- FastAPI keeps `yield`-based dependencies (like the DB session) open until the response fully completes, so long-lived SSE streams and file downloads were pinning their auth chain's pooled DB connection for the entire connection lifetime.
- A handful of open SSE tabs or slow downloads could exhaust the pool and stall every subsequent request at the auth step.
- Add an explicit `db` dependency to the affected endpoints and close the session right after auth/access checks pass, before handing off to the streaming response (`chat.py`: chat events feed, chat event stream; `attachments.py`: temp preview, preview, download).
- Add a regression test that opens two SSE streams and asserts the pool's checked-out connection count returns to baseline instead of staying pinned.

## Test plan
- [ ] `pytest backend/tests/test_streaming.py -k release_db_connection`