### PR TITLE
chore: bump claude-code to 2.1.206

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.57.0 @agentclientprotocol/codex-acp@1.1.2 @openai/codex@0.144.1 @github/copilot@1.0.36
+RUN npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.57.0 @agentclientprotocol/codex-acp@1.1.2 @openai/codex@0.144.1 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to /root/.local/bin) — used for the Cursor
 # ACP server (`cursor-agent acp`). The install script downloads the binary for

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -57,7 +57,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.119 @agentclientprotocol/claude-agent-acp@0.57.0 @agentclientprotocol/codex-acp@1.1.2 @openai/codex@0.144.1 @github/copilot@1.0.36
+    npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.57.0 @agentclientprotocol/codex-acp@1.1.2 @openai/codex@0.144.1 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to ~/.local/bin, which is already on PATH).
 RUN curl -fsS https://cursor.com/install | bash


### PR DESCRIPTION
## Summary
- Bump `@anthropic-ai/claude-code` from `2.1.119` to `2.1.206` in `backend/Dockerfile` and `sandbox/docker/Dockerfile`