### PR TITLE
Show actions before chats in command menu

### DIFF
--- a/frontend/src/components/ui/command-menu/useCommandMenuData.ts
+++ b/frontend/src/components/ui/command-menu/useCommandMenuData.ts
@@ -185,9 +185,9 @@ export function useCommandMenuData(mode: MenuMode, query: string) {
 
   const listItems = useMemo<MenuListItem[]>(
     () => [
+      ...filteredCommands.map((command) => ({ kind: 'command' as const, command })),
       ...chatRows.map((chat) => ({ kind: 'chat' as const, chat })),
       ...filteredFiles.map((file) => ({ kind: 'file' as const, file })),
-      ...filteredCommands.map((command) => ({ kind: 'command' as const, command })),
     ],
     [chatRows, filteredFiles, filteredCommands],
   );


### PR DESCRIPTION
## Summary
- Reorder the command menu's unified result list so actions appear above chats (and files)
- Keeps keyboard navigation aligned with rendering via the shared `listItems` array