### PR TITLE
feat: add find-in-terminal (⌘F) search

### DIFF
--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -156,18 +156,26 @@ class SandboxProvider:
     @staticmethod
     def build_pty_shell_command(tmux_session: str, fallback_shell: str) -> str:
         # Shared tmux launch for every provider's PTY, falling back to a bare
-        # shell when tmux isn't installed. history-limit precedes new -A: it
-        # only applies to panes created after it's set (tmux applies it fine
-        # with no server running). Mouse on: xterm has no scrollback under
-        # tmux's alternate screen, so wheel scrolling must go through tmux
-        # copy-mode. Drag-selection then copies via tmux — set-clipboard plus
-        # the Ms override forward it as OSC 52 to the frontend clipboard addon.
+        # shell when tmux isn't installed. history-limit and the smcup@/rmcup@
+        # override precede new -A: they only apply to panes/clients created
+        # after they're set (tmux applies them fine with no server running).
+        # smcup@/rmcup@ keep tmux off the alternate screen so output lands in
+        # xterm's own scrollback — native wheel scroll, drag selection, and
+        # find-in-terminal. indn@ too: with it tmux scrolls via CSI S, which
+        # xterm.js splices away instead of archiving; without it tmux falls
+        # back to linefeeds, the only path that feeds xterm scrollback.
+        # Mouse off for the same reason (an explicit off so
+        # servers started before this change lose the old mouse-on); tmux still
+        # forwards mouse-mode requests from inner TUIs. set-clipboard plus the
+        # Ms override forward inner-app/copy-mode copies as OSC 52 to the
+        # frontend clipboard addon.
         return (
             "command -v tmux >/dev/null && "
             "tmux set -g history-limit 10000"
+            " \\; set -as terminal-overrides ',xterm-256color:smcup@:rmcup@:indn@'"
             f" \\; new -A -s {shlex.quote(tmux_session)}"
             " \\; set -g status off"
-            " \\; set -g mouse on"
+            " \\; set -g mouse off"
             " \\; set -s set-clipboard on"
             " \\; set -as terminal-overrides ',xterm-256color:Ms=\\E]52;%p1%s;%p2%s\\007'"
             f" || exec {shlex.quote(fallback_shell)}"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "@tauri-apps/plugin-updater": "^2.10.0",
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-search": "^0.16.0",
         "@xterm/xterm": "^5.5.0",
         "clsx": "^2.1.1",
         "diff": "^7.0.0",
@@ -2976,6 +2977,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/addon-search": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
+      "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
+      "license": "MIT"
     },
     "node_modules/@xterm/xterm": {
       "version": "5.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/xterm": "^5.5.0",
     "clsx": "^2.1.1",
     "diff": "^7.0.0",

--- a/frontend/src/components/chat/chat-window/FindInChat.tsx
+++ b/frontend/src/components/chat/chat-window/FindInChat.tsx
@@ -18,7 +18,9 @@ export const FIND_REVEAL_EVENT = 'find-in-chat:reveal';
 
 function isEmbeddedEditor(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
-  return !!target.closest('.monaco-editor, .xterm');
+  // [data-terminal-search] is the terminal's own find bar — a ⌘F retype there
+  // must re-select that bar's input, not open this one
+  return !!target.closest('.monaco-editor, .xterm, [data-terminal-search]');
 }
 
 interface FindInChatProps {

--- a/frontend/src/components/sandbox/terminal/TerminalSearch/TerminalSearch.module.scss
+++ b/frontend/src/components/sandbox/terminal/TerminalSearch/TerminalSearch.module.scss
@@ -1,0 +1,75 @@
+@use '@/styles/globals/animations' as anim;
+@use '@/styles/globals/colors' as colors;
+@use '@/styles/globals/responsive' as responsive;
+@use '@/styles/globals/typography' as type;
+@use '@/styles/globals/zlayer' as z;
+
+.terminal-search {
+  @include z.z('raised');
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-1) var(--space-1) var(--space-2);
+  border: 1px solid colors.theme-color('border', 0.5);
+  border-radius: var(--radius-lg);
+  background-color: var(--theme-surface);
+  box-shadow: var(--shadow-medium);
+}
+
+.search-icon {
+  pointer-events: none;
+  flex: none;
+  height: var(--space-3);
+  width: var(--space-3);
+  color: var(--theme-text-quaternary);
+}
+
+.find-input {
+  @include type.type-default;
+  height: var(--space-6);
+  width: var(--space-44);
+  border: none;
+  background: transparent;
+  color: var(--theme-text-primary);
+
+  &::placeholder {
+    color: var(--theme-text-quaternary);
+  }
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.count {
+  @include type.type-meta;
+  flex: none;
+  color: var(--theme-text-quaternary);
+  // Tabular so 9/10 → 10/10 doesn't shift the nav buttons
+  font-variant-numeric: tabular-nums;
+}
+
+.nav-button {
+  @include anim.transition-colors;
+  display: flex;
+  flex: none;
+  height: var(--space-5);
+  width: var(--space-5);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  color: var(--theme-text-quaternary);
+
+  @include responsive.hover {
+    background-color: var(--theme-surface-hover);
+    color: var(--theme-text-primary);
+  }
+}
+
+.nav-icon {
+  height: var(--space-3);
+  width: var(--space-3);
+}

--- a/frontend/src/components/sandbox/terminal/TerminalSearch/TerminalSearch.test.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalSearch/TerminalSearch.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Terminal as XTerm } from '@xterm/xterm';
+import type { ISearchResultChangeEvent, SearchAddon } from '@xterm/addon-search';
+
+import { TerminalSearch } from './TerminalSearch';
+
+// Deterministic non-mac so tests drive the Ctrl+F path regardless of host OS
+vi.mock('@/utils/platform', () => ({ IS_MAC_PLATFORM: false }));
+
+type KeyHandler = (event: KeyboardEvent) => boolean;
+
+const mocks = vi.hoisted(() => ({
+  keyHandler: null as KeyHandler | null,
+  resultsListener: null as ((event: ISearchResultChangeEvent) => void) | null,
+}));
+
+const terminal = {
+  attachCustomKeyEventHandler: vi.fn((handler: KeyHandler) => {
+    mocks.keyHandler = handler;
+  }),
+  focus: vi.fn(),
+};
+
+const searchAddon = {
+  findNext: vi.fn(() => true),
+  findPrevious: vi.fn(() => true),
+  clearDecorations: vi.fn(),
+  onDidChangeResults: vi.fn((listener: (event: ISearchResultChangeEvent) => void) => {
+    mocks.resultsListener = listener;
+    return { dispose: vi.fn() };
+  }),
+};
+
+function keyEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    type: 'keydown',
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+    code: '',
+    preventDefault: vi.fn(),
+    ...overrides,
+  } as unknown as KeyboardEvent;
+}
+
+function renderSearch() {
+  return render(
+    <TerminalSearch
+      isReady
+      palette="dark"
+      searchAddonRef={{ current: searchAddon as unknown as SearchAddon }}
+      terminalRef={{ current: terminal as unknown as XTerm }}
+    />,
+  );
+}
+
+function openSearch(): HTMLElement {
+  act(() => {
+    mocks.keyHandler?.(keyEvent({ ctrlKey: true, code: 'KeyF' }));
+  });
+  return screen.getByRole('searchbox');
+}
+
+describe('TerminalSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.keyHandler = null;
+    mocks.resultsListener = null;
+  });
+
+  // No vitest globals in this repo, so RTL's automatic cleanup never registers
+  afterEach(cleanup);
+
+  it('opens on Ctrl+F, swallows the chord, and passes other keys to the PTY', () => {
+    renderSearch();
+    expect(screen.queryByRole('searchbox')).toBeNull();
+
+    const event = keyEvent({ ctrlKey: true, code: 'KeyF' });
+    let handled = true;
+    act(() => {
+      handled = mocks.keyHandler?.(event) ?? true;
+    });
+    // false keeps xterm from writing ^F to the shell; preventDefault blocks
+    // the browser's native find
+    expect(handled).toBe(false);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(document.activeElement).toBe(screen.getByRole('searchbox'));
+
+    expect(mocks.keyHandler?.(keyEvent({ ctrlKey: true, code: 'KeyC' }))).toBe(true);
+    expect(mocks.keyHandler?.(keyEvent({ code: 'KeyF' }))).toBe(true);
+  });
+
+  it('searches incrementally as the query changes', () => {
+    renderSearch();
+    const input = openSearch();
+
+    fireEvent.change(input, { target: { value: 'error' } });
+    expect(searchAddon.findNext).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({ incremental: true, decorations: expect.anything() }),
+    );
+
+    // Clearing the query drops the highlights and the stale count
+    fireEvent.change(input, { target: { value: '' } });
+    expect(searchAddon.clearDecorations).toHaveBeenCalled();
+  });
+
+  it('steps matches with Enter / Shift+Enter', () => {
+    renderSearch();
+    const input = openSearch();
+    fireEvent.change(input, { target: { value: 'error' } });
+    searchAddon.findNext.mockClear();
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(searchAddon.findNext).toHaveBeenCalledWith(
+      'error',
+      expect.not.objectContaining({ incremental: true }),
+    );
+
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+    expect(searchAddon.findPrevious).toHaveBeenCalledWith('error', expect.anything());
+  });
+
+  it('shows the active match count reported by the addon', () => {
+    renderSearch();
+    const input = openSearch();
+    fireEvent.change(input, { target: { value: 'error' } });
+
+    act(() => {
+      mocks.resultsListener?.({ resultIndex: 2, resultCount: 10 });
+    });
+    expect(screen.getByText('3/10')).toBeTruthy();
+
+    act(() => {
+      mocks.resultsListener?.({ resultIndex: -1, resultCount: 0 });
+    });
+    expect(screen.getByText('0/0')).toBeTruthy();
+  });
+
+  it('Escape closes the bar, clears highlights, and refocuses the terminal', () => {
+    renderSearch();
+    const input = openSearch();
+    fireEvent.change(input, { target: { value: 'error' } });
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(screen.queryByRole('searchbox')).toBeNull();
+    expect(searchAddon.clearDecorations).toHaveBeenCalled();
+    expect(terminal.focus).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/sandbox/terminal/TerminalSearch/TerminalSearch.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalSearch/TerminalSearch.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { MutableRefObject } from 'react';
+import { ChevronDown, ChevronUp, Search, X } from 'lucide-react';
+import type { Terminal as XTerm } from '@xterm/xterm';
+import type { ISearchResultChangeEvent, SearchAddon } from '@xterm/addon-search';
+
+import { Button } from '@/components/ui/primitives/Button/Button';
+import { Input } from '@/components/ui/primitives/Input/Input';
+import { IS_MAC_PLATFORM } from '@/utils/platform';
+import { buildSearchDecorations } from '@/utils/terminal';
+import type { Palette } from '@/types/ui.types';
+import styles from './TerminalSearch.module.scss';
+
+interface TerminalSearchProps {
+  isReady: boolean;
+  palette: Palette;
+  searchAddonRef: MutableRefObject<SearchAddon | null>;
+  terminalRef: MutableRefObject<XTerm | null>;
+}
+
+// Terminal find bar driving @xterm/addon-search: the addon selects the active
+// match, decorates the rest, and reports index/count via onDidChangeResults.
+export function TerminalSearch({
+  isReady,
+  palette,
+  searchAddonRef,
+  terminalRef,
+}: TerminalSearchProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [result, setResult] = useState<ISearchResultChangeEvent | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const decorations = useMemo(() => buildSearchDecorations(palette), [palette]);
+
+  useEffect(() => {
+    // ⌘F on mac, Ctrl+F elsewhere — plain Ctrl+F must keep reaching the shell
+    // on mac (readline forward-char). Returning false stops xterm from writing
+    // the chord to the PTY; preventDefault suppresses the browser's find.
+    if (!isReady) {
+      return;
+    }
+    terminalRef.current?.attachCustomKeyEventHandler((event) => {
+      const modifier = IS_MAC_PLATFORM ? event.metaKey : event.ctrlKey;
+      if (
+        event.type === 'keydown' &&
+        modifier &&
+        !event.shiftKey &&
+        !event.altKey &&
+        event.code === 'KeyF'
+      ) {
+        event.preventDefault();
+        setOpen(true);
+        return false;
+      }
+      return true;
+    });
+    // No detach API — the handler is disposed with the terminal itself.
+  }, [isReady, terminalRef]);
+
+  useEffect(() => {
+    if (!isReady) {
+      return undefined;
+    }
+    const addon = searchAddonRef.current;
+    if (!addon) {
+      return undefined;
+    }
+    const disposable = addon.onDidChangeResults((event) => setResult(event));
+    return () => disposable.dispose();
+  }, [isReady, searchAddonRef]);
+
+  useEffect(() => {
+    if (!open || !isReady) {
+      return;
+    }
+    const addon = searchAddonRef.current;
+    if (!addon) {
+      return;
+    }
+    if (!query) {
+      // clearDecorations fires no results event — reset the count manually.
+      addon.clearDecorations();
+      setResult(null);
+      return;
+    }
+    // Incremental: while typing, the current match stays selected if it still
+    // matches the extended term instead of jumping to the next occurrence.
+    addon.findNext(query, { incremental: true, decorations });
+  }, [open, isReady, query, decorations, searchAddonRef]);
+
+  useEffect(() => {
+    // Focus after the open commit — the input isn't in the DOM before it
+    if (open) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [open]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setResult(null);
+    searchAddonRef.current?.clearDecorations();
+    terminalRef.current?.focus();
+  }, [searchAddonRef, terminalRef]);
+
+  const goToNext = useCallback(() => {
+    if (query) {
+      searchAddonRef.current?.findNext(query, { decorations });
+    }
+  }, [query, decorations, searchAddonRef]);
+
+  const goToPrev = useCallback(() => {
+    if (query) {
+      searchAddonRef.current?.findPrevious(query, { decorations });
+    }
+  }, [query, decorations, searchAddonRef]);
+
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (e.shiftKey) {
+          goToPrev();
+        } else {
+          goToNext();
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      } else if (
+        (IS_MAC_PLATFORM ? e.metaKey : e.ctrlKey) &&
+        !e.shiftKey &&
+        !e.altKey &&
+        e.code === 'KeyF'
+      ) {
+        // Re-pressed while the bar is focused: re-select for immediate retyping
+        e.preventDefault();
+        inputRef.current?.select();
+      }
+    },
+    [goToNext, goToPrev, close],
+  );
+
+  if (!open) return null;
+
+  const hasMatches = !!result && result.resultCount > 0;
+
+  return (
+    // data-terminal-search lets FindInChat's global ⌘F handler yield to this bar
+    <div role="search" data-terminal-search className={styles['terminal-search']}>
+      <Search className={styles['search-icon']} />
+      <Input
+        ref={inputRef}
+        variant="unstyled"
+        type="text"
+        role="searchbox"
+        aria-label="Find in terminal"
+        placeholder="Find in terminal"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleInputKeyDown}
+        className={styles['find-input']}
+      />
+      {query && result && (
+        <span aria-live="polite" className={styles.count}>
+          {/* resultIndex is -1 past the addon's highlight limit — count only */}
+          {result.resultIndex >= 0
+            ? `${result.resultIndex + 1}/${result.resultCount}`
+            : hasMatches
+              ? `${result.resultCount}+`
+              : '0/0'}
+        </span>
+      )}
+      <Button
+        variant="unstyled"
+        onClick={goToPrev}
+        disabled={!hasMatches}
+        aria-label="Previous match"
+        className={styles['nav-button']}
+      >
+        <ChevronUp className={styles['nav-icon']} />
+      </Button>
+      <Button
+        variant="unstyled"
+        onClick={goToNext}
+        disabled={!hasMatches}
+        aria-label="Next match"
+        className={styles['nav-button']}
+      >
+        <ChevronDown className={styles['nav-icon']} />
+      </Button>
+      <Button
+        variant="unstyled"
+        onClick={close}
+        aria-label="Close find"
+        className={styles['nav-button']}
+      >
+        <X className={styles['nav-icon']} />
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/sandbox/terminal/TerminalTab/TerminalTab.test.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab/TerminalTab.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => {
   const terminal = {
     cols: 120,
     rows: 40,
+    attachCustomKeyEventHandler: vi.fn(),
     focus: vi.fn(),
     refresh: vi.fn(),
     reset: vi.fn(),
@@ -42,6 +43,7 @@ vi.mock('@/hooks/useXterm', () => ({
   useXterm: () => ({
     fitTerminal: mocks.fitTerminal,
     isReady: true,
+    searchAddonRef: { current: null },
     terminalRef: mocks.terminalRef,
     wrapperRef: mocks.wrapperRef,
   }),

--- a/frontend/src/components/sandbox/terminal/TerminalTab/TerminalTab.tsx
+++ b/frontend/src/components/sandbox/terminal/TerminalTab/TerminalTab.tsx
@@ -9,6 +9,7 @@ import { useUIStore } from '@/store/uiStore';
 import { resolveSandboxClient, resolveSandboxWs } from '@/lib/api';
 
 import { useXterm } from '@/hooks/useXterm';
+import { TerminalSearch } from '@/components/sandbox/terminal/TerminalSearch/TerminalSearch';
 import type { TerminalSize } from '@/types/sandbox.types';
 import type { Palette } from '@/types/ui.types';
 import styles from './TerminalTab.module.scss';
@@ -83,7 +84,7 @@ export function TerminalTab({
     lastSentSizeRef.current = size;
   }, []);
 
-  const { fitTerminal, isReady, terminalRef, wrapperRef } = useXterm({
+  const { fitTerminal, isReady, searchAddonRef, terminalRef, wrapperRef } = useXterm({
     isVisible,
     mode: palette,
     onData: (data: string) => {
@@ -334,6 +335,12 @@ export function TerminalTab({
           )}
         />
       </div>
+      <TerminalSearch
+        isReady={isReady}
+        palette={palette}
+        searchAddonRef={searchAddonRef}
+        terminalRef={terminalRef}
+      />
       {isVisible && overlayMessage && (
         <div className={styles['terminal-overlay']}>
           <div className={styles['terminal-overlay-message']}>{overlayMessage}</div>

--- a/frontend/src/hooks/useXterm.ts
+++ b/frontend/src/hooks/useXterm.ts
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react';
 import type { Terminal as XTerm } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
 import type { IClipboardProvider } from '@xterm/addon-clipboard';
+import type { SearchAddon } from '@xterm/addon-search';
 
 import { logger } from '@/utils/logger';
 import { buildTerminalTheme } from '@/utils/terminal';
@@ -31,6 +32,7 @@ interface UseXtermOptions {
 interface UseXtermReturn {
   fitTerminal: () => TerminalSize | null;
   isReady: boolean;
+  searchAddonRef: MutableRefObject<SearchAddon | null>;
   terminalRef: MutableRefObject<XTerm | null>;
   wrapperRef: MutableRefObject<HTMLDivElement | null>;
 }
@@ -41,6 +43,7 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
   // never touch a terminal whose renderer doesn't exist yet.
   const terminalRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const searchAddonRef = useRef<SearchAddon | null>(null);
   const [isReady, setIsReady] = useState(false);
   const [initAttempt, setInitAttempt] = useState(0);
 
@@ -107,10 +110,11 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
     let xterm: XTerm | null = null;
 
     void (async () => {
-      const [{ Terminal }, { FitAddon }, { ClipboardAddon }] = await Promise.all([
+      const [{ Terminal }, { FitAddon }, { ClipboardAddon }, { SearchAddon }] = await Promise.all([
         import('@xterm/xterm'),
         import('@xterm/addon-fit'),
         import('@xterm/addon-clipboard'),
+        import('@xterm/addon-search'),
       ]);
 
       // Wait for the Nerd Font before first paint so the renderer measures
@@ -126,7 +130,12 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
       }
 
       xterm = new Terminal({
-        scrollback: 1000,
+        // The search addon's match decorations use registerDecoration, which
+        // xterm still gates as a proposed API.
+        allowProposedApi: true,
+        // tmux attaches without the alternate screen (smcup@ override), so this
+        // buffer is the scroll/search history — sized to tmux's history-limit.
+        scrollback: 10000,
         fontSize: 12,
         // Nerd Font primary so PUA icon glyphs (eza/ls icons, Starship prompt
         // symbols) render; generic monospace is only a last-resort fallback.
@@ -135,8 +144,10 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
       });
       const fitAddon = new FitAddon();
       xterm.loadAddon(fitAddon);
-      // OSC 52 → system clipboard: tmux runs with mouse mode on, so drag
-      // selection is tmux copy-mode — its copy must reach navigator.clipboard.
+      const searchAddon = new SearchAddon();
+      xterm.loadAddon(searchAddon);
+      // OSC 52 → system clipboard: inner apps (vim, keyboard copy-mode) copy
+      // through tmux's set-clipboard/Ms path and must reach navigator.clipboard.
       xterm.loadAddon(new ClipboardAddon(undefined, WRITE_ONLY_CLIPBOARD));
       // Registered once for the terminal's lifetime; dispose() cleans it up.
       xterm.onData((data) => onDataRef.current(data));
@@ -144,6 +155,7 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
 
       hasInitializedRef.current = true;
       fitAddonRef.current = fitAddon;
+      searchAddonRef.current = searchAddon;
       terminalRef.current = xterm;
       setIsReady(true);
     })().catch((error: unknown) => {
@@ -155,6 +167,7 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
     return () => {
       cancelled = true;
       fitAddonRef.current = null;
+      searchAddonRef.current = null;
       terminalRef.current = null;
       xterm?.dispose();
       setIsReady(false);
@@ -233,6 +246,7 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
     () => ({
       fitTerminal,
       isReady,
+      searchAddonRef,
       terminalRef,
       wrapperRef,
     }),

--- a/frontend/src/utils/terminal.ts
+++ b/frontend/src/utils/terminal.ts
@@ -1,4 +1,5 @@
 import type { ITerminalOptions } from '@xterm/xterm';
+import type { ISearchDecorationOptions } from '@xterm/addon-search';
 import type { Palette } from '@/types/ui.types';
 import { CUSTOM_PALETTE_TOKENS, DARK_PALETTES } from '@/utils/theme';
 
@@ -26,6 +27,18 @@ export const buildTerminalTheme = (palette: Palette): ITerminalOptions['theme'] 
     cursorAccent: isDark ? '#0a0a0a' : '#ffffff',
     selectionBackground: isDark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.15)',
     selectionInactiveBackground: isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.08)',
+  };
+};
+
+export const buildSearchDecorations = (palette: Palette): ISearchDecorationOptions => {
+  // Opaque #RRGGBB only — xterm drops the alpha byte and paints the cell
+  // background solid, so the grays must keep the theme foreground readable.
+  const isDark = DARK_PALETTES.has(palette);
+  return {
+    matchBackground: isDark ? '#3f3f46' : '#d4d4d8',
+    activeMatchBackground: isDark ? '#71717a' : '#a1a1aa',
+    matchOverviewRuler: isDark ? '#71717a' : '#a1a1aa',
+    activeMatchColorOverviewRuler: isDark ? '#e4e4e7' : '#27272a',
   };
 };
 


### PR DESCRIPTION
## Summary
- Add find-in-terminal (⌘F) search backed by `@xterm/addon-search`, with a `TerminalSearch` find bar and match-count/prev/next UI.
- Stop tmux from taking over the alternate screen and mouse (`smcup@`/`rmcup@`/`indn@` overrides, `mouse off`) so xterm.js's own scrollback holds terminal history and both native wheel-scroll and the new search can operate on it.
- Bump xterm scrollback to 10000 lines (mirrors tmux's `history-limit`) and enable `allowProposedApi` for the search addon's match decorations.
- Exclude the terminal's own find bar (`[data-terminal-search]`) from triggering the chat-wide find-in-chat overlay on ⌘F.

## Test plan
- [x] `TerminalTab.test.tsx` updated for the new `searchAddonRef`/`attachCustomKeyEventHandler` surface.
- [x] Manually verify ⌘F inside a terminal pane opens the terminal find bar (not chat find), highlights matches, and prev/next navigation works.
- [x] Manually verify native mouse-wheel scroll now scrolls xterm's own history instead of triggering tmux copy-mode.