### PR TITLE
fix: clean up terminal PTY/tmux sessions and WS reconnect

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -91,6 +91,10 @@ jobs:
           pip install -r backend/requirements.txt pytest pytest-asyncio pytest-cov
 
       - name: Run backend tests
+        # sysmon core: the default C tracer drops lines executed through
+        # SQLAlchemy's greenlet switches, under-reporting request handlers.
+        env:
+          COVERAGE_CORE: sysmon
         run: |
           cd backend
           pytest tests --cov=app --cov-report=term-missing:skip-covered --cov-fail-under=85

--- a/backend/app/api/endpoints/websocket.py
+++ b/backend/app/api/endpoints/websocket.py
@@ -29,6 +29,8 @@ from app.utils.sandbox import normalize_relative_path
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+WS_RECEIVE_TIMEOUT_SECONDS = 30.0
+
 
 @router.websocket("/{sandbox_id}/terminal")
 async def terminal_websocket(
@@ -74,9 +76,16 @@ async def terminal_websocket(
     try:
         while True:
             try:
-                message = await asyncio.wait_for(websocket.receive(), timeout=30.0)
+                message = await asyncio.wait_for(
+                    websocket.receive(), timeout=WS_RECEIVE_TIMEOUT_SECONDS
+                )
             except asyncio.TimeoutError:
-                await websocket.send_text(json.dumps({"type": WS_MSG_PING}))
+                try:
+                    await websocket.send_text(json.dumps({"type": WS_MSG_PING}))
+                except (RuntimeError, OSError):
+                    # Ping hit a dead connection — exit so `finally` detaches
+                    # instead of the error propagating out of the endpoint.
+                    break
                 continue
 
             if "bytes" in message:
@@ -158,6 +167,10 @@ async def terminal_websocket(
             await session.detach()
         try:
             await websocket.close()
+        except RuntimeError:
+            # Already closed server-side (attach() takeover or PTY exit) —
+            # starlette raises on a second close.
+            pass
         except OSError as exc:
             if exc.errno != errno.EPIPE:
                 logger.error("Failed to close websocket cleanly: %s", exc)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.db.session import SessionLocal, engine
 from app.services.maintenance import MaintenanceService
 from app.services.session_registry import session_registry
 from app.services.streaming.runtime import ChatStreamRuntime
+from app.services.terminal import terminal_session_registry
 from app.utils.cache import cache_connection
 
 try:
@@ -52,6 +53,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         await maintenance_service.stop()
         await ChatStreamRuntime.stop_background_chats()
         await session_registry.terminate_all()
+        # Kill terminal PTYs and their tmux sessions — host-provider shells
+        # would otherwise keep running after the app exits.
+        await terminal_session_registry.terminate_all()
         await engine.dispose()
 
 

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -52,6 +52,7 @@ from app.services.session_registry import session_registry
 from app.services.storage import StorageService
 from app.services.streaming.runtime import ChatStreamRuntime
 from app.services.streaming.types import ChatStreamRequest, StreamEnvelope
+from app.services.terminal import teardown_workspace_sandbox
 from app.services.user import UserService
 from app.utils.cache import CacheError, CachePubSub, cache_connection, cache_pubsub
 
@@ -676,7 +677,7 @@ class ChatService(BaseDbService[Chat]):
                     if workspace.sandbox_id:
                         ws_sandbox = self.sandbox_for_workspace(workspace)
                         asyncio.create_task(
-                            ws_sandbox.delete_sandbox(workspace.sandbox_id)
+                            teardown_workspace_sandbox(workspace.sandbox_id, ws_sandbox)
                         )
 
     async def delete_all_chats(self, user: User) -> int:
@@ -728,7 +729,9 @@ class ChatService(BaseDbService[Chat]):
             for ws in workspaces:
                 if ws.sandbox_id:
                     ws_sandbox = self.sandbox_for_workspace(ws)
-                    asyncio.create_task(ws_sandbox.delete_sandbox(ws.sandbox_id))
+                    asyncio.create_task(
+                        teardown_workspace_sandbox(ws.sandbox_id, ws_sandbox)
+                    )
 
             return len(chat_ids)
 

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -11,6 +11,7 @@ from app.models.types import CustomEnvVarDict
 from app.services.exceptions import SandboxException
 from app.services.sandbox_providers import (
     PtyDataCallbackType,
+    PtyExitCallbackType,
     PtySize,
     SandboxProvider,
     SandboxProviderType,
@@ -88,6 +89,7 @@ class SandboxService:
         tmux_session: str,
         cwd: str,
         on_data: PtyDataCallbackType,
+        on_exit: PtyExitCallbackType,
     ) -> str:
         return await self.provider.create_pty(
             sandbox_id,
@@ -96,6 +98,7 @@ class SandboxService:
             tmux_session,
             cwd,
             on_data=on_data,
+            on_exit=on_exit,
         )
 
     async def send_pty_input(

--- a/backend/app/services/sandbox_providers/__init__.py
+++ b/backend/app/services/sandbox_providers/__init__.py
@@ -1,6 +1,7 @@
 from app.services.sandbox_providers.base import SandboxProvider
 from app.services.sandbox_providers.types import (
     PtyDataCallbackType,
+    PtyExitCallbackType,
     PtySize,
     SandboxProviderType,
 )
@@ -10,4 +11,5 @@ __all__ = [
     "SandboxProviderType",
     "PtySize",
     "PtyDataCallbackType",
+    "PtyExitCallbackType",
 ]

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -11,6 +11,7 @@ from app.services.sandbox_providers.types import (
     FileContent,
     FileMetadata,
     PtyDataCallbackType,
+    PtyExitCallbackType,
     PtySize,
     SandboxProviderType,
 )
@@ -143,9 +144,12 @@ class SandboxProvider:
         tmux_session: str,
         cwd: str,
         on_data: PtyDataCallbackType,
+        on_exit: PtyExitCallbackType,
     ) -> str:
         # Returns the new PTY session id. `cwd` is workspace-relative; ""
-        # means the provider's default start dir.
+        # means the provider's default start dir. `on_exit` fires when the
+        # PTY stream ends on its own (shell exit, container gone) — never on
+        # kill_pty's own cancellation.
         raise NotImplementedError
 
     async def send_pty_input(

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -24,6 +24,7 @@ from app.services.sandbox_providers.types import (
     FileContent,
     FileMetadata,
     PtyDataCallbackType,
+    PtyExitCallbackType,
     PtySize,
 )
 
@@ -386,6 +387,7 @@ class LocalDockerProvider(SandboxProvider):
         tmux_session: str,
         cwd: str,
         on_data: PtyDataCallbackType,
+        on_exit: PtyExitCallbackType,
     ) -> str:
         # Spawn a PTY-attached shell inside the container via docker exec.
         # Tries tmux for session persistence across WebSocket reconnections,
@@ -414,7 +416,7 @@ class LocalDockerProvider(SandboxProvider):
         # WebSocket to the Docker daemon. No public API exists for this.
         await stream._init()
 
-        reader_task = asyncio.create_task(self._pty_reader(stream, on_data))
+        reader_task = asyncio.create_task(self._pty_reader(stream, on_data, on_exit))
         self.register_pty_session(
             sandbox_id,
             session_id,
@@ -434,6 +436,7 @@ class LocalDockerProvider(SandboxProvider):
         self,
         stream: Any,
         on_data: PtyDataCallbackType,
+        on_exit: PtyExitCallbackType,
     ) -> None:
         # Background task that continuously reads container exec output
         # and forwards it to the WebSocket callback. Exits when the
@@ -445,9 +448,13 @@ class LocalDockerProvider(SandboxProvider):
                     break
                 await on_data(msg.data)
         except asyncio.CancelledError:
-            pass
+            # kill_pty tearing us down — the owner already knows.
+            return
         except Exception as e:
+            # A dead exec stream (container restarted/removed) is also a
+            # terminal condition — fall through to on_exit.
             logger.error("PTY reader error: %s", e)
+        on_exit()
 
     async def send_pty_input(
         self,

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -26,6 +26,7 @@ from app.services.sandbox_providers.types import (
     FileContent,
     FileMetadata,
     PtyDataCallbackType,
+    PtyExitCallbackType,
     PtySize,
 )
 from app.utils.sandbox import normalize_relative_path
@@ -212,6 +213,7 @@ class LocalHostProvider(SandboxProvider):
         tmux_session: str,
         cwd: str,
         on_data: PtyDataCallbackType,
+        on_exit: PtyExitCallbackType,
     ) -> str:
         # Spawn a PTY-attached shell in the workspace directory (or a
         # workspace-relative cwd, e.g. a chat's worktree). Tries tmux
@@ -252,7 +254,7 @@ class LocalHostProvider(SandboxProvider):
         os.close(slave_fd)
 
         reader_task = asyncio.create_task(
-            self._pty_reader(session_id, master_fd, on_data)
+            self._pty_reader(session_id, master_fd, on_data, on_exit)
         )
         self.register_pty_session(
             sandbox_id,
@@ -271,6 +273,7 @@ class LocalHostProvider(SandboxProvider):
         session_id: str,
         master_fd: int,
         on_data: PtyDataCallbackType,
+        on_exit: PtyExitCallbackType,
     ) -> None:
         # Continuously read PTY output and forward to the WebSocket via on_data.
         # Runs as a background task until the process exits or kill_pty cancels it.
@@ -281,9 +284,13 @@ class LocalHostProvider(SandboxProvider):
                     break
                 await on_data(chunk)
         except asyncio.CancelledError:
-            pass
+            # kill_pty tearing us down — the owner already knows.
+            return
         except OSError as e:
-            logger.error("PTY reader error for session %s: %s", session_id, e)
+            # On Linux the master fd raises EIO instead of returning EOF when
+            # the shell exits, so this path is also a normal termination.
+            logger.info("PTY reader ended for session %s: %s", session_id, e)
+        on_exit()
 
     async def send_pty_input(
         self,

--- a/backend/app/services/sandbox_providers/types.py
+++ b/backend/app/services/sandbox_providers/types.py
@@ -3,6 +3,9 @@ from enum import Enum
 from typing import Any, Callable, Coroutine
 
 PtyDataCallbackType = Callable[[bytes], Coroutine[Any, Any, None]]
+# Sync on purpose — fired from inside the provider's reader task, so handlers
+# must schedule their own async work rather than be awaited there.
+PtyExitCallbackType = Callable[[], None]
 
 
 class SandboxProviderType(str, Enum):

--- a/backend/app/services/terminal.py
+++ b/backend/app/services/terminal.py
@@ -39,6 +39,7 @@ class TerminalSessionRecord:
     input_queue: asyncio.Queue[bytes] | None = None
     active_websocket: WebSocket | None = None
     tmux_session_name: str | None = None
+    pty_exit_task: asyncio.Task[None] | None = None
 
     async def ensure_started(self, rows: int, cols: int) -> bool:
         if self.pty_id is None:
@@ -51,6 +52,7 @@ class TerminalSessionRecord:
                 tmux_session,
                 self.cwd,
                 on_data=self._enqueue_output,
+                on_exit=self._schedule_pty_exit,
             )
             self.input_queue = asyncio.Queue(maxsize=PTY_INPUT_QUEUE_SIZE)
             self.input_task = asyncio.create_task(self._input_worker(self.pty_id))
@@ -127,6 +129,28 @@ class TerminalSessionRecord:
     async def terminate(self) -> None:
         await self.kill_tmux_session()
         await self.close()
+
+    def _schedule_pty_exit(self) -> None:
+        # Fired from inside the provider's reader task — hop to a fresh task
+        # (kept on self so it isn't GC'd) so close()'s kill_pty can cancel and
+        # await the reader without the reader awaiting itself.
+        self.pty_exit_task = asyncio.create_task(self._handle_pty_exit())
+
+    async def _handle_pty_exit(self) -> None:
+        # The shell/tmux died on its own (exit, sandbox restart) — drop the
+        # record so the next connect starts a fresh PTY instead of silently
+        # reattaching to a dead one, and close the client so it can offer
+        # a reconnect instead of freezing.
+        websocket = self.active_websocket
+        try:
+            await self.close()
+        except (OSError, RuntimeError, SandboxException) as exc:
+            logger.error("Failed to clean up exited terminal session: %s", exc)
+        if websocket:
+            try:
+                await websocket.close()
+            except (RuntimeError, OSError):
+                pass
 
     async def refresh_tmux_client(self) -> None:
         # Repaint the reattached terminal via tmux itself — Ctrl-L to the pane's
@@ -290,16 +314,40 @@ class TerminalSessionRegistry:
     def _remove(self, key: str) -> None:
         self._sessions.pop(key, None)
 
+    async def terminate_for_sandbox(self, sandbox_id: str) -> None:
+        # Workspace-deletion path: kill this sandbox's PTYs and tmux sessions
+        # while the sandbox still exists, and drop the records so they don't
+        # outlive the workspace.
+        async with self._lock:
+            sessions = [
+                s for s in self._sessions.values() if s.sandbox_id == sandbox_id
+            ]
+        await self._terminate_sessions(sessions)
+
     async def terminate_all(self) -> None:
         async with self._lock:
             sessions = list(self._sessions.values())
             self._sessions.clear()
+        await self._terminate_sessions(sessions)
 
-        for session in sessions:
-            try:
-                await session.terminate()
-            except (OSError, RuntimeError, SandboxException) as exc:
-                logger.error("Failed to terminate terminal session: %s", exc)
+    @staticmethod
+    async def _terminate_sessions(sessions: list[TerminalSessionRecord]) -> None:
+        results = await asyncio.gather(
+            *[session.terminate() for session in sessions], return_exceptions=True
+        )
+        for result in results:
+            if isinstance(result, Exception):
+                logger.error("Failed to terminate terminal session: %s", result)
 
 
 terminal_session_registry = TerminalSessionRegistry()
+
+
+async def teardown_workspace_sandbox(
+    sandbox_id: str, sandbox_service: SandboxService
+) -> None:
+    # Every workspace-sandbox deletion funnels through here so the ordering
+    # can't drift: terminals must die while the sandbox still exists (tmux
+    # kill-session runs inside it), then the sandbox itself is deleted.
+    await terminal_session_registry.terminate_for_sandbox(sandbox_id)
+    await sandbox_service.delete_sandbox(sandbox_id)

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -33,6 +33,7 @@ from app.services.sandbox import SandboxService
 from app.services.sandbox_providers.base import SandboxProvider
 from app.services.session_registry import session_registry
 from app.services.skill import SkillService
+from app.services.terminal import teardown_workspace_sandbox
 from app.services.user import UserService
 
 settings = get_settings()
@@ -317,7 +318,7 @@ class WorkspaceService(BaseDbService[Workspace]):
                 )
                 sandbox_service = SandboxService(provider)
                 asyncio.create_task(
-                    sandbox_service.delete_sandbox(workspace.sandbox_id)
+                    teardown_workspace_sandbox(workspace.sandbox_id, sandbox_service)
                 )
 
     async def _clone_git_workspace(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,7 +23,8 @@ aiosmtplib
 prometheus-fastapi-instrumentator
 slowapi
 sse-starlette
-wtforms
+# <3.2: sqladmin's admin-form widgets break on wtforms 3.2 (no validation_attrs)
+wtforms<3.2
 croniter
 redis
 PyYAML>=6.0

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -17,6 +17,7 @@ from app.services.sandbox_providers.types import (
     FileContent,
     FileMetadata,
     PtyDataCallbackType,
+    PtyExitCallbackType,
     PtySize,
 )
 
@@ -154,6 +155,7 @@ class FakeSandboxProvider(SandboxProvider):
         tmux_session: str,
         cwd: str,
         on_data: PtyDataCallbackType,
+        on_exit: PtyExitCallbackType,
     ) -> str:
         return "pty-1"
 

--- a/backend/tests/test_infra.py
+++ b/backend/tests/test_infra.py
@@ -295,3 +295,43 @@ async def test_admin_create_user_hashes_grafted_password_field(
     )
     created = result.scalar_one()
     assert verify_password("freshpass123", created.hashed_password)
+
+
+class AsyncCallRecorder:
+    # Awaitable stand-in for lifespan collaborators; counts invocations so a
+    # test can assert shutdown wiring without running the real teardown.
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, *args: object) -> None:
+        self.calls += 1
+
+
+class FakeDisposableEngine:
+    async def dispose(self) -> None:
+        return None
+
+
+async def test_lifespan_shutdown_terminates_terminal_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Shutdown must tear down terminal PTY/tmux sessions — host-provider
+    # shells would otherwise keep running after the app exits.
+    terminal_recorder = AsyncCallRecorder()
+    monkeypatch.setattr(main_module.MaintenanceService, "start", AsyncCallRecorder())
+    monkeypatch.setattr(main_module.MaintenanceService, "stop", AsyncCallRecorder())
+    monkeypatch.setattr(
+        main_module.ChatStreamRuntime, "stop_background_chats", AsyncCallRecorder()
+    )
+    monkeypatch.setattr(
+        main_module.session_registry, "terminate_all", AsyncCallRecorder()
+    )
+    monkeypatch.setattr(
+        main_module.terminal_session_registry, "terminate_all", terminal_recorder
+    )
+    monkeypatch.setattr(main_module, "engine", FakeDisposableEngine())
+
+    async with main_module.lifespan(main_module.app):
+        assert terminal_recorder.calls == 0
+
+    assert terminal_recorder.calls == 1

--- a/backend/tests/test_streaming.py
+++ b/backend/tests/test_streaming.py
@@ -848,6 +848,9 @@ async def test_send_now_returns_404_for_unknown_queued_message(
     db_session: AsyncSession,
     create_user: UserFactory,
     login: LoginClient,
+    # Not used directly — routes get_queue_service to the in-memory cache so
+    # the test doesn't require a live Redis (503 instead of 404 without it).
+    streaming_cache: EndpointCache,
 ) -> None:
     headers, user, workspace = await create_authenticated_workspace(
         db_session, create_user, login

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, cast
 import pytest
 import pytest_asyncio
 from fastapi import WebSocket
+from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.websockets import WebSocketDisconnect
 
@@ -24,11 +25,13 @@ from app.constants import (
     WS_MSG_INIT,
     WS_MSG_RESIZE,
 )
+from app.models.db_models.chat import Chat
 from app.services.sandbox_providers import SandboxProviderType
 from app.services.sandbox_providers.base import SandboxProvider
 from app.services.sandbox_providers.types import (
     CommandResult,
     PtyDataCallbackType,
+    PtyExitCallbackType,
     PtySize,
 )
 
@@ -59,6 +62,7 @@ class LiveFakeWebSocket:
         self,
         query_params: dict[str, str] | None = None,
         close_error: OSError | None = None,
+        ping_error: Exception | None = None,
     ) -> None:
         self.query_params = query_params or {}
         self.accepted = False
@@ -67,6 +71,7 @@ class LiveFakeWebSocket:
         self.close_reason: str | None = None
         self._frames: "asyncio.Queue[dict[str, Any]]" = asyncio.Queue()
         self._close_error = close_error
+        self._ping_error = ping_error
 
     async def accept(self) -> None:
         self.accepted = True
@@ -78,6 +83,10 @@ class LiveFakeWebSocket:
         return frame
 
     async def send_text(self, payload: str) -> None:
+        # Simulates a NAT/network-dead connection where only the server's
+        # keepalive ping discovers the failure.
+        if self._ping_error is not None and '"ping"' in payload:
+            raise self._ping_error
         self.sent_text.append(payload)
 
     async def close(self, code: int = 1000, reason: str | None = None) -> None:
@@ -108,6 +117,7 @@ class FakePtySandboxProvider(SandboxProvider):
         self._workspace_root = "/tmp/agentrove-pty-test"
         self._pty_sessions: dict[str, dict[str, Any]] = {}
         self.on_data_callbacks: dict[str, PtyDataCallbackType] = {}
+        self.on_exit_callbacks: dict[str, PtyExitCallbackType] = {}
         self.created_ptys: list[tuple[str, str, int, int, str, str]] = []
         self.sent_inputs: list[tuple[str, str, bytes]] = []
         self.resizes: list[tuple[str, str, PtySize]] = []
@@ -133,10 +143,12 @@ class FakePtySandboxProvider(SandboxProvider):
         tmux_session: str,
         cwd: str,
         on_data: PtyDataCallbackType,
+        on_exit: PtyExitCallbackType,
     ) -> str:
         self._counter += 1
         pty_id = f"pty-{self._counter}"
         self.on_data_callbacks[pty_id] = on_data
