### PR TITLE
fix: preserve Codex edit diffs on terminal tool update

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ docker compose -f docker-compose-production.yml up -d --build
 
 Join the [Discord server](https://discord.gg/HvkJU8dcBA).
 
+## Contributing
+
+Contributions and feedback are welcome.
+
 ## License
 
 Apache 2.0. See [LICENSE](LICENSE).

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -359,6 +359,12 @@ class AcpClientHandler:
             parent_id=self._extract_parent_tool_id(tc),
             input=self._extract_raw_input(tc.raw_input),
         )
+        # Codex attaches edit diffs as content blocks on the initial tool_call
+        # (and re-sent tool_call updates), while its terminal tool_call_update
+        # carries only a status — capture the diffs here or they're lost.
+        diffs = self._extract_content_diffs(tc)
+        if diffs:
+            payload["result"] = {"diffs": diffs}
         self._active_tools[tc.tool_call_id] = payload
         return StreamEvent(type="tool_started", tool=payload)
 
@@ -396,7 +402,11 @@ class AcpClientHandler:
         if status == "completed":
             self._active_tools.pop(tc.tool_call_id, None)
             existing["status"] = ToolStatus.COMPLETED.value
-            existing["result"] = self._extract_tool_result(tc)
+            result = self._extract_tool_result(tc)
+            # Codex edit diffs were captured from earlier tool_call events —
+            # don't wipe them when the terminal update carries no result.
+            if result is not None or "result" not in existing:
+                existing["result"] = result
             selected_mode = self._resolved_permissions.pop(tc.tool_call_id, None)
             if selected_mode is not None:
                 existing["permission_mode"] = selected_mode
@@ -503,9 +513,12 @@ class AcpClientHandler:
         return texts
 
     @staticmethod
-    def _extract_content_diffs(tc: ToolCallProgress) -> list[dict[str, Any]]:
-        # Cursor emits its `edit` tool results as ACP FileEditToolCallContent
-        # blocks (type="diff") with path/oldText/newText, without raw_output.
+    def _extract_content_diffs(
+        tc: ToolCallStart | ToolCallProgress,
+    ) -> list[dict[str, Any]]:
+        # Cursor and Codex emit `edit` tool results as ACP FileEditToolCallContent
+        # blocks (type="diff") with path/oldText/newText, without raw_output —
+        # Cursor on the terminal update, Codex on the initial tool_call.
         # Surface these so the frontend edit renderer can show the diff.
         if not tc.content:
             return []

--- a/backend/tests/fake_acp_agent.py
+++ b/backend/tests/fake_acp_agent.py
@@ -68,6 +68,7 @@ MARKER_TOOL_LEFT_OPEN = "MARKER_TOOL_LEFT_OPEN"
 MARKER_FS_TERMINAL_STUBS = "MARKER_FS_TERMINAL_STUBS"
 MARKER_IMAGE_CONTENT = "MARKER_IMAGE_CONTENT"
 MARKER_TOOL_EMPTY_RESULT = "MARKER_TOOL_EMPTY_RESULT"
+MARKER_TOOL_START_DIFF = "MARKER_TOOL_START_DIFF"
 MARKER_TOOL_UNKNOWN_DICT_ERROR = "MARKER_TOOL_UNKNOWN_DICT_ERROR"
 MARKER_ENTER_PLAN_MODE = "MARKER_ENTER_PLAN_MODE"
 # 1x1 transparent PNG, reused wherever the protocol needs inline image bytes.
@@ -376,6 +377,7 @@ class FakeAgent:
         field_meta: dict[str, Any] | None = None,
         raw_input: Any = None,
         kind: str = "execute",
+        content: list[Any] | None = None,
     ) -> None:
         assert self._client is not None
         await self._client.session_update(
@@ -387,6 +389,7 @@ class FakeAgent:
                 kind=kind,
                 raw_input=raw_input,
                 field_meta=field_meta,
+                content=content,
             ),
         )
 
@@ -543,6 +546,15 @@ class FakeAgent:
         elif MARKER_RAW_INPUT_INVALID in text:
             raw_input = "not-json{{"
 
+        start_content: list[Any] | None = None
+        if MARKER_TOOL_START_DIFF in text:
+            # Codex attaches edit diffs to the initial tool_call and ends with a
+            # status-only update — the diff must survive to tool_completed.
+            start_content = [
+                FileEditToolCallContent(
+                    type="diff", path="app.py", old_text="old", new_text="new"
+                )
+            ]
         await self._emit_tool_started(
             session_id,
             "tool-primary",
@@ -551,6 +563,7 @@ class FakeAgent:
                 "claudeCode": {"toolName": "Read", "parentToolUseId": "parent-1"}
             },
             raw_input=raw_input,
+            content=start_content,
         )
         # Title-only update with no status — re-emitted as tool_started so the
         # UI can refresh the loading title before the tool finishes.
@@ -698,9 +711,11 @@ class FakeAgent:
                 ),
             )
             return
-        if MARKER_TOOL_EMPTY_RESULT in text:
+        if MARKER_TOOL_EMPTY_RESULT in text or MARKER_TOOL_START_DIFF in text:
             # No raw_output, no diff/text content — _extract_tool_result falls
             # all the way through to its empty-content "return None" fallback.
