### PR TITLE
test: add frontend unit tests and CI test job

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -47,6 +47,30 @@ jobs:
           cd frontend
           npm run typecheck
 
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          cd frontend
+          npm ci --legacy-peer-deps
+
+      - name: Run tests
+        run: |
+          cd frontend
+          npm test
+
   build:
     name: Build Verification
     runs-on: ubuntu-latest

--- a/frontend/src/lib/editorNavigation.test.ts
+++ b/frontend/src/lib/editorNavigation.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const openFileInEditor = vi.fn();
+const searchInFiles = vi.fn();
+const fetchQuery = vi.fn();
+
+vi.mock('@/store/uiStore', () => ({
+  useUIStore: { getState: () => ({ openFileInEditor }) },
+}));
+vi.mock('@/services/sandboxService', () => ({
+  sandboxService: {
+    searchInFiles: (...a: unknown[]) => searchInFiles(...a),
+    getFileContent: vi.fn(),
+  },
+}));
+vi.mock('@/lib/queryClient', () => ({
+  queryClient: { fetchQuery: (...a: unknown[]) => fetchQuery(...a) },
+}));
+// Avoid pulling the file util's react-hot-toast import chain into the node run.
+vi.mock('@/utils/file', () => ({ detectLanguage: () => 'plaintext' }));
+
+// Fresh module per test so the module-level activeContext/installed reset.
+async function load() {
+  vi.resetModules();
+  return import('./editorNavigation');
+}
+
+// Minimal Monaco stand-in capturing the handlers the module registers.
+function makeMonaco() {
+  const models = new Map<string, FakeModel>();
+  let opener: OpenerHandler;
+  let defProvider: DefProvider;
+  const Uri = {
+    parse: (s: string) => {
+      const match = /^(\w+):\/\/([^/]*)(\/.*)$/.exec(s)!;
+      return uri(match[1], match[2], match[3]);
+    },
+  };
+  const editor = {
+    registerEditorOpener: (o: OpenerHandler) => {
+      opener = o;
+      return { dispose() {} };
+    },
+    getModel: (u: FakeUri) => models.get(u.toString()),
+    createModel: (content: string, _lang: string, u: FakeUri) => {
+      const lines = content.split('\n');
+      const model: FakeModel = {
+        uri: u,
+        getLineCount: () => lines.length,
+        getLineContent: (n: number) => lines[n - 1] ?? '',
+      };
+      models.set(u.toString(), model);
+      return model;
+    },
+  };
+  const languages = {
+    registerDefinitionProvider: (_s: string, p: DefProvider) => {
+      defProvider = p;
+      return { dispose() {} };
+    },
+    registerReferenceProvider: () => ({ dispose() {} }),
+  };
+  const m = { editor, languages, Uri } as unknown as MonacoLike;
+  return { m, get: () => ({ opener: opener!, defProvider: defProvider! }) };
+}
+
+function uri(scheme: string, authority: string, path: string): FakeUri {
+  return { scheme, authority, path, toString: () => `${scheme}://${authority}${path}` };
+}
+
+function fakeEditor() {
+  const cbs: { focus?: () => void; move?: () => void } = {};
+  return {
+    editor: {
+      onDidFocusEditorText: (cb: () => void) => {
+        cbs.focus = cb;
+        return { dispose() {} };
+      },
+      onMouseMove: (cb: () => void) => {
+        cbs.move = cb;
+        return { dispose() {} };
+      },
+    } as unknown as Parameters<
+      (typeof import('./editorNavigation'))['attachEditorNavigationContext']
+    >[0],
+    cbs,
+  };
+}
+
+interface FakeUri {
+  scheme: string;
+  authority: string;
+  path: string;
+  toString(): string;
+}
+interface FakeModel {
+  uri: FakeUri;
+  getLineCount(): number;
+  getLineContent(n: number): string;
+}
+type OpenerHandler = {
+  openCodeEditor: (source: unknown, resource: FakeUri, sel: unknown) => boolean;
+};
+type DefProvider = {
+  provideDefinition: (model: unknown, position: unknown, token: unknown) => Promise<unknown>;
+};
+type MonacoLike = Parameters<(typeof import('./editorNavigation'))['setupEditorNavigation']>[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('editor opener context resolution', () => {
+  it('rejects a jump when no pane has claimed a context', async () => {
+    const { setupEditorNavigation } = await load();
+    const { m, get } = makeMonaco();
+    setupEditorNavigation(m);
+    const ok = get().opener.openCodeEditor({}, uri('sandbox', 'sbx', '/foo.ts'), null);
+    expect(ok).toBe(false);
+    expect(openFileInEditor).not.toHaveBeenCalled();
+  });
+
+  it('rejects a resource whose authority is not the claimed sandbox', async () => {
+    const { setupEditorNavigation, attachEditorNavigationContext } = await load();
+    const { m, get } = makeMonaco();
+    setupEditorNavigation(m);
+    attachEditorNavigationContext(fakeEditor().editor, {
+      sandboxId: 'sbx',
+      chatId: 'c1',
+      cwd: undefined,
+    });
+    expect(get().opener.openCodeEditor({}, uri('sandbox', 'other', '/foo.ts'), null)).toBe(false);
+    expect(get().opener.openCodeEditor({}, uri('file', 'sbx', '/foo.ts'), null)).toBe(false);
+  });
+
+  it('opens the file (path without leading slash) using a range start line', async () => {
+    const { setupEditorNavigation, attachEditorNavigationContext } = await load();
+    const { m, get } = makeMonaco();
+    setupEditorNavigation(m);
+    attachEditorNavigationContext(fakeEditor().editor, {
+      sandboxId: 'sbx',
+      chatId: 'c1',
+      cwd: undefined,
+    });
+    const ok = get().opener.openCodeEditor({}, uri('sandbox', 'sbx', '/src/foo.ts'), {
+      startLineNumber: 12,
+    });
+    expect(ok).toBe(true);
+    expect(openFileInEditor).toHaveBeenCalledWith('src/foo.ts', 'c1', 12);
+  });
+
+  it('uses a plain position line number when no range is present', async () => {
+    const { setupEditorNavigation, attachEditorNavigationContext } = await load();
+    const { m, get } = makeMonaco();
+    setupEditorNavigation(m);
+    attachEditorNavigationContext(fakeEditor().editor, {
+      sandboxId: 'sbx',
+      chatId: 'c1',
+      cwd: undefined,
+    });
+    get().opener.openCodeEditor({}, uri('sandbox', 'sbx', '/foo.ts'), { lineNumber: 7 });
+    expect(openFileInEditor).toHaveBeenCalledWith('foo.ts', 'c1', 7);
+  });
+
+  it('passes an undefined line when no selection is given', async () => {
+    const { setupEditorNavigation, attachEditorNavigationContext } = await load();
+    const { m, get } = makeMonaco();
+    setupEditorNavigation(m);
+    attachEditorNavigationContext(fakeEditor().editor, {
+      sandboxId: 'sbx',
+      chatId: 'c1',
+      cwd: undefined,
+    });
+    get().opener.openCodeEditor({}, uri('sandbox', 'sbx', '/foo.ts'), null);
+    expect(openFileInEditor).toHaveBeenCalledWith('foo.ts', 'c1', undefined);
+  });
+
+  it('rejects when the claiming context has no sandbox id', async () => {
+    const { setupEditorNavigation, attachEditorNavigationContext } = await load();
+    const { m, get } = makeMonaco();
+    setupEditorNavigation(m);
+    attachEditorNavigationContext(fakeEditor().editor, {
+      sandboxId: undefined,
+      chatId: 'c1',
+      cwd: undefined,
+    });
+    expect(get().opener.openCodeEditor({}, uri('sandbox', 'sbx', '/foo.ts'), null)).toBe(false);
+  });
+});
+
+describe('context claim via editor listeners', () => {
+  it('re-claims the context when a previously-attached pane fires mouse-move', async () => {
+    const { setupEditorNavigation, attachEditorNavigationContext } = await load();
+    const { m, get } = makeMonaco();
+    setupEditorNavigation(m);
+
+    const first = fakeEditor();
+    attachEditorNavigationContext(first.editor, { sandboxId: 'sbx', chatId: 'c1', cwd: undefined });
+    // A second pane becomes the active claim.
+    attachEditorNavigationContext(fakeEditor().editor, {
+      sandboxId: 'sbx',
+      chatId: 'c2',
+      cwd: undefined,
+    });
+    // Interacting with the first pane reclaims it, so jumps route to c1 again.
+    first.cbs.move?.();
+    get().opener.openCodeEditor({}, uri('sandbox', 'sbx', '/foo.ts'), null);
+    expect(openFileInEditor).toHaveBeenLastCalledWith('foo.ts', 'c1', undefined);
+  });
+});
+
+describe('provideDefinition', () => {
+  function sourceModel(word: string | null) {
+    return {
+      uri: uri('sandbox', 'sbx', '/src/a.ts'),
+      getWordAtPosition: () => (word ? { word } : null),
+      getLanguageId: () => 'typescript',
+    };
+  }
+
+  async function setup() {
+    const mod = await load();
+    const { m, get } = makeMonaco();
+    mod.setupEditorNavigation(m);
+    mod.attachEditorNavigationContext(fakeEditor().editor, {
+      sandboxId: 'sbx',
+      chatId: 'c1',
+      cwd: undefined,
+    });
+    return get().defProvider;
+  }
+
+  it('returns null when the cursor is not on a word', async () => {
+    const provider = await setup();
+    const result = await provider.provideDefinition(
+      sourceModel(null),
+      {},
+      {
+        isCancellationRequested: false,
+      },
+    );
+    expect(result).toBeNull();
+    expect(searchInFiles).not.toHaveBeenCalled();
+  });
+
+  it('locates the symbol column in the live model line (1-based)', async () => {
+    const provider = await setup();
+    searchInFiles.mockResolvedValue({ results: [{ path: 'a.ts', matches: [{ line_number: 2 }] }] });
+    fetchQuery.mockResolvedValue({ is_binary: false, content: 'line one\nconst foo = 1\n' });
+
+    const result = (await provider.provideDefinition(
+      sourceModel('foo'),
+      {},
+      {
+        isCancellationRequested: false,
+      },
+    )) as Array<{ range: Record<string, number> }>;
+
+    // 'const foo = 1' -> 'foo' starts at index 6, so column 7 (1-based).
+    expect(result).toHaveLength(1);
+    expect(result[0].range).toMatchObject({
+      startLineNumber: 2,
+      startColumn: 7,
+      endLineNumber: 2,
+      endColumn: 10,
+    });
+  });
+
+  it('skips matches whose line number exceeds the live model length', async () => {
+    const provider = await setup();
+    searchInFiles.mockResolvedValue({ results: [{ path: 'a.ts', matches: [{ line_number: 9 }] }] });
+    fetchQuery.mockResolvedValue({ is_binary: false, content: 'only one line' });
+    const result = (await provider.provideDefinition(
+      sourceModel('foo'),
+      {},
+      {
+        isCancellationRequested: false,
+      },
+    )) as unknown[];
+    expect(result).toEqual([]);
+  });
+
+  it('produces no locations for a binary target file', async () => {
+    const provider = await setup();
+    searchInFiles.mockResolvedValue({ results: [{ path: 'a.ts', matches: [{ line_number: 1 }] }] });
+    fetchQuery.mockResolvedValue({ is_binary: true });
+    const result = (await provider.provideDefinition(
+      sourceModel('foo'),
+      {},
+      {
+        isCancellationRequested: false,
+      },
+    )) as unknown[];
+    expect(result).toEqual([]);
+  });
+
+  it('returns null on a failed search (errors stay quiet)', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const provider = await setup();
+    searchInFiles.mockRejectedValue(new Error('offline'));
+    const result = await provider.provideDefinition(
+      sourceModel('foo'),
+      {},
+      {
+        isCancellationRequested: false,
+      },
+    );
+    expect(result).toBeNull();
+    errSpy.mockRestore();
+  });
+
+  it('returns null when cancelled after the search resolves', async () => {
+    const provider = await setup();
+    searchInFiles.mockResolvedValue({ results: [{ path: 'a.ts', matches: [{ line_number: 1 }] }] });
+    const result = await provider.provideDefinition(
+      sourceModel('foo'),
+      {},
+      {
+        isCancellationRequested: true,
+      },
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/src/store/chatStore.test.ts
+++ b/frontend/src/store/chatStore.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useChatStore } from './chatStore';
+import type { Chat } from '@/types/chat.types';
+
+const chat = (id: string): Chat =>
+  ({
+    id,
+    user_id: 'u1',
+    title: 'T',
+    workspace_id: 'ws',
+    sandbox_id: 'sb',
+    created_at: '2020-01-01T00:00:00Z',
+    updated_at: '2020-01-01T00:00:00Z',
+    pinned_at: null,
+    worktree_cwd: null,
+    parent_chat_id: null,
+    sub_thread_count: 0,
+    session_agent_kind: null,
+    unread: false,
+  }) as Chat;
+
+const file = (name: string) => new File(['x'], name);
+
+beforeEach(() => {
+  useChatStore.setState({ currentChat: null, attachedFilesByChat: {} });
+});
+
+describe('setCurrentChat', () => {
+  it('stores and clears the current chat', () => {
+    useChatStore.getState().setCurrentChat(chat('c1'));
+    expect(useChatStore.getState().currentChat?.id).toBe('c1');
+    useChatStore.getState().setCurrentChat(null);
+    expect(useChatStore.getState().currentChat).toBeNull();
+  });
+});
+
+describe('setAttachedFilesForChat', () => {
+  it('stores files keyed by chat id', () => {
+    const files = [file('a.png')];
+    useChatStore.getState().setAttachedFilesForChat('c1', files);
+    expect(useChatStore.getState().attachedFilesByChat.c1).toBe(files);
+  });
+
+  it('returns the same state when the identical array reference is set again', () => {
+    const files = [file('a.png')];
+    useChatStore.getState().setAttachedFilesForChat('c1', files);
+    const before = useChatStore.getState().attachedFilesByChat;
+    useChatStore.getState().setAttachedFilesForChat('c1', files);
+    // Reference-equality guard avoids spurious re-renders on no-op writes.
+    expect(useChatStore.getState().attachedFilesByChat).toBe(before);
+  });
+
+  it('replaces the map when a different array is set', () => {
+    useChatStore.getState().setAttachedFilesForChat('c1', [file('a.png')]);
+    const before = useChatStore.getState().attachedFilesByChat;
+    useChatStore.getState().setAttachedFilesForChat('c1', [file('b.png')]);
+    expect(useChatStore.getState().attachedFilesByChat).not.toBe(before);
+    expect(useChatStore.getState().attachedFilesByChat.c1[0].name).toBe('b.png');
+  });
+});
+
+describe('clearAttachedFilesForChat', () => {
+  it('drops the slot for a known chat', () => {
+    useChatStore.getState().setAttachedFilesForChat('c1', [file('a.png')]);
+    useChatStore.getState().clearAttachedFilesForChat('c1');
+    expect('c1' in useChatStore.getState().attachedFilesByChat).toBe(false);
+  });
+
+  it('returns the same state for an unknown chat', () => {
+    const before = useChatStore.getState().attachedFilesByChat;
+    useChatStore.getState().clearAttachedFilesForChat('missing');
+    expect(useChatStore.getState().attachedFilesByChat).toBe(before);
+  });
+});
+
+describe('promoteAttachedFiles', () => {
+  it('moves files from one chat slot to another and clears the source', () => {
+    const files = [file('a.png')];
+    useChatStore.getState().setAttachedFilesForChat('pending', files);
+    useChatStore.getState().promoteAttachedFiles('pending', 'c1');
+    const state = useChatStore.getState().attachedFilesByChat;
+    expect(state.c1).toBe(files);
+    expect('pending' in state).toBe(false);
+  });
+
+  it('is a no-op when the source slot is empty', () => {
+    const before = useChatStore.getState().attachedFilesByChat;
+    useChatStore.getState().promoteAttachedFiles('missing', 'c1');
+    expect(useChatStore.getState().attachedFilesByChat).toBe(before);
+  });
+
+  it('drops the files when promoting a slot onto itself', () => {
+    // Degenerate same-id case: the copy then delete removes the slot entirely.
+    // Not reached in practice (promotion is always PENDING -> real chat id).
+    useChatStore.getState().setAttachedFilesForChat('c1', [file('a.png')]);
+    useChatStore.getState().promoteAttachedFiles('c1', 'c1');
+    expect('c1' in useChatStore.getState().attachedFilesByChat).toBe(false);
+  });
+});

--- a/frontend/src/store/diffReviewStore.test.ts
+++ b/frontend/src/store/diffReviewStore.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDiffReviewStore } from './diffReviewStore';
+
+// Review keys are `path\0contentHash`; a scope groups keys under one target.
+const key = (path: string, hash: string) => `${path}\0${hash}`;
+const scoped = () => useDiffReviewStore.getState().reviewedByScope;
+
+beforeEach(() => {
+  localStorage.clear();
+  useDiffReviewStore.setState({ reviewedByScope: {} });
+});
+
+describe('toggleReviewed', () => {
+  it('marks a file reviewed under its scope', () => {
+    useDiffReviewStore.getState().toggleReviewed('scope', key('a.ts', 'h1'));
+    expect(scoped().scope).toEqual([key('a.ts', 'h1')]);
+  });
+
+  it('un-reviews on a second toggle and drops the emptied scope bucket', () => {
+    const k = key('a.ts', 'h1');
+    useDiffReviewStore.getState().toggleReviewed('scope', k);
+    useDiffReviewStore.getState().toggleReviewed('scope', k);
+    expect('scope' in scoped()).toBe(false);
+  });
+
+  it('replaces a stale hash key for the same path with the new one', () => {
+    // Reviewing the file, then editing it (new hash) and reviewing again must
+    // leave exactly one live key for that path — no stale post-edit hash lingers.
+    useDiffReviewStore.getState().toggleReviewed('scope', key('a.ts', 'old'));
+    useDiffReviewStore.getState().toggleReviewed('scope', key('a.ts', 'new'));
+    expect(scoped().scope).toEqual([key('a.ts', 'new')]);
+  });
+
+  it('keeps distinct paths in the same scope', () => {
+    useDiffReviewStore.getState().toggleReviewed('scope', key('a.ts', 'h1'));
+    useDiffReviewStore.getState().toggleReviewed('scope', key('b.ts', 'h2'));
+    expect(scoped().scope).toEqual([key('a.ts', 'h1'), key('b.ts', 'h2')]);
+  });
+
+  it('un-reviews one path without disturbing the others', () => {
+    const a = key('a.ts', 'h1');
+    const b = key('b.ts', 'h2');
+    useDiffReviewStore.getState().toggleReviewed('scope', a);
+    useDiffReviewStore.getState().toggleReviewed('scope', b);
+    useDiffReviewStore.getState().toggleReviewed('scope', a);
+    expect(scoped().scope).toEqual([b]);
+  });
+
+  it('keeps scopes isolated from each other', () => {
+    useDiffReviewStore.getState().toggleReviewed('s1', key('a.ts', 'h1'));
+    useDiffReviewStore.getState().toggleReviewed('s2', key('a.ts', 'h1'));
+    expect(scoped()).toEqual({
+      s1: [key('a.ts', 'h1')],
+      s2: [key('a.ts', 'h1')],
+    });
+  });
+});

--- a/frontend/src/store/messageQueueStore.test.ts
+++ b/frontend/src/store/messageQueueStore.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useMessageQueueStore, EMPTY_QUEUE } from './messageQueueStore';
+import { queueService } from '@/services/queueService';
+import type { LocalQueuedMessage } from '@/types/queue.types';
+
+vi.mock('@/services/queueService', () => ({
+  queueService: {
+    queueMessage: vi.fn(),
+    getQueue: vi.fn(),
+    updateQueuedMessage: vi.fn(),
+    deleteQueuedMessage: vi.fn(),
+    sendNow: vi.fn(),
+    clearQueue: vi.fn(),
+  },
+}));
+
+const svc = vi.mocked(queueService);
+
+const localMsg = (over: Partial<LocalQueuedMessage> & { id: string }): LocalQueuedMessage => ({
+  content: 'hi',
+  model_id: 'm',
+  queuedAt: 1000,
+  synced: true,
+  sendingNow: false,
+  ...over,
+});
+
+const seed = (chatId: string, msgs: LocalQueuedMessage[]) => {
+  useMessageQueueStore.setState({ queues: new Map([[chatId, msgs]]) });
+};
+
+const queueOf = (chatId: string) => useMessageQueueStore.getState().getQueue(chatId);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  useMessageQueueStore.setState({ queues: new Map() });
+});
+
+describe('queueMessage', () => {
+  it('optimistically adds a message, then swaps in the server id and marks it synced', async () => {
+    svc.queueMessage.mockResolvedValue({ id: 'server-1' });
+    const returned = await useMessageQueueStore.getState().queueMessage('c1', 'hello', 'gpt-5');
+
+    expect(returned).toBe('server-1');
+    const queue = queueOf('c1');
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({
+      id: 'server-1',
+      content: 'hello',
+      model_id: 'gpt-5',
+      synced: true,
+    });
+  });
+
+  it('keeps the unsynced local message on a network error and returns the temp id', async () => {
+    svc.queueMessage.mockRejectedValue(new TypeError('Failed to fetch'));
+    const returned = await useMessageQueueStore.getState().queueMessage('c1', 'hello', 'gpt-5');
+
+    const queue = queueOf('c1');
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe(returned);
+    expect(queue[0].synced).toBe(false);
+  });
+
+  it('rolls back the optimistic add and rethrows on a non-network error', async () => {
+    svc.queueMessage.mockRejectedValue(new Error('boom'));
+    await expect(
+      useMessageQueueStore.getState().queueMessage('c1', 'hello', 'gpt-5'),
+    ).rejects.toThrow('boom');
+    expect(queueOf('c1')).toBe(EMPTY_QUEUE);
+  });
+});
+
+describe('getQueue', () => {
+  it('returns the shared empty-queue reference for an unknown chat', () => {
+    expect(queueOf('missing')).toBe(EMPTY_QUEUE);
+  });
+});
+
+describe('updateQueuedMessage', () => {
+  it('trims and updates content locally, syncing when the message is on the server', async () => {
+    seed('c1', [localMsg({ id: 'm1', synced: true })]);
+    await useMessageQueueStore.getState().updateQueuedMessage('c1', 'm1', '  edited  ');
+
+    expect(queueOf('c1')[0].content).toBe('edited');
+    expect(svc.updateQueuedMessage).toHaveBeenCalledWith('c1', 'm1', 'edited');
+  });
+
+  it('does not hit the server for an unsynced local edit', async () => {
+    seed('c1', [localMsg({ id: 'm1', synced: false })]);
+    await useMessageQueueStore.getState().updateQueuedMessage('c1', 'm1', 'edited');
+
+    expect(queueOf('c1')[0].content).toBe('edited');
+    expect(svc.updateQueuedMessage).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for an unknown message', async () => {
+    seed('c1', [localMsg({ id: 'm1' })]);
+    await useMessageQueueStore.getState().updateQueuedMessage('c1', 'missing', 'edited');
+
+    expect(queueOf('c1')[0].content).toBe('hi');
+    expect(svc.updateQueuedMessage).not.toHaveBeenCalled();
+  });
+
+  it('removes the message when the edited content is blank', async () => {
+    seed('c1', [localMsg({ id: 'm1', synced: true })]);
+    await useMessageQueueStore.getState().updateQueuedMessage('c1', 'm1', '   ');
+
+    expect(queueOf('c1')).toBe(EMPTY_QUEUE);
+    expect(svc.deleteQueuedMessage).toHaveBeenCalledWith('c1', 'm1');
+  });
+});
+
+describe('removeMessage', () => {
+  it('removes a synced message and deletes it on the server', async () => {
+    seed('c1', [localMsg({ id: 'm1', synced: true }), localMsg({ id: 'm2', synced: true })]);
+    await useMessageQueueStore.getState().removeMessage('c1', 'm1');
+
+    expect(queueOf('c1').map((m) => m.id)).toEqual(['m2']);
+    expect(svc.deleteQueuedMessage).toHaveBeenCalledWith('c1', 'm1');
+  });
+
+  it('drops the chat bucket when the last message is removed', async () => {
+    seed('c1', [localMsg({ id: 'm1', synced: true })]);
+    await useMessageQueueStore.getState().removeMessage('c1', 'm1');
+    expect(useMessageQueueStore.getState().queues.has('c1')).toBe(false);
+  });
+
+  it('does not call the server for an unsynced message', async () => {
+    seed('c1', [localMsg({ id: 'm1', synced: false })]);
+    await useMessageQueueStore.getState().removeMessage('c1', 'm1');
+    expect(svc.deleteQueuedMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeLocalOnly', () => {
+  it('removes the message without any server call', () => {
+    seed('c1', [localMsg({ id: 'm1', synced: true })]);
+    useMessageQueueStore.getState().removeLocalOnly('c1', 'm1');
+    expect(useMessageQueueStore.getState().queues.has('c1')).toBe(false);
+    expect(svc.deleteQueuedMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('sendNow', () => {
+  it('returns false for an unsynced message and never calls the server', async () => {
+    seed('c1', [localMsg({ id: 'm1', synced: false })]);
+    const ok = await useMessageQueueStore.getState().sendNow('c1', 'm1');
+    expect(ok).toBe(false);
+    expect(svc.sendNow).not.toHaveBeenCalled();
+  });
+
+  it('returns false for an unknown message', async () => {
+    seed('c1', [localMsg({ id: 'm1', synced: true })]);
+    expect(await useMessageQueueStore.getState().sendNow('c1', 'missing')).toBe(false);
+  });
+
+  it('sends a synced message and leaves sendingNow set on success', async () => {
+    svc.sendNow.mockResolvedValue(undefined);
+    seed('c1', [localMsg({ id: 'm1', synced: true })]);
+    const ok = await useMessageQueueStore.getState().sendNow('c1', 'm1');
+
+    expect(ok).toBe(true);
+    expect(svc.sendNow).toHaveBeenCalledWith('c1', 'm1');
+    // Flag stays set until the stream actually processes and removes the message.
+    expect(queueOf('c1')[0].sendingNow).toBe(true);
+  });
+
+  it('resets sendingNow and returns false when the send fails', async () => {
+    svc.sendNow.mockRejectedValue(new Error('nope'));
+    seed('c1', [localMsg({ id: 'm1', synced: true })]);
+    const ok = await useMessageQueueStore.getState().sendNow('c1', 'm1');
+
+    expect(ok).toBe(false);
+    expect(queueOf('c1')[0].sendingNow).toBe(false);
+  });
+});
+
+describe('clearQueue / cleanupChat', () => {
+  it('clearQueue drops the whole chat bucket', () => {
+    seed('c1', [localMsg({ id: 'm1' })]);
+    useMessageQueueStore.getState().clearQueue('c1');
+    expect(useMessageQueueStore.getState().queues.has('c1')).toBe(false);
+  });
+
+  it('cleanupChat drops the whole chat bucket', () => {
+    seed('c1', [localMsg({ id: 'm1' })]);
+    useMessageQueueStore.getState().cleanupChat('c1');
+    expect(useMessageQueueStore.getState().queues.has('c1')).toBe(false);
+  });
+});
+
+describe('fetchQueue', () => {
+  it('replaces synced locals with server state and appends unsynced pending locals', async () => {
+    seed('c1', [
+      localMsg({ id: 'temp', synced: false, content: 'pending' }),
+      localMsg({ id: 's1', synced: true, content: 'stale' }),
+    ]);
+    svc.getQueue.mockResolvedValue([
+      {
+        id: 's1',
+        content: 'fresh',
+        model_id: 'm',
+        permission_mode: 'default',
+        thinking_mode: null,
+        worktree: false,
+        selected_persona_name: 'Default',
+        queued_at: '2020-01-01T00:00:00Z',
+        attachments: [],
+      },
+    ]);
+
+    await useMessageQueueStore.getState().fetchQueue('c1');
+    const queue = queueOf('c1');
+    // Server messages come first (fresh state), unsynced locals appended.
+    expect(queue.map((m) => m.id)).toEqual(['s1', 'temp']);
+    expect(queue[0]).toMatchObject({ content: 'fresh', synced: true });
+    expect(queue[0].queuedAt).toBe(new Date('2020-01-01T00:00:00Z').getTime());
+    expect(queue[1]).toMatchObject({ id: 'temp', synced: false });
+  });
+
+  it('drops the bucket when the server has nothing and no locals are pending', async () => {
+    seed('c1', [localMsg({ id: 's1', synced: true })]);
+    svc.getQueue.mockResolvedValue([]);
+
+    await useMessageQueueStore.getState().fetchQueue('c1');
+    expect(useMessageQueueStore.getState().queues.has('c1')).toBe(false);
+  });
+
+  it('swallows fetch errors and leaves existing state intact', async () => {
+    seed('c1', [localMsg({ id: 'm1' })]);
+    svc.getQueue.mockRejectedValue(new Error('offline'));
+
+    await useMessageQueueStore.getState().fetchQueue('c1');
+    expect(queueOf('c1').map((m) => m.id)).toEqual(['m1']);
+  });
+});

--- a/frontend/src/store/modelStore.test.ts
+++ b/frontend/src/store/modelStore.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useModelStore } from './modelStore';
+
+beforeEach(() => {
+  localStorage.clear();
+  useModelStore.setState({ modelByChat: {}, favoriteModelIds: [] });
+});
+
+describe('selectModel', () => {
+  it('records the model for a chat', () => {
+    useModelStore.getState().selectModel('c1', 'gpt-5');
+    expect(useModelStore.getState().modelByChat.c1).toBe('gpt-5');
+  });
+
+  it('trims surrounding whitespace before storing', () => {
+    useModelStore.getState().selectModel('c1', '  gpt-5  ');
+    expect(useModelStore.getState().modelByChat.c1).toBe('gpt-5');
+  });
+
+  it('ignores empty or whitespace-only ids', () => {
+    useModelStore.getState().selectModel('c1', '   ');
+    expect('c1' in useModelStore.getState().modelByChat).toBe(false);
+  });
+
+  it('returns the same state when the id is unchanged', () => {
+    useModelStore.getState().selectModel('c1', 'gpt-5');
+    const before = useModelStore.getState().modelByChat;
+    useModelStore.getState().selectModel('c1', 'gpt-5');
+    expect(useModelStore.getState().modelByChat).toBe(before);
+  });
+
+  it('keeps per-chat selections independent', () => {
+    useModelStore.getState().selectModel('c1', 'gpt-5');
+    useModelStore.getState().selectModel('c2', 'claude');
+    expect(useModelStore.getState().modelByChat).toEqual({ c1: 'gpt-5', c2: 'claude' });
+  });
+});
+
+describe('toggleFavoriteModel', () => {
+  it('adds a model to favorites on first toggle', () => {
+    useModelStore.getState().toggleFavoriteModel('m1');
+    expect(useModelStore.getState().favoriteModelIds).toEqual(['m1']);
+  });
+
+  it('removes a model on the second toggle', () => {
+    useModelStore.getState().toggleFavoriteModel('m1');
+    useModelStore.getState().toggleFavoriteModel('m1');
+    expect(useModelStore.getState().favoriteModelIds).toEqual([]);
+  });
+
+  it('preserves insertion order and only removes the toggled id', () => {
+    const toggle = useModelStore.getState().toggleFavoriteModel;
+    toggle('m1');
+    toggle('m2');
+    toggle('m3');
+    toggle('m2');
+    expect(useModelStore.getState().favoriteModelIds).toEqual(['m1', 'm3']);
+  });
+});

--- a/frontend/src/store/permissionStore.test.ts
+++ b/frontend/src/store/permissionStore.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePermissionStore } from './permissionStore';
+import type { PermissionRequest } from '@/types/chat.types';
+
+const request = (id: string, seq = 0): PermissionRequest => ({
+  request_id: id,
+  tool_name: 'Bash',
+  tool_input: {},
+  options: [],
+  seq,
+});
+
+const queueOf = (chatId: string) => usePermissionStore.getState().pendingRequests.get(chatId);
+
+beforeEach(() => {
+  usePermissionStore.setState({ pendingRequests: new Map() });
+});
+
+describe('enqueuePermissionRequest', () => {
+  it('enqueues a new request and reports it as newly added', () => {
+    const added = usePermissionStore.getState().enqueuePermissionRequest('c1', request('r1'));
+    expect(added).toBe(true);
+    expect(queueOf('c1')?.map((r) => r.request_id)).toEqual(['r1']);
+  });
+
+  it('preserves FIFO order across multiple requests', () => {
+    const enqueue = usePermissionStore.getState().enqueuePermissionRequest;
+    enqueue('c1', request('r1'));
+    enqueue('c1', request('r2'));
+    enqueue('c1', request('r3'));
+    expect(queueOf('c1')?.map((r) => r.request_id)).toEqual(['r1', 'r2', 'r3']);
+  });
+
+  it('dedupes by request_id and reports the duplicate as not added', () => {
+    const enqueue = usePermissionStore.getState().enqueuePermissionRequest;
+    expect(enqueue('c1', request('r1'))).toBe(true);
+    expect(enqueue('c1', request('r1', 5))).toBe(false);
+    expect(queueOf('c1')?.length).toBe(1);
+    // The first envelope wins — the duplicate never overwrites it.
+    expect(queueOf('c1')?.[0].seq).toBe(0);
+  });
+
+  it('keeps separate queues per chat', () => {
+    const enqueue = usePermissionStore.getState().enqueuePermissionRequest;
+    enqueue('c1', request('r1'));
+    enqueue('c2', request('r2'));
+    expect(queueOf('c1')?.map((r) => r.request_id)).toEqual(['r1']);
+    expect(queueOf('c2')?.map((r) => r.request_id)).toEqual(['r2']);
+  });
+});
+
+describe('resolvePermissionRequest', () => {
+  it('removes the matching request while keeping the rest', () => {
+    const enqueue = usePermissionStore.getState().enqueuePermissionRequest;
+    enqueue('c1', request('r1'));
+    enqueue('c1', request('r2'));
+    usePermissionStore.getState().resolvePermissionRequest('c1', 'r1');
+    expect(queueOf('c1')?.map((r) => r.request_id)).toEqual(['r2']);
+  });
+
+  it('deletes the chat bucket once its last request resolves', () => {
+    usePermissionStore.getState().enqueuePermissionRequest('c1', request('r1'));
+    usePermissionStore.getState().resolvePermissionRequest('c1', 'r1');
+    expect(usePermissionStore.getState().pendingRequests.has('c1')).toBe(false);
+  });
+
+  it('returns the same state when the request id is unknown', () => {
+    usePermissionStore.getState().enqueuePermissionRequest('c1', request('r1'));
+    const before = usePermissionStore.getState().pendingRequests;
+    usePermissionStore.getState().resolvePermissionRequest('c1', 'missing');
+    expect(usePermissionStore.getState().pendingRequests).toBe(before);
+  });
+
+  it('returns the same state when the chat is unknown', () => {
+    const before = usePermissionStore.getState().pendingRequests;
+    usePermissionStore.getState().resolvePermissionRequest('missing', 'r1');
+    expect(usePermissionStore.getState().pendingRequests).toBe(before);
+  });
+});

--- a/frontend/src/store/sidebarFilters.test.ts
+++ b/frontend/src/store/sidebarFilters.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EMPTY_SIDEBAR_FILTERS,
+  clearSidebarFilters,
+  countActiveSidebarFilters,
+  type SidebarFilters,
+} from './sidebarFilters';
+
+const filters = (over: Partial<SidebarFilters> = {}): SidebarFilters => ({
+  ...EMPTY_SIDEBAR_FILTERS,
+  ...over,
+});
+
+describe('clearSidebarFilters', () => {
+  it('resets every filter dimension but preserves groupBy', () => {
+    const cleared = clearSidebarFilters(
+      filters({
+        statuses: ['unread', 'running'],
+        agentKind: 'claude',
+        source: 'local',
+        workspaceId: 'ws-1',
+        groupBy: 'workspace',
+      }),
+    );
+    expect(cleared).toEqual({
+      statuses: [],
+      agentKind: null,
+      source: 'all',
+      workspaceId: null,
+      groupBy: 'workspace',
+    });
+  });
+
+  it('returns a fresh object, never mutating the input', () => {
+    const input = filters({ statuses: ['done'] });
+    const cleared = clearSidebarFilters(input);
+    expect(cleared).not.toBe(input);
+    expect(input.statuses).toEqual(['done']);
+  });
+});
+
+describe('countActiveSidebarFilters', () => {
+  it('counts zero for the empty filter set', () => {
+    expect(countActiveSidebarFilters(EMPTY_SIDEBAR_FILTERS)).toBe(0);
+  });
+
+  it('adds one per status entry', () => {
+    expect(countActiveSidebarFilters(filters({ statuses: ['unread', 'done', 'needs-you'] }))).toBe(
+      3,
+    );
+  });
+
+  it('counts agentKind, non-all source, and workspaceId as one each', () => {
+    expect(
+      countActiveSidebarFilters(
+        filters({ agentKind: 'codex', source: 'cloud', workspaceId: 'ws-1' }),
+      ),
+    ).toBe(3);
+  });
+
+  it('treats source "all" as inactive', () => {
+    expect(countActiveSidebarFilters(filters({ source: 'all' }))).toBe(0);
+    expect(countActiveSidebarFilters(filters({ source: 'local' }))).toBe(1);
+  });
+
+  it('excludes groupBy from the active count (presentation, not a filter)', () => {
+    expect(countActiveSidebarFilters(filters({ groupBy: 'status' }))).toBe(0);
+  });
+});

--- a/frontend/src/store/streamStore.test.ts
+++ b/frontend/src/store/streamStore.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useStreamStore } from './streamStore';
+import type { ActiveStream } from '@/types/stream.types';
+
+vi.mock('@/utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Minimal EventSource stand-in — only the members shutdownStream touches.
+function makeSource() {
+  return {
+    removeEventListener: vi.fn(),
+    close: vi.fn(),
+    onerror: (() => {}) as unknown,
+  };
+}
+
+function makeStream(id: string, chatId: string, messageId: string, isActive = true): ActiveStream {
+  return {
+    id,
+    chatId,
+    messageId,
+    source: makeSource() as unknown as EventSource,
+    startTime: 1000,
+    isActive,
+    listeners: [{ type: 'message', handler: vi.fn() }],
+    callbacks: { onEnvelope: vi.fn() },
+  };
+}
+
+beforeEach(() => {
+  useStreamStore.setState({
+    activeStreams: new Map(),
+    streamIdByChatMessage: new Map(),
+    activeStreamMetadata: [],
+    completedChatIds: new Set(),
+  });
+});
+
+describe('addStream', () => {
+  it('indexes the stream by id and by chat/message, and records metadata', () => {
+    const stream = makeStream('s1', 'c1', 'm1');
+    useStreamStore.getState().addStream(stream);
+    const state = useStreamStore.getState();
+    expect(state.getStream('s1')).toBe(stream);
+    expect(state.getStreamByChatAndMessage('c1', 'm1')).toBe(stream);
+    expect(state.activeStreamMetadata).toEqual([
+      { chatId: 'c1', messageId: 'm1', startTime: 1000 },
+    ]);
+  });
+
+  it('keeps one metadata entry per chat, replacing on re-add', () => {
+    useStreamStore.getState().addStream(makeStream('s1', 'c1', 'm1'));
+    useStreamStore.getState().addStream(makeStream('s2', 'c1', 'm2'));
+    const meta = useStreamStore.getState().activeStreamMetadata;
+    expect(meta).toHaveLength(1);
+    expect(meta[0].messageId).toBe('m2');
+  });
+});
+
+describe('getStreamByChat', () => {
+  it('returns the active stream for a chat', () => {
+    const stream = makeStream('s1', 'c1', 'm1');
+    useStreamStore.getState().addStream(stream);
+    expect(useStreamStore.getState().getStreamByChat('c1')).toBe(stream);
+  });
+
+  it('ignores inactive streams', () => {
+    useStreamStore.getState().addStream(makeStream('s1', 'c1', 'm1', false));
+    expect(useStreamStore.getState().getStreamByChat('c1')).toBeUndefined();
+  });
+});
+
+describe('removeStream', () => {
+  it('shuts down the stream and drops it from every index', () => {
+    const stream = makeStream('s1', 'c1', 'm1');
+    const source = stream.source as unknown as ReturnType<typeof makeSource>;
+    useStreamStore.getState().addStream(stream);
+    useStreamStore.getState().removeStream('s1');
+
+    const state = useStreamStore.getState();
+    expect(state.getStream('s1')).toBeUndefined();
+    expect(state.getStreamByChatAndMessage('c1', 'm1')).toBeUndefined();
+    expect(state.activeStreamMetadata).toEqual([]);
+    expect(source.close).toHaveBeenCalledOnce();
+    expect(source.removeEventListener).toHaveBeenCalledOnce();
+    expect(stream.isActive).toBe(false);
+    expect(stream.callbacks).toBeUndefined();
+    expect(source.onerror).toBeNull();
+  });
+
+  it('keeps chat metadata while another active stream remains for the chat', () => {
+    useStreamStore.getState().addStream(makeStream('s1', 'c1', 'm1'));
+    useStreamStore.getState().addStream(makeStream('s2', 'c1', 'm2'));
+    useStreamStore.getState().removeStream('s2');
+    // s1 is still active for c1, so its rollup metadata must survive.
+    expect(useStreamStore.getState().activeStreamMetadata).toHaveLength(1);
+  });
+
+  it('is a no-op for an unknown stream id', () => {
+    const before = useStreamStore.getState();
+    useStreamStore.getState().removeStream('missing');
+    expect(useStreamStore.getState()).toBe(before);
+  });
+});
+
+describe('abortStream', () => {
+  it('delegates to removeStream', () => {
+    useStreamStore.getState().addStream(makeStream('s1', 'c1', 'm1'));
+    useStreamStore.getState().abortStream('s1');
+    expect(useStreamStore.getState().getStream('s1')).toBeUndefined();
+  });
+});
+
+describe('completed chat tracking', () => {
+  it('marks and clears completed chats', () => {
+    useStreamStore.getState().markCompleted('c1');
+    expect(useStreamStore.getState().completedChatIds.has('c1')).toBe(true);
+    useStreamStore.getState().clearCompleted('c1');
+    expect(useStreamStore.getState().completedChatIds.has('c1')).toBe(false);
+  });
+
+  it('returns the same state when clearing a chat that was not completed', () => {
+    const before = useStreamStore.getState().completedChatIds;
+    useStreamStore.getState().clearCompleted('c1');
+    expect(useStreamStore.getState().completedChatIds).toBe(before);
+  });
+});
+
+describe('updateStreamCallbacks', () => {
+  it('replaces callbacks on an active stream', () => {
+    const stream = makeStream('s1', 'c1', 'm1');
+    useStreamStore.getState().addStream(stream);
+    const callbacks = { onError: vi.fn() };
+    useStreamStore.getState().updateStreamCallbacks('c1', 'm1', callbacks);
+    expect(useStreamStore.getState().getStream('s1')?.callbacks).toBe(callbacks);
+  });
+
+  it('leaves callbacks untouched for an inactive stream', () => {
+    const stream = makeStream('s1', 'c1', 'm1', false);
+    const original = stream.callbacks;
+    useStreamStore.getState().addStream(stream);
+    useStreamStore.getState().updateStreamCallbacks('c1', 'm1', { onError: vi.fn() });
+    expect(useStreamStore.getState().getStream('s1')?.callbacks).toBe(original);
+  });
+});
+
+describe('updateStreamMessageId', () => {
+  it('re-keys the stream, restarts the clock, and refreshes metadata', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2020-01-01T00:00:05Z'));
+    const stream = makeStream('s1', 'c1', 'old');
+    useStreamStore.getState().addStream(stream);
+
+    useStreamStore.getState().updateStreamMessageId('c1', 'old', 'new');
+    const state = useStreamStore.getState();
+    const now = new Date('2020-01-01T00:00:05Z').getTime();
+
+    expect(state.getStreamByChatAndMessage('c1', 'old')).toBeUndefined();
+    const moved = state.getStreamByChatAndMessage('c1', 'new');
+    expect(moved?.messageId).toBe('new');
+    expect(moved?.startTime).toBe(now);
+    expect(state.activeStreamMetadata).toEqual([
+      { chatId: 'c1', messageId: 'new', startTime: now },
+    ]);
+    vi.useRealTimers();
+  });
+
+  it('is a no-op when the old message id is not tracked', () => {
+    const before = useStreamStore.getState();
+    useStreamStore.getState().updateStreamMessageId('c1', 'old', 'new');
+    expect(useStreamStore.getState()).toBe(before);
+  });
+});
+
+describe('removeStreamMetadata', () => {
+  it('shuts down every stream for the chat and drops its metadata', () => {
+    const s1 = makeStream('s1', 'c1', 'm1');
+    const s2 = makeStream('s2', 'c1', 'm2');
+    const other = makeStream('s3', 'c2', 'm3');
+    useStreamStore.getState().addStream(s1);
+    useStreamStore.getState().addStream(s2);
+    useStreamStore.getState().addStream(other);
+
+    useStreamStore.getState().removeStreamMetadata('c1');
+    const state = useStreamStore.getState();
+    expect(state.getStream('s1')).toBeUndefined();
+    expect(state.getStream('s2')).toBeUndefined();
+    expect(state.getStream('s3')).toBe(other);
+    expect(state.activeStreamMetadata.map((m) => m.chatId)).toEqual(['c2']);
+  });
+});
+
+describe('addStreamMetadata / addStreamMetadataIfAbsent', () => {
+  it('upserts by chat id with addStreamMetadata', () => {
+    useStreamStore.getState().addStreamMetadata({ chatId: 'c1', messageId: 'm1', startTime: 1 });
+    useStreamStore.getState().addStreamMetadata({ chatId: 'c1', messageId: 'm2', startTime: 2 });
+    const meta = useStreamStore.getState().activeStreamMetadata;
+    expect(meta).toEqual([{ chatId: 'c1', messageId: 'm2', startTime: 2 }]);
+  });
+
+  it('keeps the existing entry with addStreamMetadataIfAbsent', () => {
+    useStreamStore.getState().addStreamMetadata({ chatId: 'c1', messageId: 'm1', startTime: 1 });
+    useStreamStore
+      .getState()
+      .addStreamMetadataIfAbsent({ chatId: 'c1', messageId: 'm2', startTime: 2 });
+    // A live stream's startTime must not reset on restoration/event replay.
+    expect(useStreamStore.getState().activeStreamMetadata).toEqual([
+      { chatId: 'c1', messageId: 'm1', startTime: 1 },
+    ]);
+  });
+
+  it('appends a new chat entry with addStreamMetadataIfAbsent', () => {
+    useStreamStore
+      .getState()
+      .addStreamMetadataIfAbsent({ chatId: 'c1', messageId: 'm1', startTime: 1 });
+    expect(useStreamStore.getState().activeStreamMetadata).toHaveLength(1);
+  });
+});

--- a/frontend/src/utils/agentTool.test.ts
+++ b/frontend/src/utils/agentTool.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { extractResultText } from './agentTool';
+
+describe('extractResultText', () => {
+  it('returns a non-empty string as-is', () => {
+    expect(extractResultText('done')).toBe('done');
+  });
+
+  it('maps an empty string to undefined', () => {
+    expect(extractResultText('')).toBeUndefined();
+  });
+
+  it('joins text blocks with newlines', () => {
+    expect(
+      extractResultText([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: 'b' },
+      ]),
+    ).toBe('a\nb');
+  });
+
+  it('ignores non-text blocks when collecting text', () => {
+    const result = [
+      { type: 'image', source: {} },
+      { type: 'text', text: 'keep' },
+      { type: 'tool_use', text: 42 },
+    ];
+    expect(extractResultText(result)).toBe('keep');
+  });
+
+  it('returns undefined for an array with no text blocks', () => {
+    expect(extractResultText([{ type: 'image' }, { type: 'tool_use' }])).toBeUndefined();
+  });
+
+  it('returns undefined for an empty array', () => {
+    expect(extractResultText([])).toBeUndefined();
+  });
+
+  it('filters blocks whose text is not a string', () => {
+    expect(extractResultText([{ type: 'text', text: 123 }])).toBeUndefined();
+  });
+
+  it('skips null/non-object array entries', () => {
+    expect(extractResultText([null, 'raw', { type: 'text', text: 'ok' }])).toBe('ok');
+  });
+
+  it.each([[null], [undefined], [42], [{ type: 'text', text: 'x' }], [true]])(
+    'returns undefined for non-string, non-array input: %p',
+    (input) => {
+      expect(extractResultText(input)).toBeUndefined();
+    },
+  );
+
+  // Suspicious-but-harmless: a single empty-string text block yields '' (not
+  // undefined), unlike the top-level string branch which maps '' to undefined.
+  it('returns an empty string for an array holding only an empty text block', () => {
+    expect(extractResultText([{ type: 'text', text: '' }])).toBe('');
+  });
+});

--- a/frontend/src/utils/attachmentUrl.test.ts
+++ b/frontend/src/utils/attachmentUrl.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isApiAttachmentUrl,
+  toApiEndpoint,
+  toDownloadUrl,
+  isBrowserObjectUrl,
+} from './attachmentUrl';
+
+describe('isApiAttachmentUrl', () => {
+  it('matches a relative attachments path', () => {
+    expect(isApiAttachmentUrl('/api/v1/attachments/abc.png')).toBe(true);
+    expect(isApiAttachmentUrl('/api/v1/attachments/')).toBe(true);
+  });
+
+  it('matches an absolute URL whose path is under attachments', () => {
+    expect(isApiAttachmentUrl('https://host/api/v1/attachments/x')).toBe(true);
+  });
+
+  it('rejects other API paths and non-attachment URLs', () => {
+    expect(isApiAttachmentUrl('/api/v1/other')).toBe(false);
+    expect(isApiAttachmentUrl('https://cdn.example.com/pic.png')).toBe(false);
+  });
+
+  it('returns false for an unparseable URL', () => {
+    // 'http://' has no host, so the URL constructor throws and parseUrl yields null.
+    expect(isApiAttachmentUrl('http://')).toBe(false);
+  });
+});
+
+describe('toApiEndpoint', () => {
+  it('strips the /api/v1 prefix and preserves the query string', () => {
+    expect(toApiEndpoint('/api/v1/attachments/x?token=1')).toBe('/attachments/x?token=1');
+  });
+
+  it('drops the origin of an absolute API URL, keeping only the endpoint path', () => {
+    expect(toApiEndpoint('https://host/api/v1/attachments/x?token=1')).toBe(
+      '/attachments/x?token=1',
+    );
+  });
+
+  it('returns the input unchanged when the path is not under /api/v1', () => {
+    expect(toApiEndpoint('/other/path')).toBe('/other/path');
+  });
+});
+
+describe('toDownloadUrl', () => {
+  it('rewrites a relative /preview path to /download, keeping the query', () => {
+    expect(toDownloadUrl('/api/v1/attachments/x/preview?token=1')).toBe(
+      '/api/v1/attachments/x/download?token=1',
+    );
+  });
+
+  it('rewrites an absolute /preview URL to /download, preserving the origin', () => {
+    expect(toDownloadUrl('https://host/api/v1/attachments/x/preview')).toBe(
+      'https://host/api/v1/attachments/x/download',
+    );
+  });
+
+  it('leaves URLs without a /preview suffix untouched', () => {
+    expect(toDownloadUrl('/api/v1/attachments/x/download')).toBe('/api/v1/attachments/x/download');
+  });
+});
+
+describe('isBrowserObjectUrl', () => {
+  it('matches blob: and data: URLs', () => {
+    expect(isBrowserObjectUrl('blob:https://host/uuid')).toBe(true);
+    expect(isBrowserObjectUrl('data:image/png;base64,AAAA')).toBe(true);
+  });
+
+  it('rejects http and API URLs', () => {
+    expect(isBrowserObjectUrl('https://host/x.png')).toBe(false);
+    expect(isBrowserObjectUrl('/api/v1/attachments/x')).toBe(false);
+  });
+});

--- a/frontend/src/utils/automationSchedule.test.ts
+++ b/frontend/src/utils/automationSchedule.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildCronExpression,
+  parseCronExpression,
+  describeCron,
+  DEFAULT_SCHEDULE,
+  type ScheduleForm,
+} from './automationSchedule';
+
+const form = (over: Partial<ScheduleForm>): ScheduleForm => ({ ...DEFAULT_SCHEDULE, ...over });
+
+describe('buildCronExpression', () => {
+  it('builds an hourly step expression ignoring time', () => {
+    expect(buildCronExpression(form({ frequency: 'hourly', everyHours: 6 }))).toBe('0 */6 * * *');
+  });
+
+  it('builds a daily expression with minute then hour', () => {
+    expect(buildCronExpression(form({ frequency: 'daily', time: '09:30' }))).toBe('30 9 * * *');
+  });
+
+  it('builds a weekly expression with the day-of-week in the last field', () => {
+    expect(buildCronExpression(form({ frequency: 'weekly', time: '08:15', dayOfWeek: 1 }))).toBe(
+      '15 8 * * 1',
+    );
+  });
+
+  it('builds a monthly expression with the day-of-month in the third field', () => {
+    expect(buildCronExpression(form({ frequency: 'monthly', time: '00:00', dayOfMonth: 15 }))).toBe(
+      '0 0 15 * *',
+    );
+  });
+
+  it('trims the raw cron for custom frequency', () => {
+    expect(buildCronExpression(form({ frequency: 'custom', cron: '  5 4 * * *  ' }))).toBe(
+      '5 4 * * *',
+    );
+  });
+
+  it('falls back to 09:00 when the time string is unparseable', () => {
+    expect(buildCronExpression(form({ frequency: 'daily', time: 'not-a-time' }))).toBe('0 9 * * *');
+  });
+
+  it('handles boundary hours 0 and 23', () => {
+    expect(buildCronExpression(form({ frequency: 'daily', time: '00:00' }))).toBe('0 0 * * *');
+    expect(buildCronExpression(form({ frequency: 'daily', time: '23:59' }))).toBe('59 23 * * *');
+  });
+});
+
+describe('parseCronExpression', () => {
+  it('parses an hourly step', () => {
+    const parsed = parseCronExpression('0 */6 * * *');
+    expect(parsed.frequency).toBe('hourly');
+    expect(parsed.everyHours).toBe(6);
+  });
+
+  it('parses an every-hour step of 1', () => {
+    expect(parseCronExpression('0 */1 * * *').everyHours).toBe(1);
+  });
+
+  it('leaves step >= 24 in custom mode (exceeds cron hour range)', () => {
+    const parsed = parseCronExpression('0 */24 * * *');
+    expect(parsed.frequency).toBe('custom');
+    expect(parsed.cron).toBe('0 */24 * * *');
+  });
+
+  it('parses a daily expression back into HH:MM', () => {
+    const parsed = parseCronExpression('30 9 * * *');
+    expect(parsed.frequency).toBe('daily');
+    expect(parsed.time).toBe('09:30');
+  });
+
+  it('parses a weekly expression with day-of-week and time', () => {
+    const parsed = parseCronExpression('15 8 * * 1');
+    expect(parsed.frequency).toBe('weekly');
+    expect(parsed.dayOfWeek).toBe(1);
+    expect(parsed.time).toBe('08:15');
+  });
+
+  it('normalizes Sunday-as-7 to 0', () => {
+    expect(parseCronExpression('0 9 * * 7').dayOfWeek).toBe(0);
+    expect(parseCronExpression('0 9 * * 0').dayOfWeek).toBe(0);
+  });
+
+  it('parses boundary weekdays 0 (Sunday) and 6 (Saturday)', () => {
+    expect(parseCronExpression('0 9 * * 6').dayOfWeek).toBe(6);
+  });
+
+  it('parses a monthly expression with day-of-month', () => {
+    const parsed = parseCronExpression('0 0 15 * *');
+    expect(parsed.frequency).toBe('monthly');
+    expect(parsed.dayOfMonth).toBe(15);
+    expect(parsed.time).toBe('00:00');
+  });
+
+  it('falls back to custom for unrecognized shapes', () => {
+    const parsed = parseCronExpression('*/5 1,2,3 * * *');
+    expect(parsed.frequency).toBe('custom');
+    expect(parsed.cron).toBe('*/5 1,2,3 * * *');
+  });
+
+  it('falls back to custom for empty input', () => {
+    const parsed = parseCronExpression('');
+    expect(parsed.frequency).toBe('custom');
+    expect(parsed.cron).toBe('');
+  });
+});
+
+describe('build/parse round-trips', () => {
+  it('round-trips hourly', () => {
+    const original = form({ frequency: 'hourly', everyHours: 4 });
+    const parsed = parseCronExpression(buildCronExpression(original));
+    expect(parsed.frequency).toBe('hourly');
+    expect(parsed.everyHours).toBe(4);
+  });
+
+  it('round-trips daily', () => {
+    const original = form({ frequency: 'daily', time: '07:45' });
+    const parsed = parseCronExpression(buildCronExpression(original));
+    expect(parsed.frequency).toBe('daily');
+    expect(parsed.time).toBe('07:45');
+  });
+
+  it('round-trips weekly across every weekday', () => {
+    for (let day = 0; day <= 6; day++) {
+      const original = form({ frequency: 'weekly', time: '12:30', dayOfWeek: day });
+      const parsed = parseCronExpression(buildCronExpression(original));
+      expect(parsed.frequency).toBe('weekly');
+      expect(parsed.dayOfWeek).toBe(day);
+      expect(parsed.time).toBe('12:30');
+    }
+  });
+
+  it('round-trips monthly', () => {
+    const original = form({ frequency: 'monthly', time: '23:00', dayOfMonth: 28 });
+    const parsed = parseCronExpression(buildCronExpression(original));
+    expect(parsed.frequency).toBe('monthly');
+    expect(parsed.dayOfMonth).toBe(28);
+    expect(parsed.time).toBe('23:00');
+  });
+
+  it('round-trips a custom cron unchanged', () => {
+    const original = form({ frequency: 'custom', cron: '0 0 1 1 *' });
+    const parsed = parseCronExpression(buildCronExpression(original));
+    expect(parsed.frequency).toBe('custom');
+    expect(parsed.cron).toBe('0 0 1 1 *');
+  });
+});
+
+describe('describeCron', () => {
+  it('describes an every-hour schedule in the singular', () => {
+    expect(describeCron('0 */1 * * *')).toBe('Every hour');
+  });
+
+  it('describes a multi-hour step in the plural', () => {
+    expect(describeCron('0 */6 * * *')).toBe('Every 6 hours');
+  });
+
+  it('describes a daily schedule', () => {
+    expect(describeCron('30 9 * * *')).toBe('Daily at 09:30');
+  });
+
+  it('describes a weekly schedule with the weekday label', () => {
+    expect(describeCron('15 8 * * 1')).toBe('Mondays at 08:15');
+    expect(describeCron('0 9 * * 0')).toBe('Sundays at 09:00');
+    expect(describeCron('0 9 * * 6')).toBe('Saturdays at 09:00');
+  });
+
+  it('describes a monthly schedule', () => {
+    expect(describeCron('0 0 15 * *')).toBe('Monthly on day 15 at 00:00');
+  });
+
+  it('returns the raw cron for custom shapes', () => {
+    expect(describeCron('*/5 1,2,3 * * *')).toBe('*/5 1,2,3 * * *');
+  });
+});

--- a/frontend/src/utils/base64.test.ts
+++ b/frontend/src/utils/base64.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { base64ToUint8Array } from './base64';
+
+describe('base64ToUint8Array', () => {
+  it('returns an empty array for an empty string', () => {
+    const result = base64ToUint8Array('');
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result).toHaveLength(0);
+  });
+
+  it('decodes ASCII bytes', () => {
+    // btoa('hi') === 'aGk='
+    expect(Array.from(base64ToUint8Array('aGk='))).toEqual([104, 105]);
+  });
+
+  it('decodes high bytes preserving values above 127', () => {
+    // Bytes [0, 255] encode to 'AP8='.
+    expect(Array.from(base64ToUint8Array('AP8='))).toEqual([0, 255]);
+  });
+
+  it('round-trips arbitrary bytes through btoa', () => {
+    const bytes = [0, 1, 2, 127, 128, 200, 255];
+    const b64 = btoa(String.fromCharCode(...bytes));
+    expect(Array.from(base64ToUint8Array(b64))).toEqual(bytes);
+  });
+});

