### PR TITLE
feat: multiplex per-user SSE streams onto one connection

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -11,7 +11,6 @@ from fastapi import (
     Form,
     HTTPException,
     Query,
-    Request,
     UploadFile,
     status,
 )
@@ -76,7 +75,7 @@ from app.services.session_registry import session_registry
 from app.services.storage import StorageService
 from app.services.streaming.runtime import ChatStreamRuntime
 from app.utils.cache import CacheError, cache_connection
-from app.utils.parsing import parse_non_negative_seq
+from app.utils.parsing import parse_stream_cursors
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -307,6 +306,39 @@ async def stream_user_chat_events(
     )
 
 
+@router.get("/chats/streams")
+async def stream_user_streams(
+    cursors: str | None = Query(None, max_length=8192),
+    current_user: User = Depends(get_current_user),
+    chat_service: ChatService = Depends(get_chat_service),
+    db: AsyncSession = Depends(get_db),
+) -> EventSourceResponse:
+    # Single multiplexed SSE feed carrying every active stream for the user —
+    # envelopes self-route client-side via chatId, so N streaming chats share one
+    # connection instead of exhausting the browser's per-origin HTTP/1.1 pool.
+    # `cursors` is a JSON object of chat id -> last seen seq for backlog replay.
+    try:
+        requested = parse_stream_cursors(cursors)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        ) from e
+    owned = await chat_service.filter_owned_chat_ids(current_user.id, list(requested))
+    replay_cursors = {cid: seq for cid, seq in requested.items() if cid in owned}
+
+    # Same rationale as /chats/events: auth is done — release the pooled DB
+    # session so the long-lived SSE connection doesn't pin it until disconnect.
+    await db.close()
+    return EventSourceResponse(
+        chat_service.create_user_streams_feed(current_user.id, replay_cursors),
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
 @router.get("/chats/{chat_id}/sub-threads", response_model=list[ChatSchema])
 async def get_sub_threads(
     chat_id: UUID,
@@ -445,35 +477,6 @@ async def get_chat_messages(
 ) -> CursorPaginatedResponse[MessageSchema]:
     return await chat_service.get_chat_messages(
         chat_id, current_user, pagination.cursor, pagination.limit
-    )
-
-
-@router.get("/chats/{chat_id}/stream")
-async def stream_events(
-    chat_id: UUID,
-    request: Request,
-    _chat: Chat = Depends(ensure_chat_access),
-    chat_service: ChatService = Depends(get_chat_service),
-    db: AsyncSession = Depends(get_db),
-) -> EventSourceResponse:
-    # Browser EventSource reconnects send the current cursor via Last-Event-ID.
-    # Keep query-param baseline support and use whichever is more advanced.
-    after_seq = max(
-        parse_non_negative_seq(request.query_params.get("after_seq")),
-        parse_non_negative_seq(request.headers.get("Last-Event-ID")),
-    )
-
-    # Access checks are done; release the request session (shared with the auth
-    # chain via the dependency cache) so this SSE stream doesn't pin a pooled DB
-    # connection for its whole lifetime — the generator opens its own sessions.
-    await db.close()
-    return EventSourceResponse(
-        chat_service.create_event_stream(chat_id, after_seq),
-        headers={
-            "Cache-Control": "no-cache",
-            "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",
-        },
     )
 
 

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -12,7 +12,7 @@ class ModelInfo(NamedTuple):
     context_window: int | None
 
 
-REDIS_KEY_CHAT_STREAM_LIVE: Final[str] = "chat:{chat_id}:stream:live"
+REDIS_KEY_USER_STREAMS_LIVE: Final[str] = "user:{user_id}:streams:live"
 REDIS_KEY_USER_CHATS_LIVE: Final[str] = "user:{user_id}:chats:live"
 REDIS_KEY_USER_SETTINGS: Final[str] = "user_settings:{user_id}"
 REDIS_KEY_CHAT_CONTEXT_USAGE: Final[str] = "chat:{chat_id}:context_usage"

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -5,7 +5,7 @@ import math
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from typing import Any, cast
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from sqlalchemy import exists, func, select, update
 from sqlalchemy.exc import SQLAlchemyError
@@ -13,8 +13,8 @@ from sqlalchemy.orm import aliased, selectinload
 
 from app.constants import (
     MODELS,
-    REDIS_KEY_CHAT_STREAM_LIVE,
     REDIS_KEY_USER_CHATS_LIVE,
+    REDIS_KEY_USER_STREAMS_LIVE,
 )
 from app.models.db_models.chat import Chat, ChatCheckpoint, Message
 from app.models.db_models.enums import MessageRole, MessageStreamStatus, StreamEventKind
@@ -87,21 +87,6 @@ class ChatService(BaseDbService[Chat]):
             workspace.sandbox_provider, workspace_path=workspace.workspace_path
         )
         return SandboxService(provider)
-
-    @staticmethod
-    def _extract_queue_processing_message_id(raw_data: Any) -> UUID | None:
-        if not isinstance(raw_data, str):
-            return None
-        if StreamEventKind.QUEUE_PROCESSING.value not in raw_data:
-            return None
-        try:
-            env = json.loads(raw_data)
-            if env.get("kind") != StreamEventKind.QUEUE_PROCESSING.value:
-                return None
-            new_mid = (env.get("payload") or {}).get("assistant_message_id")
-            return UUID(new_mid) if new_mid else None
-        except (json.JSONDecodeError, ValueError):
-            return None
 
     async def get_user_chats(
         self,
@@ -905,7 +890,7 @@ class ChatService(BaseDbService[Chat]):
         payload: dict[str, Any],
     ) -> dict[str, Any]:
         # Canonical builder for the SSE envelope shape sent to the frontend.
-        # The live-Redis path in _stream_live_redis_events constructs the same
+        # The live path in _stream_live_user_envelopes constructs the same
         # {id, event, data} shape directly from pre-serialized envelope JSON.
         return {
             "id": str(seq),
@@ -920,70 +905,36 @@ class ChatService(BaseDbService[Chat]):
             ),
         }
 
