### PR TITLE
docs: note building against stable Xcode SDK for iOS beta devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ nothing is hardcoded to anyone else's server.
 Requirements: macOS with Xcode (plus its iOS SDK and Simulator), the Rust iOS
 targets (`rustup target add aarch64-apple-ios aarch64-apple-ios-sim`), and CocoaPods.
 
+> If your device runs an iOS beta whose SDK isn't in a stable Xcode yet, build against the latest stable Xcode's SDK (`sudo xcode-select -s /Applications/Xcode.app`) — apps built with an older SDK still run on newer iOS.
+
 Point the app at your instance:
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a one-line note under the **Mobile (iOS)** requirements explaining that if your device runs an iOS beta whose SDK isn't in a stable Xcode yet, you should build against the latest stable Xcode's SDK (`sudo xcode-select -s /Applications/Xcode.app`).
- Apps built with an older SDK still run on newer iOS, so this avoids the (transient) beta-toolchain build/runtime issues without any code changes.