### PR TITLE
feat: add find-in-chat (⌘F) search

### DIFF
--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -11,6 +11,7 @@ import { Input } from '@/components/chat/message-input/Input';
 import { ChatSkeleton } from './ChatSkeleton';
 import { ScrollButton } from './ScrollButton';
 import { MessageTrail } from './MessageTrail';
+import { FindInChat } from './FindInChat';
 import { StatusTypewriter } from './StatusTypewriter';
 import { useChatScroll } from './useChatScroll';
 import { Spinner } from '@/components/ui/primitives/Spinner/Spinner';
@@ -343,6 +344,8 @@ export const Chat = memo(function Chat() {
               </div>
             </div>
             <MessageTrail messages={messages} scrollerRef={scrollerRef} />
+            {/* Keyed by chat so query/match state resets on chat switch */}
+            <FindInChat key={chatId ?? 'chat'} messages={messages} scrollerRef={scrollerRef} />
           </>
         )}
       </div>

--- a/frontend/src/components/chat/chat-window/FindInChat.module.scss
+++ b/frontend/src/components/chat/chat-window/FindInChat.module.scss
@@ -1,0 +1,90 @@
+@use '@/styles/globals/colors' as colors;
+@use '@/styles/globals/typography' as type;
+@use '@/styles/globals/animations' as anim;
+@use '@/styles/globals/responsive' as responsive;
+@use '@/styles/globals/zlayer' as z;
+
+.find-in-chat {
+  @include z.z('raised');
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-1) var(--space-1) var(--space-2);
+  border: 1px solid colors.theme-color('border', 0.5);
+  border-radius: var(--radius-lg);
+  background-color: var(--theme-surface);
+  box-shadow: var(--shadow-medium);
+}
+
+.search-icon {
+  pointer-events: none;
+  flex: none;
+  height: var(--space-3);
+  width: var(--space-3);
+  color: var(--theme-text-quaternary);
+}
+
+.find-input {
+  @include type.type-default;
+  height: var(--space-6);
+  width: var(--space-44);
+  border: none;
+  background: transparent;
+  color: var(--theme-text-primary);
+
+  &::placeholder {
+    color: var(--theme-text-quaternary);
+  }
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.count {
+  @include type.type-meta;
+  flex: none;
+  color: var(--theme-text-quaternary);
+  // Tabular so 9/10 → 10/10 doesn't shift the nav buttons
+  font-variant-numeric: tabular-nums;
+}
+
+.nav-button {
+  @include anim.transition-colors;
+  display: flex;
+  flex: none;
+  height: var(--space-5);
+  width: var(--space-5);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  color: var(--theme-text-quaternary);
+
+  @include responsive.hover {
+    background-color: var(--theme-surface-hover);
+    color: var(--theme-text-primary);
+  }
+}
+
+.nav-icon {
+  height: var(--space-3);
+  width: var(--space-3);
+}
+
+// Match styling for the ranges FindInChat.tsx registers in CSS.highlights — the
+// pseudo-element is unscopable, so declare it :global; inverse tokens keep the
+// current match monochrome but clearly distinct from the rest.
+:global {
+  ::highlight(find-in-chat) {
+    background-color: var(--theme-surface-active);
+    color: var(--theme-text-primary);
+  }
+
+  ::highlight(find-in-chat-current) {
+    background-color: var(--theme-surface-inverse);
+    color: var(--theme-text-inverse);
+  }
+}

--- a/frontend/src/components/chat/chat-window/FindInChat.tsx
+++ b/frontend/src/components/chat/chat-window/FindInChat.tsx
@@ -1,0 +1,241 @@
+import { memo, useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import { ChevronDown, ChevronUp, Search, X } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button/Button';
+import { Input } from '@/components/ui/primitives/Input/Input';
+import { useMountEffect } from '@/hooks/useMountEffect';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { useUIStore } from '@/store/uiStore';
+import type { Message } from '@/types/chat.types';
+import styles from './FindInChat.module.scss';
+
+// Registry names referenced by the ::highlight() rules in FindInChat.module.scss
+const HIGHLIGHT_ALL = 'find-in-chat';
+const HIGHLIGHT_CURRENT = 'find-in-chat-current';
+
+// Bubbling event dispatched from a match before jumping to it — collapsible blocks
+// (ThinkingBlock) listen on their root and expand so the match is actually visible
+export const FIND_REVEAL_EVENT = 'find-in-chat:reveal';
+
+function isEmbeddedEditor(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return !!target.closest('.monaco-editor, .xterm');
+}
+
+interface FindInChatProps {
+  messages: Message[];
+  scrollerRef: RefObject<HTMLDivElement | null>;
+}
+
+// In-chat find bar (⌘F): matches rendered message text via the CSS Custom Highlight
+// API — markdown splits content across arbitrary DOM nodes, so highlighting through
+// the registry avoids wrapping <mark> elements inside React-owned DOM.
+export const FindInChat = memo(function FindInChat({ messages, scrollerRef }: FindInChatProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [matchCount, setMatchCount] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const rangesRef = useRef<Range[]>([]);
+  const activeIndexRef = useRef(0);
+  const prevQueryRef = useRef('');
+  // Debounced so the TreeWalker pass doesn't run on every keystroke
+  const debouncedQuery = useDebouncedValue(query, 150);
+
+  const setActiveMatch = useCallback(
+    (index: number, scroll: boolean) => {
+      activeIndexRef.current = index;
+      setActiveIndex(index);
+      CSS.highlights.delete(HIGHLIGHT_CURRENT);
+      const range = rangesRef.current[index];
+      if (!range) return;
+      const current = new Highlight(range);
+      // Wins over the all-matches highlight covering the same range
+      current.priority = 1;
+      CSS.highlights.set(HIGHLIGHT_CURRENT, current);
+      if (!scroll) return;
+      range.startContainer.parentElement?.dispatchEvent(
+        new CustomEvent(FIND_REVEAL_EVENT, { bubbles: true }),
+      );
+      // Scroll a frame later so a reveal-triggered expansion has committed to the DOM
+      requestAnimationFrame(() => {
+        const scroller = scrollerRef.current;
+        if (!scroller) return;
+        // Nested scrollables (thinking traces cap their height and scroll internally)
+        // must be scrolled first so the range's rect is valid in the outer scroller
+        let ancestor = range.startContainer.parentElement;
+        while (ancestor && ancestor !== scroller) {
+          // overflow-y check, not scrollHeight: overflow-hidden clip containers
+          // (e.g. a thinking body mid-expand-transition) must not be scrolled
+          if (ancestor.scrollHeight > ancestor.clientHeight) {
+            const overflowY = getComputedStyle(ancestor).overflowY;
+            if (overflowY === 'auto' || overflowY === 'scroll') {
+              const rect = range.getBoundingClientRect();
+              const ancestorRect = ancestor.getBoundingClientRect();
+              ancestor.scrollTop += rect.top - ancestorRect.top - ancestor.clientHeight / 2;
+            }
+          }
+          ancestor = ancestor.parentElement;
+        }
+        const rect = range.getBoundingClientRect();
+        const scrollerRect = scroller.getBoundingClientRect();
+        // Already fully visible — jumping would re-center needlessly while typing
+        if (rect.top >= scrollerRect.top && rect.bottom <= scrollerRect.bottom) return;
+        const top = rect.top - scrollerRect.top + scroller.scrollTop - scroller.clientHeight / 2;
+        scroller.scrollTo({ top, behavior: 'smooth' });
+      });
+    },
+    [scrollerRef],
+  );
+
+  useMountEffect(() => {
+    // Plain ⌘F only — ⌘⇧F belongs to search-in-files; Monaco/xterm keep their own find
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey || e.code !== 'KeyF') return;
+      if (isEmbeddedEditor(e.target)) return;
+      if (useUIStore.getState().commandMenuOpen) return;
+      e.preventDefault();
+      setOpen(true);
+      // Already open: re-select the query for immediate retyping
+      inputRef.current?.select();
+    };
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
+  });
+
+  useEffect(() => {
+    // Focus after the open commit — the input isn't in the DOM before it
+    if (open) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    // messages.length gate doubles as the dep read: rescanning on every messages
+    // change keeps matches fresh while streaming or paginating older pages in
+    const scroller = scrollerRef.current;
+    rangesRef.current = [];
+    const needle = debouncedQuery.toLowerCase();
+    if (open && needle && scroller && messages.length > 0) {
+      const ranges: Range[] = [];
+      for (const el of scroller.querySelectorAll('[data-message-id]')) {
+        const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+        let node: Node | null;
+        while ((node = walker.nextNode())) {
+          const lower = node.textContent?.toLowerCase();
+          if (!lower) continue;
+          // Preview snippets duplicate content matched elsewhere and unmount on
+          // expand, which would leave dead ranges behind
+          if (node.parentElement?.closest('[data-find-exclude]')) continue;
+          let idx = lower.indexOf(needle);
+          while (idx !== -1) {
+            const range = new Range();
+            range.setStart(node, idx);
+            range.setEnd(node, idx + needle.length);
+            // display:none content has no boxes and can't be revealed by a jump — skip
+            // it; CSS-clipped collapsibles keep boxes and expand via FIND_REVEAL_EVENT
+            if (range.getClientRects().length > 0) ranges.push(range);
+            idx = lower.indexOf(needle, idx + needle.length);
+          }
+        }
+      }
+      rangesRef.current = ranges;
+    }
+    const ranges = rangesRef.current;
+    setMatchCount(ranges.length);
+    if (ranges.length > 0) {
+      CSS.highlights.set(HIGHLIGHT_ALL, new Highlight(...ranges));
+    } else {
+      CSS.highlights.delete(HIGHLIGHT_ALL);
+    }
+    // Jump to the first match on a new query; hold position on streaming rescans
+    const queryChanged = prevQueryRef.current !== debouncedQuery;
+    prevQueryRef.current = debouncedQuery;
+    const index = queryChanged
+      ? 0
+      : Math.min(activeIndexRef.current, Math.max(0, ranges.length - 1));
+    setActiveMatch(index, queryChanged);
+    return () => {
+      CSS.highlights.delete(HIGHLIGHT_ALL);
+      CSS.highlights.delete(HIGHLIGHT_CURRENT);
+    };
+  }, [open, debouncedQuery, messages, scrollerRef, setActiveMatch]);
+
+  const goToNext = useCallback(() => {
+    const count = rangesRef.current.length;
+    if (count > 0) setActiveMatch((activeIndexRef.current + 1) % count, true);
+  }, [setActiveMatch]);
+
+  const goToPrev = useCallback(() => {
+    const count = rangesRef.current.length;
+    if (count > 0) setActiveMatch((activeIndexRef.current - 1 + count) % count, true);
+  }, [setActiveMatch]);
+
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (e.shiftKey) {
+          goToPrev();
+        } else {
+          goToNext();
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        setOpen(false);
+      }
+    },
+    [goToNext, goToPrev],
+  );
+
+  if (!open) return null;
+
+  return (
+    <div role="search" className={styles['find-in-chat']}>
+      <Search className={styles['search-icon']} />
+      <Input
+        ref={inputRef}
+        variant="unstyled"
+        type="text"
+        role="searchbox"
+        aria-label="Find in chat"
+        placeholder="Find in chat"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleInputKeyDown}
+        className={styles['find-input']}
+      />
+      {debouncedQuery && (
+        <span aria-live="polite" className={styles.count}>
+          {matchCount > 0 ? `${activeIndex + 1}/${matchCount}` : '0/0'}
+        </span>
+      )}
+      <Button
+        variant="unstyled"
+        onClick={goToPrev}
+        disabled={matchCount === 0}
+        aria-label="Previous match"
+        className={styles['nav-button']}
+      >
+        <ChevronUp className={styles['nav-icon']} />
+      </Button>
+      <Button
+        variant="unstyled"
+        onClick={goToNext}
+        disabled={matchCount === 0}
+        aria-label="Next match"
+        className={styles['nav-button']}
+      >
+        <ChevronDown className={styles['nav-icon']} />
+      </Button>
+      <Button
+        variant="unstyled"
+        onClick={() => setOpen(false)}
+        aria-label="Close find"
+        className={styles['nav-button']}
+      >
+        <X className={styles['nav-icon']} />
+      </Button>
+    </div>
+  );
+});

