### PR TITLE
feat: add Grok agent support via ACP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentrove
 
-Self-hosted AI coding workspace for running Claude Code, Codex, Copilot, Cursor, and OpenCode agents from one interface.
+Self-hosted AI coding workspace for running Claude Code, Codex, Copilot, Cursor, Grok, and OpenCode agents from one interface.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
@@ -13,7 +13,7 @@ Self-hosted AI coding workspace for running Claude Code, Codex, Copilot, Cursor,
 
 ## What It Does
 
-- Runs Claude, Codex, Copilot, Cursor, and OpenCode through ACP adapters.
+- Runs Claude, Codex, Copilot, Cursor, Grok, and OpenCode through ACP adapters.
 - Gives each workspace its own Docker or host sandbox.
 - Combines chat, code editor, terminal, file tree, diffs, secrets, and git tools in one workspace.
 - Supports workspaces from empty folders, git clones, existing local folders, or GitHub repositories.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -7,7 +7,7 @@
 - Test through HTTP/WebSocket routes so the real route handlers, dependencies, and services run together
 - Use a real isolated test database for backend endpoint tests when persistence matters
 - Stub only external boundaries: email delivery, third-party APIs, ACP/provider processes, Docker/host sandbox execution, Redis/cache when needed
-- Provider coverage should exercise endpoint flows with fake ACP/provider boundaries; don't call real Claude, Codex, OpenCode, Cursor, or Copilot in default tests
+- Provider coverage should exercise endpoint flows with fake ACP/provider boundaries; don't call real Claude, Codex, OpenCode, Cursor, Grok, or Copilot in default tests
 - CI's backend test job should stay generic (`Backend Tests`) and expand its pytest command as more test files are added
 
 ## Code Style

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,6 +40,12 @@ RUN curl -fsSL https://opencode.ai/install | bash && \
     cp /root/.opencode/bin/opencode /usr/local/bin/opencode && \
     chmod +x /usr/local/bin/opencode
 
+# Grok Build CLI (installs `grok` to /root/.local/bin) — used for the Grok ACP
+# server (`grok agent stdio`).
+RUN curl -fsSL https://x.ai/cli/install.sh | bash && \
+    cp /root/.local/bin/grok /usr/local/bin/grok && \
+    chmod +x /usr/local/bin/grok
+
 # Install uv package manager
 RUN curl -LsSf https://astral.sh/uv/install.sh | bash
 

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -209,6 +209,10 @@ MODELS: dict[str, ModelInfo] = {
         "Grok 4.20 Thinking", AgentKind.CURSOR, 200_000
     ),
     "cursor:kimi-k2.5": ModelInfo("Kimi K2.5", AgentKind.CURSOR, 262_000),
+    "grok:grok-4.5": ModelInfo("Grok 4.5", AgentKind.GROK, 500_000),
+    "grok:grok-composer-2.5-fast": ModelInfo(
+        "Composer 2.5 (Grok)", AgentKind.GROK, 200_000
+    ),
     "opencode:opencode/big-pickle": ModelInfo(
         "Big Pickle (OpenCode)", AgentKind.OPENCODE, 200_000
     ),
@@ -1703,6 +1707,9 @@ BUILTIN_SLASH_COMMANDS: dict[AgentKind, list[dict[str, str]]] = {
     # Cursor's slash commands live in its TUI client, not the ACP server, so
     # cursor-agent treats them as prompt text rather than commands.
     AgentKind.CURSOR: [],
+    # Grok's ACP server advertises its commands (compact, session-info, user
+    # skills, ...) via availableCommands, so we rely on runtime discovery.
+    AgentKind.GROK: [],
     # OpenCode's slash commands live in its TUI; the ACP server surfaces only
     # user-defined commands, so we rely on runtime discovery.
     AgentKind.OPENCODE: [],

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -9,6 +9,7 @@ PermissionMode: TypeAlias = Literal[
     "agent",
     "autopilot",
     "auto",
+    "code",
     "read-only",
     "full-access",
     "ask",

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -14,6 +14,7 @@ class AgentKind(str, Enum):
     CODEX = "codex"
     COPILOT = "copilot"
     CURSOR = "cursor"
+    GROK = "grok"
     OPENCODE = "opencode"
 
 
@@ -28,6 +29,9 @@ NATIVE_FILE_TYPES: dict[AgentKind, frozenset[str]] = {
     AgentKind.CODEX: frozenset({"image"}),
     AgentKind.COPILOT: frozenset({"image"}),
     AgentKind.CURSOR: frozenset({"image"}),
+    # Grok advertises ACP promptCapabilities image: false — attachments are
+    # referenced via sandbox paths instead.
+    AgentKind.GROK: frozenset(),
     AgentKind.OPENCODE: frozenset({"image"}),
 }
 
@@ -62,6 +66,16 @@ COPILOT_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
 # Cursor CLI exposes three ACP session modes (see https://cursor.com/docs/cli/acp).
 CURSOR_SESSION_MODES = frozenset({"agent", "plan", "ask"})
 
+# Grok Build's ACP session modes: `code` is normal full execution, `plan`
+# blocks writes except the session plan file. Grok auto-approves every tool
+# call over ACP stdio (it never sends session/request_permission), so there
+# is no separate ask/approve mode to expose.
+GROK_SESSION_MODES = frozenset({"code", "plan"})
+# Only Grok 4.5 exposes the low/medium/high reasoning-effort dial; Composer
+# ignores it, so the effort launch flag is skipped for other models.
+GROK_VALID_THINKING_MODES = frozenset({"low", "medium", "high"})
+GROK_REASONING_MODEL_IDS = frozenset({"grok:grok-4.5"})
+
 # OpenCode's built-in primary agents double as ACP session modes; `plan`
 # restricts edits to `.opencode/plans/*.md`, `build` has full tool access.
 OPENCODE_SESSION_MODES = frozenset({"build", "plan"})
@@ -75,16 +89,19 @@ NORMAL_SESSION_MODE: dict[AgentKind, PermissionMode] = {
     AgentKind.CODEX: "auto",
     AgentKind.COPILOT: "agent",
     AgentKind.CURSOR: "agent",
+    AgentKind.GROK: "code",
     AgentKind.OPENCODE: "build",
 }
 
 # Agents that can have their base system prompt replaced by a persona.
 # Claude/Codex expose a first-class mechanism (ACP _meta.systemPrompt for
 # Claude; model_instructions_file via CODEX_CONFIG for Codex). OpenCode uses a custom
-# primary agent injected through OPENCODE_CONFIG_CONTENT. Cursor and Copilot
-# ignore system prompt replacement over ACP, so personas would have no effect.
+# primary agent injected through OPENCODE_CONFIG_CONTENT. Grok documents
+# session/new _meta.systemPromptOverride/rules in its ACP docs. Cursor and
+# Copilot ignore system prompt replacement over ACP, so personas would have
+# no effect.
 PERSONAS_SUPPORTED_AGENTS: frozenset[AgentKind] = frozenset(
-    {AgentKind.CLAUDE, AgentKind.CODEX, AgentKind.OPENCODE}
+    {AgentKind.CLAUDE, AgentKind.CODEX, AgentKind.GROK, AgentKind.OPENCODE}
 )
 
 
@@ -150,6 +167,7 @@ class AgentAdapter(ABC):
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
+        reasoning_effort: str | None = None,
     ) -> LaunchConfig:
         raise NotImplementedError
 
@@ -188,6 +206,7 @@ class ClaudeAgentAdapter(AgentAdapter):
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
+        reasoning_effort: str | None = None,
     ) -> LaunchConfig:
         # Claude doesn't use CLI args — all config is via env vars and session meta.
         return LaunchConfig(binary="claude-agent-acp")
