### PR TITLE
chore: add tmux to backend Docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     gosu docker-cli \
     build-essential \
     openssh-client \
-    gh ripgrep fd-find jq less tree unzip && \
+    gh ripgrep fd-find jq less tree unzip tmux && \
     ln -s "$(command -v fdfind)" /usr/local/bin/fd && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \


### PR DESCRIPTION
## Summary
- Adds `tmux` to the apt-get install list in `backend/Dockerfile`, required by the recently added terminal PTY/tmux session support (see #813, #812, #811).