-    async def _build_stream_error_event(
+    async def has_cancelable_pending_start(self, chat_id: UUID) -> bool:
+        message = await self.message_service.get_in_progress_assistant_message(chat_id)
+        return bool(message and message.active_stream_id is None)
+
+    async def filter_owned_chat_ids(
+        self, user_id: UUID, chat_ids: list[UUID]
+    ) -> set[UUID]:
+        # Cursor chat ids come straight from the client — replay only chats the
+        # user owns. One query instead of a per-chat get_chat fan-out.
+        if not chat_ids:
+            return set()
+        async with self.session_factory() as db:
+            result = await db.execute(
+                select(Chat.id).filter(
+                    Chat.id.in_(chat_ids),
+                    Chat.user_id == user_id,
+                    Chat.deleted_at.is_(None),
+                )
+            )
+            return set(result.scalars().all())
+
+    async def _stream_live_user_envelopes(
         self,
-        *,
-        chat_id: UUID,
-        message_id: UUID | None,
-        stream_id: UUID | None,
-        fallback_seq: int,
-        error_message: str,
-    ) -> dict[str, Any]:
-        # Build an error SSE event that the client can always display. The caller
-        # (create_event_stream) already resolves message/stream IDs before entering
-        # the try block — if they're None, no active stream existed so we synthesize
-        # IDs. If they're set, we persist the error to DB for replay on reconnect.
-        payload = {"error": error_message}
-
-        if message_id is None:
-            return self._build_stream_sse_event(
-                chat_id=chat_id,
-                message_id=uuid4(),
-                stream_id=stream_id or uuid4(),
-                seq=fallback_seq + 1,
-                kind="error",
-                payload=payload,
-            )
-
-        resolved_stream_id = stream_id or uuid4()
-
-        try:
-            error_seq = await self.message_service.append_event_with_next_seq(
-                chat_id=chat_id,
-                message_id=message_id,
-                stream_id=resolved_stream_id,
-                event_type="error",
-                render_payload=payload,
-                audit_payload={"payload": payload},
-            )
-        except Exception as exc:
-            # Broad catch so the client always receives an error event, even if
-            # DB persistence fails; fall back to a synthesized seq.
-            logger.warning(
-                "Failed to persist stream error event for chat %s: %s",
-                chat_id,
-                exc,
-            )
-            error_seq = fallback_seq + 1
-
-        return self._build_stream_sse_event(
-            chat_id=chat_id,
-            message_id=message_id,
-            stream_id=resolved_stream_id,
-            seq=error_seq,
-            kind="error",
-            payload=payload,
-        )
-
-    async def _stream_live_redis_events(
-        self,
-        chat_id: UUID,
-        last_seq: int,
+        user_id: UUID,
+        last_seq_by_chat: dict[str, int],
         live_pubsub: CachePubSub,
     ) -> AsyncIterator[dict[str, Any]]:
-        # Real-time leg of the SSE connection: events are published as full
-        # envelopes on the Redis channel so we can yield them directly without
-        # a DB round-trip.
+        # Live leg of the multiplexed feed: every envelope for the user arrives on
+        # one channel and self-routes client-side via its chatId. Terminal events
+        # end a single turn, not the connection — other chats keep streaming.
         while True:
             message = await live_pubsub.get_message(
                 ignore_subscribe_messages=True, timeout=1.0
@@ -998,112 +949,74 @@ class ChatService(BaseDbService[Chat]):
             try:
                 envelope = json.loads(raw)
             except (json.JSONDecodeError, TypeError):
-                logger.warning("Malformed Redis stream message for chat %s", chat_id)
+                logger.warning("Malformed stream message for user %s", user_id)
                 continue
 
             if not isinstance(envelope, dict) or "seq" not in envelope:
-                logger.warning("Redis stream message missing seq for chat %s", chat_id)
+                logger.warning("Stream message missing seq for user %s", user_id)
+                continue
+
+            chat_key = str(envelope.get("chatId") or "")
+            if not chat_key:
                 continue
 
             seq = int(envelope["seq"])
-            if seq <= last_seq:
-                continue
-
-            # Gap detected — a pub/sub message was missed. Fall back to DB
-            # to recover the skipped events before yielding this one.
-            if seq > last_seq + 1:
-                async for event in self._replay_stream_backlog(chat_id, last_seq):
-                    yield event
-                    last_seq = int(event["id"])
-                if last_seq >= seq:
-                    if envelope.get("kind") in TERMINAL_STREAM_EVENT_TYPES:
-                        return
+            # An untracked chat is a turn started after connect — the subscription
+            # predates its first event, so that event is a safe seq baseline.
+            last_seq = last_seq_by_chat.get(chat_key)
+            if last_seq is not None:
+                if seq <= last_seq:
                     continue
+
+                # Gap detected — a pub/sub message was missed. Fall back to DB
+                # to recover the skipped events before yielding this one.
+                if seq > last_seq + 1:
+                    async for event in self._replay_stream_backlog(
+                        UUID(chat_key), last_seq
+                    ):
+                        yield event
+                        last_seq = int(event["id"])
+                    last_seq_by_chat[chat_key] = last_seq
+                    if last_seq >= seq:
+                        continue
 
             yield {
                 "id": str(seq),
                 "event": StreamEventKind.STREAM.value,
                 "data": raw,
             }
-            last_seq = seq
+            last_seq_by_chat[chat_key] = seq
 
-            if envelope.get("kind") in TERMINAL_STREAM_EVENT_TYPES:
-                return
-
-    async def has_cancelable_pending_start(self, chat_id: UUID) -> bool:
-        message = await self.message_service.get_in_progress_assistant_message(chat_id)
-        return bool(message and message.active_stream_id is None)
-
-    async def _get_active_stream_targets(
-        self, chat_id: UUID
-    ) -> tuple[UUID | None, UUID | None]:
-        # Look up the in-progress assistant message so create_event_stream has
-        # real IDs for error reporting if the stream fails unexpectedly.
-        active_assistant_message = (
-            await self.message_service.get_in_progress_assistant_message(chat_id)
-        )
-        if active_assistant_message:
-            return (
-                active_assistant_message.id,
-                active_assistant_message.active_stream_id,
-            )
-        return None, None
-
-    async def create_event_stream(
-        self, chat_id: UUID, after_seq: int
+    async def create_user_streams_feed(
+        self, user_id: UUID, cursors: dict[UUID, int]
     ) -> AsyncIterator[dict[str, Any]]:
-        # Entry point for the SSE connection: replays missed events from the DB,
-        # then switches to live Redis pub/sub. If anything fails, yields an error
-        # event so the client always gets feedback instead of hanging.
-        active_message_id, active_stream_id = await self._get_active_stream_targets(
-            chat_id
-        )
-        last_seq = after_seq
-
+        # One SSE connection carrying every active stream for the user — per-chat
+        # connections would exhaust the browser's 6-per-origin HTTP/1.1 pool once
+        # several chats stream concurrently. Replays each cursor chat's backlog
+        # from the DB, then switches to live pub/sub.
+        last_seq_by_chat: dict[str, int] = {}
         try:
             async with cache_connection() as cache:
-                channel = REDIS_KEY_CHAT_STREAM_LIVE.format(chat_id=chat_id)
+                channel = REDIS_KEY_USER_STREAMS_LIVE.format(user_id=user_id)
                 async with cache_pubsub(cache, channel) as live_pubsub:
-                    async for item in self._replay_stream_backlog(chat_id, after_seq):
-                        yield item
-                        last_seq = int(item["id"])
-                        new_mid = self._extract_queue_processing_message_id(
-                            item.get("data")
-                        )
-                        if new_mid:
-                            active_message_id = new_mid
-                            active_stream_id = None
+                    # Subscribe before replaying so nothing published mid-replay is
+                    # lost; the live leg drops what replay already covered via seq.
+                    for chat_id, after_seq in cursors.items():
+                        last_seq_by_chat[str(chat_id)] = after_seq
+                        async for item in self._replay_stream_backlog(
+                            chat_id, after_seq
+                        ):
+                            yield item
+                            last_seq_by_chat[str(chat_id)] = int(item["id"])
 
-                    async for event in self._stream_live_redis_events(
-                        chat_id,
-                        last_seq,
-                        live_pubsub,
+                    async for event in self._stream_live_user_envelopes(
+                        user_id, last_seq_by_chat, live_pubsub
                     ):
                         yield event
-                        event_seq = int(event["id"])
-                        if event_seq > last_seq:
-                            last_seq = event_seq
-
-                        new_mid = self._extract_queue_processing_message_id(
-                            event.get("data")
-                        )
-                        if new_mid:
-                            active_message_id = new_mid
-                            active_stream_id = None
-
-        except Exception as exc:
-            # Final SSE safety net — any failure must surface as an error
-            # event rather than a silently hung connection.
-            logger.error(
-                "Error in event stream for chat %s: %s", chat_id, exc, exc_info=True
-            )
-            yield await self._build_stream_error_event(
-                chat_id=chat_id,
-                message_id=active_message_id,
-                stream_id=active_stream_id,
-                fallback_seq=last_seq,
-                error_message=str(exc),
-            )
+        except Exception:
+            # A transport failure isn't a turn failure, so no per-message error
+            # event — ending the feed lets the client reconnect with fresh cursors.
+            logger.error("User streams feed failed for %s", user_id, exc_info=True)
 
     async def create_chat_events_stream(
         self, user_id: UUID

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import selectinload
 from app.constants import (
     MODELS,
     REDIS_KEY_CHAT_CONTEXT_USAGE,
-    REDIS_KEY_CHAT_STREAM_LIVE,
+    REDIS_KEY_USER_STREAMS_LIVE,
 )
 from app.core.config import get_settings
 from app.db.session import SessionLocal
@@ -339,9 +339,11 @@ class ChatStreamRuntime:
         )
 
     async def _publish_to_redis(self, events: list[str]) -> None:
+        # Envelopes carry chatId, so all of a user's streams share one channel —
+        # the multiplexed SSE feed subscribes once and routes client-side.
         if not self.cache or not events:
             return
-        channel = REDIS_KEY_CHAT_STREAM_LIVE.format(chat_id=self.chat_id)
+        channel = REDIS_KEY_USER_STREAMS_LIVE.format(user_id=self.chat.user_id)
         for raw in events:
             try:
                 await self.cache.publish(channel, raw)
@@ -951,6 +953,7 @@ class ChatStreamRuntime:
     async def emit_bootstrap_error(
         *,
         chat_id: str,
+        user_id: str,
         assistant_message_id: str | None,
         session_factory: SessionFactoryType,
         error_message: str,
@@ -973,7 +976,7 @@ class ChatStreamRuntime:
                 audit_payload={"payload": payload},
             )
             async with cache_connection() as cache:
-                channel = REDIS_KEY_CHAT_STREAM_LIVE.format(chat_id=chat_id)
+                channel = REDIS_KEY_USER_STREAMS_LIVE.format(user_id=user_id)
                 envelope = StreamEnvelope.serialize(
                     chat_id=UUID(chat_id),
                     message_id=UUID(assistant_message_id),
@@ -1136,6 +1139,7 @@ class ChatStreamRuntime:
             )
             await cls.emit_bootstrap_error(
                 chat_id=chat_id,
+                user_id=str(request.chat_data["user_id"]),
                 assistant_message_id=request.assistant_message_id,
                 session_factory=session_factory,
                 error_message=str(exc),

--- a/backend/app/utils/parsing.py
+++ b/backend/app/utils/parsing.py
@@ -1,11 +1,25 @@
-def parse_non_negative_seq(value: str | None) -> int:
-    if value is None:
-        return 0
+import json
+from uuid import UUID
+
+
+def parse_stream_cursors(value: str | None) -> dict[UUID, int]:
+    # Query-param JSON object of chat id -> last seen seq, used by the multiplexed
+    # SSE feed to decide which chats need backlog replay and from where.
+    if not value:
+        return {}
     try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return 0
-    return parsed if parsed >= 0 else 0
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError("cursors must be valid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("cursors must be a JSON object")
+
+    cursors: dict[UUID, int] = {}
+    for key, raw_seq in parsed.items():
+        if not isinstance(raw_seq, int) or isinstance(raw_seq, bool) or raw_seq < 0:
+            raise ValueError("cursor seq must be a non-negative integer")
+        cursors[UUID(str(key))] = raw_seq
+    return cursors
 
 
 def parse_pty_dimension(

--- a/backend/tests/test_streaming.py
+++ b/backend/tests/test_streaming.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.endpoints import chat as chat_endpoint
 from app.core import deps
-from app.constants import MODELS, REDIS_KEY_CHAT_STREAM_LIVE
+from app.constants import MODELS, REDIS_KEY_USER_STREAMS_LIVE
 from app.db.session import engine
 from app.models.db_models.chat import Chat
 from app.models.db_models.enums import MessageStreamStatus
@@ -1129,7 +1129,10 @@ async def test_stream_sse_replays_backlog_then_delivers_live_events(
         async with (
             sse_client,
             sse_client.stream(
-                "GET", f"/api/v1/chat/chats/{chat.id}/stream", headers=headers
+                "GET",
+                "/api/v1/chat/chats/streams",
+                params={"cursors": json.dumps({str(chat.id): 0})},
+                headers=headers,
             ) as response,
         ):
             assert response.status_code == 200
@@ -1158,14 +1161,16 @@ async def test_stream_sse_replays_backlog_then_delivers_live_events(
                 payload={},
             )
             await streaming_cache.store.publish(
-                REDIS_KEY_CHAT_STREAM_LIVE.format(chat_id=chat.id), live_envelope
+                REDIS_KEY_USER_STREAMS_LIVE.format(user_id=user.id), live_envelope
             )
 
-            # A terminal live event must close the stream server-side, ending
-            # this iteration instead of hanging on a never-finished response.
+            # The multiplexed feed stays open across terminal events (other
+            # chats may still be streaming), so read exactly one live event
+            # instead of draining until server-side close.
             async for line in lines:
                 if line.startswith("data:"):
                     envelopes.append(json.loads(line.removeprefix("data:").strip()))
+                    break
 
     assert [e["seq"] for e in envelopes] == [backlog["seq"], backlog["seq"] + 1]
 
@@ -1196,7 +1201,10 @@ async def test_sse_endpoints_release_db_connection_while_streaming(
                 "GET", "/api/v1/chat/chats/events", headers=headers
             ) as events_response,
             sse_client.stream(
-                "GET", f"/api/v1/chat/chats/{chat.id}/stream", headers=headers
+                "GET",
+                "/api/v1/chat/chats/streams",
+                params={"cursors": json.dumps({str(chat.id): 0})},
+                headers=headers,
             ) as chat_stream_response,
         ):
             assert events_response.status_code == 200

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -114,7 +114,6 @@ export function useChatStreaming({
     startStream,
     replayStream,
     stopStream,
-    updateMessageInCache,
     addMessageToCache,
     setPendingUserMessageId,
   } = useStreamCallbacks({
@@ -242,7 +241,6 @@ export function useChatStreaming({
     setCurrentMessageId,
     setMessages,
     addMessageToCache,
-    updateMessageInCache,
     replayStream,
   });
 

--- a/frontend/src/hooks/useMessageCache.ts
+++ b/frontend/src/hooks/useMessageCache.ts
@@ -15,27 +15,6 @@ interface UseMessageCacheParams {
 // Scoped to the current chatId — callers needing cross-chat writes must use
 // queryClient directly with the target chatId.
 export function useMessageCache({ chatId, queryClient }: UseMessageCacheParams) {
-  const updateMessageInCache = useCallback(
-    (messageId: string, updater: (msg: Message) => Message) => {
-      if (!chatId) return;
-
-      queryClient.setQueryData(
-        queryKeys.messages(chatId),
-        (oldData: { pages: PaginatedMessages[]; pageParams: unknown[] } | undefined) => {
-          if (!oldData?.pages) return oldData;
-          return {
-            ...oldData,
-            pages: oldData.pages.map((page: PaginatedMessages) => ({
-              ...page,
-              items: page.items.map((msg: Message) => (msg.id === messageId ? updater(msg) : msg)),
-            })),
-          };
-        },
-      );
-    },
-    [chatId, queryClient],
-  );
-
   // Uses unshift into page 0 so newest messages match the backend's DESC
   // ordering. Optionally prepends the paired user message when both arrive together.
   const addMessageToCache = useCallback(
@@ -95,7 +74,6 @@ export function useMessageCache({ chatId, queryClient }: UseMessageCacheParams) 
   );
 
   return {
-    updateMessageInCache,
     addMessageToCache,
     removeMessagesFromCache,
   };

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -73,7 +73,6 @@ interface UseStreamCallbacksResult {
   ) => Promise<{ messageId: string; checkpointId: string | null; worktreeCwd: string | null }>;
   replayStream: (messageId: string, afterSeq?: number) => Promise<string>;
   stopStream: (messageId: string) => Promise<void>;
-  updateMessageInCache: ReturnType<typeof useMessageCache>['updateMessageInCache'];
   addMessageToCache: ReturnType<typeof useMessageCache>['addMessageToCache'];
   removeMessagesFromCache: ReturnType<typeof useMessageCache>['removeMessagesFromCache'];
   setPendingUserMessageId: (id: string | null) => void;
@@ -119,7 +118,7 @@ export function useStreamCallbacks({
   const chatIdRef = useRef(chatId);
   chatIdRef.current = chatId;
 
-  const { updateMessageInCache, addMessageToCache, removeMessagesFromCache } = useMessageCache({
+  const { addMessageToCache, removeMessagesFromCache } = useMessageCache({
     chatId,
     queryClient,
   });
@@ -726,8 +725,9 @@ export function useStreamCallbacks({
   );
 
   // Stash the latest callbacks in a ref so startStream/replayStream — which are
-  // intentionally stable (only the stable queryClient in deps) to avoid
-  // re-registering the EventSource — always dispatch through the freshest closures.
+  // intentionally stable (only the stable queryClient in deps) so re-renders
+  // don't re-fire the effects that consume them — always dispatch through the
+  // freshest closures.
   useEffect(() => {
     optionsRef.current = chatId
       ? { chatId, onEnvelope, onComplete, onError, onQueueProcess }
@@ -813,7 +813,6 @@ export function useStreamCallbacks({
     startStream,
     replayStream,
     stopStream,
-    updateMessageInCache,
     addMessageToCache,
     removeMessagesFromCache,
     setPendingUserMessageId,

--- a/frontend/src/hooks/useStreamReconnect.ts
+++ b/frontend/src/hooks/useStreamReconnect.ts
@@ -20,7 +20,6 @@ interface UseStreamReconnectParams {
   setCurrentMessageId: Dispatch<SetStateAction<string | null>>;
   setMessages: Dispatch<SetStateAction<Message[]>>;
   addMessageToCache: (message: Message) => void;
-  updateMessageInCache: (messageId: string, updater: (msg: Message) => Message) => void;
   replayStream: (messageId: string, afterSeq?: number) => Promise<string>;
 }
 
@@ -41,7 +40,6 @@ export function useStreamReconnect({
   setCurrentMessageId,
   setMessages,
   addMessageToCache,
-  updateMessageInCache,
   replayStream,
 }: UseStreamReconnectParams): void {
   const fetchedMessagesRef = useRef(fetchedMessages);
@@ -85,16 +83,6 @@ export function useStreamReconnect({
         const messages = fetchedMessagesRef.current;
         const existingMessage = messages.find((msg) => msg.id === targetMessageId);
         const messageExists = existingMessage != null;
-        // Snapshot the message's current content before replay so we can
-        // restore it if the replay connection fails partway through.
-        const previousSnapshot = existingMessage
-          ? {
-              content_text: existingMessage.content_text,
-              content_render: existingMessage.content_render,
-              last_seq: existingMessage.last_seq,
-              active_stream_id: existingMessage.active_stream_id ?? null,
-            }
-          : null;
 
         // Pick the highest known seq across three sources: server status, local
         // storage (persisted across page refreshes), and the message's own cursor.
@@ -139,34 +127,10 @@ export function useStreamReconnect({
           setMessages((prev) => [...prev, placeholderMessage]);
         }
 
-        try {
-          await replayStream(targetMessageId, replayAfterSeq);
-        } catch (replayError) {
-          logger.error('Stream reconnect failed', 'useStreamReconnect', replayError);
-          if (previousSnapshot) {
-            setMessages((prev) =>
-              prev.map((msg) =>
-                msg.id === targetMessageId ? { ...msg, ...previousSnapshot } : msg,
-              ),
-            );
-            updateMessageInCache(targetMessageId, (msg) => ({
-              ...msg,
-              ...previousSnapshot,
-            }));
-          } else {
-            const markFailed = (msg: Message): Message => ({
-              ...msg,
-              active_stream_id: null,
-              stream_status: 'failed',
-            });
-            setMessages((prev) =>
-              prev.map((msg) => (msg.id === targetMessageId ? markFailed(msg) : msg)),
-            );
-            updateMessageInCache(targetMessageId, markFailed);
-          }
-          setStreamState('idle');
-          setCurrentMessageId(null);
-        }
+        // Replay registers the stream on the shared connection and cannot fail
+        // synchronously — a connection that ultimately gives up routes through
+        // the stream's onError callback (message marked failed, UI reset there).
+        await replayStream(targetMessageId, replayAfterSeq);
       } catch (checkError) {
         logger.error('Active task check failed', 'useStreamReconnect', checkError);
       }
@@ -184,7 +148,6 @@ export function useStreamReconnect({
     isInitialLoading,
     replayStream,
     streamState,
-    updateMessageInCache,
     wasAborted,
     addMessageToCache,
     setStreamState,

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -62,10 +62,16 @@ async function createCompletion(
       }>('/chat/chat', formData, signal);
 
       const payload = ensureResponse(taskResponse, 'Failed to start chat completion');
-      const eventSource = createEventSource(payload.chat_id, signal, payload.last_seq);
+
+      // Seed the replay cursor for the multiplexed feed: events published before
+      // the shared connection (re)opens are recovered by replaying after last_seq.
+      const storedSeq = normalizePositiveInt(chatStorage.getEventId(payload.chat_id));
+      const providedSeq = normalizePositiveInt(payload.last_seq);
+      if (providedSeq > storedSeq) {
+        chatStorage.setEventId(payload.chat_id, String(providedSeq));
+      }
 
       return {
-        source: eventSource,
         messageId: payload.message_id,
         checkpointId: payload.checkpoint_id,
         worktreeCwd: payload.worktree_cwd,
@@ -108,23 +114,6 @@ async function getActiveStreams(): Promise<ActiveStreamSnapshot[]> {
     const streams = await apiClient.get<ActiveStreamSnapshot[]>('/chat/chats/active-streams');
     return streams ?? [];
   });
-}
-
-async function reconnectToStream(
-  chatId: string,
-  messageId: string,
-  signal?: AbortSignal,
-  afterSeq?: number,
-): Promise<{
-  source: EventSource;
-  messageId: string;
-}> {
-  const eventSource = createEventSource(chatId, signal, afterSeq);
-
-  return {
-    source: eventSource,
-    messageId,
-  };
 }
 
 async function stopStream(chatId: string): Promise<void> {
@@ -249,49 +238,6 @@ function normalizePositiveInt(value: unknown): number {
     return 0;
   }
   return Math.floor(parsed);
-}
-
-function createEventSource(
-  chatId: string,
-  signal?: AbortSignal,
-  baselineSeq?: number,
-): EventSource {
-  const client = resolveChatClient(chatId);
-  const token = client.getToken();
-  if (!token) {
-    throw new Error('Authentication token required');
-  }
-
-  const storedSeq = normalizePositiveInt(chatStorage.getEventId(chatId));
-  const providedSeq = normalizePositiveInt(baselineSeq);
-  const afterSeq = Math.max(storedSeq, providedSeq);
-  if (afterSeq > storedSeq) {
-    chatStorage.setEventId(chatId, String(afterSeq));
-  }
-
-  const baseUrl = `${client.getBaseUrl()}/chat/chats/${chatId}/stream`;
-
-  const params = new URLSearchParams();
-  params.append('token', token);
-  params.append('after_seq', String(afterSeq));
-
-  const url = `${baseUrl}?${params.toString()}`;
-  const eventSource = new EventSource(url);
-
-  if (signal) {
-    const abortHandler = () => {
-      signal.removeEventListener('abort', abortHandler);
-      eventSource.close();
-    };
-
-    signal.addEventListener('abort', abortHandler);
-    if (signal.aborted) {
-      abortHandler();
-      throw new DOMException('The operation was aborted.', 'AbortError');
-    }
-  }
-
-  return eventSource;
 }
 
 function createChatEventsSource(): EventSource {
@@ -433,7 +379,6 @@ export const chatService = {
   startCompletion,
   checkChatStatus,
   getActiveStreams,
-  reconnectToStream,
   stopStream,
   getMessages,
   listChats,

--- a/frontend/src/services/streamConnection.ts
+++ b/frontend/src/services/streamConnection.ts
@@ -1,0 +1,254 @@
+import { resolveChatClient } from '@/lib/api';
+import { useStreamStore } from '@/store/streamStore';
+import { chatStorage } from '@/utils/storage';
+import { logger } from '@/utils/logger';
+
+type StreamApiClient = ReturnType<typeof resolveChatClient>;
+
+interface StreamConnectionHandlers {
+  onEnvelopeData: (raw: string) => void;
+  onConnectionFailure: (chatIds: string[]) => void;
+}
+
+interface ManagedConnection {
+  source: EventSource | null;
+  // Chats whose backlog the current EventSource replayed at open — a chat
+  // needing replay that isn't in here forces a reopen with fresh cursors.
+  replayedChatIds: Set<string>;
+  retryAttempts: number;
+  retryTimer: ReturnType<typeof setTimeout> | null;
+  stableTimer: ReturnType<typeof setTimeout> | null;
+  // Bumped on every (re)open/teardown so in-flight async opens self-cancel.
+  generation: number;
+}
+
+const MAX_RECONNECT_ATTEMPTS = 5;
+const RECONNECT_BASE_DELAY_MS = 1000;
+const RECONNECT_MAX_DELAY_MS = 15000;
+// How long a connection must stay open before its retry budget resets — an
+// instant reset on `open` would let a feed that 200s then immediately dies
+// (e.g. Redis down) loop forever without ever tripping the failure path.
+const CONNECTION_STABLE_MS = 15000;
+
+// Owns the single multiplexed SSE connection per API host (local + cloud). The
+// server forwards every stream envelope for the user over one connection, so N
+// streaming chats no longer hold N sockets — browsers cap HTTP/1.1 at 6 per
+// origin, which froze all other requests once ~6 chats streamed concurrently.
+// Lifecycle is store-driven: the connection opens when a client's first active
+// stream registers in streamStore and closes when its last one is removed.
+class StreamConnectionManager {
+  private connections = new Map<StreamApiClient, ManagedConnection>();
+  private handlers: StreamConnectionHandlers | null = null;
+
+  configure(handlers: StreamConnectionHandlers): void {
+    this.handlers = handlers;
+    useStreamStore.subscribe(() => this.reconcile());
+  }
+
+  // Force the next connection for this chat's host to include it in the replay
+  // cursor set — reopens a live connection, since an already-open feed only
+  // carries events published after it connected.
+  requestReplay(chatId: string): void {
+    const client = resolveChatClient(chatId);
+    const connection = this.connections.get(client);
+    if (!connection) {
+      // reconcile() (triggered by the stream registration) opens it with this
+      // chat's cursor included; nothing to force.
+      return;
+    }
+    if (!connection.replayedChatIds.has(chatId)) {
+      this.open(client);
+    }
+  }
+
+  private reconcile(): void {
+    const byClient = this.activeChatIdsByClient();
+
+    for (const [client, connection] of this.connections) {
+      const activeChatIds = byClient.get(client);
+      if (!activeChatIds) {
+        this.teardown(client, connection);
+        continue;
+      }
+      // Replay membership is per registered stream, not per connection lifetime:
+      // once a chat's stream ends, a later turn in it must be able to force a
+      // replay again — its send-window events arrive before the new stream
+      // registers and would otherwise never be recovered.
+      for (const chatId of connection.replayedChatIds) {
+        if (!activeChatIds.has(chatId)) {
+          connection.replayedChatIds.delete(chatId);
+        }
+      }
+    }
+
+    for (const client of byClient.keys()) {
+      if (!this.connections.has(client)) {
+        this.open(client);
+      }
+    }
+  }
+
+  private activeChatIdsByClient(): Map<StreamApiClient, Set<string>> {
+    const byClient = new Map<StreamApiClient, Set<string>>();
+    for (const stream of useStreamStore.getState().activeStreams.values()) {
+      if (!stream.isActive) continue;
+      const client = resolveChatClient(stream.chatId);
+      const chatIds = byClient.get(client) ?? new Set<string>();
+      chatIds.add(stream.chatId);
+      byClient.set(client, chatIds);
+    }
+    return byClient;
+  }
+
+  private buildCursors(chatIds: Set<string>): Record<string, number> {
+    // chatStorage cursors advance on every processed envelope, so they are the
+    // freshest resume point; 0 (no cursor) means replay the chat from the start.
+    const cursors: Record<string, number> = {};
+    for (const chatId of chatIds) {
+      const stored = Number(chatStorage.getEventId(chatId) || 0);
+      cursors[chatId] = Number.isFinite(stored) && stored > 0 ? Math.floor(stored) : 0;
+    }
+    return cursors;
+  }
+
+  private open(client: StreamApiClient): void {
+    const connection = this.connections.get(client) ?? {
+      source: null,
+      replayedChatIds: new Set<string>(),
+      retryAttempts: 0,
+      retryTimer: null,
+      stableTimer: null,
+      generation: 0,
+    };
+    this.connections.set(client, connection);
+
+    const chatIds = this.activeChatIdsByClient().get(client);
+    if (!chatIds || chatIds.size === 0) {
+      this.teardown(client, connection);
+      return;
+    }
+
+    const generation = this.resetSocket(connection);
+    // Snapshot cursors synchronously so a requestReplay racing the token fetch
+    // sees exactly which chats this open will replay.
+    const cursors = this.buildCursors(chatIds);
+    connection.replayedChatIds = new Set(chatIds);
+
+    void this.connect(client, connection, generation, cursors, chatIds).catch((error) => {
+      logger.error('Stream connection open failed', 'streamConnection', error);
+      if (this.connections.get(client) === connection && connection.generation === generation) {
+        this.scheduleReconnect(client, connection);
+      }
+    });
+  }
+
+  private async connect(
+    client: StreamApiClient,
+    connection: ManagedConnection,
+    generation: number,
+    cursors: Record<string, number>,
+    chatIds: Set<string>,
+  ): Promise<void> {
+    // The connection is long-lived and reopens after failures, so the cached
+    // token may be expired — mint a fresh one on every open.
+    const token = await client.getValidToken();
+    if (this.connections.get(client) !== connection || connection.generation !== generation) {
+      return;
+    }
+    if (!token) {
+      // Session is dead (getValidToken already tore it down) — fail the streams
+      // instead of retrying an unauthenticatable feed forever. Use the open-time
+      // chat set: cloud session expiry clears the cloud-origin registry, so a
+      // recompute here would resolve those chats to the local client and miss them.
+      this.failClient(client, connection, chatIds);
+      return;
+    }
+
+    const params = new URLSearchParams();
+    params.append('token', token);
+    params.append('cursors', JSON.stringify(cursors));
+    const source = new EventSource(`${client.getBaseUrl()}/chat/chats/streams?${params}`);
+    connection.source = source;
+
+    source.addEventListener('stream', (event: Event) => {
+      const data = (event as MessageEvent).data;
+      if (data) this.handlers?.onEnvelopeData(data);
+    });
+    source.onopen = () => {
+      if (connection.source !== source || connection.stableTimer) return;
+      connection.stableTimer = setTimeout(() => {
+        connection.stableTimer = null;
+        connection.retryAttempts = 0;
+      }, CONNECTION_STABLE_MS);
+    };
+    source.onerror = () => {
+      if (connection.source !== source) return;
+      if (connection.stableTimer) {
+        clearTimeout(connection.stableTimer);
+        connection.stableTimer = null;
+      }
+      // Don't let EventSource auto-reconnect: its URL carries the cursors from
+      // open time, so chats subscribed since then would lose the outage window.
+      // Reopening ourselves rebuilds cursors from fresh chatStorage state.
+      source.close();
+      connection.source = null;
+      this.scheduleReconnect(client, connection);
+    };
+  }
+
+  private scheduleReconnect(client: StreamApiClient, connection: ManagedConnection): void {
+    if (connection.retryTimer) return;
+    connection.retryAttempts += 1;
+    if (connection.retryAttempts > MAX_RECONNECT_ATTEMPTS) {
+      this.failClient(client, connection);
+      return;
+    }
+    const delay = Math.min(
+      RECONNECT_BASE_DELAY_MS * 2 ** (connection.retryAttempts - 1),
+      RECONNECT_MAX_DELAY_MS,
+    );
+    connection.retryTimer = setTimeout(() => {
+      connection.retryTimer = null;
+      this.open(client);
+    }, delay);
+  }
+
+  private failClient(
+    client: StreamApiClient,
+    connection: ManagedConnection,
+    affectedChatIds?: Set<string>,
+  ): void {
+    const chatIds = affectedChatIds ?? this.activeChatIdsByClient().get(client);
+    // Kill the socket but keep the map entry while the failure callback removes
+    // streams — each removal triggers reconcile, and a missing entry would
+    // immediately reopen a doomed connection mid-loop.
+    this.resetSocket(connection);
+    if (chatIds && chatIds.size > 0) {
+      this.handlers?.onConnectionFailure([...chatIds]);
+    }
+    this.teardown(client, connection);
+  }
+
+  private teardown(client: StreamApiClient, connection: ManagedConnection): void {
+    this.resetSocket(connection);
+    this.connections.delete(client);
+  }
+
+  // Bumping the generation strands any in-flight connect() for this connection.
+  private resetSocket(connection: ManagedConnection): number {
+    connection.generation += 1;
+    if (connection.retryTimer) {
+      clearTimeout(connection.retryTimer);
+      connection.retryTimer = null;
+    }
+    if (connection.stableTimer) {
+      clearTimeout(connection.stableTimer);
+      connection.stableTimer = null;
+    }
+    connection.source?.close();
+    connection.source = null;
+    return connection.generation;
+  }
+}
+
+export const streamConnection = new StreamConnectionManager();

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -9,6 +9,7 @@ import type {
 } from '@/types/stream.types';
 import { StreamProcessingError } from '@/types/stream.types';
 import { chatService } from '@/services/chatService';
+import { streamConnection } from '@/services/streamConnection';
 import { logger } from '@/utils/logger';
 import { chatStorage } from '@/utils/storage';
 
@@ -45,6 +46,13 @@ interface StreamReconnectOptions {
 class StreamService {
   private readonly maxRecentSeqPerChat = 4096;
   private readonly recentSeqByChat = new Map<string, Set<number>>();
+
+  constructor() {
+    streamConnection.configure({
+      onEnvelopeData: (raw) => this.handleEnvelopeData(raw),
+      onConnectionFailure: (chatIds) => this.failStreamsForChats(chatIds),
+    });
+  }
 
   private parseStreamEvent<T>(data: string): T | null {
     try {
@@ -154,14 +162,18 @@ class StreamService {
     }
   }
 
-  private handleStreamEnvelope(event: MessageEvent, streamId: string, chatId: string): void {
-    if (!event.data) return;
+  private handleEnvelopeData(raw: string): void {
+    const parsed = this.parseStreamEvent<StreamEnvelope>(raw);
+    if (!parsed?.chatId) return;
+    const chatId = parsed.chatId;
 
-    const currentStream = useStreamStore.getState().getStream(streamId);
+    // The multiplexed feed carries every stream of the user, including chats with
+    // no client-side stream registered (e.g. background sub-threads). Those must
+    // be ignored entirely — marking their seqs seen or advancing the chatStorage
+    // cursor would make a later replay of that chat skip its content.
+    const currentStream = useStreamStore.getState().getStreamByChat(chatId);
     if (!currentStream) return;
-
-    const parsed = this.parseStreamEvent<StreamEnvelope>(event.data);
-    if (!parsed) return;
+    const streamId = currentStream.id;
 
     const seq = Number(parsed.seq);
     if (!Number.isFinite(seq) || seq <= 0) {
@@ -216,24 +228,18 @@ class StreamService {
     }
   }
 
-  private handleGenericError(event: Event | ErrorEvent, streamId: string, messageId: string): void {
-    const currentStream = useStreamStore.getState().getStream(streamId);
-    if (!currentStream) return;
-
-    // EventSource emits transport "error" while reconnecting; do not fail fast.
-    if (currentStream.source.readyState === EventSource.CONNECTING) {
-      return;
+  // Invoked when the shared connection gives up reconnecting — every stream
+  // riding it is unreachable, so fail them all like a fatal transport error.
+  private failStreamsForChats(chatIds: string[]): void {
+    for (const chatId of chatIds) {
+      const stream = useStreamStore.getState().getStreamByChat(chatId);
+      if (!stream) continue;
+      this.cleanupStream(
+        stream.id,
+        new StreamProcessingError('Stream connection error'),
+        stream.messageId,
+      );
     }
-
-    currentStream.source.close();
-
-    const error =
-      event instanceof ErrorEvent && event.error instanceof Error
-        ? event.error
-        : new Error('Stream connection error');
-
-    const wrappedError = new StreamProcessingError('Stream connection error', error);
-    this.cleanupStream(streamId, wrappedError, messageId);
   }
 
   private finalizeStreamAsCancelled(stream: ActiveStream): void {
@@ -246,61 +252,39 @@ class StreamService {
     useStreamStore.getState().abortStream(stream.id);
   }
 
-  private attachStreamHandlers(streamId: string, messageId: string): void {
-    const activeStream = useStreamStore.getState().getStream(streamId);
-    if (!activeStream) return;
-
-    const { source, chatId } = activeStream;
-
-    const register = (type: string, handler: EventListener) => {
-      source.addEventListener(type, handler);
-      activeStream.listeners.push({ type, handler });
-    };
-
-    register('stream', (event: Event) =>
-      this.handleStreamEnvelope(event as MessageEvent, streamId, chatId),
-    );
-
-    source.onerror = (event) => {
-      this.handleGenericError(event, streamId, messageId);
-    };
+  // Registering the stream opens the shared connection if it isn't already, and
+  // the replay request covers the already-open case — events published before
+  // this registration (send request window, pre-reconnect backlog) would
+  // otherwise be dropped, since an open feed only replays chats from its
+  // open-time cursors. The resume point is the chat's chatStorage cursor.
+  private registerAndReplay(
+    chatId: string,
+    messageId: string,
+    options: StreamOptions | StreamReconnectOptions,
+  ): void {
+    useStreamStore.getState().addStream({
+      id: crypto.randomUUID(),
+      chatId,
+      messageId,
+      startTime: Date.now(),
+      isActive: true,
+      callbacks: {
+        onEnvelope: options.onEnvelope,
+        onComplete: options.onComplete,
+        onError: options.onError,
+        onQueueProcess: options.onQueueProcess,
+      },
+    });
+    streamConnection.requestReplay(chatId);
   }
 
-  async startStream(
-    options: StreamOptions,
-  ): Promise<Pick<ApiStreamResponse, 'messageId' | 'checkpointId' | 'worktreeCwd'>> {
-    const streamId = crypto.randomUUID();
-
-    try {
-      const { source, messageId, checkpointId, worktreeCwd } = await chatService.createCompletion(
-        options.request,
-        options.signal,
-      );
-
-      const activeStream: ActiveStream = {
-        id: streamId,
-        chatId: options.chatId,
-        messageId,
-        source,
-        startTime: Date.now(),
-        isActive: true,
-        listeners: [],
-        callbacks: {
-          onEnvelope: options.onEnvelope,
-          onComplete: options.onComplete,
-          onError: options.onError,
-          onQueueProcess: options.onQueueProcess,
-        },
-      };
-
-      useStreamStore.getState().addStream(activeStream);
-      this.attachStreamHandlers(streamId, messageId);
-
-      return { messageId, checkpointId, worktreeCwd };
-    } catch (error) {
-      useStreamStore.getState().removeStream(streamId);
-      throw error;
-    }
+  async startStream(options: StreamOptions): Promise<ApiStreamResponse> {
+    const { messageId, checkpointId, worktreeCwd } = await chatService.createCompletion(
+      options.request,
+      options.signal,
+    );
+    this.registerAndReplay(options.chatId, messageId, options);
+    return { messageId, checkpointId, worktreeCwd };
   }
 
   async stopStreamByMessage(chatId: string, messageId: string): Promise<boolean> {
@@ -314,49 +298,15 @@ class StreamService {
     return false;
   }
 
-  async reconnectToStream(options: StreamReconnectOptions): Promise<string> {
-    const streamId = crypto.randomUUID();
-
-    try {
-      const { source } = await chatService.reconnectToStream(
-        options.chatId,
-        options.messageId,
-        undefined,
-        options.afterSeq,
-      );
-
-      const activeStream: ActiveStream = {
-        id: streamId,
-        chatId: options.chatId,
-        messageId: options.messageId,
-        source,
-        startTime: Date.now(),
-        isActive: true,
-        listeners: [],
-        callbacks: {
-          onEnvelope: options.onEnvelope,
-          onComplete: options.onComplete,
-          onError: options.onError,
-          onQueueProcess: options.onQueueProcess,
-        },
-      };
-
-      useStreamStore.getState().addStream(activeStream);
-
-      this.attachStreamHandlers(streamId, options.messageId);
-
-      return options.messageId;
-    } catch (error) {
-      useStreamStore.getState().removeStream(streamId);
-      throw error;
-    }
-  }
-
   async replayStream(options: StreamReconnectOptions): Promise<string> {
+    // A from-zero replay rebuilds the whole message, so the dedup window must
+    // not swallow the re-sent seqs. The actual resume point comes from the
+    // chatStorage cursor the reconnect flow wrote before calling this.
     if (!options.afterSeq || options.afterSeq <= 0) {
       this.recentSeqByChat.delete(options.chatId);
     }
-    return this.reconnectToStream(options);
+    this.registerAndReplay(options.chatId, options.messageId, options);
+    return options.messageId;
   }
 }
 

--- a/frontend/src/store/streamStore.test.ts
+++ b/frontend/src/store/streamStore.test.ts
@@ -2,28 +2,13 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useStreamStore } from './streamStore';
 import type { ActiveStream } from '@/types/stream.types';
 
-vi.mock('@/utils/logger', () => ({
-  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-}));
-
-// Minimal EventSource stand-in — only the members shutdownStream touches.
-function makeSource() {
-  return {
-    removeEventListener: vi.fn(),
-    close: vi.fn(),
-    onerror: (() => {}) as unknown,
-  };
-}
-
 function makeStream(id: string, chatId: string, messageId: string, isActive = true): ActiveStream {
   return {
     id,
     chatId,
     messageId,
-    source: makeSource() as unknown as EventSource,
     startTime: 1000,
     isActive,
-    listeners: [{ type: 'message', handler: vi.fn() }],
     callbacks: { onEnvelope: vi.fn() },
   };
 }
@@ -74,7 +59,6 @@ describe('getStreamByChat', () => {
 describe('removeStream', () => {
   it('shuts down the stream and drops it from every index', () => {
     const stream = makeStream('s1', 'c1', 'm1');
-    const source = stream.source as unknown as ReturnType<typeof makeSource>;
     useStreamStore.getState().addStream(stream);
     useStreamStore.getState().removeStream('s1');
 
@@ -82,11 +66,8 @@ describe('removeStream', () => {
     expect(state.getStream('s1')).toBeUndefined();
     expect(state.getStreamByChatAndMessage('c1', 'm1')).toBeUndefined();
     expect(state.activeStreamMetadata).toEqual([]);
-    expect(source.close).toHaveBeenCalledOnce();
-    expect(source.removeEventListener).toHaveBeenCalledOnce();
     expect(stream.isActive).toBe(false);
     expect(stream.callbacks).toBeUndefined();
-    expect(source.onerror).toBeNull();
   });
 
   it('keeps chat metadata while another active stream remains for the chat', () => {

--- a/frontend/src/store/streamStore.ts
+++ b/frontend/src/store/streamStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { logger } from '@/utils/logger';
 import type { ActiveStream, StreamMetadata } from '@/types/stream.types';
 
 interface StreamState {
@@ -48,24 +47,10 @@ const removeStreamMetadataEntry = (metadata: StreamMetadata[], chatId: string): 
   metadata.filter((item) => item.chatId !== chatId);
 
 const shutdownStream = (stream: ActiveStream) => {
-  try {
-    stream.listeners.forEach(({ type, handler }) => {
-      stream.source.removeEventListener(type, handler);
-    });
-    stream.listeners.length = 0;
-  } catch (error) {
-    logger.error('Stream listener cleanup failed', 'store', error);
-  }
-
-  try {
-    stream.source.close();
-  } catch (error) {
-    logger.error('Stream close failed', 'store', error);
-  }
-
+  // The shared multiplexed connection (streamConnection) reconciles against the
+  // store, so dropping the entry is enough — no per-stream socket to close.
   stream.isActive = false;
   stream.callbacks = undefined;
-  stream.source.onerror = null;
 };
 
 export const useStreamStore = create<StreamState>((set, get) => ({

--- a/frontend/src/types/stream.types.ts
+++ b/frontend/src/types/stream.types.ts
@@ -42,7 +42,6 @@ export interface QueueProcessingData {
 }
 
 export interface ApiStreamResponse {
-  source: EventSource;
   messageId: string;
   checkpointId: string | null;
   // Set when this turn bound the chat to a worktree — created server-side
@@ -50,14 +49,14 @@ export interface ApiStreamResponse {
   worktreeCwd: string | null;
 }
 
+// Envelopes arrive over the shared multiplexed connection (streamConnection)
+// and route here via envelope.chatId — a stream entry no longer owns a socket.
 export interface ActiveStream {
   id: string;
   chatId: string;
   messageId: string;
-  source: EventSource;
   startTime: number;
   isActive: boolean;
-  listeners: Array<{ type: string; handler: EventListener }>;
   callbacks?: {
     onEnvelope?: (envelope: StreamEnvelope) => void;
     onComplete?: (


### PR DESCRIPTION
## Summary
- Browsers cap HTTP/1.1 to 6 connections per origin, so once ~6 chats streamed concurrently, every other request on the page froze.
- Replace the per-chat `GET /chats/{chat_id}/stream` endpoint with a single per-user `GET /chats/streams` feed that multiplexes every active stream for the user over one SSE connection, self-routing envelopes client-side by `chatId`.
- Backlog replay is now cursor-based: the client sends a JSON map of `chat_id -> last_seen_seq` and the server replays each chat's missed events before switching to live Redis pub/sub (now keyed per-user instead of per-chat).
- Add a frontend `streamConnection` manager that owns one shared `EventSource` per API host, reconciles it against `streamStore`'s active streams, and handles reconnect/backoff/replay — replacing the one-`EventSource`-per-stream model in `streamService`/`chatService`.

## Test plan
- [x] `backend/tests/test_streaming.py` updated for the new `/chats/streams` endpoint and multiplexed pub/sub channel
- [ ] Manually verify streaming still works end-to-end with multiple concurrent chats in the browser