@@ -240,6 +259,7 @@ class CodexAgentAdapter(AgentAdapter):
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
+        reasoning_effort: str | None = None,
     ) -> LaunchConfig:
         # codex-acp ignores CLI args entirely — customization goes through the
         # CODEX_CONFIG env var, a JSON object merged into the Codex session
@@ -310,6 +330,7 @@ class CopilotCliAdapter(AgentAdapter):
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
+        reasoning_effort: str | None = None,
     ) -> LaunchConfig:
         return LaunchConfig(binary="copilot", cli_args=["--acp", "--stdio"])
 
@@ -367,6 +388,7 @@ class CursorAgentAdapter(AgentAdapter):
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
+        reasoning_effort: str | None = None,
     ) -> LaunchConfig:
         return LaunchConfig(binary="cursor-agent", cli_args=["acp"])
 
@@ -401,6 +423,79 @@ class CursorAgentAdapter(AgentAdapter):
         return model_id.removeprefix("cursor:")
 
 
+class GrokAgentAdapter(AgentAdapter):
+    # Grok Build (xAI) runs as an ACP server via `grok agent stdio`. Reasoning
+    # effort is a launch-only flag (`grok agent --reasoning-effort <tier> stdio`)
+    # — there is no ACP method to change it mid-session, so effort changes take
+    # effect through the session fingerprint respawning the process. Grok
+    # auto-approves every tool call over ACP stdio (it never sends
+    # session/request_permission), so its modes (code/plan) are workflow
+    # choices rather than approval policies.
+
+    def __init__(self) -> None:
+        super().__init__(kind=AgentKind.GROK)
+
+    def build_launch_config(
+        self,
+        *,
+        system_prompt: str | None,
+        system_prompt_is_full_replace: bool,
+        instructions_file_path: str | None = None,
+        reasoning_effort: str | None = None,
+    ) -> LaunchConfig:
+        # Agent-level flags must precede the `stdio` subcommand.
+        cli_args = ["agent"]
+        if reasoning_effort:
+            cli_args.extend(["--reasoning-effort", reasoning_effort])
+        cli_args.append("stdio")
+        return LaunchConfig(binary="grok", cli_args=cli_args)
+
+    def build_session_config(
+        self,
+        *,
+        system_prompt: str | None,
+        system_prompt_is_full_replace: bool,
+        model_id: str,
+        thinking_mode: str | None,
+        permission_mode: str,
+    ) -> SessionConfig:
+        # Grok's session/new _meta supports systemPromptOverride (full
+        # replacement) and rules (appended to the default prompt).
+        meta: dict[str, Any] = {}
+        if system_prompt:
+            if system_prompt_is_full_replace:
+                meta["systemPromptOverride"] = system_prompt
+            else:
+                meta["rules"] = system_prompt
+
+        reasoning_effort = (
+            coerce_thinking_mode(thinking_mode, GROK_VALID_THINKING_MODES)
+            if model_id in GROK_REASONING_MODEL_IDS
+            else None
+        )
+
+        return SessionConfig(
+            meta=meta,
+            reasoning_effort=reasoning_effort,
+            permission=PermissionConfig(
+                session_mode=self.map_session_mode(permission_mode)
+            ),
+        )
+
+    def map_session_mode(self, permission_mode: str) -> str:
+        # Persisted settings may still carry mode strings from a different
+        # previous agent. Default to Grok's normal code mode — both Grok modes
+        # auto-approve what they allow, so no mapping widens permissions.
+        if permission_mode not in GROK_SESSION_MODES:
+            return "code"
+        return permission_mode
+
+    def map_model_id(self, model_id: str) -> str:
+        # Internal keys use "grok:" prefix to namespace; the CLI expects the
+        # raw model ID (e.g. "grok-4.5" not "grok:grok-4.5").
+        return model_id.removeprefix("grok:")
+
+
 class OpencodeAgentAdapter(AgentAdapter):
     # OpenCode CLI runs as an ACP server via `opencode acp` and speaks the same
     # ACP transport as the other adapters. OpenCode's "primary agents" (build,