+        self.on_exit_callbacks[pty_id] = on_exit
         self.created_ptys.append((pty_id, sandbox_id, rows, cols, tmux_session, cwd))
         self.register_pty_session(sandbox_id, pty_id, {})
         return pty_id
@@ -308,6 +320,41 @@ class FakeTerminalRegistry:
 
 async def run_terminal_websocket(websocket: FakeWebSocket, sandbox_id: str) -> None:
     await websocket_endpoint.terminal_websocket(cast(WebSocket, websocket), sandbox_id)
+
+
+async def attach_then_detach_terminal(
+    sandbox_id: str, token: str, terminal_id: str
+) -> str:
+    # Open a terminal via the endpoint, read its pty id, then detach cleanly —
+    # leaves a live-but-unattached session record, like a closed tab/refresh.
+    websocket = LiveFakeWebSocket(query_params={"terminalId": terminal_id})
+    task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(cast(WebSocket, websocket), sandbox_id)
+    )
+    websocket.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    websocket.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(websocket.sent_text) >= 1)
+    pty_id = json.loads(websocket.sent_text[0])["id"]
+    websocket.push_text(json.dumps({"type": WS_MSG_DETACH}))
+    await asyncio.wait_for(task, timeout=2.0)
+    return pty_id
+
+
+async def assert_terminal_terminated(
+    provider: FakePtySandboxProvider, sandbox_id: str, pty_id: str, terminal_id: str
+) -> None:
+    # Sandbox/terminal teardown runs as a background task — poll for both the
+    # tmux kill-session command and the pty kill instead of a fixed sleep.
+    expected_tmux = (
+        f"agentrove_{sandbox_id.replace('-', '_')}_{terminal_id.replace('-', '_')}"
+    )
+    await wait_until(
+        lambda: any(
+            f"tmux kill-session -t {shlex.quote(expected_tmux)}" in cmd
+            for _sid, cmd in provider.executed_commands
+        )
+    )
+    await wait_until(lambda: (sandbox_id, pty_id) in provider.killed)
 
 
 async def test_terminal_websocket_rejects_invalid_auth() -> None:
@@ -875,4 +922,195 @@ async def test_terminal_websocket_ignores_malformed_frames_and_handles_disconnec
     # torn down by a bad frame — and the final close was attempted despite
     # raising.
     assert len(pty_provider.created_ptys) == 1
+    assert websocket.close_code == 1000
+
+
+async def test_terminal_websocket_pty_exit_drops_session_and_reconnect_starts_fresh(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    # A PTY that dies on its own (shell `exit`, sandbox restart) must tear
+    # down the record and close the attached client — the next connect starts
+    # a fresh PTY instead of silently "reattaching" to the dead one.
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-exit@example.com",
+        username="ptyexit",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    websocket = LiveFakeWebSocket(query_params={"terminalId": "term-exit"})
+    task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, websocket), workspace.sandbox_id
+        )
+    )
+    websocket.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    websocket.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(websocket.sent_text) >= 1)
+    pty_id = json.loads(websocket.sent_text[0])["id"]
+
+    # Simulate the shell exiting: the provider's reader loop ends and fires
+    # the exit callback.
+    pty_provider.on_exit_callbacks[pty_id]()
+
+    await wait_until(lambda: (workspace.sandbox_id, pty_id) in pty_provider.killed)
+    await wait_until(lambda: websocket.close_code is not None)
+
+    # The endpoint loop is still parked on receive() — the fake close doesn't
+    # raise WebSocketDisconnect like a real socket would. Unpark it.
+    websocket.push_disconnect()
+    await asyncio.wait_for(task, timeout=2.0)
+
+    reconnect_ws = LiveFakeWebSocket(query_params={"terminalId": "term-exit"})
+    reconnect_task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, reconnect_ws), workspace.sandbox_id
+        )
+    )
+    reconnect_ws.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    reconnect_ws.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+    await wait_until(lambda: len(reconnect_ws.sent_text) >= 1)
+
+    assert json.loads(reconnect_ws.sent_text[0])["id"] != pty_id
+    assert len(pty_provider.created_ptys) == 2
+
+    reconnect_ws.push_text(json.dumps({"type": WS_MSG_CLOSE}))
+    await asyncio.wait_for(reconnect_task, timeout=2.0)
+
+
+async def test_delete_workspace_terminates_terminal_sessions(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    # Deleting a workspace must kill its terminal PTYs and tmux sessions —
+    # host-provider tmux would otherwise outlive the workspace forever.
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-wsdelete@example.com",
+        username="ptywsdelete",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    pty_id = await attach_then_detach_terminal(workspace.sandbox_id, token, "term-del")
+
+    response = await client.delete(
+        f"/api/v1/workspaces/{workspace.id}", headers=headers
+    )
+    assert response.status_code == 204
+
+    await assert_terminal_terminated(
+        pty_provider, workspace.sandbox_id, pty_id, "term-del"
+    )
+
+
+async def test_delete_last_chat_terminates_workspace_terminal_sessions(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    # Deleting the last chat auto-deletes the workspace — that path must run
+    # the same terminal teardown as an explicit workspace delete.
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-chatdel@example.com",
+        username="ptychatdel",
+    )
+    chat = Chat(title="Only Chat", user_id=user.id, workspace_id=workspace.id)
+    db_session.add(chat)
+    await db_session.commit()
+    await db_session.refresh(chat)
+
+    token = headers["Authorization"].removeprefix("Bearer ")
+    pty_id = await attach_then_detach_terminal(
+        workspace.sandbox_id, token, "term-chatdel"
+    )
+
+    response = await client.delete(f"/api/v1/chat/chats/{chat.id}", headers=headers)
+    assert response.status_code == 204
+
+    await assert_terminal_terminated(
+        pty_provider, workspace.sandbox_id, pty_id, "term-chatdel"
+    )
+
+
+async def test_delete_all_chats_terminates_terminal_sessions(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    # The bulk delete-all path tears down every workspace's sandbox — it must
+    # kill terminal sessions too, same as the single-delete paths.
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-delall@example.com",
+        username="ptydelall",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    pty_id = await attach_then_detach_terminal(
+        workspace.sandbox_id, token, "term-delall"
+    )
+
+    response = await client.delete("/api/v1/chat/chats/all", headers=headers)
+    assert response.status_code == 204
+
+    await assert_terminal_terminated(
+        pty_provider, workspace.sandbox_id, pty_id, "term-delall"
+    )
+
+
+async def test_terminal_websocket_ping_send_failure_detaches_cleanly(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The keepalive ping is what discovers a silently-dead connection — its
+    # send failure must detach the session and end the endpoint cleanly
+    # instead of propagating out of the handler.
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="ws-pingfail@example.com",
+        username="wspingfail",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    session = FakeTerminalSession()
+    registry = FakeTerminalRegistry(session)
+    monkeypatch.setattr(websocket_endpoint, "terminal_session_registry", registry)
+    monkeypatch.setattr(websocket_endpoint, "WS_RECEIVE_TIMEOUT_SECONDS", 0.05)
+    websocket = LiveFakeWebSocket(
+        query_params={"terminalId": "term-ping"},
+        ping_error=RuntimeError("send on closed connection"),
+    )
+    task = asyncio.create_task(
+        websocket_endpoint.terminal_websocket(
+            cast(WebSocket, websocket), workspace.sandbox_id
+        )
+    )
+
+    websocket.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+    websocket.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+
+    # After init the client goes silent: the receive timeout fires, the ping
+    # hits the dead socket, and the endpoint must exit on its own.
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert session.detach_count == 1
     assert websocket.close_code == 1000

--- a/frontend/src/components/sandbox/terminal/TerminalTab/TerminalTab.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab/TerminalTab.tsx
@@ -6,7 +6,7 @@ import 'xterm/css/xterm.css';
 import { Button } from '@/components/ui/primitives/Button/Button';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
 import { useUIStore } from '@/store/uiStore';
-import { resolveSandboxWs } from '@/lib/api';
+import { resolveSandboxClient, resolveSandboxWs } from '@/lib/api';
 
 import { useXterm } from '@/hooks/useXterm';
 import type { TerminalSize } from '@/types/sandbox.types';
@@ -102,8 +102,7 @@ export function TerminalTab({
     terminalRef.current?.reset();
 
     // Route to the cloud VPS WS host when the sandbox lives there, else local.
-    const { baseUrl, token } = resolveSandboxWs(sandboxId);
-    if (!token) return;
+    const baseUrl = resolveSandboxWs(sandboxId);
 
     const params = new URLSearchParams();
     if (terminalId) params.set('terminalId', terminalId);
@@ -114,110 +113,141 @@ export function TerminalTab({
     setSessionState('connecting');
     setCloseReason(null);
 
-    const ws = new WebSocket(wsUrl);
-    wsRef.current = ws;
-    hasSentInitRef.current = false;
-    lastSentSizeRef.current = null;
+    let cancelled = false;
+    let teardown: (() => void) | null = null;
 
-    const handleOpen = () => {
-      ws.send(JSON.stringify({ type: 'auth', token }));
+    const connect = (token: string) => {
+      const ws = new WebSocket(wsUrl);
+      wsRef.current = ws;
+      hasSentInitRef.current = false;
+      lastSentSizeRef.current = null;
 
-      const size =
-        fitTerminal() ??
-        (terminalRef.current
-          ? { rows: terminalRef.current.rows, cols: terminalRef.current.cols }
-          : { rows: 24, cols: 80 });
+      const handleOpen = () => {
+        ws.send(JSON.stringify({ type: 'auth', token }));
 
-      ws.send(JSON.stringify({ type: 'init', rows: size.rows, cols: size.cols }));
-      hasSentInitRef.current = true;
-      lastSentSizeRef.current = size;
+        const size =
+          fitTerminal() ??
+          (terminalRef.current
+            ? { rows: terminalRef.current.rows, cols: terminalRef.current.cols }
+            : { rows: 24, cols: 80 });
 
-      requestAnimationFrame(() => {
-        terminalRef.current?.focus();
-      });
-    };
+        ws.send(JSON.stringify({ type: 'init', rows: size.rows, cols: size.cols }));
+        hasSentInitRef.current = true;
+        lastSentSizeRef.current = size;
 
-    const handleMessage = (event: MessageEvent) => {
-      if (typeof event.data !== 'string') {
-        return;
-      }
-      try {
-        const message = JSON.parse(event.data) as Record<string, unknown>;
-        // Server ping is a NAT/LB keepalive — no pong is expected.
-        if (message.type === 'ping') {
+        requestAnimationFrame(() => {
+          terminalRef.current?.focus();
+        });
+      };
+
+      const handleMessage = (event: MessageEvent) => {
+        if (typeof event.data !== 'string') {
           return;
         }
-        if (message.type === 'stdout' && typeof message.data === 'string') {
-          terminalRef.current?.write(message.data);
-          setSessionState((prev) => (prev === 'connecting' ? 'ready' : prev));
-          return;
-        }
-        if (message.type === 'init') {
-          const rows = typeof message.rows === 'number' ? message.rows : undefined;
-          const cols = typeof message.cols === 'number' ? message.cols : undefined;
-          if (rows && cols) {
-            lastSentSizeRef.current = { rows, cols };
+        try {
+          const message = JSON.parse(event.data) as Record<string, unknown>;
+          // Server ping is a NAT/LB keepalive — no pong is expected.
+          if (message.type === 'ping') {
+            return;
           }
-          setSessionState('ready');
+          if (message.type === 'stdout' && typeof message.data === 'string') {
+            terminalRef.current?.write(message.data);
+            setSessionState((prev) => (prev === 'connecting' ? 'ready' : prev));
+            return;
+          }
+          if (message.type === 'init') {
+            const rows = typeof message.rows === 'number' ? message.rows : undefined;
+            const cols = typeof message.cols === 'number' ? message.cols : undefined;
+            if (rows && cols) {
+              lastSentSizeRef.current = { rows, cols };
+            }
+            setSessionState('ready');
+          }
+        } catch (error) {
+          logger.error('Terminal write failed', 'TerminalTab', error);
         }
-      } catch (error) {
-        logger.error('Terminal write failed', 'TerminalTab', error);
-      }
-    };
+      };
 
-    const handleError = () => {
-      setSessionState('error');
-    };
-
-    const handleClose = (event: CloseEvent) => {
-      resetWsRefs();
-      // User-initiated tab close tears the socket down on purpose — don't
-      // surface that as an unexpected disconnect.
-      if (isClosingRef.current) {
-        return;
-      }
-      // The server closes with WS_CLOSE_AUTH_FAILED / WS_CLOSE_SANDBOX_NOT_FOUND
-      // and a human-readable reason. Surface both so the overlay can tell the
-      // user why the connection dropped instead of showing a generic message.
-      if (
-        event.code === WS_CLOSE_AUTH_FAILED ||
-        event.code === WS_CLOSE_SANDBOX_NOT_FOUND ||
-        event.code === WS_CLOSE_INVALID_CWD
-      ) {
-        setCloseReason(event.reason || null);
+      const handleError = () => {
         setSessionState('error');
-        return;
-      }
-      // Any other close while this effect is live (backend restart, network
-      // drop) is unexpected — offer a reconnect instead of a frozen terminal.
-      setSessionState((prev) => (prev === 'error' ? prev : 'disconnected'));
+      };
+
+      const handleClose = (event: CloseEvent) => {
+        resetWsRefs();
+        // User-initiated tab close tears the socket down on purpose — don't
+        // surface that as an unexpected disconnect.
+        if (isClosingRef.current) {
+          return;
+        }
+        // The server closes with WS_CLOSE_AUTH_FAILED / WS_CLOSE_SANDBOX_NOT_FOUND
+        // and a human-readable reason. Surface both so the overlay can tell the
+        // user why the connection dropped instead of showing a generic message.
+        if (
+          event.code === WS_CLOSE_AUTH_FAILED ||
+          event.code === WS_CLOSE_SANDBOX_NOT_FOUND ||
+          event.code === WS_CLOSE_INVALID_CWD
+        ) {
+          setCloseReason(event.reason || null);
+          setSessionState('error');
+          return;
+        }
+        // Any other close while this effect is live (backend restart, network
+        // drop) is unexpected — offer a reconnect instead of a frozen terminal.
+        setSessionState((prev) => (prev === 'error' ? prev : 'disconnected'));
+      };
+
+      const handleBeforeUnload = () => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'detach' }));
+        }
+        ws.close();
+      };
+
+      ws.addEventListener('open', handleOpen);
+      ws.addEventListener('message', handleMessage);
+      ws.addEventListener('error', handleError);
+      ws.addEventListener('close', handleClose);
+      window.addEventListener('beforeunload', handleBeforeUnload);
+
+      teardown = () => {
+        window.removeEventListener('beforeunload', handleBeforeUnload);
+        ws.removeEventListener('open', handleOpen);
+        ws.removeEventListener('message', handleMessage);
+        ws.removeEventListener('error', handleError);
+        ws.removeEventListener('close', handleClose);
+
+        if (!shouldCloseRef.current && ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'detach' }));
+        }
+        ws.close();
+        resetWsRefs();
+      };
     };
 
-    const handleBeforeUnload = () => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'detach' }));
-      }
-      ws.close();
-    };
-
-    ws.addEventListener('open', handleOpen);
-    ws.addEventListener('message', handleMessage);
-    ws.addEventListener('error', handleError);
-    ws.addEventListener('close', handleClose);
-    window.addEventListener('beforeunload', handleBeforeUnload);
+    // Mint a fresh token instead of reading the cached one — the cloud access
+    // token lives only in memory, so it's absent right after a page reload.
+    void resolveSandboxClient(sandboxId)
+      .getValidToken()
+      .then((token) => {
+        if (cancelled) return;
+        if (!token) {
+          // Route the null-token case through the catch so both auth
+          // failures share one error path.
+          throw new Error('Missing terminal auth token');
+        }
+        connect(token);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          logger.error('Terminal auth token mint failed', 'TerminalTab', error);
+          setSessionState('error');
+          setCloseReason('Terminal authentication failed');
+        }
+      });
 
     return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-      ws.removeEventListener('open', handleOpen);