--- a/frontend/src/utils/chatOrigin.test.ts
+++ b/frontend/src/utils/chatOrigin.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  markCloudChats,
+  isCloudChat,
+  markCloudSandboxes,
+  isCloudSandbox,
+  clearCloudOrigins,
+} from './chatOrigin';
+
+const CHATS_KEY = 'cloud-chat-ids';
+const SANDBOXES_KEY = 'cloud-sandbox-ids';
+
+describe('chatOrigin tracking', () => {
+  beforeEach(() => {
+    clearCloudOrigins();
+    localStorage.clear();
+    clearCloudOrigins(); // re-persist the cleared (empty) sets after wiping storage
+  });
+
+  it('marks and reports cloud chats independently from sandboxes', () => {
+    markCloudChats(['c1', 'c2']);
+    expect(isCloudChat('c1')).toBe(true);
+    expect(isCloudChat('c2')).toBe(true);
+    expect(isCloudChat('c3')).toBe(false);
+    // Sandbox set is separate — a chat id is not a sandbox id.
+    expect(isCloudSandbox('c1')).toBe(false);
+  });
+
+  it('marks and reports cloud sandboxes', () => {
+    markCloudSandboxes(['s1']);
+    expect(isCloudSandbox('s1')).toBe(true);
+    expect(isCloudChat('s1')).toBe(false);
+  });
+
+  it('persists marked chat ids to localStorage', () => {
+    markCloudChats(['x']);
+    expect(JSON.parse(localStorage.getItem(CHATS_KEY) ?? '[]')).toEqual(['x']);
+  });
+
+  it('is idempotent for already-marked ids', () => {
+    markCloudChats(['dup']);
+    markCloudChats(['dup']);
+    expect(JSON.parse(localStorage.getItem(CHATS_KEY) ?? '[]')).toEqual(['dup']);
+  });
+
+  it('clears both sets and their persisted storage', () => {
+    markCloudChats(['c1']);
+    markCloudSandboxes(['s1']);
+    clearCloudOrigins();
+    expect(isCloudChat('c1')).toBe(false);
+    expect(isCloudSandbox('s1')).toBe(false);
+    expect(JSON.parse(localStorage.getItem(CHATS_KEY) ?? '[]')).toEqual([]);
+    expect(JSON.parse(localStorage.getItem(SANDBOXES_KEY) ?? '[]')).toEqual([]);
+  });
+});
+
+describe('chatOrigin hydration from localStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('hydrates only string ids, dropping non-strings', async () => {
+    localStorage.setItem(CHATS_KEY, JSON.stringify(['a', 'b', 1, null]));
+    const mod = await import('./chatOrigin');
+    expect(mod.isCloudChat('a')).toBe(true);
+    expect(mod.isCloudChat('b')).toBe(true);
+    expect(mod.isCloudChat('1')).toBe(false);
+  });
+
+  it('ignores a non-array persisted value', async () => {
+    localStorage.setItem(CHATS_KEY, JSON.stringify('not-an-array'));
+    const mod = await import('./chatOrigin');
+    expect(mod.isCloudChat('n')).toBe(false);
+  });
+
+  it('recovers from malformed JSON without throwing', async () => {
+    localStorage.setItem(CHATS_KEY, '{not valid json');
+    const mod = await import('./chatOrigin');
+    expect(mod.isCloudChat('anything')).toBe(false);
+  });
+});