@@ -418,6 +513,7 @@ class OpencodeAgentAdapter(AgentAdapter):
         system_prompt: str | None,
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
+        reasoning_effort: str | None = None,
     ) -> LaunchConfig:
         return LaunchConfig(binary="opencode", cli_args=["acp"])
 
@@ -494,5 +590,6 @@ AGENT_ADAPTERS: dict[AgentKind, AgentAdapter] = {
     AgentKind.CODEX: CodexAgentAdapter(),
     AgentKind.COPILOT: CopilotCliAdapter(),
     AgentKind.CURSOR: CursorAgentAdapter(),
+    AgentKind.GROK: GrokAgentAdapter(),
     AgentKind.OPENCODE: OpencodeAgentAdapter(),
 }

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -474,7 +474,12 @@ class AcpClientHandler:
         # write, grep, glob, webfetch, task, todowrite, skill, question) in
         # `title` — its ACP `kind` collapses distinct tools (edit/write/patch
         # all become "edit"), so title is the only way to distinguish them.
-        # Codex/Copilot/Cursor use the top-level `kind` field.
+        # Grok puts the raw tool name (write, search_replace, read_file, grep,
+        # run_terminal_command, ...) in field_meta["x.ai/tool"].name — its
+        # initial tool_call has no `kind` and later updates rewrite `title`
+        # to a human label. Web search calls lack that meta, so they fall
+        # through to `kind` ("search"). Codex/Copilot/Cursor use the
+        # top-level `kind` field.
         meta = getattr(tc, "field_meta", None) or {}
         claude_meta = meta.get("claudeCode", {})
         if tool_name := claude_meta.get("toolName"):
@@ -482,6 +487,9 @@ class AcpClientHandler:
         if self.agent_kind == AgentKind.OPENCODE:
             if title := getattr(tc, "title", None):
                 return str(title)
+        if self.agent_kind == AgentKind.GROK:
+            if tool_name := meta.get("x.ai/tool", {}).get("name"):
+                return str(tool_name)
         kind = getattr(tc, "kind", None)
         if kind:
             return str(kind)
@@ -553,8 +561,14 @@ class AcpClientHandler:
         texts = cls._extract_content_texts(tc)
         return "\n".join(texts) if texts else None
 
-    @classmethod
-    def _extract_tool_error(cls, tc: ToolCallProgress) -> str:
+    def _extract_tool_error(self, tc: ToolCallProgress) -> str:
+        # Grok's failed updates carry a variant-tag dict in raw_output (e.g.
+        # {"type": "FileNotFound"}) while the readable message lives in the
+        # content text blocks, so prefer those.
+        if self.agent_kind == AgentKind.GROK:
+            texts = self._extract_content_texts(tc)
+            if texts:
+                return "\n".join(texts)
         if tc.raw_output is not None:
             if isinstance(tc.raw_output, dict):
                 # Codex wraps the error in formatted_output; opencode uses a
@@ -566,5 +580,5 @@ class AcpClientHandler:
                         return str(value)
                 return str(tc.raw_output)
             return str(tc.raw_output)
-        texts = cls._extract_content_texts(tc)
+        texts = self._extract_content_texts(tc)
         return "\n".join(texts) if texts else "Tool execution failed"

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -493,6 +493,7 @@ class AcpSession:
             system_prompt=config.system_prompt,
             system_prompt_is_full_replace=config.system_prompt_is_full_replace,
             instructions_file_path=config.codex_instructions_file_path,
+            reasoning_effort=config.reasoning_effort,
         )
 
     @staticmethod

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -45,12 +45,16 @@ class SkillService:
 
         # .{name}/skills namespaces each agent searches. Codex/Copilot/Cursor share
         # the Vercel .agents/skills ecosystem; OpenCode additionally cross-reads
-        # Claude-compatible skills.
+        # Claude-compatible skills; Grok scans .agents plus the Claude and Cursor
+        # skill directories by default.
         result: dict[str, list[Path]] = {
             AgentKind.CODEX.value: ns(workspace_path, base, ["codex", "agents"]),
             AgentKind.COPILOT.value: ns(workspace_path, base, ["copilot", "agents"]),
             AgentKind.CURSOR.value: ns(workspace_path, base, ["cursor", "agents"]),
             AgentKind.CLAUDE.value: ns(workspace_path, base, ["claude"]),
+            AgentKind.GROK.value: ns(
+                workspace_path, base, ["grok", "agents", "claude", "cursor"]
+            ),
             AgentKind.OPENCODE.value: ns(
                 workspace_path, base, ["opencode", "agents", "claude"]
             ),

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -24,6 +24,7 @@ import { getAgentKindForModelId, type AgentKind } from '@/types/chat.types';
 const AGENTS_WITHOUT_USAGE_UPDATE: ReadonlySet<AgentKind> = new Set([
   'copilot',
   'cursor',
+  'grok',
   'opencode',
 ]);
 

--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -21,6 +21,7 @@ const AGENT_LABELS: Record<AgentKind, string> = {
   codex: 'Codex',
   copilot: 'Copilot',
   cursor: 'Cursor',
+  grok: 'Grok',
   opencode: 'OpenCode',
 };
 

--- a/frontend/src/components/chat/permission-mode-selector/permissionModes.ts
+++ b/frontend/src/components/chat/permission-mode-selector/permissionModes.ts
@@ -68,6 +68,19 @@ export const CURSOR_PERMISSION_MODES: PermissionModeOption[] = [
   },
 ];
 