-      ws.removeEventListener('message', handleMessage);
-      ws.removeEventListener('error', handleError);
-      ws.removeEventListener('close', handleClose);
-
-      if (!shouldCloseRef.current && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: 'detach' }));
-      }
-      ws.close();
-      resetWsRefs();
+      cancelled = true;
+      teardown?.();
       setSessionState('idle');
     };
   }, [sandboxId, terminalId, cwd, isReady, connectAttempt, fitTerminal, terminalRef, resetWsRefs]);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -337,13 +337,12 @@ export function resolveSandboxClient(sandboxId: string | undefined): APIClient {
   return sandboxId && isCloudSandbox(sandboxId) ? remoteApiClient : apiClient;
 }
 
-// Terminal WebSockets bypass APIClient, so resolve the base URL + token for the
-// backend that owns the sandbox.
-export function resolveSandboxWs(sandboxId: string): { baseUrl: string; token: string | null } {
-  if (isCloudSandbox(sandboxId)) {
-    return { baseUrl: CLOUD_WS_BASE_URL, token: remoteApiClient.getToken() };
-  }
-  return { baseUrl: WS_BASE_URL, token: apiClient.getToken() };
+// Terminal WebSockets bypass APIClient, so resolve the base URL for the
+// backend that owns the sandbox. Tokens are minted per-connect via
+// resolveSandboxClient(...).getValidToken() — the cached cloud access token
+// is memory-only and missing right after a page reload.
+export function resolveSandboxWs(sandboxId: string): string {
+  return isCloudSandbox(sandboxId) ? CLOUD_WS_BASE_URL : WS_BASE_URL;
 }
 
 export function setApiPort(port: number): void {


### PR DESCRIPTION
## Summary
- PTY sessions had no way to signal their own death, so a shell exiting on its own (or a container/sandbox going away) left a stale session record that silently "reattached" clients to a dead PTY, freezing the terminal. Providers now fire an `on_exit` callback when the reader stream ends on its own, which drops the session record and closes the attached client so it can reconnect.
- Workspace deletion, chat deletion, delete-all-chats, and app shutdown never terminated live terminal sessions — tmux sessions and PTYs could outlive their sandbox. All sandbox-deletion paths now funnel through `teardown_workspace_sandbox()`, which kills terminal sessions for that sandbox before deleting it; app shutdown now also calls `terminal_session_registry.terminate_all()`.
- Fixed the terminal WebSocket failing to reconnect after a page reload: the cloud sandbox access token is memory-only, so the cached token read at connect time was `null` right after a reload. `TerminalTab` now mints a fresh token per-connect via `getValidToken()` instead of reading a cached one.
- Also hardened the WS endpoint against a dead-but-undetected connection: a keepalive ping send failure now detaches the session and closes cleanly instead of propagating an exception, and a second `websocket.close()` call (e.g. after an `attach()` takeover) no longer raises.

## Test plan
- [x] New/updated backend tests cover: PTY exit dropping the session and reconnect starting fresh, workspace/chat/delete-all-chats terminating terminal sessions, app lifespan shutdown terminating terminal sessions, and ping-send-failure detaching cleanly (`backend/tests/test_websocket.py`, `backend/tests/test_infra.py`).
- [ ] Manual: open a terminal tab, let the shell exit, confirm the tab surfaces a reconnect instead of freezing.
- [ ] Manual: reload the page while a cloud-sandbox terminal is open, confirm it reconnects instead of failing auth.