### PR TITLE
fix: stop suppressing Claude plan updates

### DIFF
--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -442,10 +442,9 @@ class AcpClientHandler:
         return StreamEvent(type="system", data={})
 
     def _map_plan(self, plan: AgentPlanUpdate) -> StreamEvent | None:
-        # Claude/OpenCode todos already arrive as TodoWrite/todowrite tool
-        # events with dedicated renderers — mapping their plan updates too
-        # would show the same checklist twice.
-        if self.agent_kind in (AgentKind.CLAUDE, AgentKind.OPENCODE):
+        # Claude sends TodoWrite and Task* state only as plan updates. OpenCode
+        # also emits todowrite tool calls, so forwarding its plan would duplicate it.
+        if self.agent_kind == AgentKind.OPENCODE:
             return None
         # Each ACP plan update carries the complete entry list; the frontend
         # replaces the whole plan rather than appending.


### PR DESCRIPTION
## Summary
- Claude reports TodoWrite/Task* state exclusively through ACP plan updates (unlike OpenCode, which also emits dedicated todowrite tool events), so plan updates were being incorrectly dropped for Claude, hiding the checklist entirely.
- Now only OpenCode's plan updates are suppressed, since it duplicates them via its own todowrite tool events.