+export const GROK_PERMISSION_MODES: PermissionModeOption[] = [
+  {
+    value: 'code',
+    label: 'Code',
+    description: 'Full tool access, tool calls run without approval prompts',
+  },
+  {
+    value: 'plan',
+    label: 'Plan',
+    description: 'Blocks edits while Grok designs an approach first',
+  },
+];
+
 export const OPENCODE_PERMISSION_MODES: PermissionModeOption[] = [
   {
     value: 'build',
@@ -86,6 +99,7 @@ export const MODES_BY_AGENT: Record<AgentKind, PermissionModeOption[]> = {
   codex: CODEX_PERMISSION_MODES,
   copilot: COPILOT_PERMISSION_MODES,
   cursor: CURSOR_PERMISSION_MODES,
+  grok: GROK_PERMISSION_MODES,
   opencode: OPENCODE_PERMISSION_MODES,
 };
 
@@ -94,6 +108,7 @@ const DEFAULT_BY_AGENT: Record<AgentKind, PermissionMode> = {
   codex: 'full-access',
   copilot: 'agent',
   cursor: 'agent',
+  grok: 'code',
   opencode: 'build',
 };
 

--- a/frontend/src/components/chat/persona-selector/personaSupport.ts
+++ b/frontend/src/components/chat/persona-selector/personaSupport.ts
@@ -1,10 +1,12 @@
 import type { AgentKind } from '@/types/chat.types';
 
 // Claude and Codex expose direct prompt-replacement hooks; OpenCode uses a
-// generated primary agent with the persona prompt. Cursor and Copilot ignore
-// prompt replacement over ACP, so personas are hidden for those agents.
+// generated primary agent with the persona prompt; Grok accepts a
+// systemPromptOverride on session/new. Cursor and Copilot ignore prompt
+// replacement over ACP, so personas are hidden for those agents.
 export const PERSONAS_SUPPORTED_AGENTS: ReadonlySet<AgentKind> = new Set<AgentKind>([
   'claude',
   'codex',
+  'grok',
   'opencode',
 ]);

--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -47,11 +47,21 @@ const CODEX_ULTRA_MODEL_IDS = new Set(['gpt-5.6-sol', 'gpt-5.6-terra']);
 // so an empty list hides the selector.
 const EMPTY_THINKING_MODES: ThinkingModeOption[] = [];
 
+// Grok's reasoning-effort dial only exists on Grok 4.5 (Composer ignores it),
+// so the selector is model-gated like Claude's xhigh tier.
+const GROK_THINKING_MODES: ThinkingModeOption[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+const GROK_REASONING_MODEL_IDS = new Set(['grok:grok-4.5']);
+
 export const THINKING_MODES_BY_AGENT: Record<AgentKind, ThinkingModeOption[]> = {
   claude: CLAUDE_THINKING_MODES,
   codex: CODEX_THINKING_MODES,
   copilot: CODEX_THINKING_MODES,
   cursor: EMPTY_THINKING_MODES,
+  grok: EMPTY_THINKING_MODES,
   opencode: EMPTY_THINKING_MODES,
 };
 
@@ -60,6 +70,7 @@ const DEFAULT_BY_AGENT: Record<AgentKind, string> = {
   codex: 'high',
   copilot: 'high',
   cursor: 'high',
+  grok: 'high',
   opencode: 'high',
 };
 
@@ -76,6 +87,9 @@ export function getThinkingModesForAgent(
   }
   if (agentKind === 'codex' && modelId && CODEX_MAX_MODEL_IDS.has(modelId)) {
     return CODEX_MAX_THINKING_MODES;
+  }
+  if (agentKind === 'grok' && modelId && GROK_REASONING_MODEL_IDS.has(modelId)) {
+    return GROK_THINKING_MODES;
   }
 
   return THINKING_MODES_BY_AGENT[agentKind];

--- a/frontend/src/components/chat/tools/grok/BashTool.module.scss
+++ b/frontend/src/components/chat/tools/grok/BashTool.module.scss
@@ -1,0 +1,25 @@
+@use '@/styles/globals/typography' as type;
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+// Command line preview (`$ <command>`) — reads one shade lighter than the shared
+// output-pre body, so it needs its own asymmetric light/dark pair.
+.command-pre {
+  @include type.type-mono(0.625rem, 1.625);
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--theme-text-secondary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-tertiary);
+  }
+}
+
+.command-prompt {
+  user-select: none;
+  color: var(--theme-text-quaternary);
+}

--- a/frontend/src/components/chat/tools/grok/BashTool.tsx
+++ b/frontend/src/components/chat/tools/grok/BashTool.tsx
@@ -1,0 +1,53 @@
+import { memo } from 'react';
+import { Terminal } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import toolText from '../common/toolText.module.scss';
+import toolIcon from './toolIcon.module.scss';
+import type { GrokBashInput, GrokBashOutput } from './grokPayload';
+import styles from './BashTool.module.scss';
+
+const ICON = <Terminal className={toolIcon.icon} />;
+
+export const BashTool = memo(function BashTool({ tool }: { tool: ToolAggregate }) {
+  const input = tool.input as GrokBashInput | undefined;
+  const result = tool.result as GrokBashOutput | undefined;
+
+  const command = input?.command ?? '';
+  const description = input?.description?.trim();
+  // output_for_prompt starts with an "exit: N" line on completion — the exit
+  // code already colors the card status, so strip it from the visible output.
+  const output = (result?.output_for_prompt ?? '').replace(/^exit: -?\d+\n?/, '');
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        const label = description || command || 'command';
+        switch (status) {
+          case 'completed':
+            return `Ran: ${label}`;
+          case 'failed':
+            return `Failed: ${label}`;
+          default:
+            return `Running: ${label}`;
+        }
+      }}
+      loadingContent="Running command..."
+      error={tool.error}
+    >
+      {(command || output) && (
+        <div className={styles.body}>
+          {command && (
+            <pre className={styles['command-pre']}>
+              <span className={styles['command-prompt']}>$ </span>
+              {command}
+            </pre>
+          )}
+          {output && <pre className={toolText['output-pre']}>{output}</pre>}
+        </div>
+      )}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/grok/EditTool.tsx
+++ b/frontend/src/components/chat/tools/grok/EditTool.tsx
@@ -1,0 +1,43 @@
+import { memo } from 'react';
+import { FileEdit } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import { DiffView } from '../common/DiffView/DiffView';
+import { OpenInEditorButton } from '../common/OpenInEditorButton/OpenInEditorButton';
+import { buildUnifiedDiff } from '../common/buildUnifiedDiff';
+import toolIcon from './toolIcon.module.scss';
+import type { GrokEditInput } from './grokPayload';
+
+const ICON = <FileEdit className={toolIcon.icon} />;
+
+export const EditTool = memo(function EditTool({ tool }: { tool: ToolAggregate }) {
+  const input = tool.input as GrokEditInput | undefined;
+  const filePath = input?.file_path ?? '';
+  const fileName = filePath ? extractFilename(filePath) : tool.title?.trim() || 'file';
+  const oldText = input?.old_string ?? '';
+  const newText = input?.new_string ?? '';
+  const diff = oldText || newText ? buildUnifiedDiff(oldText, newText) : '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Edited ${fileName}`;
+          case 'failed':
+            return `Failed to edit ${fileName}`;
+          default:
+            return `Editing ${fileName}...`;
+        }
+      }}
+      loadingContent="Applying changes..."
+      error={tool.error}
+      actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
+    >
+      {diff && <DiffView diff={diff} />}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/grok/GrepTool.tsx
+++ b/frontend/src/components/chat/tools/grok/GrepTool.tsx
@@ -1,0 +1,44 @@
+import { memo } from 'react';
+import { FileSearch } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import { SearchLoadingDots } from '../common/SearchLoadingDots/SearchLoadingDots';
+import toolText from '../common/toolText.module.scss';
+import toolIcon from './toolIcon.module.scss';
+import type { GrokGrepInput, GrokGrepOutput } from './grokPayload';
+
+const ICON = <FileSearch className={toolIcon.icon} />;
+
+export const GrepTool = memo(function GrepTool({ tool }: { tool: ToolAggregate }) {
+  const input = tool.input as GrokGrepInput | undefined;
+  const result = tool.result as GrokGrepOutput | undefined;
+
+  const pattern = input?.pattern ?? 'pattern';
+  const matches = result?.match_count;
+  const output = result?.stdout ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed': {
+            if (typeof matches !== 'number') return `Searched for "${pattern}"`;
+            return `Found ${matches} match${matches === 1 ? '' : 'es'}`;
+          }
+          case 'failed':
+            return `Search failed: ${pattern}`;
+          default:
+            return `Searching for "${pattern}"...`;
+        }
+      }}
+      loadingContent={<SearchLoadingDots label="Searching files" />}
+      error={tool.error}
+    >
+      {output && typeof matches === 'number' && matches > 0 && (
+        <pre className={toolText['output-pre']}>{output}</pre>
+      )}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/grok/ListDirTool.tsx
+++ b/frontend/src/components/chat/tools/grok/ListDirTool.tsx
@@ -1,0 +1,40 @@
+import { memo } from 'react';
+import { FolderOpen } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import toolText from '../common/toolText.module.scss';
+import toolIcon from './toolIcon.module.scss';
+import type { GrokListDirInput, GrokListDirOutput } from './grokPayload';
+
+const ICON = <FolderOpen className={toolIcon.icon} />;
+
+export const ListDirTool = memo(function ListDirTool({ tool }: { tool: ToolAggregate }) {
+  const input = tool.input as GrokListDirInput | undefined;
+  const result = tool.result as GrokListDirOutput | undefined;
+
+  const dirPath = input?.target_directory ?? '';
+  const dirName = dirPath ? extractFilename(dirPath) : 'directory';
+  const listing = typeof result?.Content === 'string' ? result.Content : '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Listed ${dirName}`;
+          case 'failed':
+            return `Failed to list ${dirName}`;
+          default:
+            return `Listing ${dirName}...`;
+        }
+      }}
+      loadingContent="Listing directory..."
+      error={tool.error}
+    >
+      {listing && <pre className={toolText['output-pre']}>{listing}</pre>}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/grok/ReadTool.tsx
+++ b/frontend/src/components/chat/tools/grok/ReadTool.tsx
@@ -1,0 +1,42 @@
+import { memo } from 'react';
+import { FileSearch } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import { NumberedContent } from '../common/NumberedContent/NumberedContent';
+import { OpenInEditorButton } from '../common/OpenInEditorButton/OpenInEditorButton';
+import toolIcon from './toolIcon.module.scss';
+import type { GrokReadInput, GrokReadOutput } from './grokPayload';
+
+const ICON = <FileSearch className={toolIcon.icon} />;
+
+export const ReadTool = memo(function ReadTool({ tool }: { tool: ToolAggregate }) {
+  const input = tool.input as GrokReadInput | undefined;
+  const result = tool.result as GrokReadOutput | undefined;
+
+  const filePath = input?.target_file ?? '';
+  const fileName = filePath ? extractFilename(filePath) : tool.title?.trim() || 'file';
+  const content = result?.FileContent?.raw_output ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Read ${fileName}`;
+          case 'failed':
+            return `Failed to read ${fileName}`;
+          default:
+            return `Reading ${fileName}...`;
+        }
+      }}
+      loadingContent="Loading file content..."
+      error={tool.error}
+      actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
+    >
+      {content && <NumberedContent content={content} />}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/grok/TodoWriteTool.tsx
+++ b/frontend/src/components/chat/tools/grok/TodoWriteTool.tsx
@@ -1,0 +1,36 @@
+import { memo } from 'react';
+import { ListTodo } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import toolIcon from './toolIcon.module.scss';
+import type { GrokTodoWriteInput } from './grokPayload';
+
+const ICON = <ListTodo className={toolIcon.icon} />;
+
+export const TodoWriteTool = memo(function TodoWriteTool({ tool }: { tool: ToolAggregate }) {
+  // Grok mirrors every todo_write into an ACP plan update that renders the
+  // full checklist, and merge updates carry partial entries (content: null) —
+  // so this card stays a compact marker instead of repeating the list.
+  const input = tool.input as GrokTodoWriteInput | undefined;
+  const total = input?.todos?.length ?? 0;
+  const suffix = total > 0 ? ` (${total} item${total !== 1 ? 's' : ''})` : '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Updated plan${suffix}`;
+          case 'failed':
+            return 'Failed to update plan';
+          default:
+            return 'Updating plan...';
+        }
+      }}
+      loadingContent="Updating plan..."
+      error={tool.error}
+    />
+  );
+});