--- a/frontend/src/utils/chatRequest.test.ts
+++ b/frontend/src/utils/chatRequest.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { buildAgentChatFields } from './chatRequest';
+import type { Model } from '@/types/chat.types';
+import type { Persona } from '@/types/user.types';
+
+const model = (
+  over: Partial<Model> & { model_id: string; agent_kind: Model['agent_kind'] },
+): Model => ({
+  name: over.model_id,
+  context_window: null,
+  ...over,
+});
+
+const raw = (over: Partial<Parameters<typeof buildAgentChatFields>[2]> = {}) => ({
+  permissionMode: 'bypassPermissions' as const,
+  thinkingMode: 'high',
+  worktree: false,
+  persona: 'Default',
+  ...over,
+});
+
+describe('buildAgentChatFields', () => {
+  it('resolves the agent kind from the model map and coerces an incompatible permission mode', () => {
+    const map = new Map<string, Model>([['m1', model({ model_id: 'm1', agent_kind: 'codex' })]]);
+    const fields = buildAgentChatFields(
+      'm1',
+      map,
+      raw({ permissionMode: 'bypassPermissions' }),
+      [],
+    );
+    // 'bypassPermissions' is a Claude mode -> falls back to the codex default.
+    expect(fields.permission_mode).toBe('full-access');
+  });
+
+  it('falls back to model-id conventions when the model map lacks the id', () => {
+    const fields = buildAgentChatFields(
+      'gpt-5.5',
+      new Map(),
+      raw({ permissionMode: 'default' }),
+      [],
+    );
+    // gpt-5.5 is a known codex id -> coerced to the codex default.
+    expect(fields.permission_mode).toBe('full-access');
+  });
+
+  it('keeps a valid permission and thinking mode for a claude model', () => {
+    const fields = buildAgentChatFields(
+      'claude-sonnet-5',
+      new Map(),
+      raw({ permissionMode: 'plan', thinkingMode: 'max' }),
+      [],
+    );
+    expect(fields.permission_mode).toBe('plan');
+    expect(fields.thinking_mode).toBe('max');
+  });
+
+  it('coerces a thinking mode the model does not support to the agent default', () => {
+    // gpt-5.5 (codex, non-max) has no 'max' tier -> falls back to 'high'.
+    const fields = buildAgentChatFields('gpt-5.5', new Map(), raw({ thinkingMode: 'max' }), []);
+    expect(fields.thinking_mode).toBe('high');
+  });
+
+  it('maps worktree to true only when enabled, else undefined', () => {
+    const on = buildAgentChatFields('claude-x', new Map(), raw({ worktree: true }), []);
+    const off = buildAgentChatFields('claude-x', new Map(), raw({ worktree: false }), []);
+    expect(on.worktree).toBe(true);
+    expect(off.worktree).toBeUndefined();
+  });
+
+  it('keeps a known custom persona and drops an unknown one back to Default', () => {
+    const personas: Persona[] = [{ name: 'Reviewer', content: '' }];
+    const known = buildAgentChatFields(
+      'claude-x',
+      new Map(),
+      raw({ persona: 'Reviewer' }),
+      personas,
+    );
+    const unknown = buildAgentChatFields(
+      'claude-x',
+      new Map(),
+      raw({ persona: 'Ghost' }),
+      personas,
+    );
+    expect(known.selected_persona_name).toBe('Reviewer');
+    expect(unknown.selected_persona_name).toBe('Default');
+  });
+});