--- a/frontend/src/components/chat/message-bubble/ThinkingBlock.tsx
+++ b/frontend/src/components/chat/message-bubble/ThinkingBlock.tsx
@@ -1,7 +1,9 @@
-import { useState, useMemo, memo, type CSSProperties } from 'react';
+import { useState, useMemo, useRef, memo, type CSSProperties } from 'react';
 import clsx from 'clsx';
 import { ChevronRight, Brain } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button/Button';
+import { FIND_REVEAL_EVENT } from '@/components/chat/chat-window/FindInChat';
+import { useMountEffect } from '@/hooks/useMountEffect';
 import styles from './ThinkingBlock.module.scss';
 
 const DELAY_0: CSSProperties = { animationDelay: '0ms' };
@@ -18,6 +20,17 @@ export const ThinkingBlock = memo(function ThinkingBlock({
   isActiveThinking,
 }: ThinkingBlockProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useMountEffect(() => {
+    // Find-in-chat jumps to a match inside the collapsed body dispatch a reveal
+    // event that bubbles up here — expand so the match is visible when it scrolls
+    const node = rootRef.current;
+    if (!node) return;
+    const expand = () => setIsExpanded(true);
+    node.addEventListener(FIND_REVEAL_EVENT, expand);
+    return () => node.removeEventListener(FIND_REVEAL_EVENT, expand);
+  });
 
   const previewText = useMemo(() => {
     if (!content) return '';
@@ -33,7 +46,7 @@ export const ThinkingBlock = memo(function ThinkingBlock({
   }, [content]);
 
   return (
-    <div>
+    <div ref={rootRef}>
       <Button
         type="button"
         variant="unstyled"
@@ -52,7 +65,11 @@ export const ThinkingBlock = memo(function ThinkingBlock({
           </div>
         )}
         {!isExpanded && content && (
-          <span className={styles['thinking-preview']}>{previewText}</span>
+          // data-find-exclude: duplicates the body's first line and unmounts on
+          // expand — matching it would leave dead find-in-chat ranges
+          <span data-find-exclude className={styles['thinking-preview']}>
+            {previewText}
+          </span>
         )}
         <ChevronRight
           className={clsx(

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -1,3 +1,9 @@
 interface Window {
   pdfBlobUrls?: Record<string, boolean>;
 }
+
+// TS 5.7's lib.dom types HighlightRegistry with only forEach — add the maplike members we use
+interface HighlightRegistry {
+  set(name: string, highlight: Highlight): this;
+  delete(name: string): boolean;
+}


### PR DESCRIPTION
## Summary
- Adds an in-chat search bar (triggered by ⌘F/Ctrl+F) that finds and highlights text across rendered messages using the CSS Custom Highlight API, so it doesn't need to wrap `<mark>` elements inside React-owned markdown DOM.
- Jumping to a match auto-expands collapsed `ThinkingBlock`s via a bubbling reveal event so the matched text is actually visible, and scrolls nested scrollables (thinking traces) before the outer chat scroller.
- Excludes duplicate preview text (`data-find-exclude`) from matching so collapsing/expanding a thinking block doesn't leave stale highlight ranges.

## Test plan
- [ ] Open a chat with several messages, press ⌘F, type a query, and confirm matches highlight and the counter updates
- [ ] Use next/prev (Enter / Shift+Enter, chevron buttons) to cycle through matches and confirm scroll-to-match works, including into collapsed thinking blocks
- [ ] Confirm ⌘F is ignored while a Monaco editor or terminal (xterm) has focus, and while the command menu is open
- [ ] Switch chats while find is open and confirm state resets