--- a/frontend/src/components/chat/tools/grok/WebFetchTool.module.scss
+++ b/frontend/src/components/chat/tools/grok/WebFetchTool.module.scss
@@ -1,0 +1,17 @@
+@use '@/styles/globals/typography' as type;
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+}
+
+.url {
+  @include type.type-mono-meta;
+  @include type.type-overflow;
+  color: var(--theme-text-tertiary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-quaternary);
+  }
+}

--- a/frontend/src/components/chat/tools/grok/WebFetchTool.tsx
+++ b/frontend/src/components/chat/tools/grok/WebFetchTool.tsx
@@ -1,0 +1,46 @@
+import { memo } from 'react';
+import { Globe } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractDomain } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import toolText from '../common/toolText.module.scss';
+import toolIcon from './toolIcon.module.scss';
+import type { GrokWebFetchInput, GrokWebFetchOutput } from './grokPayload';
+import styles from './WebFetchTool.module.scss';
+
+const ICON = <Globe className={toolIcon.icon} />;
+
+export const WebFetchTool = memo(function WebFetchTool({ tool }: { tool: ToolAggregate }) {
+  const input = tool.input as GrokWebFetchInput | undefined;
+  const result = tool.result as GrokWebFetchOutput | undefined;
+
+  const url = input?.url ?? '';
+  const domain = extractDomain(url) || url || 'content';
+  const output = result?.Content?.content ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Fetched: ${domain}`;
+          case 'failed':
+            return `Failed to fetch: ${domain}`;
+          default:
+            return `Fetching: ${domain}`;
+        }
+      }}
+      loadingContent="Fetching content..."
+      error={tool.error}
+    >
+      {(url || output) && (
+        <div className={styles.body}>
+          {url && <div className={styles.url}>{url}</div>}
+          {output && <pre className={toolText['output-pre']}>{output}</pre>}
+        </div>
+      )}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/grok/WebSearchTool.tsx
+++ b/frontend/src/components/chat/tools/grok/WebSearchTool.tsx
@@ -1,0 +1,34 @@
+import { memo } from 'react';
+import { Globe } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import { SearchLoadingDots } from '../common/SearchLoadingDots/SearchLoadingDots';
+import toolIcon from './toolIcon.module.scss';
+
+const ICON = <Globe className={toolIcon.icon} />;
+
+export const WebSearchTool = memo(function WebSearchTool({ tool }: { tool: ToolAggregate }) {
+  // Grok's backend web search exposes no query in rawInput — the ACP title
+  // ("Web search: <query>") is the only place the query surfaces.
+  const query = tool.title?.replace(/^Web search:\s*/i, '').trim() ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        const label = query ? `"${query}"` : 'the web';
+        switch (status) {
+          case 'completed':
+            return `Searched ${label}`;
+          case 'failed':
+            return `Web search failed`;
+          default:
+            return `Searching ${label}...`;
+        }
+      }}
+      loadingContent={<SearchLoadingDots label="Searching the web" />}
+      error={tool.error}
+    />
+  );
+});

--- a/frontend/src/components/chat/tools/grok/WriteTool.tsx
+++ b/frontend/src/components/chat/tools/grok/WriteTool.tsx
@@ -1,0 +1,40 @@
+import { memo } from 'react';
+import { FilePlus } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import { NumberedContent } from '../common/NumberedContent/NumberedContent';
+import { OpenInEditorButton } from '../common/OpenInEditorButton/OpenInEditorButton';
+import toolIcon from './toolIcon.module.scss';
+import type { GrokWriteInput } from './grokPayload';
+
+const ICON = <FilePlus className={toolIcon.icon} />;
+
+export const WriteTool = memo(function WriteTool({ tool }: { tool: ToolAggregate }) {
+  const input = tool.input as GrokWriteInput | undefined;
+  const filePath = input?.file_path ?? '';
+  const fileName = filePath ? extractFilename(filePath) : tool.title?.trim() || 'file';
+  const content = input?.content ?? '';
+
+  return (
+    <ToolCard
+      icon={ICON}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Wrote ${fileName}`;
+          case 'failed':
+            return `Failed to write ${fileName}`;
+          default:
+            return `Writing ${fileName}...`;
+        }
+      }}
+      loadingContent="Writing file..."
+      error={tool.error}
+      actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
+    >
+      {content && <NumberedContent content={content} />}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/grok/grokPayload.ts
+++ b/frontend/src/components/chat/tools/grok/grokPayload.ts
@@ -1,0 +1,92 @@
+// Grok Build speaks ACP with its raw tool names surfaced in
+// _meta["x.ai/tool"].name (backend extracts it as tool_name for grok); web
+// search calls lack that meta and fall through to the ACP kind "search".
+//
+// rawOutput is a variant-tagged dict, e.g. {"type": "Bash", ...flat fields}
+// for terminal commands or {"type": "ReadFile", "FileContent": {...}} for
+// reads. rawInput shapes below mirror the tool argument payloads Grok emits.
+
+export interface GrokBashInput {
+  command?: string;
+  description?: string;
+  is_background?: boolean;
+}
+
+export interface GrokBashOutput {
+  output_for_prompt?: string;
+  exit_code?: number;
+  command?: string;
+  truncated?: boolean;
+}
+
+export interface GrokWriteInput {
+  file_path?: string;
+  content?: string;
+}
+
+export interface GrokEditInput {
+  file_path?: string;
+  old_string?: string;
+  new_string?: string;
+  replace_all?: boolean;
+}
+
+export interface GrokReadInput {
+  target_file?: string;
+  offset?: number;
+}
+
+export interface GrokReadOutput {
+  FileContent?: {
+    // `content` is line-numbered for the prompt; raw_output is the plain text.
+    content?: string;
+    raw_output?: string;
+    absolute_path?: string;
+    total_lines?: number;
+  };
+}
+
+export interface GrokListDirInput {
+  target_directory?: string;
+}
+
+export interface GrokListDirOutput {
+  Content?: unknown;
+}
+
+export interface GrokGrepInput {
+  pattern?: string;
+  path?: string;
+  glob?: string | null;
+}
+
+export interface GrokGrepOutput {
+  stdout?: string;
+  stderr?: string;
+  exit_code?: number;
+  match_count?: number;
+  file_matches?: number;
+}
+
+export interface GrokWebFetchInput {
+  url?: string;
+}
+
+export interface GrokWebFetchOutput {
+  Content?: {
+    url?: string;
+    content?: string;
+    content_type?: string;
+  };
+}
+
+export interface GrokTodoInfo {
+  id?: string;
+  content?: string | null;
+  status?: 'pending' | 'in_progress' | 'completed' | 'cancelled';
+}
+
+export interface GrokTodoWriteInput {
+  todos?: GrokTodoInfo[];
+  merge?: boolean;
+}