+            # For START_DIFF the diffs captured from the ToolCallStart must
+            # survive this bare terminal update (Codex edit shape).
             await self._client.session_update(
                 session_id=session_id,
                 update=ToolCallProgress(

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -31,6 +31,7 @@ from tests.fake_acp_agent import (
     MARKER_TOOL_LEFT_OPEN,
     MARKER_TOOL_PROGRESS_NEW,
     MARKER_TOOL_PROGRESS_ORPHAN,
+    MARKER_TOOL_START_DIFF,
     MARKER_TOOL_STRING_ERROR,
     MARKER_TOOL_TEXT_ERROR,
     MARKER_TOOL_TEXT_RESULT,
@@ -415,6 +416,12 @@ async def test_enhance_prompt_survives_config_option_failures(
             {"diffs": [{"path": "app.py", "oldText": "old", "newText": "new"}]},
         ),
         (MARKER_TOOL_TEXT_RESULT, "tool-primary", "result", "plain text result"),
+        (
+            MARKER_TOOL_START_DIFF,
+            "tool-primary",
+            "result",
+            {"diffs": [{"path": "app.py", "oldText": "old", "newText": "new"}]},
+        ),
         (MARKER_TOOL_CODEX_ERROR, "tool-secondary", "error", "boom codex"),
         (MARKER_TOOL_STRING_ERROR, "tool-secondary", "error", "boom plain string"),
         (

--- a/frontend/src/components/chat/tools/codex/EditTool.tsx
+++ b/frontend/src/components/chat/tools/codex/EditTool.tsx
@@ -1,5 +1,6 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import clsx from 'clsx';
+import { structuredPatch } from 'diff';
 import { FileEdit, FilePlus } from 'lucide-react';
 import type { ToolAggregate } from '@/types/tools.types';
 import { extractFilename } from '@/utils/format';
@@ -14,6 +15,12 @@ interface FileChange {
   move_path?: string | null;
 }
 
+interface DiffBlock {
+  path?: string | null;
+  oldText?: string | null;
+  newText?: string | null;
+}
+
 interface EditInput {
   changes?: Record<string, FileChange>;
 }
@@ -22,7 +29,30 @@ interface EditOutput {
   success?: boolean;
   stdout?: string;
   changes?: Record<string, FileChange>;
+  diffs?: DiffBlock[];
 }
+
+// codex-acp sends ACP diff blocks carrying full old/new file contents, so
+// compute hunked unified diffs to render only the changed regions.
+const toUnifiedDiff = (oldText: string, newText: string): string => {
+  const patch = structuredPatch('', '', oldText, newText);
+  return patch.hunks
+    .map((h) =>
+      [`@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@`, ...h.lines].join('\n'),
+    )
+    .join('\n');
+};
+
+const diffBlockToFileChange = (block: DiffBlock): FileChange => {
+  // ACP diff semantics: empty oldText = create, empty newText = delete.
+  if (!block.oldText) {
+    return { type: 'add', content: block.newText ?? '' };
+  }
+  if (!block.newText) {
+    return { type: 'delete', unified_diff: toUnifiedDiff(block.oldText, '') };
+  }
+  return { type: 'update', unified_diff: toUnifiedDiff(block.oldText, block.newText) };
+};
 
 function DiffLine({ line }: { line: string }) {
   const isAdded = line.startsWith('+') && !line.startsWith('+++');
@@ -89,7 +119,14 @@ export const EditTool = memo(function EditTool({ tool }: { tool: ToolAggregate }
   const input = tool.input as EditInput | undefined;
   const result = tool.result as EditOutput | undefined;
 
-  const changedFiles = Object.entries(input?.changes ?? result?.changes ?? {});
+  const changedFiles = useMemo<[string, FileChange][]>(() => {
+    const changes = input?.changes ?? result?.changes;
+    if (changes) return Object.entries(changes);
+    return (result?.diffs ?? []).map((block): [string, FileChange] => [
+      block.path ?? '',
+      diffBlockToFileChange(block),
+    ]);
+  }, [input, result]);
 
   const firstFilePath = changedFiles[0]?.[0] ?? '';
   const firstFileName = firstFilePath ? extractFilename(firstFilePath) : '';

--- a/frontend/src/types/diff.d.ts
+++ b/frontend/src/types/diff.d.ts
@@ -7,4 +7,25 @@ declare module 'diff' {
   }
 
   export function diffLines(oldStr: string, newStr: string): Change[];
+
+  export interface Hunk {
+    oldStart: number;
+    oldLines: number;
+    newStart: number;
+    newLines: number;
+    lines: string[];
+  }
+
+  export interface StructuredPatch {
+    oldFileName: string;
+    newFileName: string;
+    hunks: Hunk[];
+  }
+
+  export function structuredPatch(
+    oldFileName: string,
+    newFileName: string,
+    oldStr: string,
+    newStr: string,
+  ): StructuredPatch;
 }


### PR DESCRIPTION
## Summary
- Codex attaches edit diffs as content blocks on the initial `tool_call`, while its terminal `tool_call_update` carries only a status — the terminal update was overwriting the previously captured diff result with `None`. Now the result is only overwritten when the terminal update actually carries one.
- `EditTool` now falls back to rendering directly from ACP diff blocks (computing hunked unified diffs) when no `changes` map is present, covering the Codex shape.
- Added a `MARKER_TOOL_START_DIFF` fake-agent scenario and backend test to cover diffs attached at `tool_call` start surviving through to `tool_completed`.
- Minor README addition of a Contributing section.

## Test plan
- [ ] `pytest backend/tests/test_acp.py -k tool_start_diff` (or full backend/tests/test_acp.py run)
- [ ] Manually run a Codex-backed chat that edits a file and confirm the diff renders in the UI