### PR TITLE
fix: client-driven tmux repaint, PTY race fix, xterm migration

### DIFF
--- a/backend/app/api/endpoints/websocket.py
+++ b/backend/app/api/endpoints/websocket.py
@@ -16,6 +16,7 @@ from app.constants import (
     WS_MSG_DETACH,
     WS_MSG_INIT,
     WS_MSG_PING,
+    WS_MSG_REFRESH,
     WS_MSG_RESIZE,
 )
 from app.core.security import (
@@ -40,7 +41,7 @@ async def terminal_websocket(
     # Client protocol: after accept, the first frame must be an auth message
     # (handled by wait_for_websocket_auth). Subsequent frames are either raw
     # bytes (forwarded to the PTY stdin) or JSON control messages
-    # (init / resize / close / detach). A 30s receive-timeout drives a
+    # (init / refresh / resize / close / detach). A 30s receive-timeout drives a
     # server→client ping so idle connections keep NAT/LB state alive.
     await websocket.accept()
 
@@ -121,7 +122,7 @@ async def terminal_websocket(
                     max_value=500,
                 )
 
-                is_reattach = await session.ensure_started(rows, cols)
+                await session.ensure_started(rows, cols)
                 await session.attach(websocket)
 
                 await websocket.send_text(
@@ -135,10 +136,13 @@ async def terminal_websocket(
                     )
                 )
 
-                if is_reattach:
-                    # Repaint through tmux rather than the pane's stdin — the
-                    # foreground app (e.g. a TUI) may swallow injected keys.
-                    await session.refresh_tmux_client()
+            elif data_type == WS_MSG_REFRESH:
+                # Client-requested repaint after its xterm is open and sized —
+                # a reattach with an unchanged size emits nothing on its own,
+                # and repainting at init time can land on a connection that a
+                # racing reconnect is about to replace. Goes through tmux, not
+                # the pane's stdin: a foreground TUI would swallow injected keys.
+                await session.refresh_tmux_client()
 
             elif data_type == WS_MSG_RESIZE:
                 rows = parse_pty_dimension(

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -115,6 +115,7 @@ WS_MSG_RESIZE: Final[str] = "resize"
 WS_MSG_CLOSE: Final[str] = "close"
 WS_MSG_PING: Final[str] = "ping"
 WS_MSG_DETACH: Final[str] = "detach"
+WS_MSG_REFRESH: Final[str] = "refresh"
 
 WS_CLOSE_AUTH_FAILED: Final[int] = 4001
 WS_CLOSE_SANDBOX_NOT_FOUND: Final[int] = 4004

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 import posixpath
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -151,6 +152,26 @@ class SandboxProvider:
         # PTY stream ends on its own (shell exit, container gone) — never on
         # kill_pty's own cancellation.
         raise NotImplementedError
+
+    @staticmethod
+    def build_pty_shell_command(tmux_session: str, fallback_shell: str) -> str:
+        # Shared tmux launch for every provider's PTY, falling back to a bare
+        # shell when tmux isn't installed. history-limit precedes new -A: it
+        # only applies to panes created after it's set (tmux applies it fine
+        # with no server running). Mouse on: xterm has no scrollback under
+        # tmux's alternate screen, so wheel scrolling must go through tmux
+        # copy-mode. Drag-selection then copies via tmux — set-clipboard plus
+        # the Ms override forward it as OSC 52 to the frontend clipboard addon.
+        return (
+            "command -v tmux >/dev/null && "
+            "tmux set -g history-limit 10000"
+            f" \\; new -A -s {shlex.quote(tmux_session)}"
+            " \\; set -g status off"
+            " \\; set -g mouse on"
+            " \\; set -s set-clipboard on"
+            " \\; set -as terminal-overrides ',xterm-256color:Ms=\\E]52;%p1%s;%p2%s\\007'"
+            f" || exec {shlex.quote(fallback_shell)}"
+        )
 
     async def send_pty_input(
         self,

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -398,7 +398,7 @@ class LocalDockerProvider(SandboxProvider):
         cmd = [
             "bash",
             "-c",
-            f"command -v tmux >/dev/null && tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off \\; set -g mouse off || exec bash",
+            self.build_pty_shell_command(tmux_session, "bash"),
         ]
 
         # Root terminals keep $HOME as the start dir (dotfiles, existing

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -236,10 +236,7 @@ class LocalHostProvider(SandboxProvider):
             env["HOME"] = str(host_home)
         env["TERM"] = TERMINAL_TYPE
         shell = env.get("SHELL", "/bin/bash")
-        cmd = (
-            "command -v tmux >/dev/null && "
-            f"tmux new -A -s {shlex.quote(tmux_session)} \\; set -g status off \\; set -g mouse off || exec {shlex.quote(shell)}"
-        )
+        cmd = self.build_pty_shell_command(tmux_session, shell)
         process = await asyncio.to_thread(
             subprocess.Popen,
             ["bash", "-lc", cmd],

--- a/backend/app/services/terminal.py
+++ b/backend/app/services/terminal.py
@@ -4,7 +4,7 @@ import logging
 import re
 import shlex
 from asyncio import QueueEmpty, QueueFull
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from typing import Callable, TypeVar
 
@@ -40,27 +40,30 @@ class TerminalSessionRecord:
     active_websocket: WebSocket | None = None
     tmux_session_name: str | None = None
     pty_exit_task: asyncio.Task[None] | None = None
+    start_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
-    async def ensure_started(self, rows: int, cols: int) -> bool:
-        if self.pty_id is None:
-            tmux_session = self._get_tmux_session_name()
-            self.output_queue = asyncio.Queue(maxsize=PTY_OUTPUT_QUEUE_SIZE)
-            self.pty_id = await self.sandbox_service.create_pty_session(
-                self.sandbox_id,
-                rows,
-                cols,
-                tmux_session,
-                self.cwd,
-                on_data=self._enqueue_output,
-                on_exit=self._schedule_pty_exit,
-            )
-            self.input_queue = asyncio.Queue(maxsize=PTY_INPUT_QUEUE_SIZE)
-            self.input_task = asyncio.create_task(self._input_worker(self.pty_id))
-            self.input_task.add_done_callback(self._handle_input_task_done)
-            return False
+    async def ensure_started(self, rows: int, cols: int) -> None:
+        # Serialized: a page refresh can race two connections into the same
+        # record; without the lock both see pty_id=None and spawn two PTYs.
+        async with self.start_lock:
+            if self.pty_id is None:
+                tmux_session = self._get_tmux_session_name()
+                self.output_queue = asyncio.Queue(maxsize=PTY_OUTPUT_QUEUE_SIZE)
+                self.pty_id = await self.sandbox_service.create_pty_session(
+                    self.sandbox_id,
+                    rows,
+                    cols,
+                    tmux_session,
+                    self.cwd,
+                    on_data=self._enqueue_output,
+                    on_exit=self._schedule_pty_exit,
+                )
+                self.input_queue = asyncio.Queue(maxsize=PTY_INPUT_QUEUE_SIZE)
+                self.input_task = asyncio.create_task(self._input_worker(self.pty_id))
+                self.input_task.add_done_callback(self._handle_input_task_done)
+                return
 
-        await self.resize(rows, cols)
-        return True
+            await self.resize(rows, cols)
 
     def enqueue_input(self, data: bytes) -> None:
         if not self.input_queue:
@@ -156,6 +159,8 @@ class TerminalSessionRecord:
         # Repaint the reattached terminal via tmux itself — Ctrl-L to the pane's
         # stdin only redraws shells; full-screen TUIs swallow it, leaving the
         # fresh xterm blank.
+        if self.pty_id is None:
+            return
         session_name = shlex.quote(self._get_tmux_session_name())
         command = (
             "for c in $(tmux list-clients -t "

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -23,6 +23,7 @@ from app.constants import (
     WS_MSG_CLOSE,
     WS_MSG_DETACH,
     WS_MSG_INIT,
+    WS_MSG_REFRESH,
     WS_MSG_RESIZE,
 )
 from app.models.db_models.chat import Chat
@@ -124,6 +125,8 @@ class FakePtySandboxProvider(SandboxProvider):
         self.killed: list[tuple[str, str]] = []
         self.executed_commands: list[tuple[str, str]] = []
         self._counter = 0
+        # Widens the create_pty await window so tests can race two inits.
+        self.create_delay = 0.0
 
     @property
     def workspace_root(self) -> str:
@@ -145,6 +148,8 @@ class FakePtySandboxProvider(SandboxProvider):
         on_data: PtyDataCallbackType,
         on_exit: PtyExitCallbackType,
     ) -> str:
+        if self.create_delay:
+            await asyncio.sleep(self.create_delay)
         self._counter += 1
         pty_id = f"pty-{self._counter}"
         self.on_data_callbacks[pty_id] = on_data
@@ -266,10 +271,13 @@ class FakeTerminalSession:
         self.attach_count = 0
         self.detach_count = 0
         self.terminate_count = 0
+        self.refresh_count = 0
 
-    async def ensure_started(self, rows: int, cols: int) -> bool:
+    async def ensure_started(self, rows: int, cols: int) -> None:
         self.ensure_started_calls.append((rows, cols))
-        return False
+
+    async def refresh_tmux_client(self) -> None:
+        self.refresh_count += 1
 
     async def attach(self, websocket: WebSocket) -> None:
         self.active_websocket = websocket
@@ -431,6 +439,7 @@ async def test_terminal_websocket_handles_control_frames(
             {"text": json.dumps({"type": WS_MSG_AUTH, "token": token})},
             {"text": "{not-json"},
             {"text": json.dumps({"type": WS_MSG_INIT, "rows": 40, "cols": 120})},
+            {"text": json.dumps({"type": WS_MSG_REFRESH})},
             {"bytes": b"ls\n"},
             {"text": json.dumps({"type": WS_MSG_RESIZE, "rows": 50, "cols": 140})},
             {"text": json.dumps({"type": WS_MSG_DETACH})},
@@ -458,6 +467,7 @@ async def test_terminal_websocket_handles_control_frames(
         "cols": 120,
     }
     assert session.ensure_started_calls == [(40, 120)]
+    assert session.refresh_count == 1
     assert session.resize_calls == [(50, 140)]
     assert session.inputs == [b"ls\n"]
     assert session.attach_count == 1
@@ -610,13 +620,66 @@ async def test_terminal_websocket_buffered_output_replays_on_reconnect(
         "data": "buffered-1 buffered-2",
     }
     assert len(pty_provider.created_ptys) == 1
-    # Reattaching an already-started session (is_reattach) repaints via tmux.
-    assert any(
+
+    # The repaint is client-driven: nothing is redrawn until the reconnected
+    # client asks, so the restored screen lands on the socket displaying it.
+    assert not any(
         "tmux refresh-client" in cmd for _sid, cmd in pty_provider.executed_commands
+    )
+    second_ws.push_text(json.dumps({"type": WS_MSG_REFRESH}))
+    await wait_until(
+        lambda: any(
+            "tmux refresh-client" in cmd for _sid, cmd in pty_provider.executed_commands
+        )
     )
 
     second_ws.push_text(json.dumps({"type": WS_MSG_CLOSE}))
     await asyncio.wait_for(second_task, timeout=2.0)
+
+
+async def test_terminal_websocket_concurrent_inits_share_one_pty(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    pty_provider: FakePtySandboxProvider,
+) -> None:
+    # A page refresh can race two connections into the same session record —
+    # ensure_started must serialize so only one PTY/tmux client is spawned
+    # and the second connection reattaches instead.
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="pty-race@example.com",
+        username="ptyrace",
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    pty_provider.create_delay = 0.05
+
+    sockets = [
+        LiveFakeWebSocket(query_params={"terminalId": "term-race"}) for _ in range(2)
+    ]
+    tasks = [
+        asyncio.create_task(
+            websocket_endpoint.terminal_websocket(
+                cast(WebSocket, ws), workspace.sandbox_id
+            )
+        )
+        for ws in sockets
+    ]
+    for ws in sockets:
+        ws.push_text(json.dumps({"type": WS_MSG_AUTH, "token": token}))
+        ws.push_text(json.dumps({"type": WS_MSG_INIT, "rows": 24, "cols": 80}))
+
+    await wait_until(lambda: sum(len(ws.sent_text) for ws in sockets) >= 2)
+    assert len(pty_provider.created_ptys) == 1
+    # The loser of the create race went down the reattach path.
+    assert len(pty_provider.resizes) == 1
+
+    for ws in sockets:
+        ws.push_text(json.dumps({"type": WS_MSG_DETACH}))
+    for task in tasks:
+        await asyncio.wait_for(task, timeout=2.0)
 
 
 async def test_terminal_websocket_input_and_resize_before_init_are_noops(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,9 @@
         "@tauri-apps/plugin-process": "^2.3.0",
         "@tauri-apps/plugin-store": "^2.4.0",
         "@tauri-apps/plugin-updater": "^2.10.0",
+        "@xterm/addon-clipboard": "^0.2.0",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
         "clsx": "^2.1.1",
         "diff": "^7.0.0",
         "dompurify": "^3.3.0",
@@ -41,8 +44,6 @@
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
         "xlsx": "^0.18.5",
-        "xterm": "^5.3.0",
-        "xterm-addon-fit": "^0.8.0",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -2958,6 +2959,30 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xterm/addon-clipboard": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-clipboard/-/addon-clipboard-0.2.0.tgz",
+      "integrity": "sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -5045,6 +5070,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/js-base64": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.8.1.tgz",
+      "integrity": "sha512-5xVjhUZlHHeuO2W7w2rDFj/Kl1xLX+HjZxdOQwCsUOifl6UaoH1o1wsbsTMz+r0aeC7gCijvru02j6TfKZWzKg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -10174,21 +10205,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/xterm": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead."
-    },
-    "node_modules/xterm-addon-fit": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
-      "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
-      "deprecated": "This package is now deprecated. Move to @xterm/addon-fit instead.",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,9 @@
     "@tauri-apps/plugin-process": "^2.3.0",
     "@tauri-apps/plugin-store": "^2.4.0",
     "@tauri-apps/plugin-updater": "^2.10.0",
+    "@xterm/addon-clipboard": "^0.2.0",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "clsx": "^2.1.1",
     "diff": "^7.0.0",
     "dompurify": "^3.3.0",
@@ -57,8 +60,6 @@
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0",
     "xlsx": "^0.18.5",
-    "xterm": "^5.3.0",
-    "xterm-addon-fit": "^0.8.0",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/frontend/src/components/sandbox/terminal/TerminalTab/TerminalTab.test.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab/TerminalTab.test.tsx
@@ -91,6 +91,12 @@ class FakeWebSocket {
     this.dispatch('message', new MessageEvent('message', { data: JSON.stringify(data) }));
   }
 
+  sentMessages(): unknown[] {
+    return this.send.mock.calls
+      .filter(([payload]) => typeof payload === 'string')
+      .map(([payload]) => JSON.parse(payload as string) as unknown);
+  }
+
   private dispatch(type: string, event: Event): void {
     for (const listener of this.listeners.get(type) ?? []) {
       if (typeof listener === 'function') {
@@ -110,11 +116,14 @@ describe('TerminalTab restored output', () => {
     vi.stubGlobal('WebSocket', FakeWebSocket);
     // The real xterm is opened asynchronously, so the mount-time focus frame
     // runs before terminalRef is populated. Keep that frame pending here too.
-    vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1));
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 1),
+    );
     vi.stubGlobal('cancelAnimationFrame', vi.fn());
   });
 
-  it('repaints and focuses only after the first restored write is parsed', async () => {
+  it('requests a repaint after init, then focuses only after the first write is parsed', async () => {
     render(<TerminalTab isVisible sandboxId="sandbox-1" terminalId="terminal-1" />);
 
     await waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
@@ -122,6 +131,12 @@ describe('TerminalTab restored output', () => {
 
     act(() => websocket.open());
     expect(mocks.terminal.focus).not.toHaveBeenCalled();
+    // No repaint request until the server acks init — the session may not
+    // even have a PTY yet.
+    expect(websocket.sentMessages()).not.toContainEqual({ type: 'refresh' });
+
+    act(() => websocket.message({ type: 'init', id: 'pty-1', rows: 40, cols: 120 }));
+    expect(websocket.sentMessages()).toContainEqual({ type: 'refresh' });
 
     act(() => websocket.message({ type: 'stdout', data: '\u001b[?1004hrestored screen' }));
     expect(mocks.terminal.write).toHaveBeenCalledWith(

--- a/frontend/src/components/sandbox/terminal/TerminalTab/TerminalTab.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab/TerminalTab.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import { logger } from '@/utils/logger';
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { Button } from '@/components/ui/primitives/Button/Button';
 import { useResolvedTheme } from '@/hooks/useResolvedTheme';
@@ -102,7 +102,7 @@ export function TerminalTab({
     if (!sandboxId || !isReady) return;
 
     // Reset on every (re)connect so stale screen contents and cursor position
-    // do not leak into the next PTY — the server repaints via tmux on reattach.
+    // do not leak into the next PTY — the server repaints via tmux on request.
     terminalRef.current?.reset();
 
     // Route to the cloud VPS WS host when the sandbox lives there, else local.
@@ -141,49 +141,65 @@ export function TerminalTab({
         lastSentSizeRef.current = size;
       };
 
+      const handleStdout = (data: string) => {
+        const terminal = terminalRef.current;
+        if (!terminal) {
+          return;
+        }
+        const focusAfterWrite = focusOnNextWriteRef.current;
+        focusOnNextWriteRef.current = false;
+        terminal.write(
+          data,
+          focusAfterWrite
+            ? () => {
+                // Reattached tmux modes must be parsed before focus so TUIs
+                // receive the focus event and paint without a user click.
+                if (wsRef.current !== ws) {
+                  return;
+                }
+                terminal.refresh(0, terminal.rows - 1);
+                if (isVisibleRef.current) {
+                  terminal.focus();
+                }
+              }
+            : undefined,
+        );
+        setSessionState((prev) => (prev === 'connecting' ? 'ready' : prev));
+      };
+
       const handleMessage = (event: MessageEvent) => {
         if (typeof event.data !== 'string') {
           return;
         }
+
+        let message: Record<string, unknown>;
         try {
-          const message = JSON.parse(event.data) as Record<string, unknown>;
-          // Server ping is a NAT/LB keepalive — no pong is expected.
-          if (message.type === 'ping') {
-            return;
+          message = JSON.parse(event.data) as Record<string, unknown>;
+        } catch {
+          logger.error('Malformed terminal frame', 'TerminalTab', event.data);
+          return;
+        }
+
+        // Server ping is a NAT/LB keepalive — no pong is expected.
+        if (message.type === 'ping') {
+          return;
+        }
+        if (message.type === 'stdout' && typeof message.data === 'string') {
+          handleStdout(message.data);
+          return;
+        }
+        if (message.type === 'init') {
+          const rows = typeof message.rows === 'number' ? message.rows : undefined;
+          const cols = typeof message.cols === 'number' ? message.cols : undefined;
+          if (rows && cols) {
+            lastSentSizeRef.current = { rows, cols };
           }
-          if (message.type === 'stdout' && typeof message.data === 'string') {
-            const terminal = terminalRef.current;
-            const focusAfterWrite = focusOnNextWriteRef.current;
-            focusOnNextWriteRef.current = false;
-            terminal?.write(
-              message.data,
-              focusAfterWrite
-                ? () => {
-                    // Reattached tmux modes must be parsed before focus so TUIs
-                    // receive the focus event and paint without a user click.
-                    if (wsRef.current !== ws) {
-                      return;
-                    }
-                    terminal.refresh(0, terminal.rows - 1);
-                    if (isVisibleRef.current) {
-                      terminal.focus();
-                    }
-                  }
-                : undefined,
-            );
-            setSessionState((prev) => (prev === 'connecting' ? 'ready' : prev));
-            return;
-          }
-          if (message.type === 'init') {
-            const rows = typeof message.rows === 'number' ? message.rows : undefined;
-            const cols = typeof message.cols === 'number' ? message.cols : undefined;
-            if (rows && cols) {
-              lastSentSizeRef.current = { rows, cols };
-            }
-            setSessionState('ready');
-          }
-        } catch (error) {
-          logger.error('Terminal write failed', 'TerminalTab', error);
+          // A reattach with an unchanged size produces no output on its own,
+          // so ask tmux for a repaint now that this socket can display it —
+          // an earlier connection torn down mid-handshake may have consumed
+          // the previous repaint.
+          ws.send(JSON.stringify({ type: 'refresh' }));
+          setSessionState('ready');
         }
       };
 

--- a/frontend/src/hooks/useXterm.ts
+++ b/frontend/src/hooks/useXterm.ts
@@ -1,23 +1,25 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MutableRefObject } from 'react';
-import type { Terminal as XTerm } from 'xterm';
-import type { FitAddon as FitAddonType } from 'xterm-addon-fit';
+import type { Terminal as XTerm } from '@xterm/xterm';
+import type { FitAddon } from '@xterm/addon-fit';
+import type { IClipboardProvider } from '@xterm/addon-clipboard';
 
+import { logger } from '@/utils/logger';
 import { buildTerminalTheme } from '@/utils/terminal';
 import type { TerminalSize } from '@/types/sandbox.types';
 import type { Palette } from '@/types/ui.types';
 
-type XTermCore = {
-  _core?: {
-    _renderService?: {
-      _renderer?: { value?: unknown };
-    };
-  };
+// Write-only OSC 52: an OSC 52 query ('?') from a sandbox process must not be
+// able to read the user's clipboard back through the PTY — tmux copy-mode
+// only needs the write direction. navigator.clipboard is undefined in
+// non-secure contexts (self-hosted plain-http), so degrade to a silent no-op.
+const WRITE_ONLY_CLIPBOARD: IClipboardProvider = {
+  readText: () => Promise.resolve(''),
+  writeText: (selection, text) =>
+    selection === 'c' && navigator.clipboard
+      ? navigator.clipboard.writeText(text)
+      : Promise.resolve(),
 };
-
-function hasRenderer(terminal: XTerm): boolean {
-  return !!(terminal as unknown as XTermCore)._core?._renderService?._renderer?.value;
-}
 
 interface UseXtermOptions {
   isVisible: boolean;
@@ -35,43 +37,46 @@ interface UseXtermReturn {
 
 export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): UseXtermReturn => {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  // Assigned only after open() succeeds, so consumers (fit, theme, writes)
+  // never touch a terminal whose renderer doesn't exist yet.
   const terminalRef = useRef<XTerm | null>(null);
-  const fitAddonRef = useRef<FitAddonType | null>(null);
-  const inputHandlerRef = useRef<ReturnType<XTerm['onData']> | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
   const [isReady, setIsReady] = useState(false);
   const [initAttempt, setInitAttempt] = useState(0);
 
+  // Route callbacks/theme through refs so the open-once effect and the stable
+  // fitTerminal don't re-run (tearing down the terminal) on parent re-renders.
+  const onDataRef = useRef(onData);
+  const onFitRef = useRef(onFit);
   const modeRef = useRef(mode);
+  onDataRef.current = onData;
+  onFitRef.current = onFit;
   modeRef.current = mode;
+
   const hasInitializedRef = useRef(false);
+  // Once created, keep the terminal alive through visibility toggles so a
+  // hidden tab doesn't lose its scrollback.
   const shouldInitialize = hasInitializedRef.current || isVisible;
 
   const fitTerminal = useCallback((): TerminalSize | null => {
     const fitAddon = fitAddonRef.current;
     const terminal = terminalRef.current;
-
-    if (!fitAddon || !terminal || !hasRenderer(terminal)) {
+    if (!fitAddon || !terminal) {
       return null;
     }
 
-    try {
-      fitAddon.fit();
-    } catch (error) {
-      if (error instanceof TypeError && error.message.includes('dimensions')) {
-        return null;
-      }
-      throw error;
+    // proposeDimensions returns undefined/NaN while the wrapper has no size
+    // (hidden tab, mid-layout) — skip instead of resizing to a garbage grid.
+    const proposed = fitAddon.proposeDimensions();
+    if (!proposed || !Number.isFinite(proposed.rows) || !Number.isFinite(proposed.cols)) {
+      return null;
     }
 
-    const size = {
-      rows: terminal.rows,
-      cols: terminal.cols,
-    };
-
-    onFit(size);
-
+    fitAddon.fit();
+    const size = { rows: terminal.rows, cols: terminal.cols };
+    onFitRef.current(size);
     return size;
-  }, [onFit]);
+  }, []);
 
   useEffect(() => {
     if (!shouldInitialize) {
@@ -83,6 +88,8 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
       return undefined;
     }
 
+    // Opening xterm into a zero-size element makes the renderer measure a
+    // broken cell grid — wait for the wrapper to gain real dimensions first.
     const rect = container.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) {
       const observer = new ResizeObserver((entries) => {
@@ -97,16 +104,16 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
     }
 
     let cancelled = false;
-    let openFrameId: number | null = null;
     let xterm: XTerm | null = null;
 
-    (async () => {
-      const [{ Terminal }, { FitAddon }] = await Promise.all([
-        import('xterm'),
-        import('xterm-addon-fit'),
+    void (async () => {
+      const [{ Terminal }, { FitAddon }, { ClipboardAddon }] = await Promise.all([
+        import('@xterm/xterm'),
+        import('@xterm/addon-fit'),
+        import('@xterm/addon-clipboard'),
       ]);
 
-      // Wait for the Nerd Font before first paint so the DOM renderer measures
+      // Wait for the Nerd Font before first paint so the renderer measures
       // cell dimensions against the real glyphs, not the fallback (cold load).
       try {
         await document.fonts?.load('12px "JetBrainsMono Nerd Font"');
@@ -114,7 +121,9 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
         // Font unavailable — open anyway; text falls back to monospace.
       }
 
-      if (cancelled) return;
+      if (cancelled || !container.isConnected) {
+        return;
+      }
 
       xterm = new Terminal({
         scrollback: 1000,
@@ -125,43 +134,29 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
         theme: buildTerminalTheme(modeRef.current),
       });
       const fitAddon = new FitAddon();
+      xterm.loadAddon(fitAddon);
+      // OSC 52 → system clipboard: tmux runs with mouse mode on, so drag
+      // selection is tmux copy-mode — its copy must reach navigator.clipboard.
+      xterm.loadAddon(new ClipboardAddon(undefined, WRITE_ONLY_CLIPBOARD));
+      // Registered once for the terminal's lifetime; dispose() cleans it up.
+      xterm.onData((data) => onDataRef.current(data));
+      xterm.open(container);
 
       hasInitializedRef.current = true;
       fitAddonRef.current = fitAddon;
       terminalRef.current = xterm;
-
-      xterm.loadAddon(fitAddon);
-
-      const currentXterm = xterm;
-      openFrameId = requestAnimationFrame(() => {
-        openFrameId = null;
-        if (cancelled || !container.isConnected || terminalRef.current !== currentXterm) {
-          return;
-        }
-        try {
-          currentXterm.open(container);
-          setIsReady(true);
-        } catch {
-          terminalRef.current = null;
-          hasInitializedRef.current = false;
-        }
-      });
-    })();
+      setIsReady(true);
+    })().catch((error: unknown) => {
+      // Chunk-load or open() failure — the overlay stays on "Initializing",
+      // and remounting the tab retries from scratch.
+      logger.error('Terminal initialization failed', 'useXterm', error);
+    });
 
     return () => {
       cancelled = true;
-      if (openFrameId !== null) {
-        cancelAnimationFrame(openFrameId);
-      }
-      inputHandlerRef.current?.dispose();
-      inputHandlerRef.current = null;
       fitAddonRef.current = null;
       terminalRef.current = null;
-      try {
-        xterm?.dispose();
-      } catch {
-        // Ignore dispose errors
-      }
+      xterm?.dispose();
       setIsReady(false);
       hasInitializedRef.current = false;
     };
@@ -169,33 +164,15 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
 
   useEffect(() => {
     const terminal = terminalRef.current;
-
     if (!terminal) {
-      return;
+      return undefined;
     }
 
-    inputHandlerRef.current?.dispose();
-    inputHandlerRef.current = terminal.onData(onData);
+    terminal.options.theme = buildTerminalTheme(mode);
 
-    return () => {
-      inputHandlerRef.current?.dispose();
-      inputHandlerRef.current = null;
-    };
-  }, [onData]);
-
-  useEffect(() => {
-    const terminal = terminalRef.current;
-    if (!terminal || !hasRenderer(terminal)) {
-      return;
-    }
-
-    try {
-      terminal.options.theme = buildTerminalTheme(mode);
-    } catch {
-      return;
-    }
-
-    if (isReady && isVisible) {
+    if (isVisible) {
+      // Refit after the theme swap settles — palette changes can nudge cell
+      // metrics via the renderer's measured styles.
       const frame = requestAnimationFrame(() => {
         fitTerminal();
       });
@@ -215,10 +192,11 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
     let cancelled = false;
 
     const scheduleFit = () => {
-      if (frame) {
+      if (frame !== null) {
         cancelAnimationFrame(frame);
       }
       frame = requestAnimationFrame(() => {
+        frame = null;
         if (!cancelled) {
           fitTerminal();
         }
@@ -230,12 +208,12 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
         scheduleFit();
       }
     });
-
     resizeObserver.observe(container);
 
     if (isVisible) {
       scheduleFit();
-      document.fonts?.ready.then(() => {
+      // Late font loads change glyph metrics — refit once everything settled.
+      void document.fonts?.ready.then(() => {
         if (!cancelled) {
           fitTerminal();
         }
@@ -244,7 +222,7 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
 
     return () => {
       cancelled = true;
-      if (frame) {
+      if (frame !== null) {
         cancelAnimationFrame(frame);
       }
       resizeObserver.disconnect();

--- a/frontend/src/utils/terminal.ts
+++ b/frontend/src/utils/terminal.ts
@@ -1,4 +1,4 @@
-import type { ITerminalOptions } from 'xterm';
+import type { ITerminalOptions } from '@xterm/xterm';
 import type { Palette } from '@/types/ui.types';
 import { CUSTOM_PALETTE_TOKENS, DARK_PALETTES } from '@/utils/theme';
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
           'react-vendor': ['react', 'react-dom', 'react-router-dom'],
           'query-vendor': ['@tanstack/react-query', '@tanstack/react-query-devtools'],
           monaco: ['monaco-editor', '@monaco-editor/react'],
-          terminal: ['xterm', 'xterm-addon-fit'],
+          terminal: ['@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-clipboard'],
           mermaid: ['mermaid'],
           markdown: ['react-markdown', 'remark-gfm', 'remark-math', 'rehype-katex'],
         },


### PR DESCRIPTION
## Summary
- Move the tmux reattach repaint from server-triggered (on `ensure_started` detecting an existing session) to an explicit client-sent `refresh` message after `init` — avoids repainting a connection a racing reconnect is about to replace, and avoids repainting before the client's xterm is even open/sized.
- Serialize `TerminalSessionRecord.ensure_started` with an `asyncio.Lock` so two connections racing into the same session record (e.g. a page refresh) can't spawn two PTYs; add a regression test that races two inits and asserts only one PTY is created.
- Extract the tmux PTY launch command into `SandboxProvider.build_pty_shell_command`, shared by the Docker and host providers, and enable tmux mouse mode + OSC 52 clipboard forwarding (scrollback/selection didn't work under tmux's alternate screen before).
- Migrate frontend terminal deps from the deprecated `xterm` / `xterm-addon-fit` to `@xterm/xterm` / `@xterm/addon-fit`, and add `@xterm/addon-clipboard` (write-only provider — sandbox processes must not read the user's clipboard back through the PTY).
- Simplify `useXterm`: drop the private-field renderer probe (`_core._renderService...`) in favor of `FitAddon.proposeDimensions()`, route callbacks through refs to keep the open effect stable across re-renders, and remove the now-unnecessary `requestAnimationFrame` deferral around `terminal.open()`.

## Test plan
- [x] `backend/tests/test_websocket.py` — added `test_terminal_websocket_concurrent_inits_share_one_pty` and updated the reattach test to assert the repaint only happens after an explicit `refresh` message
- [x] `frontend/.../TerminalTab.test.tsx` — updated to assert `refresh` is sent only after `init` is acked
- [ ] Manual smoke test of terminal reattach/reconnect and mouse scroll/selection in a running sandbox