--- a/frontend/src/components/chat/tools/grok/toolIcon.module.scss
+++ b/frontend/src/components/chat/tools/grok/toolIcon.module.scss
@@ -1,0 +1,11 @@
+// Shared ToolCard header-icon style — reused by every Grok tool card
+// (asymmetric: light reads text-secondary, dark drops to text-tertiary).
+.icon {
+  height: var(--space-3-5);
+  width: var(--space-3-5);
+  color: var(--theme-text-secondary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-tertiary);
+  }
+}

--- a/frontend/src/components/chat/tools/registry.tsx
+++ b/frontend/src/components/chat/tools/registry.tsx
@@ -34,6 +34,21 @@ const cursorToolLoaders: Record<string, ToolModuleLoader> = {
   edit: () => import('./cursor/EditTool').then((m) => ({ default: m.EditTool })),
 };
 
+// Grok surfaces its raw tool names via _meta["x.ai/tool"].name (the backend
+// extracts these as tool_name for grok sessions). Backend web searches carry
+// no x.ai/tool meta, so they arrive under the ACP kind "search".
+const grokToolLoaders: Record<string, ToolModuleLoader> = {
+  run_terminal_command: () => import('./grok/BashTool').then((m) => ({ default: m.BashTool })),
+  write: () => import('./grok/WriteTool').then((m) => ({ default: m.WriteTool })),
+  search_replace: () => import('./grok/EditTool').then((m) => ({ default: m.EditTool })),
+  read_file: () => import('./grok/ReadTool').then((m) => ({ default: m.ReadTool })),
+  list_dir: () => import('./grok/ListDirTool').then((m) => ({ default: m.ListDirTool })),
+  grep: () => import('./grok/GrepTool').then((m) => ({ default: m.GrepTool })),
+  web_fetch: () => import('./grok/WebFetchTool').then((m) => ({ default: m.WebFetchTool })),
+  search: () => import('./grok/WebSearchTool').then((m) => ({ default: m.WebSearchTool })),
+  todo_write: () => import('./grok/TodoWriteTool').then((m) => ({ default: m.TodoWriteTool })),
+};
+
 // OpenCode uses the raw tool names (bash, read, edit, write, grep, glob,
 // webfetch, task, todowrite, skill, question) rather than ACP kinds — the
 // backend's tool-name extractor picks these out of the ACP `title` field for