--- a/frontend/src/utils/date.test.ts
+++ b/frontend/src/utils/date.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { formatRelativeTime, getRelativeTime, formatDuration, formatFullTimestamp } from './date';
+
+// Fixed instant so relative-time math is deterministic; timezone-agnostic because
+// every assertion is built from Date arithmetic or the same Intl call the code uses.
+const NOW = new Date('2026-07-11T12:00:00.000Z');
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe('formatRelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('returns "just now" under a minute', () => {
+    expect(formatRelativeTime(ago(30 * SECOND))).toBe('just now');
+  });
+
+  it('pluralizes minutes', () => {
+    expect(formatRelativeTime(ago(MINUTE))).toBe('1 minute ago');
+    expect(formatRelativeTime(ago(5 * MINUTE))).toBe('5 minutes ago');
+  });
+
+  it('pluralizes hours', () => {
+    expect(formatRelativeTime(ago(HOUR))).toBe('1 hour ago');
+    expect(formatRelativeTime(ago(3 * HOUR))).toBe('3 hours ago');
+  });
+
+  it('says "yesterday" at exactly one day', () => {
+    expect(formatRelativeTime(ago(DAY))).toBe('yesterday');
+  });
+
+  it('reports days up to a week', () => {
+    expect(formatRelativeTime(ago(3 * DAY))).toBe('3 days ago');
+    expect(formatRelativeTime(ago(6 * DAY))).toBe('6 days ago');
+  });
+
+  it('falls back to an absolute date beyond a week (same year: no year shown)', () => {
+    const target = ago(10 * DAY);
+    const expected = new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: undefined,
+    }).format(target);
+    expect(formatRelativeTime(target)).toBe(expected);
+  });
+
+  it('includes the year when the target is in a different year', () => {
+    const target = new Date('2025-01-01T12:00:00.000Z');
+    const expected = new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    }).format(target);
+    expect(formatRelativeTime(target)).toBe(expected);
+  });
+
+  it('accepts an ISO string input', () => {
+    expect(formatRelativeTime(ago(5 * MINUTE).toISOString())).toBe('5 minutes ago');
+  });
+});
+
+describe('getRelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('returns "now" under a minute', () => {
+    expect(getRelativeTime(ago(30 * SECOND).toISOString())).toBe('now');
+  });
+
+  it('formats minutes, hours, days and weeks with compact units', () => {
+    expect(getRelativeTime(ago(5 * MINUTE).toISOString())).toBe('5m');
+    expect(getRelativeTime(ago(2 * HOUR).toISOString())).toBe('2h');
+    expect(getRelativeTime(ago(3 * DAY).toISOString())).toBe('3d');
+    expect(getRelativeTime(ago(14 * DAY).toISOString())).toBe('2w');
+  });
+
+  it('switches to months past ~4 weeks', () => {
+    expect(getRelativeTime(ago(40 * DAY).toISOString())).toBe('1mo');
+  });
+
+  it('boundary: 7 days is 1w, 6 days is 6d', () => {
+    expect(getRelativeTime(ago(7 * DAY).toISOString())).toBe('1w');
+    expect(getRelativeTime(ago(6 * DAY).toISOString())).toBe('6d');
+  });
+
+  // Suspicious-but-harmless: 28-29 days is 4 weeks (skips the <4 weeks branch) but
+  // floor(days/30) is still 0, so it renders "0mo". Documenting current behavior.
+  it('renders "0mo" for 28 days (known edge)', () => {
+    expect(getRelativeTime(ago(28 * DAY).toISOString())).toBe('0mo');
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats sub-minute durations in seconds', () => {
+    expect(formatDuration(0)).toBe('0s');
+    expect(formatDuration(5000)).toBe('5s');
+  });
+
+  it('rounds to the nearest second', () => {
+    expect(formatDuration(59499)).toBe('59s');
+    expect(formatDuration(59500)).toBe('1m 0s');
+  });
+
+  it('formats minutes and seconds past a minute', () => {
+    expect(formatDuration(60000)).toBe('1m 0s');
+    expect(formatDuration(90000)).toBe('1m 30s');
+    expect(formatDuration(65000)).toBe('1m 5s');
+  });
+});
+
+describe('formatFullTimestamp', () => {
+  it('matches the same Intl formatting the code uses (locale-agnostic)', () => {
+    const target = new Date('2026-07-11T12:00:00.000Z');
+    const expected = new Intl.DateTimeFormat(undefined, {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(target);
+    expect(formatFullTimestamp(target)).toBe(expected);
+    expect(formatFullTimestamp(target.toISOString())).toBe(expected);
+  });
+});

--- a/frontend/src/utils/definitionPatterns.test.ts
+++ b/frontend/src/utils/definitionPatterns.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDefinitionSearch,
+  escapeSymbolForRegex,
+  searchIncludeForLanguage,
+} from './definitionPatterns';
+
+describe('escapeSymbolForRegex', () => {
+  it('leaves a plain identifier untouched', () => {
+    expect(escapeSymbolForRegex('fooBar')).toBe('fooBar');
+  });
+
+  it('escapes regex metacharacters', () => {
+    expect(escapeSymbolForRegex('a.b')).toBe('a\\.b');
+    expect(escapeSymbolForRegex('$var')).toBe('\\$var');
+    expect(escapeSymbolForRegex('a(b)[c]')).toBe('a\\(b\\)\\[c\\]');
+  });
+});
+
+describe('buildDefinitionSearch', () => {
+  it('substitutes the symbol into every pattern and drops the placeholder', () => {
+    const { pattern } = buildDefinitionSearch('typescript', 'foo');
+    expect(pattern).toContain('foo');
+    expect(pattern).not.toContain('__SYMBOL__');
+  });
+
+  it('joins the language patterns with an alternation', () => {
+    const { pattern } = buildDefinitionSearch('typescript', 'foo');
+    // Two TS patterns are OR-ed together.
+    expect(pattern.split('|').length).toBeGreaterThan(1);
+  });
+
+  it('returns the language file-family include', () => {
+    expect(buildDefinitionSearch('typescript', 'foo').include).toBe(
+      '*.{ts,tsx,js,jsx,mts,cts,mjs,cjs}',
+    );
+    expect(buildDefinitionSearch('python', 'foo').include).toBe('*.py');
+    expect(buildDefinitionSearch('go', 'foo').include).toBe('*.go');
+    expect(buildDefinitionSearch('rust', 'foo').include).toBe('*.rs');
+    expect(buildDefinitionSearch('ruby', 'foo').include).toBe('*.rb');
+  });
+
+  it('falls back to the default query (no include) for unknown languages', () => {
+    const { pattern, include } = buildDefinitionSearch('cobol', 'foo');
+    expect(include).toBeUndefined();
+    expect(pattern).toContain('foo');
+    expect(pattern).not.toContain('__SYMBOL__');
+  });
+
+  it('escapes regex specials in the symbol before substitution', () => {
+    const { pattern } = buildDefinitionSearch('typescript', 'foo.bar');
+    // The dot is escaped so it matches a literal `.`, not any char.
+    expect(pattern).toContain('foo\\.bar');
+    expect(pattern).not.toContain('foo.bar'); // no unescaped form leaks through
+  });
+
+  it('produces a regex that matches definitions but not call sites', () => {
+    const { pattern } = buildDefinitionSearch('typescript', 'foo');
+    const re = new RegExp(pattern);
+    expect(re.test('function foo() {}')).toBe(true);
+    expect(re.test('const foo = 1')).toBe(true);
+    expect(re.test('interface foo {}')).toBe(true);
+    expect(re.test('foo: (')).toBe(true);
+    // A bare call site has no preceding definition keyword or `:`/`=`.
+    expect(re.test('  foo()')).toBe(false);
+  });
+
+  it('escapes the symbol so specials do not act as wildcards in the compiled regex', () => {
+    const { pattern } = buildDefinitionSearch('typescript', 'a.b');
+    const re = new RegExp(pattern);
+    expect(re.test('const a.b = 1')).toBe(true);
+    // The `.` is literal, so `aXb` must not match.
+    expect(re.test('const aXb = 1')).toBe(false);
+  });
+});
+
+describe('searchIncludeForLanguage', () => {
+  it('returns the include glob for a known language', () => {
+    expect(searchIncludeForLanguage('python')).toBe('*.py');
+  });
+
+  it('returns undefined for an unknown language (default query has no include)', () => {
+    expect(searchIncludeForLanguage('cobol')).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/diffSelection.test.ts
+++ b/frontend/src/utils/diffSelection.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import type { ChangeContent, ContextContent, FileDiffMetadata, Hunk } from '@pierre/diffs';
+import { getSelectedDiffText } from './diffSelection';
+
+// Minimal hunk-content builders — getSelectedDiffText only reads the fields below.
+const ctx = (lines: number, delIdx: number, addIdx: number): ContextContent => ({
+  type: 'context',
+  lines,
+  deletionLineIndex: delIdx,
+  additionLineIndex: addIdx,
+});
+
+const chg = (
+  deletions: number,
+  delIdx: number,
+  additions: number,
+  addIdx: number,
+): ChangeContent => ({
+  type: 'change',
+  deletions,
+  deletionLineIndex: delIdx,
+  additions,
+  additionLineIndex: addIdx,
+});
+
+const hunk = (
+  over: Pick<
+    Hunk,
+    'deletionStart' | 'additionStart' | 'deletionLineIndex' | 'additionLineIndex' | 'hunkContent'
+  >,
+): Hunk => over as Hunk;
+
+const file = (over: {
+  additionLines: string[];
+  deletionLines: string[];
+  hunks: Hunk[];
+}): FileDiffMetadata =>
+  ({ name: 'f.ts', type: 'change', isPartial: false, ...over }) as unknown as FileDiffMetadata;
+
+// Full-file diff (line N ↔ index N-1) with one change in the middle.
+const singleHunkFullBody = file({
+  additionLines: ['a\n', 'b-new\n', 'c\n'],
+  deletionLines: ['a\n', 'b-old\n', 'c\n'],
+  hunks: [
+    hunk({
+      deletionStart: 1,
+      additionStart: 1,
+      deletionLineIndex: 0,
+      additionLineIndex: 0,
+      hunkContent: [ctx(1, 0, 0), chg(1, 1, 1, 1), ctx(1, 2, 2)],
+    }),
+  ],
+});
+
+// Full-file diff with two hunks separated by an unchanged gap (lines 3–5). Full
+// bodies let the gap be expanded and addressed by line number.
+const twoHunkFullBody = file({
+  additionLines: ['l1\n', 'l2\n', 'l3\n', 'l4\n', 'l5\n', 'l6\n', 'l7\n'],
+  deletionLines: ['l1\n', 'l2old\n', 'l3\n', 'l4\n', 'l5\n', 'l6old\n', 'l7\n'],
+  hunks: [
+    hunk({
+      deletionStart: 1,
+      additionStart: 1,
+      deletionLineIndex: 0,
+      additionLineIndex: 0,
+      hunkContent: [ctx(1, 0, 0), chg(1, 1, 1, 1)],
+    }),
+    hunk({
+      deletionStart: 6,
+      additionStart: 6,
+      deletionLineIndex: 5,
+      additionLineIndex: 5,
+      hunkContent: [chg(1, 5, 1, 5), ctx(1, 6, 6)],
+    }),
+  ],
+});
+
+// Partial patch: line arrays hold only patch lines, hunk indices don't align to
+// line numbers, so the gap between hunks (lines 12–49) can't be expanded.
+const twoHunkPartial = file({
+  additionLines: ['c1\n', 'new1\n', 'new2\n', 'c2\n'],
+  deletionLines: ['c1\n', 'old1\n', 'old2\n', 'c2\n'],
+  hunks: [
+    hunk({
+      deletionStart: 10,
+      additionStart: 10,
+      deletionLineIndex: 0,
+      additionLineIndex: 0,
+      hunkContent: [ctx(1, 0, 0), chg(1, 1, 1, 1)],
+    }),
+    hunk({
+      deletionStart: 50,
+      additionStart: 50,
+      deletionLineIndex: 2,
+      additionLineIndex: 2,
+      hunkContent: [chg(1, 2, 1, 2), ctx(1, 3, 3)],
+    }),
+  ],
+});
+
+// Partial patch removing two lines — a change block with additions: 0.
+const pureDeletionPartial = file({
+  additionLines: ['keep\n'],
+  deletionLines: ['keep\n', 'gone1\n', 'gone2\n'],
+  hunks: [
+    hunk({
+      deletionStart: 5,
+      additionStart: 5,
+      deletionLineIndex: 0,
+      additionLineIndex: 0,
+      hunkContent: [ctx(1, 0, 0), chg(2, 1, 0, 1)],
+    }),
+  ],
+});
+
+describe('getSelectedDiffText — single-hunk full body', () => {
+  it('emits the whole hunk with unified prefixes when no side is given', () => {
+    const text = getSelectedDiffText(singleHunkFullBody, { start: 1, end: 3 });
+    expect(text).toBe(' a\n-b-old\n+b-new\n c');
+  });
+
+  it('selects a single line on the deletion side', () => {
+    const text = getSelectedDiffText(singleHunkFullBody, { start: 2, end: 2, side: 'deletions' });
+    expect(text).toBe('-b-old');
+  });
+
+  it('selects a single line on the addition side', () => {
+    const text = getSelectedDiffText(singleHunkFullBody, { start: 2, end: 2, side: 'additions' });
+    expect(text).toBe('+b-new');
+  });
+
+  it('honors endSide differing from side across the changed pair', () => {
+    const text = getSelectedDiffText(singleHunkFullBody, {
+      start: 2,
+      side: 'deletions',
+      end: 2,
+      endSide: 'additions',
+    });
+    expect(text).toBe('-b-old\n+b-new');
+  });
+
+  it('returns null when the range does not resolve against the hunks', () => {
+    expect(getSelectedDiffText(singleHunkFullBody, { start: 99, end: 100 })).toBeNull();
+  });
+});
+
+describe('getSelectedDiffText — multi-hunk full body (gap expansion)', () => {
+  it('fills the unchanged gap between hunks when selecting across it', () => {
+    const text = getSelectedDiffText(twoHunkFullBody, {
+      start: 2,
+      side: 'additions',
+      end: 6,
+      endSide: 'additions',
+    });
+    expect(text).toBe('+l2\n l3\n l4\n l5\n-l6old\n+l6');
+  });
+
+  it('resolves a deletion-side range spanning the gap', () => {
+    const text = getSelectedDiffText(twoHunkFullBody, {
+      start: 2,
+      side: 'deletions',
+      end: 6,
+      endSide: 'deletions',
+    });
+    expect(text).toBe('-l2old\n+l2\n l3\n l4\n l5\n-l6old');
+  });
+});
+
+describe('getSelectedDiffText — partial patch (no gap expansion)', () => {
+  it('joins the two hunks directly, silently omitting the unexpandable gap', () => {
+    // Documented behavior: partial patches can't expand context between hunks,
+    // so lines 12–49 are absent and the addition rows sit adjacent.
+    const text = getSelectedDiffText(twoHunkPartial, {
+      start: 11,
+      side: 'additions',
+      end: 50,
+      endSide: 'additions',
+    });
+    expect(text).toBe('+new1\n-old2\n+new2');
+  });
+
+  it('returns null for a line number that lives inside the unrendered gap', () => {
+    expect(
+      getSelectedDiffText(twoHunkPartial, {
+        start: 30,
+        side: 'additions',
+        end: 30,
+        endSide: 'additions',
+      }),
+    ).toBeNull();
+  });
+
+  it('resolves a context line on either implicit side', () => {
+    expect(getSelectedDiffText(twoHunkPartial, { start: 10, end: 10 })).toBe(' c1');
+  });
+});
+
+describe('getSelectedDiffText — pure deletion block', () => {
+  it('selects consecutive deleted lines', () => {
+    const text = getSelectedDiffText(pureDeletionPartial, {
+      start: 6,
+      side: 'deletions',
+      end: 7,
+      endSide: 'deletions',
+    });
+    expect(text).toBe('-gone1\n-gone2');
+  });
+
+  it('returns null when asking for an addition line that never existed', () => {
+    expect(
+      getSelectedDiffText(pureDeletionPartial, {
+        start: 6,
+        side: 'additions',
+        end: 6,
+        endSide: 'additions',
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('getSelectedDiffText — empty input', () => {
+  it('returns null for a file with no hunks', () => {
+    const empty = file({ additionLines: [], deletionLines: [], hunks: [] });
+    expect(getSelectedDiffText(empty, { start: 1, end: 1 })).toBeNull();
+  });
+});

--- a/frontend/src/utils/file.test.ts
+++ b/frontend/src/utils/file.test.ts
@@ -1,0 +1,270 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import toast from 'react-hot-toast';
+import {
+  sortFiles,
+  getFileName,
+  getAncestorFolderPaths,
+  findFileInStructure,
+  findFileByToolPath,
+  detectLanguage,
+  filterChatAttachmentFiles,
+  buildFileStructureFromSandboxFiles,
+  hasActualFiles,
+  traverseFileStructure,
+  fetchAttachmentBlob,
+  downloadAttachmentFile,
+  convertDataUrlToUploadedFile,
+} from './file';
+import type { FileStructure } from '@/types/file-system.types';
+import type { FileMetadata } from '@/types/sandbox.types';
+
+vi.mock('react-hot-toast', () => ({ default: { error: vi.fn(), success: vi.fn() } }));
+
+const fileNode = (path: string): FileStructure => ({ path, type: 'file', content: '' });
+const folderNode = (path: string, children: FileStructure[]): FileStructure => ({
+  path,
+  type: 'folder',
+  content: '',
+  children,
+});
+
+// filterChatAttachmentFiles reads name/size/type only.
+const upload = (name: string, type: string, size: number): File =>
+  ({ name, type, size }) as unknown as File;
+
+describe('sortFiles', () => {
+  it('places folders before files and sorts each group by path', () => {
+    const sorted = sortFiles([fileNode('zeta.md'), fileNode('alpha.md'), folderNode('src', [])]);
+    expect(sorted.map((f) => f.path)).toEqual(['src', 'alpha.md', 'zeta.md']);
+  });
+
+  it('recurses into folder children', () => {
+    const sorted = sortFiles([folderNode('src', [fileNode('src/b.ts'), fileNode('src/a.ts')])]);
+    expect(sorted[0].children?.map((c) => c.path)).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+});
+
+describe('getFileName', () => {
+  it('returns the last path segment', () => {
+    expect(getFileName('a/b/c.ts')).toBe('c.ts');
+    expect(getFileName('single')).toBe('single');
+  });
+});
+
+describe('getAncestorFolderPaths', () => {
+  it('returns each cumulative ancestor folder, excluding the file itself', () => {
+    expect(getAncestorFolderPaths('a/b/c/file.ts')).toEqual(['a', 'a/b', 'a/b/c']);
+  });
+
+  it('returns an empty array for a root-level file', () => {
+    expect(getAncestorFolderPaths('file.ts')).toEqual([]);
+  });
+});
+
+describe('findFileInStructure', () => {
+  const tree = [folderNode('src', [fileNode('src/a.ts')]), fileNode('root.ts')];
+
+  it('finds nested and top-level entries by exact path', () => {
+    expect(findFileInStructure(tree, 'src/a.ts')?.path).toBe('src/a.ts');
+    expect(findFileInStructure(tree, 'root.ts')?.path).toBe('root.ts');
+  });
+
+  it('returns undefined for an unknown path', () => {
+    expect(findFileInStructure(tree, 'nope.ts')).toBeUndefined();
+  });
+});
+
+describe('findFileByToolPath', () => {
+  const tree = [folderNode('src', [fileNode('src/foo.ts')])];
+
+  it('matches an absolute tool path by stripping leading segments', () => {
+    expect(findFileByToolPath(tree, '/home/user/project/src/foo.ts')?.path).toBe('src/foo.ts');
+  });
+
+  it('matches an already-relative path directly', () => {
+    expect(findFileByToolPath(tree, 'src/foo.ts')?.path).toBe('src/foo.ts');
+  });
+
+  it('returns undefined for a relative path with no match', () => {
+    expect(findFileByToolPath(tree, 'other/foo.ts')).toBeUndefined();
+  });
+});
+
+describe('detectLanguage', () => {
+  it('maps known extensions case-insensitively', () => {
+    expect(detectLanguage('a.ts')).toBe('typescript');
+    expect(detectLanguage('a.PY')).toBe('python');
+  });
+
+  it('falls back to plaintext for unknown extensions', () => {
+    expect(detectLanguage('a.unknownext')).toBe('plaintext');
+    expect(detectLanguage('Makefile')).toBe('plaintext');
+  });
+
+  it('returns javascript for an empty path', () => {
+    expect(detectLanguage('')).toBe('javascript');
+  });
+});
+
+describe('filterChatAttachmentFiles', () => {
+  beforeEach(() => vi.mocked(toast.error).mockClear());
+
+  it('keeps supported files within the size limit', () => {
+    const ok = upload('a.png', 'image/png', 1000);
+    expect(filterChatAttachmentFiles([ok])).toEqual([ok]);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('drops unsupported files and toasts', () => {
+    const result = filterChatAttachmentFiles([upload('a.txt', 'text/plain', 10)]);
+    expect(result).toEqual([]);
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('not a supported file type'));
+  });
+
+  it('drops oversized supported files and toasts the MB limit', () => {
+    const big = upload('a.png', 'image/png', 6 * 1024 * 1024);
+    expect(filterChatAttachmentFiles([big])).toEqual([]);
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('5MB limit'));
+  });
+
+  it('suppresses toasts when toastOnError is false', () => {
+    filterChatAttachmentFiles([upload('a.txt', 'text/plain', 10)], { toastOnError: false });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildFileStructureFromSandboxFiles', () => {
+  it('auto-creates parent folders, dedupes, and skips empty paths', () => {
+    const meta: FileMetadata[] = [
+      { path: 'zeta.md', type: 'file' },
+      { path: 'src/b.ts', type: 'file' },
+      { path: '/src/a.ts', type: 'file' },
+      { path: 'src/a.ts', type: 'file' },
+      { path: '', type: 'file' },
+      { path: 'alpha.md', type: 'file' },
+    ];
+    const tree = buildFileStructureFromSandboxFiles(meta);
+    expect(tree.map((n) => n.path)).toEqual(['src', 'alpha.md', 'zeta.md']);
+    const src = tree.find((n) => n.path === 'src');
+    // '/src/a.ts' normalizes to 'src/a.ts', so the later duplicate is ignored.
+    expect(src?.children?.map((c) => c.path)).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+
+  it('carries the binary flag onto file nodes', () => {
+    const tree = buildFileStructureFromSandboxFiles([
+      { path: 'bin.dat', type: 'file', is_binary: true },
+    ]);
+    expect(tree[0].is_binary).toBe(true);
+  });
+});
+
+describe('hasActualFiles', () => {
+  it('is true when a file exists anywhere in the tree', () => {
+    expect(hasActualFiles([folderNode('src', [fileNode('src/a.ts')])])).toBe(true);
+  });
+
+  it('is false for a tree of empty folders', () => {
+    expect(hasActualFiles([folderNode('a', [folderNode('a/b', [])])])).toBe(false);
+  });
+});
+
+describe('traverseFileStructure', () => {
+  it('visits every node, dropping ones the processor maps to null', () => {
+    const tree = [folderNode('src', [fileNode('src/a.ts')]), fileNode('root.ts')];
+    const files = traverseFileStructure(tree, (item) => (item.type === 'file' ? item.path : null));
+    expect(files).toEqual(['src/a.ts', 'root.ts']);
+  });
+
+  it('passes the parent path to the processor', () => {
+    const tree = [folderNode('src', [fileNode('src/a.ts')])];
+    const parents = traverseFileStructure(tree, (item, parentPath) => `${parentPath}>${item.path}`);
+    expect(parents).toEqual(['>src', 'src>src/a.ts']);
+  });
+});
+
+describe('fetchAttachmentBlob', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('routes API attachment URLs through the api client endpoint', async () => {
+    const blob = new Blob(['x']);
+    const getBlob = vi.fn().mockResolvedValue(blob);
+    const result = await fetchAttachmentBlob('/api/v1/attachments/x?t=1', { getBlob });
+    expect(getBlob).toHaveBeenCalledWith('/attachments/x?t=1', undefined);
+    expect(result).toBe(blob);
+  });
+
+  it('fetches non-API URLs directly', async () => {
+    const blob = new Blob(['y']);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) });
+    vi.stubGlobal('fetch', fetchMock);
+    const result = await fetchAttachmentBlob('https://cdn/x.png', { getBlob: vi.fn() });
+    expect(fetchMock).toHaveBeenCalledWith('https://cdn/x.png', { signal: undefined });
+    expect(result).toBe(blob);
+  });
+
+  it('throws on a non-ok HTTP response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    await expect(fetchAttachmentBlob('https://cdn/x.png', { getBlob: vi.fn() })).rejects.toThrow(
+      'HTTP error! status: 404',
+    );
+  });
+});
+
+describe('downloadAttachmentFile', () => {
+  let clickSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    vi.stubGlobal(
+      'URL',
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => 'blob:generated'),
+        revokeObjectURL: vi.fn(),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    clickSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('downloads a browser object URL via an anchor without hitting the network', async () => {
+    const getBlob = vi.fn();
+    await downloadAttachmentFile('blob:existing', 'file.png', { getBlob });
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(getBlob).not.toHaveBeenCalled();
+  });
+
+  it('rewrites a preview URL to download, fetches via the api client, and revokes the blob', async () => {
+    const blob = new Blob(['x']);
+    const getBlob = vi.fn().mockResolvedValue(blob);
+    await downloadAttachmentFile('/api/v1/attachments/x/preview', 'file.png', { getBlob });
+    expect(getBlob).toHaveBeenCalledWith('/attachments/x/download', undefined);
+    expect(URL.createObjectURL).toHaveBeenCalledWith(blob);
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:generated');
+  });
+});
+
+describe('convertDataUrlToUploadedFile', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('fetches the data URL and wraps the blob in a named File', async () => {
+    const blob = new Blob(['x'], { type: 'image/png' });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ blob: () => Promise.resolve(blob) }));
+    const result = await convertDataUrlToUploadedFile('data:image/png;base64,AAAA', 'pic.png');
+    expect(result).toBeInstanceOf(File);
+    expect(result.name).toBe('pic.png');
+    expect(result.type).toBe('image/png');
+  });
+
+  it('defaults the filename and type', async () => {
+    const blob = new Blob(['x']);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ blob: () => Promise.resolve(blob) }));
+    const result = await convertDataUrlToUploadedFile('data:image/png;base64,AAAA');
+    expect(result.name).toBe('image.png');
+    expect(result.type).toBe('image/png');
+  });
+});

--- a/frontend/src/utils/fileTypes.test.ts
+++ b/frontend/src/utils/fileTypes.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isUploadedImageFile,
+  isUploadedPdfFile,
+  isUploadedXlsxFile,
+  isSupportedUploadedFile,
+  isMarkdownFile,
+  isCsvFile,
+  isXlsxFile,
+  isImageFile,
+  isHtmlFile,
+  isPowerPointFile,
+  isPdfFile,
+  isPreviewableFile,
+  isImageUrl,
+  detectFileType,
+} from './fileTypes';
+import type { FileStructure } from '@/types/file-system.types';
+
+// checkMimeType only reads name/type, so a bare object stands in for a File.
+const file = (name: string, type: string): File => ({ name, type }) as unknown as File;
+
+const node = (path: string, type: FileStructure['type'] = 'file'): FileStructure => ({
+  path,
+  type,
+  content: '',
+});
+
+describe('isUploadedImageFile', () => {
+  it('accepts the backend-allowed image mime types', () => {
+    expect(isUploadedImageFile(file('a.png', 'image/png'))).toBe(true);
+    expect(isUploadedImageFile(file('a.webp', 'image/webp'))).toBe(true);
+  });
+
+  it('rejects svg — not in the allowed mime list and no extension fallback here', () => {
+    expect(isUploadedImageFile(file('logo.svg', 'image/svg+xml'))).toBe(false);
+  });
+
+  it('rejects a png known only by extension (image check has no extension fallback)', () => {
+    expect(isUploadedImageFile(file('a.png', ''))).toBe(false);
+  });
+});
+
+describe('isUploadedPdfFile', () => {
+  it('accepts by mime type', () => {
+    expect(isUploadedPdfFile(file('a.pdf', 'application/pdf'))).toBe(true);
+  });
+
+  it('accepts by extension when the mime is missing', () => {
+    expect(isUploadedPdfFile(file('a.PDF', ''))).toBe(true);
+  });
+
+  it('rejects unrelated files', () => {
+    expect(isUploadedPdfFile(file('a.txt', 'text/plain'))).toBe(false);
+  });
+});
+
+describe('isUploadedXlsxFile', () => {
+  it('accepts by mime type and by .xlsx extension', () => {
+    expect(
+      isUploadedXlsxFile(
+        file('a.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
+      ),
+    ).toBe(true);
+    expect(isUploadedXlsxFile(file('a.xlsx', ''))).toBe(true);
+  });
+
+  it('rejects a legacy .xls (only .xlsx is the extension fallback here)', () => {
+    expect(isUploadedXlsxFile(file('a.xls', 'application/vnd.ms-excel'))).toBe(false);
+  });
+});
+
+describe('isSupportedUploadedFile', () => {
+  it('is true for supported image/pdf/xlsx uploads', () => {
+    expect(isSupportedUploadedFile(file('a.png', 'image/png'))).toBe(true);
+    expect(isSupportedUploadedFile(file('a.pdf', 'application/pdf'))).toBe(true);
+    expect(isSupportedUploadedFile(file('a.xlsx', ''))).toBe(true);
+  });
+
+  it('is false for an unsupported type', () => {
+    expect(isSupportedUploadedFile(file('a.txt', 'text/plain'))).toBe(false);
+  });
+});
+
+describe('FileStructure type predicates', () => {
+  it('detects markdown by .md and .markdown', () => {
+    expect(isMarkdownFile(node('docs/readme.md'))).toBe(true);
+    expect(isMarkdownFile(node('docs/notes.markdown'))).toBe(true);
+  });
+
+  it('matches extensions case-insensitively', () => {
+    expect(isImageFile(node('pics/A.PNG'))).toBe(true);
+  });
+
+  it('detects csv, xlsx, html, powerpoint and pdf', () => {
+    expect(isCsvFile(node('data.csv'))).toBe(true);
+    expect(isXlsxFile(node('sheet.xls'))).toBe(true);
+    expect(isHtmlFile(node('page.htm'))).toBe(true);
+    expect(isPowerPointFile(node('deck.pptx'))).toBe(true);
+    expect(isPdfFile(node('doc.pdf'))).toBe(true);
+  });
+
+  it('returns false for null, folders, and unknown extensions', () => {
+    expect(isMarkdownFile(null)).toBe(false);
+    expect(isImageFile(node('assets', 'folder'))).toBe(false);
+    expect(isPdfFile(node('script.ts'))).toBe(false);
+  });
+});
+
+describe('isPreviewableFile', () => {
+  it('is true for any previewable kind and false otherwise', () => {
+    expect(isPreviewableFile(node('a.md'))).toBe(true);
+    expect(isPreviewableFile(node('a.png'))).toBe(true);
+    expect(isPreviewableFile(node('a.ts'))).toBe(false);
+    expect(isPreviewableFile(null)).toBe(false);
+  });
+});
+
+describe('isImageUrl', () => {
+  it('matches known image extensions case-insensitively', () => {
+    expect(isImageUrl('https://host/a.PNG')).toBe(true);
+    expect(isImageUrl('logo.svg')).toBe(true);
+  });
+
+  it('rejects non-image URLs', () => {
+    expect(isImageUrl('https://host/a.txt')).toBe(false);
+  });
+});
+
+describe('detectFileType', () => {
+  it('classifies pdf by mime or extension', () => {
+    expect(detectFileType('report.pdf')).toBe('pdf');
+    expect(detectFileType('nameless', 'application/pdf')).toBe('pdf');
+  });
+
+  it('classifies images by mime or extension', () => {
+    expect(detectFileType('photo.JPG')).toBe('image');
+    expect(detectFileType('nameless', 'image/png')).toBe('image');
+  });
+
+  it('classifies xlsx/xls including the legacy excel mime', () => {
+    expect(detectFileType('data.xlsx')).toBe('xlsx');
+    expect(detectFileType('old.xls')).toBe('xlsx');
+    expect(detectFileType('nameless', 'application/vnd.ms-excel')).toBe('xlsx');
+  });
+
+  it('throws for unsupported types', () => {
+    expect(() => detectFileType('notes.txt')).toThrow('Unsupported file type: notes.txt');
+  });
+});

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatResult,
+  formatValue,
+  extractFilename,
+  formatBytes,
+  formatNumberCompact,
+  stripMarkdownTitle,
+  extractDomain,
+} from './format';
+
+describe('formatResult', () => {
+  it('returns strings unchanged', () => {
+    expect(formatResult('hello')).toBe('hello');
+  });
+
+  it('returns an empty string for null and undefined', () => {
+    expect(formatResult(null)).toBe('');
+    expect(formatResult(undefined)).toBe('');
+  });
+
+  it('pretty-prints non-string values with 2-space indent', () => {
+    expect(formatResult({ a: 1 })).toBe('{\n  "a": 1\n}');
+  });
+});
+
+describe('formatValue', () => {
+  it('returns strings unchanged', () => {
+    expect(formatValue('x')).toBe('x');
+  });
+
+  it('JSON-stringifies non-strings compactly', () => {
+    expect(formatValue({ a: 1 })).toBe('{"a":1}');
+    expect(formatValue(42)).toBe('42');
+  });
+});
+
+describe('extractFilename', () => {
+  it('returns the last path segment', () => {
+    expect(extractFilename('/a/b/c.txt')).toBe('c.txt');
+  });
+
+  it('returns the input when there is no slash', () => {
+    expect(extractFilename('file.txt')).toBe('file.txt');
+  });
+
+  // `?? path` only guards against pop() returning undefined; an empty last
+  // segment (trailing slash) is a string, so it is returned as-is.
+  it('returns an empty string for a trailing slash', () => {
+    expect(extractFilename('a/b/')).toBe('');
+  });
+});
+
+describe('formatBytes', () => {
+  it('formats bytes under 1KB', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+
+  it('formats kilobytes with one decimal', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+
+  it('formats megabytes with one decimal', () => {
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(1.5 * 1024 * 1024)).toBe('1.5 MB');
+  });
+});
+
+describe('formatNumberCompact', () => {
+  it('returns the plain number under 1000', () => {
+    expect(formatNumberCompact(0)).toBe('0');
+    expect(formatNumberCompact(999)).toBe('999');
+  });
+
+  it('formats thousands with a rounded K', () => {
+    expect(formatNumberCompact(1000)).toBe('1K');
+    expect(formatNumberCompact(1500)).toBe('2K');
+    expect(formatNumberCompact(12345)).toBe('12K');
+  });
+
+  it('formats millions with one decimal, trimming .0', () => {
+    expect(formatNumberCompact(1_000_000)).toBe('1M');
+    expect(formatNumberCompact(2_500_000)).toBe('2.5M');
+  });
+
+  // Suspicious-but-harmless: 999_500..999_999 round up to 1000 while still < 1M,
+  // so they render "1000K" rather than "1M". Documenting current behavior.
+  it('renders "1000K" just below one million (known edge)', () => {
+    expect(formatNumberCompact(999_999)).toBe('1000K');
+  });
+});
+
+describe('stripMarkdownTitle', () => {
+  it('strips bold and italic pairs', () => {
+    expect(stripMarkdownTitle('**bold**')).toBe('bold');
+    expect(stripMarkdownTitle('*italic*')).toBe('italic');
+    expect(stripMarkdownTitle('__under__')).toBe('under');
+  });
+
+  it('leaves an isolated underscore intact', () => {
+    expect(stripMarkdownTitle('my_var')).toBe('my_var');
+  });
+
+  it('strips a leading heading marker', () => {
+    expect(stripMarkdownTitle('## Heading')).toBe('Heading');
+  });
+
+  it('strips inline code and strikethrough', () => {
+    expect(stripMarkdownTitle('`code`')).toBe('code');
+    expect(stripMarkdownTitle('~~gone~~')).toBe('gone');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(stripMarkdownTitle('  spaced  ')).toBe('spaced');
+  });
+});
+
+describe('extractDomain', () => {
+  it('returns the hostname without a www. prefix', () => {
+    expect(extractDomain('https://www.example.com/path')).toBe('example.com');
+    expect(extractDomain('https://sub.example.com')).toBe('sub.example.com');
+  });
+
+  it('falls back to the raw string for invalid URLs', () => {
+    expect(extractDomain('not a url')).toBe('not a url');
+  });
+
+  it('truncates a long invalid string with an ellipsis', () => {
+    const long = 'x'.repeat(40);
+    const result = extractDomain(long);
+    expect(result).toBe(`${'x'.repeat(27)}…`);
+    expect(result).toHaveLength(28);
+  });
+});

--- a/frontend/src/utils/fuzzySearch.test.ts
+++ b/frontend/src/utils/fuzzySearch.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { fuzzySearch } from './fuzzySearch';
+
+describe('fuzzySearch', () => {
+  it('returns an empty array when there are no items', () => {
+    expect(fuzzySearch('anything', [], { limit: 5 })).toEqual([]);
+  });
+
+  it('returns the first `limit` items when the query is empty', () => {
+    expect(fuzzySearch('', ['a', 'b', 'c'], { limit: 2 })).toEqual(['a', 'b']);
+  });
+
+  it('treats a whitespace-only query as empty', () => {
+    expect(fuzzySearch('   ', ['a', 'b', 'c'], { limit: 2 })).toEqual(['a', 'b']);
+  });
+
+  it('treats an undefined query as empty', () => {
+    expect(fuzzySearch(undefined, ['a', 'b'], { limit: 5 })).toEqual(['a', 'b']);
+  });
+
+  it('ranks the best match first for a string list', () => {
+    const result = fuzzySearch('app', ['grape', 'apple', 'banana'], { limit: 10 });
+    expect(result[0]).toBe('apple');
+    expect(result).not.toContain('banana');
+  });
+
+  it('searches by object keys and returns the source objects', () => {
+    const items = [{ name: 'apple' }, { name: 'banana' }];
+    const result = fuzzySearch('apple', items, { keys: ['name'], limit: 10 });
+    expect(result[0]).toEqual({ name: 'apple' });
+  });
+
+  it('honors the limit for matched results', () => {
+    const result = fuzzySearch('a', ['a', 'ba', 'ca', 'da'], { limit: 2 });
+    expect(result).toHaveLength(2);
+  });
+});

--- a/frontend/src/utils/mentionParser.test.ts
+++ b/frontend/src/utils/mentionParser.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTokenQuery,
+  insertToken,
+  getHighlightTokenRanges,
+  buildHighlightSegments,
+} from './mentionParser';
+
+describe('parseTokenQuery', () => {
+  it('is inactive when the trigger is absent before the cursor', () => {
+    expect(parseTokenQuery('hello', 5, '@')).toEqual({
+      isActive: false,
+      query: '',
+      tokenStartPos: -1,
+      tokenEndPos: -1,
+    });
+  });
+
+  it('activates for a trigger at the start of the message', () => {
+    expect(parseTokenQuery('@foo', 4, '@')).toEqual({
+      isActive: true,
+      query: 'foo',
+      tokenStartPos: 0,
+      tokenEndPos: 4,
+    });
+  });
+
+  it('activates for a trigger preceded by a space', () => {
+    const r = parseTokenQuery('hi @foo', 7, '@');
+    expect(r.isActive).toBe(true);
+    expect(r.query).toBe('foo');
+    expect(r.tokenStartPos).toBe(3);
+    expect(r.tokenEndPos).toBe(7);
+  });
+
+  it('activates for a trigger preceded by a newline', () => {
+    expect(parseTokenQuery('hi\n@foo', 7, '@').isActive).toBe(true);
+  });
+
+  it('lowercases the query', () => {
+    expect(parseTokenQuery('@FooBar', 7, '@').query).toBe('foobar');
+  });
+
+  it('is inactive when the trigger sits mid-word (e.g. an email)', () => {
+    expect(parseTokenQuery('user@host', 9, '@').isActive).toBe(false);
+  });
+
+  it('is inactive when whitespace separates the trigger from the cursor', () => {
+    expect(parseTokenQuery('@foo bar', 8, '@').isActive).toBe(false);
+  });
+
+  it('is inactive when a newline separates the trigger from the cursor', () => {
+    expect(parseTokenQuery('@foo\nbar', 8, '@').isActive).toBe(false);
+  });
+
+  it('only inspects text before the cursor', () => {
+    // The '@' is after the cursor, so it is invisible to the parser.
+    expect(parseTokenQuery('a @foo', 1, '@').isActive).toBe(false);
+  });
+
+  it('anchors on the last trigger, so an invalid last trigger wins over an earlier valid one', () => {
+    // Earlier '@a' is valid, but the parser looks only at the last '@' (in b@c).
+    expect(parseTokenQuery('@a b@c', 6, '@').isActive).toBe(false);
+  });
+
+  it('uses the last valid trigger when several are present', () => {
+    const r = parseTokenQuery('@a @b', 5, '@');
+    expect(r.isActive).toBe(true);
+    expect(r.query).toBe('b');
+    expect(r.tokenStartPos).toBe(3);
+  });
+
+  it('supports the slash trigger', () => {
+    expect(parseTokenQuery('/hel', 4, '/')).toEqual({
+      isActive: true,
+      query: 'hel',
+      tokenStartPos: 0,
+      tokenEndPos: 4,
+    });
+  });
+
+  it('reports an empty query for a bare trigger at the cursor', () => {
+    const r = parseTokenQuery('@', 1, '@');
+    expect(r.isActive).toBe(true);
+    expect(r.query).toBe('');
+  });
+});
+
+describe('insertToken', () => {
+  it('replaces the in-progress token and appends a closing space', () => {
+    // "@fo|" -> pick "@foo.ts"
+    const r = insertToken('@fo', '@foo.ts', 0, 3);
+    expect(r.text).toBe('@foo.ts ');
+    expect(r.cursor).toBe(8);
+  });
+
+  it('does not add a separator when the following text already starts with a space', () => {
+    const r = insertToken('@fo rest', '@foo', 0, 3);
+    expect(r.text).toBe('@foo rest');
+    expect(r.cursor).toBe(4);
+  });
+
+  it('replaces a token embedded in surrounding text', () => {
+    const r = insertToken('say @fo now', '@foo', 4, 7);
+    expect(r.text).toBe('say @foo now');
+    // The existing space after the token means no separator is added, so the
+    // cursor lands right after the inserted token.
+    expect(r.cursor).toBe(8);
+  });
+});
+
+describe('getHighlightTokenRanges', () => {
+  it('returns no ranges for empty or token-free text', () => {
+    expect(getHighlightTokenRanges('')).toEqual([]);
+    expect(getHighlightTokenRanges('just words')).toEqual([]);
+  });
+
+  it('captures a mention at the start of the string', () => {
+    expect(getHighlightTokenRanges('@foo bar')).toEqual([[0, 4]]);
+  });
+
+  it('captures a command after a space', () => {
+    expect(getHighlightTokenRanges('run /cmd')).toEqual([[4, 8]]);
+  });
+
+  it('captures multiple tokens without including the leading whitespace', () => {
+    expect(getHighlightTokenRanges('a @b @c')).toEqual([
+      [2, 4],
+      [5, 7],
+    ]);
+  });
+
+  it('ignores a trigger that is not at a word boundary', () => {
+    expect(getHighlightTokenRanges('a@b')).toEqual([]);
+  });
+});
+
+describe('buildHighlightSegments', () => {
+  it('returns an empty array for an empty message', () => {
+    expect(buildHighlightSegments('')).toEqual([]);
+  });
+
+  it('returns a single plain run when there are no tokens', () => {
+    expect(buildHighlightSegments('plain text')).toEqual([{ text: 'plain text', isToken: false }]);
+  });
+
+  it('marks a lone token run as a token', () => {
+    expect(buildHighlightSegments('@foo')).toEqual([{ text: '@foo', isToken: true }]);
+  });
+
+  it('splits leading text, token, and trailing text into ordered runs', () => {
+    expect(buildHighlightSegments('hi @foo there')).toEqual([
+      { text: 'hi ', isToken: false },
+      { text: '@foo', isToken: true },
+      { text: ' there', isToken: false },
+    ]);
+  });
+
+  it('interleaves multiple tokens with their separating text', () => {
+    expect(buildHighlightSegments('a @b @c')).toEqual([
+      { text: 'a ', isToken: false },
+      { text: '@b', isToken: true },
+      { text: ' ', isToken: false },
+      { text: '@c', isToken: true },
+    ]);
+  });
+});

--- a/frontend/src/utils/message.test.ts
+++ b/frontend/src/utils/message.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Message } from '@/types/chat.types';
+import { isAssistantMessage, createInitialMessage, createAttachmentsFromFiles } from './message';
+
+const msg = (over: Partial<Message>): Message => ({
+  id: 'm1',
+  chat_id: 'c1',
+  content_text: '',
+  content_render: { events: [] },
+  last_seq: 0,
+  active_stream_id: null,
+  stream_status: 'completed',
+  role: 'assistant',
+  attachments: [],
+  model_id: null,
+  duration_ms: null,
+  created_at: '2020-01-01T00:00:00.000Z',
+  checkpoint_id: null,
+  ...over,
+});
+
+describe('isAssistantMessage', () => {
+  it('trusts is_bot=true regardless of role', () => {
+    expect(isAssistantMessage(msg({ is_bot: true, role: 'user' }))).toBe(true);
+  });
+
+  it('trusts is_bot=false regardless of role (assistant role does not override)', () => {
+    expect(isAssistantMessage(msg({ is_bot: false, role: 'assistant' }))).toBe(false);
+  });
+
+  it('falls back to the role when is_bot is undefined', () => {
+    expect(isAssistantMessage(msg({ is_bot: undefined, role: 'assistant' }))).toBe(true);
+    expect(isAssistantMessage(msg({ is_bot: undefined, role: 'user' }))).toBe(false);
+  });
+});
+
+describe('createInitialMessage', () => {
+  it('builds a completed user message seeded with a user_text event', () => {
+    const m = createInitialMessage('hello', null, 'model-x', 'chat-1');
+    expect(m.content_text).toBe('hello');
+    expect(m.content_render.events).toEqual([{ type: 'user_text', text: 'hello' }]);
+    expect(m.role).toBe('user');
+    expect(m.is_bot).toBe(false);
+    expect(m.stream_status).toBe('completed');
+    expect(m.model_id).toBe('model-x');
+    expect(m.chat_id).toBe('chat-1');
+    expect(m.attachments).toEqual([]);
+    expect(typeof m.id).toBe('string');
+  });
+
+  it('maps attached files into typed attachments', () => {
+    const file = new File(['x'], 'shot.png', { type: 'image/png' });
+    const m = createInitialMessage('with file', [file], 'model-x', 'chat-1');
+    expect(m.attachments).toHaveLength(1);
+    const [att] = m.attachments;
+    expect(att.filename).toBe('shot.png');
+    expect(att.file_type).toBe('image');
+    expect(att.file_url).toMatch(/^blob:/);
+  });
+
+  it('produces an empty attachments array for an empty file list', () => {
+    expect(createInitialMessage('p', [], 'm', 'c').attachments).toEqual([]);
+  });
+});
+
+describe('createAttachmentsFromFiles', () => {
+  it('returns undefined for null or empty input', () => {
+    const store = vi.fn();
+    expect(createAttachmentsFromFiles(null, store)).toBeUndefined();
+    expect(createAttachmentsFromFiles([], store)).toBeUndefined();
+    expect(store).not.toHaveBeenCalled();
+  });
+
+  it('maps files to attachments and stores the blob url only for pdfs', () => {
+    const store = vi.fn();
+    const png = new File(['x'], 'a.png', { type: 'image/png' });
+    const pdf = new File(['y'], 'b.pdf', { type: 'application/pdf' });
+    const atts = createAttachmentsFromFiles([png, pdf], store);
+
+    expect(atts).toHaveLength(2);
+    expect(atts?.[0].file_type).toBe('image');
+    expect(atts?.[1].file_type).toBe('pdf');
+    expect(atts?.[1].file_url).toMatch(/^blob:/);
+    // storeBlobUrl fires for the pdf only, with the file and its blob url.
+    expect(store).toHaveBeenCalledTimes(1);
+    expect(store).toHaveBeenCalledWith(pdf, atts?.[1].file_url);
+    // message_id is a millisecond timestamp string.
+    expect(atts?.[0].message_id).toMatch(/^\d+$/);
+  });
+});

--- a/frontend/src/utils/permissionResponse.test.ts
+++ b/frontend/src/utils/permissionResponse.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { resolvePermissionRequest, addResolvedPermission } = vi.hoisted(() => ({
+  resolvePermissionRequest: vi.fn(),
+  addResolvedPermission: vi.fn(),
+}));
+
+vi.mock('@/store/permissionStore', () => ({
+  usePermissionStore: { getState: () => ({ resolvePermissionRequest }) },
+}));
+vi.mock('@/utils/permissionStorage', () => ({ addResolvedPermission }));
+
+import { executePermissionResponse, clearPermissionRequest } from './permissionResponse';
+
+function makeOpts() {
+  return {
+    setIsLoading: vi.fn(),
+    setError: vi.fn(),
+    errorMessage: 'fallback',
+    clearRequest: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('executePermissionResponse', () => {
+  it('returns success and clears the request when the service resolves', async () => {
+    const opts = makeOpts();
+    const result = await executePermissionResponse(async () => {}, opts);
+    expect(result).toBe('success');
+    expect(opts.clearRequest).toHaveBeenCalledTimes(1);
+    expect(opts.setError).toHaveBeenCalledWith(null);
+  });
+
+  it('toggles loading on around the call regardless of outcome', async () => {
+    const opts = makeOpts();
+    await executePermissionResponse(async () => {}, opts);
+    expect(opts.setIsLoading).toHaveBeenNthCalledWith(1, true);
+    expect(opts.setIsLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it('treats a 404 Error as expired: clears the request, sets no error', async () => {
+    const opts = makeOpts();
+    const err = Object.assign(new Error('gone'), { status: 404 });
+    const result = await executePermissionResponse(async () => {
+      throw err;
+    }, opts);
+    expect(result).toBe('expired');
+    expect(opts.clearRequest).toHaveBeenCalledTimes(1);
+    // Only the initial reset — the expired branch never sets an error message.
+    expect(opts.setError).toHaveBeenCalledTimes(1);
+    expect(opts.setError).toHaveBeenCalledWith(null);
+    expect(opts.setIsLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it('treats a non-Error 404-shaped rejection as expired', async () => {
+    const opts = makeOpts();
+    const result = await executePermissionResponse(async () => {
+      throw { status: 404 };
+    }, opts);
+    expect(result).toBe('expired');
+    expect(opts.clearRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces an Error message and does not clear on a non-404 failure', async () => {
+    const opts = makeOpts();
+    const result = await executePermissionResponse(async () => {
+      throw new Error('boom');
+    }, opts);
+    expect(result).toBe('error');
+    expect(opts.setError).toHaveBeenLastCalledWith('boom');
+    expect(opts.clearRequest).not.toHaveBeenCalled();
+    expect(opts.setIsLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it('falls back to errorMessage when a non-Error without status is thrown', async () => {
+    const opts = makeOpts();
+    const result = await executePermissionResponse(async () => {
+      throw 'plain string';
+    }, opts);
+    expect(result).toBe('error');
+    expect(opts.setError).toHaveBeenLastCalledWith('fallback');
+  });
+});
+
+describe('clearPermissionRequest', () => {
+  it('records the resolved seq then drops the in-memory request', () => {
+    clearPermissionRequest('chat-1', 'req-9', 42);
+    expect(addResolvedPermission).toHaveBeenCalledWith('chat-1', 42);
+    expect(resolvePermissionRequest).toHaveBeenCalledWith('chat-1', 'req-9');
+  });
+});

--- a/frontend/src/utils/permissionStorage.test.ts
+++ b/frontend/src/utils/permissionStorage.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { filterOptions, addResolvedPermission, isPermissionResolved } from './permissionStorage';
+import type { PermissionOption } from '@/types/chat.types';
+
+const STORAGE_KEY = 'agentrove_resolved_permission_seqs';
+
+const opt = (kind: PermissionOption['kind']): PermissionOption => ({
+  kind,
+  name: kind,
+  option_id: kind,
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('filterOptions', () => {
+  const options = [
+    opt('allow_once'),
+    opt('allow_always'),
+    opt('reject_once'),
+    opt('reject_always'),
+  ];
+
+  it('keeps only allow-prefixed options', () => {
+    expect(filterOptions(options, 'allow').map((o) => o.kind)).toEqual([
+      'allow_once',
+      'allow_always',
+    ]);
+  });
+
+  it('keeps only reject-prefixed options', () => {
+    expect(filterOptions(options, 'reject').map((o) => o.kind)).toEqual([
+      'reject_once',
+      'reject_always',
+    ]);
+  });
+
+  it('returns an empty array when there are no options', () => {
+    expect(filterOptions([], 'allow')).toEqual([]);
+  });
+});
+
+describe('addResolvedPermission / isPermissionResolved', () => {
+  it('marks a seq resolved and scopes by chat id and seq', () => {
+    addResolvedPermission('chat-a', 5);
+    expect(isPermissionResolved('chat-a', 5)).toBe(true);
+    expect(isPermissionResolved('chat-a', 6)).toBe(false);
+    expect(isPermissionResolved('chat-b', 5)).toBe(false);
+  });
+
+  it('does not store duplicate keys', () => {
+    addResolvedPermission('chat-a', 5);
+    addResolvedPermission('chat-a', 5);
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) as string) as string[];
+    expect(stored).toEqual(['chat-a:5']);
+  });
+
+  it('recovers from malformed stored JSON', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-json{');
+    expect(isPermissionResolved('chat-a', 1)).toBe(false);
+    addResolvedPermission('chat-a', 1);
+    expect(isPermissionResolved('chat-a', 1)).toBe(true);
+  });
+
+  it('caps stored entries, dropping the oldest', () => {
+    for (let seq = 0; seq < 205; seq++) addResolvedPermission('c', seq);
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) as string) as string[];
+    expect(stored).toHaveLength(200);
+    // 205 pushes, capped at 200 -> the first 5 (seq 0..4) are evicted.
+    expect(isPermissionResolved('c', 4)).toBe(false);
+    expect(isPermissionResolved('c', 5)).toBe(true);
+    expect(isPermissionResolved('c', 204)).toBe(true);
+  });
+});

--- a/frontend/src/utils/settings.test.ts
+++ b/frontend/src/utils/settings.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mergeByName,
+  createDefaultEnvVarForm,
+  validateEnvVarForm,
+  resolvePersona,
+  createDefaultPersonaForm,
+  validatePersonaForm,
+  createDefaultStreamActionForm,
+  validateStreamActionForm,
+  getGeneralSecretFields,
+} from './settings';
+import type { CustomEnvVar, Persona, StreamAction } from '@/types/user.types';
+
+describe('mergeByName', () => {
+  it('returns primary unchanged when secondary is empty', () => {
+    const primary = [{ name: 'a' }];
+    expect(mergeByName(primary, [])).toBe(primary);
+  });
+
+  it('appends only secondary items whose names are not already present (case-insensitive)', () => {
+    const merged = mergeByName([{ name: 'Alpha' }], [{ name: 'alpha' }, { name: 'Beta' }]);
+    expect(merged.map((i) => i.name)).toEqual(['Alpha', 'Beta']);
+  });
+});
+
+describe('validateEnvVarForm', () => {
+  const form = (over: Partial<CustomEnvVar> = {}): CustomEnvVar => ({
+    key: 'KEY',
+    value: 'val',
+    ...over,
+  });
+
+  it('returns null for a valid, unique form', () => {
+    expect(validateEnvVarForm(form(), null, [])).toBeNull();
+  });
+
+  it('requires a key', () => {
+    expect(validateEnvVarForm(form({ key: '  ' }), null, [])).toBe(
+      'Environment variable name is required',
+    );
+  });
+
+  it('requires a value', () => {
+    expect(validateEnvVarForm(form({ value: '' }), null, [])).toBe(
+      'Environment variable value is required',
+    );
+  });
+
+  it('rejects a duplicate key case-sensitively', () => {
+    const existing = [form({ key: 'KEY' })];
+    expect(validateEnvVarForm(form({ key: 'KEY' }), null, existing)).toBe(
+      'An environment variable with this name already exists',
+    );
+    // Env var names are case-sensitive, so a differently-cased key is allowed.
+    expect(validateEnvVarForm(form({ key: 'key' }), null, existing)).toBeNull();
+  });
+
+  it('ignores the row being edited when checking uniqueness', () => {
+    const existing = [form({ key: 'KEY' })];
+    expect(validateEnvVarForm(form({ key: 'KEY' }), 0, existing)).toBeNull();
+  });
+});
+
+describe('resolvePersona', () => {
+  const personas: Persona[] = [{ name: 'Reviewer', content: '' }];
+
+  it('keeps a non-default persona that exists', () => {
+    expect(resolvePersona('Reviewer', personas)).toBe('Reviewer');
+  });
+
+  it('falls back to Default for an unknown persona', () => {
+    expect(resolvePersona('Ghost', personas)).toBe('Default');
+  });
+
+  it('passes Default through untouched', () => {
+    expect(resolvePersona('Default', personas)).toBe('Default');
+  });
+});
+
+describe('validatePersonaForm', () => {
+  const form = (over: Partial<Persona> = {}): Persona => ({ name: 'P', content: 'c', ...over });
+
+  it('returns null for a valid form', () => {
+    expect(validatePersonaForm(form(), null, [])).toBeNull();
+  });
+
+  it('requires a name and content', () => {
+    expect(validatePersonaForm(form({ name: '' }), null, [])).toBe('Name is required');
+    expect(validatePersonaForm(form({ content: '' }), null, [])).toBe('Content is required');
+  });
+
+  it('rejects a duplicate name case-insensitively', () => {
+    const existing = [form({ name: 'Reviewer' })];
+    expect(validatePersonaForm(form({ name: 'reviewer' }), null, existing)).toBe(
+      'A persona with this name already exists',
+    );
+  });
+});
+
+describe('validateStreamActionForm', () => {
+  const form = (over: Partial<StreamAction> = {}): StreamAction => ({
+    ...createDefaultStreamActionForm(),
+    label: 'Run',
+    model_id: 'm1',
+    command: 'do it',
+    ...over,
+  });
+
+  it('returns null for a valid form', () => {
+    expect(validateStreamActionForm(form(), null, [])).toBeNull();
+  });
+
+  it('requires label, model, and command', () => {
+    expect(validateStreamActionForm(form({ label: '' }), null, [])).toBe('Label is required');
+    expect(validateStreamActionForm(form({ model_id: '' }), null, [])).toBe('Model is required');
+    expect(validateStreamActionForm(form({ command: '' }), null, [])).toBe('Command is required');
+  });
+
+  it('rejects a duplicate label', () => {
+    const existing = [form({ label: 'Run' })];
+    expect(validateStreamActionForm(form({ label: 'run' }), null, existing)).toBe(
+      'An action with this label already exists',
+    );
+  });
+});
+
+describe('form factories and static config', () => {
+  it('creates empty env var and persona forms', () => {
+    expect(createDefaultEnvVarForm()).toEqual({ key: '', value: '' });
+    expect(createDefaultPersonaForm()).toEqual({ name: '', content: '' });
+  });
+
+  it('seeds a stream action form with the shared defaults', () => {
+    expect(createDefaultStreamActionForm()).toMatchObject({
+      label: '',
+      enabled: true,
+      persona_name: 'Default',
+      permission_mode: 'bypassPermissions',
+      thinking_mode: 'high',
+    });
+  });
+
+  it('exposes the GitHub PAT secret field', () => {
+    const fields = getGeneralSecretFields();
+    expect(fields).toHaveLength(1);
+    expect(fields[0].key).toBe('github_personal_access_token');
+  });
+});

--- a/frontend/src/utils/stream.test.ts
+++ b/frontend/src/utils/stream.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { logger } from '@/utils/logger';
+import { StreamContentBuffer, extractAssistantText, PROMPT_SUGGESTIONS_RE } from './stream';
+import type { AssistantStreamEvent } from '@/types/chat.types';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PROMPT_SUGGESTIONS_RE', () => {
+  it('strips a complete suggestions tag, including multiline content', () => {
+    const input = 'a<prompt_suggestions>\n["x"]\n</prompt_suggestions>b';
+    expect(input.replace(PROMPT_SUGGESTIONS_RE, '')).toBe('ab');
+  });
+
+  it('strips every occurrence (global flag)', () => {
+    const input =
+      '<prompt_suggestions>1</prompt_suggestions>x<prompt_suggestions>2</prompt_suggestions>';
+    expect(input.replace(PROMPT_SUGGESTIONS_RE, '')).toBe('x');
+  });
+
+  it('leaves an unclosed tag in place (only complete tags match)', () => {
+    const input = 'keep<prompt_suggestions>partial';
+    expect(input.replace(PROMPT_SUGGESTIONS_RE, '')).toBe(input);
+  });
+});
+
+describe('extractAssistantText — array source', () => {
+  it('joins assistant_text events and ignores other kinds', () => {
+    const events: AssistantStreamEvent[] = [
+      { type: 'assistant_text', text: 'Hello ' },
+      { type: 'assistant_thinking', thinking: 'ignored' },
+      { type: 'user_text', text: 'ignored' },
+      { type: 'assistant_text', text: 'world' },
+    ];
+    expect(extractAssistantText(events)).toBe('Hello world');
+  });
+
+  it('strips a trailing suggestions tag and trims trailing whitespace', () => {
+    const events: AssistantStreamEvent[] = [
+      { type: 'assistant_text', text: 'answer <prompt_suggestions>["a"]</prompt_suggestions>' },
+    ];
+    expect(extractAssistantText(events)).toBe('answer');
+  });
+
+  it('returns an empty string when there are no assistant_text events', () => {
+    expect(extractAssistantText([{ type: 'assistant_thinking', thinking: 't' }])).toBe('');
+  });
+});
+
+describe('extractAssistantText — string source', () => {
+  it('wraps plain (non-JSON) content as a single assistant_text', () => {
+    expect(extractAssistantText('just a message')).toBe('just a message');
+  });
+
+  it('parses a JSON event-array string', () => {
+    const source = JSON.stringify([
+      { type: 'assistant_text', text: 'a' },
+      { type: 'assistant_text', text: 'b' },
+    ]);
+    expect(extractAssistantText(source)).toBe('ab');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(extractAssistantText('')).toBe('');
+  });
+
+  it('treats a JSON array that is not an event array as plain text', () => {
+    // [1,2,3] parses but fails the event-array shape check -> wrapped as text.
+    expect(extractAssistantText('[1,2,3]')).toBe('[1,2,3]');
+  });
+
+  it('treats malformed JSON as plain text and logs the parse failure', () => {
+    expect(extractAssistantText('[not valid json')).toBe('[not valid json');
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('extractAssistantText — parse cache', () => {
+  it('parses identical content only once (cache hit skips the reparse)', () => {
+    const malformed = `[${'z'.repeat(200)}`;
+    extractAssistantText(malformed);
+    extractAssistantText(malformed);
+    // A cache hit does not reparse, so the parse-failure log fires exactly once.
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not serve a false cache hit for distinct content', () => {
+    extractAssistantText(`[${'a'.repeat(200)}`);
+    extractAssistantText(`[${'b'.repeat(200)}`);
+    expect(logger.error).toHaveBeenCalledTimes(2);
+  });
+
+  it('keys long strings by fingerprint but guards against fingerprint collisions', () => {
+    // Same length + first-50 + last-50, differing only in the middle -> same
+    // cache key. The content-equality guard must still return each own result.
+    const head = 'H'.repeat(50);
+    const tail = 'T'.repeat(50);
+    const a = head + 'A'.repeat(50) + tail;
+    const b = head + 'B'.repeat(50) + tail;
+    expect(extractAssistantText(a)).toBe(a);
+    expect(extractAssistantText(b)).toBe(b);
+  });
+
+  it('evicts the oldest entry once the 20-entry cap is exceeded (FIFO)', () => {
+    const sentinel = `[${'S'.repeat(200)}`;
+    extractAssistantText(sentinel); // parse -> 1 log
+    // 20 distinct long entries fully refill the capped cache, evicting sentinel.
+    for (let i = 0; i < 20; i++) {
+      extractAssistantText(`[evict${i}${'q'.repeat(200)}`);
+    }
+    extractAssistantText(sentinel); // evicted -> reparse -> +1 log
+    expect(logger.error).toHaveBeenCalledTimes(22);
+  });
+});
+
+describe('StreamContentBuffer', () => {
+  it('starts empty', () => {
+    const buf = new StreamContentBuffer();
+    expect(buf.getEvents()).toEqual([]);
+    expect(buf.getContentText()).toBe('');
+    expect(buf.serialize()).toBe('[]');
+    expect(buf.snapshot()).toEqual({ events: [] });
+  });
+
+  it('seeds text from initial assistant_text events', () => {
+    const buf = new StreamContentBuffer([
+      { type: 'assistant_text', text: 'foo' },
+      { type: 'assistant_thinking', thinking: 'skip' },
+      { type: 'assistant_text', text: 'bar' },
+    ]);
+    expect(buf.getContentText()).toBe('foobar');
+  });
+
+  it('prefers explicit initialText over reconstructing from events', () => {
+    const buf = new StreamContentBuffer(
+      [{ type: 'assistant_text', text: 'fromEvents' }],
+      'fromText',
+    );
+    expect(buf.getContentText()).toBe('fromText');
+  });
+
+  it('accumulates pushed assistant_text into events and content', () => {
+    const buf = new StreamContentBuffer();
+    buf.push({ type: 'assistant_text', text: 'a' });
+    buf.push({ type: 'assistant_text', text: 'b' });
+    expect(buf.getContentText()).toBe('ab');
+    expect(buf.getEvents()).toHaveLength(2);
+  });
+
+  it('records non-text events without changing the joined text', () => {
+    const buf = new StreamContentBuffer();
+    buf.push({ type: 'assistant_thinking', thinking: 'hmm' });
+    expect(buf.getContentText()).toBe('');
+    expect(buf.getEvents()).toHaveLength(1);
+  });
+
+  it('ignores empty assistant_text for the text buffer but still records the event', () => {
+    const buf = new StreamContentBuffer();
+    buf.push({ type: 'assistant_text', text: '' });
+    expect(buf.getContentText()).toBe('');
+    expect(buf.getEvents()).toHaveLength(1);
+  });
+
+  it('snapshot returns a copy that is decoupled from later pushes', () => {
+    const buf = new StreamContentBuffer();
+    buf.push({ type: 'assistant_text', text: 'a' });
+    const snap = buf.snapshot();
+    buf.push({ type: 'assistant_text', text: 'b' });
+    expect(snap.events).toHaveLength(1);
+  });
+
+  it('serializes the events to JSON', () => {
+    const buf = new StreamContentBuffer();
+    buf.push({ type: 'assistant_text', text: 'hi' });
+    expect(buf.serialize()).toBe(JSON.stringify([{ type: 'assistant_text', text: 'hi' }]));
+  });
+
+  it('does not mutate the caller-provided initialEvents array', () => {
+    const initial: AssistantStreamEvent[] = [{ type: 'assistant_text', text: 'a' }];
+    const buf = new StreamContentBuffer(initial);
+    buf.push({ type: 'assistant_text', text: 'b' });
+    expect(initial).toHaveLength(1);
+  });
+});

--- a/frontend/src/utils/terminal.test.ts
+++ b/frontend/src/utils/terminal.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { buildTerminalTheme, terminalStorageKey, clearTerminalStorage } from './terminal';
+import { CUSTOM_PALETTE_TOKENS } from '@/utils/theme';
+
+describe('terminalStorageKey', () => {
+  it('joins chat id and panel key under the terminal namespace', () => {
+    expect(terminalStorageKey('chat-1', 'main')).toBe('terminal:chat-1:main');
+  });
+});
+
+describe('buildTerminalTheme', () => {
+  it('uses the light base surface and light-mode accents for light', () => {
+    const theme = buildTerminalTheme('light');
+    expect(theme).toMatchObject({
+      background: '#f9f9f9',
+      foreground: '#27272a',
+      cursor: '#27272a',
+      cursorAccent: '#ffffff',
+      selectionBackground: 'rgba(0, 0, 0, 0.15)',
+      selectionInactiveBackground: 'rgba(0, 0, 0, 0.08)',
+    });
+  });
+
+  it('uses the dark base surface and dark-mode accents for dark', () => {
+    const theme = buildTerminalTheme('dark');
+    expect(theme).toMatchObject({
+      background: '#141414',
+      foreground: '#e4e4e7',
+      cursorAccent: '#0a0a0a',
+      selectionBackground: 'rgba(255, 255, 255, 0.2)',
+    });
+  });
+
+  it('derives a dark custom palette from its shared tokens', () => {
+    const theme = buildTerminalTheme('dim');
+    expect(theme?.background).toBe(CUSTOM_PALETTE_TOKENS.dim.surfaceSecondary);
+    expect(theme?.foreground).toBe(CUSTOM_PALETTE_TOKENS.dim.textPrimary);
+    // dim rides the dark base -> dark cursor accent.
+    expect(theme?.cursorAccent).toBe('#0a0a0a');
+  });
+
+  it('derives a light custom palette with light-mode accents', () => {
+    const theme = buildTerminalTheme('sepia');
+    expect(theme?.background).toBe(CUSTOM_PALETTE_TOKENS.sepia.surfaceSecondary);
+    expect(theme?.foreground).toBe(CUSTOM_PALETTE_TOKENS.sepia.textPrimary);
+    expect(theme?.cursorAccent).toBe('#ffffff');
+  });
+});
+
+describe('clearTerminalStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('terminal:c1:main', '1');
+    localStorage.setItem('terminal:c1:side', '1');
+    localStorage.setItem('terminal:c2:main', '1');
+    localStorage.setItem('unrelated:c1', '1');
+  });
+
+  it('sweeps only the given chat and leaves other entries', () => {
+    clearTerminalStorage('c1');
+    expect(localStorage.getItem('terminal:c1:main')).toBeNull();
+    expect(localStorage.getItem('terminal:c1:side')).toBeNull();
+    expect(localStorage.getItem('terminal:c2:main')).toBe('1');
+    expect(localStorage.getItem('unrelated:c1')).toBe('1');
+  });
+
+  it('sweeps every terminal entry when no chat id is given', () => {
+    clearTerminalStorage();
+    expect(localStorage.getItem('terminal:c1:main')).toBeNull();
+    expect(localStorage.getItem('terminal:c2:main')).toBeNull();
+    expect(localStorage.getItem('unrelated:c1')).toBe('1');
+  });
+});

--- a/frontend/src/utils/tileHelpers.test.ts
+++ b/frontend/src/utils/tileHelpers.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isSecondaryPaneActive,
+  isSecondaryTile,
+  tileIdToViewType,
+  viewTypeToTileId,
+  tileViewKinds,
+  VIEW_LABELS,
+  VIEW_ICONS,
+} from './tileHelpers';
+import type { ViewType } from '@/types/ui.types';
+
+const ALL_VIEWS: ViewType[] = ['agent', 'diff', 'editor', 'terminal', 'secrets'];
+
+describe('isSecondaryPaneActive', () => {
+  it('is active only when the secondary agent pane is focused and bound to a chat', () => {
+    expect(isSecondaryPaneActive('agent:secondary', 'chat-1')).toBe(true);
+  });
+
+  it('is inactive without a bound secondary chat', () => {
+    expect(isSecondaryPaneActive('agent:secondary', null)).toBe(false);
+  });
+
+  it('is inactive when the primary agent pane is focused', () => {
+    expect(isSecondaryPaneActive('agent:primary', 'chat-1')).toBe(false);
+  });
+});
+
+describe('isSecondaryTile', () => {
+  it('matches any tile with the :secondary suffix', () => {
+    expect(isSecondaryTile('agent:secondary')).toBe(true);
+    expect(isSecondaryTile('diff:secondary')).toBe(true);
+  });
+
+  it('rejects primary and bare view tiles', () => {
+    expect(isSecondaryTile('agent:primary')).toBe(false);
+    expect(isSecondaryTile('diff')).toBe(false);
+  });
+});
+
+describe('tileIdToViewType', () => {
+  it('strips the primary agent suffix back to the view kind', () => {
+    expect(tileIdToViewType('agent:primary')).toBe('agent');
+    expect(tileIdToViewType('agent:secondary')).toBe('agent');
+  });
+
+  it('strips a :secondary suffix off non-agent tiles', () => {
+    expect(tileIdToViewType('diff:secondary')).toBe('diff');
+    expect(tileIdToViewType('terminal:secondary')).toBe('terminal');
+  });
+
+  it('returns a bare primary tile unchanged', () => {
+    expect(tileIdToViewType('editor')).toBe('editor');
+  });
+});
+
+describe('viewTypeToTileId', () => {
+  it('maps the agent view to agent:primary regardless of the secondary flag', () => {
+    expect(viewTypeToTileId('agent', false)).toBe('agent:primary');
+    expect(viewTypeToTileId('agent', true)).toBe('agent:primary');
+  });
+
+  it('maps a non-agent primary view to its bare tile id', () => {
+    expect(viewTypeToTileId('diff', false)).toBe('diff');
+  });
+
+  it('maps a non-agent secondary view to the :secondary tile id', () => {
+    expect(viewTypeToTileId('terminal', true)).toBe('terminal:secondary');
+  });
+});
+
+describe('tileViewKinds', () => {
+  it('collapses the two agent panes into a single agent kind, preserving order', () => {
+    expect(tileViewKinds(['agent:primary', 'agent:secondary', 'diff'])).toEqual(['agent', 'diff']);
+  });
+
+  it('dedupes a primary and secondary of the same non-agent view', () => {
+    expect(tileViewKinds(['diff', 'diff:secondary'])).toEqual(['diff']);
+  });
+
+  it('returns an empty array for no tiles', () => {
+    expect(tileViewKinds([])).toEqual([]);
+  });
+});
+
+describe('VIEW_LABELS / VIEW_ICONS', () => {
+  it('define a label and an icon for every view kind', () => {
+    for (const view of ALL_VIEWS) {
+      expect(VIEW_LABELS[view]).toBeTruthy();
+      expect(VIEW_ICONS[view]).toBeTruthy();
+    }
+  });
+});

--- a/frontend/src/utils/validation.test.ts
+++ b/frontend/src/utils/validation.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidEmail,
+  isValidUsername,
+  isValidPassword,
+  validateRequired,
+  validateUnique,
+  validateId,
+} from './validation';
+import { ValidationError } from '@/services/base/ServiceError';
+
+describe('isValidEmail', () => {
+  it('accepts well-formed addresses', () => {
+    expect(isValidEmail('a@b.co')).toBe(true);
+    expect(isValidEmail('user.name+tag@sub.example.com')).toBe(true);
+  });
+
+  it('rejects addresses without an @ or a valid TLD', () => {
+    expect(isValidEmail('no-at')).toBe(false);
+    expect(isValidEmail('a@b.c')).toBe(false); // single-char TLD
+    expect(isValidEmail('@b.co')).toBe(false);
+    expect(isValidEmail('a b@c.co')).toBe(false); // whitespace
+    expect(isValidEmail('')).toBe(false);
+  });
+});
+
+describe('isValidUsername', () => {
+  it('accepts alphanumeric/underscore names of length 3-30', () => {
+    expect(isValidUsername('abc')).toBe(true);
+    expect(isValidUsername('a_b')).toBe(true);
+    expect(isValidUsername('ABC123')).toBe(true);
+    expect(isValidUsername('a'.repeat(30))).toBe(true);
+  });
+
+  it('rejects out-of-range lengths', () => {
+    expect(isValidUsername('ab')).toBe(false);
+    expect(isValidUsername('a'.repeat(31))).toBe(false);
+  });
+
+  it('rejects illegal characters', () => {
+    expect(isValidUsername('a-b')).toBe(false);
+    expect(isValidUsername('a b')).toBe(false);
+  });
+
+  it('rejects leading or trailing underscores', () => {
+    expect(isValidUsername('_abc')).toBe(false);
+    expect(isValidUsername('abc_')).toBe(false);
+  });
+});
+
+describe('isValidPassword', () => {
+  it('enforces the default 8-char minimum', () => {
+    expect(isValidPassword('1234567')).toBe(false);
+    expect(isValidPassword('12345678')).toBe(true);
+  });
+
+  it('honors a custom minimum length', () => {
+    expect(isValidPassword('abc', 3)).toBe(true);
+    expect(isValidPassword('ab', 3)).toBe(false);
+  });
+});
+
+describe('validateRequired', () => {
+  it('throws for null, undefined and blank strings', () => {
+    expect(() => validateRequired(null, 'Name')).toThrow(ValidationError);
+    expect(() => validateRequired(undefined, 'Name')).toThrow('Name is required');
+    expect(() => validateRequired('   ', 'Name')).toThrow('Name is required');
+  });
+
+  it('passes for non-empty values, including falsy non-strings', () => {
+    expect(() => validateRequired('x', 'Name')).not.toThrow();
+    expect(() => validateRequired(0, 'Count')).not.toThrow();
+    expect(() => validateRequired(false, 'Flag')).not.toThrow();
+  });
+});
+
+describe('validateUnique', () => {
+  const items = [{ name: 'Alpha' }, { name: 'Beta' }];
+
+  it('throws with the article + display name when a duplicate exists', () => {
+    expect(() => validateUnique('name', 'Alpha', items, null, 'agent', 'An')).toThrow(
+      'An agent already exists',
+    );
+  });
+
+  it('is case-insensitive by default', () => {
+    expect(() => validateUnique('name', 'alpha', items, null, 'agent', 'An')).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('respects case when caseInsensitive is false', () => {
+    expect(() => validateUnique('name', 'alpha', items, null, 'agent', 'An', false)).not.toThrow();
+  });
+
+  it('skips the row being edited', () => {
+    expect(() => validateUnique('name', 'Alpha', items, 0, 'agent', 'An')).not.toThrow();
+  });
+
+  it('passes when no duplicate is found', () => {
+    expect(() => validateUnique('name', 'Gamma', items, null, 'agent', 'An')).not.toThrow();
+  });
+});
+
+describe('validateId', () => {
+  it('throws when the id is missing', () => {
+    expect(() => validateId(null)).toThrow('ID is required');
+    expect(() => validateId('')).toThrow('ID is required');
+  });
+
+  it('throws when the id is not a string', () => {
+    expect(() => validateId(123)).toThrow('ID must be a string');
+  });
+
+  it('uses a custom field name', () => {
+    expect(() => validateId(123, 'Chat ID')).toThrow('Chat ID must be a string');
+  });
+
+  it('passes for a non-empty string id', () => {
+    expect(() => validateId('abc')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 423 Vitest unit tests across 30 co-located test files covering the frontend's pure-logic core: stream event parsing, mention/token parsing, automation cron build/parse round-trips, diff line-range resolution (`@pierre/diffs` fixtures), file/attachment type handling, permission response/storage, settings, fuzzy search, and editor navigation (fake Monaco)
- Add full state-transition coverage for the Zustand stores: `messageQueueStore`, `streamStore`, `permissionStore`, `sidebarFilters`, `chatStore`, `diffReviewStore`, `modelStore`
- Add a **Unit Tests** job to `frontend-checks.yml` so `npm test` gates PRs alongside lint/typecheck/build

## Notes
- Tests run in the default `node` environment; files needing DOM/localStorage opt into jsdom via the per-file directive, matching the existing vitest setup
- No timezone/locale-dependent assertions (suite passes in any TZ)
- No production source changes were needed — edge-case testing found no bugs; a few odd-but-harmless behaviors (e.g. `getRelativeTime` "0mo" at 28–29 days, `formatNumberCompact` "1000K" just under 1M) are documented in test comments rather than changed
- Full suite: 33 files / 452 tests, ~1.7s locally