@@ -118,6 +133,10 @@ export const getToolComponent = (toolName: string, agentKind?: AgentKind): ToolC
 
   if (agentKind === 'cursor' && cursorToolLoaders[toolName]) {
     return getOrCreateLazy(`cursor:${toolName}`, cursorToolLoaders[toolName]);
+  }
+
+  if (agentKind === 'grok' && grokToolLoaders[toolName]) {
+    return getOrCreateLazy(`grok:${toolName}`, grokToolLoaders[toolName]);
   }
 
   if (agentKind === 'opencode' && opencodeToolLoaders[toolName]) {

--- a/frontend/src/components/layout/Sidebar/SidebarFilterSubmenu.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarFilterSubmenu.tsx
@@ -24,6 +24,7 @@ export const AGENT_OPTIONS: { value: AgentKind; label: string }[] = [
   { value: 'codex', label: 'Codex' },
   { value: 'copilot', label: 'Copilot' },
   { value: 'cursor', label: 'Cursor' },
+  { value: 'grok', label: 'Grok' },
   { value: 'opencode', label: 'OpenCode' },
 ];
 

--- a/frontend/src/components/settings/tabs/PersonasSettingsTab/PersonasSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/PersonasSettingsTab/PersonasSettingsTab.tsx
@@ -28,7 +28,7 @@ export function PersonasSettingsTab() {
     <>
       <ListManagementTab<Persona>
         title="Personas"
-        description="Create personas with custom system prompts. Select from the persona dropdown in the input bar. Claude, Codex, and OpenCode support replacing the system prompt; the persona selector is hidden for Cursor and Copilot."
+        description="Create personas with custom system prompts. Select from the persona dropdown in the input bar. Claude, Codex, Grok, and OpenCode support replacing the system prompt; the persona selector is hidden for Cursor and Copilot."
         items={localSettings.personas ?? []}
         emptyIcon={UserCircle}
         emptyText="No personas configured yet"

--- a/frontend/src/components/settings/tabs/SkillsSettingsTab/SkillsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/SkillsSettingsTab/SkillsSettingsTab.tsx
@@ -71,8 +71,8 @@ export function SkillsSettingsTab() {
           )}
         </div>
         <p className={styles.description}>
-          Skills available in the selected workspace, from the Claude, Codex, Copilot, Cursor, or
-          OpenCode CLI.
+          Skills available in the selected workspace, from the Claude, Codex, Copilot, Cursor, Grok,
+          or OpenCode CLI.
         </p>
       </div>
 

--- a/frontend/src/components/ui/icons/GrokIcon.tsx
+++ b/frontend/src/components/ui/icons/GrokIcon.tsx
@@ -1,0 +1,12 @@
+import type { SVGProps } from 'react';
+
+export function GrokIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" {...props}>
+      <path
+        fill="currentColor"
+        d="M6.469 8.776 16.512 23h-4.464L2.005 8.776H6.47Zm-.004 7.9 2.233 3.164L6.467 23H2l4.465-6.324ZM22 2.582V23h-3.659V7.764L22 2.582ZM22 1l-9.952 14.095-2.233-3.163L17.533 1H22Z"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/ui/icons/ProviderIcon.tsx
+++ b/frontend/src/components/ui/icons/ProviderIcon.tsx
@@ -3,6 +3,7 @@ import { ClaudeIcon } from './ClaudeIcon';
 import { CodexIcon } from './CodexIcon';
 import { CopilotIcon } from './CopilotIcon';
 import { CursorIcon } from './CursorIcon';
+import { GrokIcon } from './GrokIcon';
 import { OpencodeIcon } from './OpencodeIcon';
 import type { AgentKind } from '@/types/chat.types';
 
@@ -11,6 +12,7 @@ export const AGENT_ICONS: Record<AgentKind, ComponentType<SVGProps<SVGSVGElement
   codex: CodexIcon,
   copilot: CopilotIcon,
   cursor: CursorIcon,
+  grok: GrokIcon,
   opencode: OpencodeIcon,
 };
 

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -25,5 +25,6 @@ export const EMPTY_BUILTIN_COMMANDS: Record<AgentKind, SlashCommand[]> = {
   codex: [],
   copilot: [],
   cursor: [],
+  grok: [],
   opencode: [],
 };

--- a/frontend/src/hooks/useSkillsFilter.ts
+++ b/frontend/src/hooks/useSkillsFilter.ts
@@ -5,7 +5,7 @@ import { fuzzySearch } from '@/utils/fuzzySearch';
 
 // Chip order for the source filter — typed against AgentKind so it can't drift
 // from the canonical provider set if a kind is added, removed, or renamed.
-const SOURCE_ORDER: AgentKind[] = ['claude', 'codex', 'copilot', 'cursor', 'opencode'];
+const SOURCE_ORDER: AgentKind[] = ['claude', 'codex', 'copilot', 'cursor', 'grok', 'opencode'];
 
 export function useSkillsFilter(items: CustomSkill[], workspaceId: string | undefined) {
   const [searchQuery, setSearchQuery] = useState('');

--- a/frontend/src/store/chatSettingsStore.ts
+++ b/frontend/src/store/chatSettingsStore.ts
@@ -9,6 +9,7 @@ type PermissionMode =
   | 'agent'
   | 'autopilot'
   | 'auto'
+  | 'code'
   | 'read-only'
   | 'full-access'
   | 'ask'

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -125,7 +125,7 @@ export interface CreateChatRequest {
   parent_chat_id?: string;
 }
 
-export type AgentKind = 'claude' | 'codex' | 'copilot' | 'cursor' | 'opencode';
+export type AgentKind = 'claude' | 'codex' | 'copilot' | 'cursor' | 'grok' | 'opencode';
 
 export interface Model {
   model_id: string;
@@ -157,6 +157,7 @@ export function getAgentKindForModelId(modelId: string | null | undefined): Agen
   // convention instead of maintaining a duplicate static set.
   if (modelId.startsWith('copilot:')) return 'copilot';
   if (modelId.startsWith('cursor:')) return 'cursor';
+  if (modelId.startsWith('grok:')) return 'grok';
   if (modelId.startsWith('opencode:')) return 'opencode';
   return 'claude';
 }

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -68,6 +68,9 @@ RUN curl -fsSL https://opencode.ai/install | bash && \
     mkdir -p /home/user/.local/bin && \
     ln -sf /home/user/.opencode/bin/opencode /home/user/.local/bin/opencode
 
+# Grok Build CLI (installs `grok` to ~/.local/bin, which is already on PATH).
+RUN curl -fsSL https://x.ai/cli/install.sh | bash
+
 RUN python3 -m pip install --user --upgrade pip && \
     python3 -m pip install --user \
     uv


### PR DESCRIPTION
## Summary
- Adds Grok (xAI) as a new agent kind alongside Claude, Codex, Copilot, Cursor, and OpenCode
- Installs the Grok Build CLI in both the backend and sandbox Docker images
- Adds a `GrokAgentAdapter` covering session modes (code/plan), launch-time reasoning-effort flag, persona system-prompt override/rules via `session/new` `_meta`, and tool-name extraction from `field_meta["x.ai/tool"]`
- Adds a new `code` permission mode and wires Grok into the frontend model selector, permission-mode selector, thinking-mode selector, persona support, skills filter/namespaces, and sidebar filters
- Adds Grok-specific tool renderers (bash, write, edit, read, list-dir, grep, web-fetch, web-search, todo-write) and a `GrokIcon`

## Test plan
- [ ] Launch a chat with a Grok model and confirm the agent starts and responds
- [ ] Verify tool calls (edit/write/read/grep/bash/web search) render with the correct Grok tool components
- [ ] Verify persona system-prompt override and permission mode switching (code/plan) work as expected