### PR TITLE
feat: allow asking about text selected in chat messages

### DIFF
--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -114,10 +114,12 @@ class EnhancePromptResponse(BaseModel):
 class AskCodeRequest(BaseModel):
     question: str = Field(..., min_length=1, max_length=10000)
     code: str = Field(..., min_length=1, max_length=100000)
-    file_path: str = Field(..., min_length=1, max_length=1024)
-    language: str = Field(..., min_length=1, max_length=64)
-    start_line: int = Field(..., ge=1)
-    end_line: int = Field(..., ge=1)
+    # Location fields exist only for editor code selections — chat-page text
+    # selections have no file identity and omit them.
+    file_path: str | None = Field(None, min_length=1, max_length=1024)
+    language: str | None = Field(None, min_length=1, max_length=64)
+    start_line: int | None = Field(None, ge=1)
+    end_line: int | None = Field(None, ge=1)
     model_id: str = Field(..., min_length=1, max_length=255)
 
 

--- a/backend/app/prompts/inline_chat.py
+++ b/backend/app/prompts/inline_chat.py
@@ -1,7 +1,8 @@
 INLINE_CHAT_SYSTEM_PROMPT = (
-    "You are answering a developer's question about a code selection from their "
-    "editor. Base your answer on the provided snippet, using the file path and "
-    "line range only as context. Answer directly and concisely in Markdown — "
-    "short paragraphs and small code examples, no headings or preamble. Do not "
-    "use tools and do not modify files."
+    "You are answering a developer's question about a selection they made — "
+    "code from their editor or text from their chat conversation. Base your "
+    "answer on the provided selection, using any file path and line range only "
+    "as context. Answer directly and concisely in Markdown — short paragraphs "
+    "and small code examples, no headings or preamble. Do not use tools and do "
+    "not modify files."
 )

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -315,24 +315,32 @@ class AgentService:
         self,
         question: str,
         code: str,
-        file_path: str,
-        language: str,
-        start_line: int,
-        end_line: int,
+        file_path: str | None,
+        language: str | None,
+        start_line: int | None,
+        end_line: int | None,
         model_id: str,
         user: User,
         chat: Chat,
     ) -> str:
-        line_ref = (
-            str(start_line)
-            if start_line == end_line
-            else str(start_line) + "-" + str(end_line)
-        )
+        # No file identity = chat-page text selection; label it accordingly so
+        # the model doesn't hunt for a file.
+        if file_path and language and start_line and end_line:
+            line_ref = (
+                str(start_line)
+                if start_line == end_line
+                else str(start_line) + "-" + str(end_line)
+            )
+            header = (
+                "File: " + file_path + " (lines " + line_ref + ", " + language + ")"
+            )
+        else:
+            header = "Selected text from the conversation:"
         # XML-ish wrapping instead of Markdown fences — snippets can contain
         # backtick runs that would close any fence we pick.
         user_message = (
-            "File: " + file_path + " (lines " + line_ref + ", " + language + ")\n"
-            "<code>\n" + code + "\n</code>\n\n"
+            header + "\n"
+            "<selection>\n" + code + "\n</selection>\n\n"
             "<question>\n" + question + "\n</question>"
         )
         result = await self._generate_text(

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -119,7 +119,7 @@ class ChatCompletionServiceOverride:
 class AgentServiceOverride:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, User]] = []
-        self.ask_code_calls: list[tuple[str, str, str, str, User, Chat]] = []
+        self.ask_code_calls: list[tuple[str, str, str | None, str, User, Chat]] = []
         self.title_calls: list[tuple[str, str, User, Chat | None]] = []
         self.fail = False
         self.next_title: str | None = "Generated Title"
@@ -137,10 +137,10 @@ class AgentServiceOverride:
         self,
         question: str,
         code: str,
-        file_path: str,
-        language: str,
-        start_line: int,
-        end_line: int,
+        file_path: str | None,
+        language: str | None,
+        start_line: int | None,
+        end_line: int | None,
         model_id: str,
         user: User,
         chat: Chat,
@@ -525,6 +525,19 @@ async def test_ask_code_endpoint_answers_and_enforces_chat_access(
     )
     assert stored_user.id == user.id
     assert stored_chat.id == chat.id
+
+    # Chat-page text selections omit the location fields entirely.
+    text_payload = {
+        "question": "Summarize this",
+        "code": "The deploy failed because the token expired.",
+        "model_id": TEST_MODEL_ID,
+    }
+    text_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/ask-code", json=text_payload, headers=headers
+    )
+    assert text_response.status_code == 200
+    assert text_response.json() == {"answer": "Answer: Summarize this"}
+    assert agent_service.ask_code_calls[-1][2] is None
 
     other_headers, _other_user, _other_workspace = await create_authenticated_workspace(
         db_session,

--- a/frontend/src/components/chat/chat-window/Chat.module.scss
+++ b/frontend/src/components/chat/chat-window/Chat.module.scss
@@ -22,6 +22,11 @@
   overflow-x: hidden;
 }
 
+// Positioning context for the selection-actions layer anchored to message content.
+.content {
+  position: relative;
+}
+
 // Centered message column — full width, capped and centered from the lg breakpoint
 .column {
   width: 100%;

--- a/frontend/src/components/chat/chat-window/Chat.tsx
+++ b/frontend/src/components/chat/chat-window/Chat.tsx
@@ -12,6 +12,7 @@ import { ChatSkeleton } from './ChatSkeleton';
 import { ScrollButton } from './ScrollButton';
 import { MessageTrail } from './MessageTrail';
 import { FindInChat } from './FindInChat';
+import { ChatSelectionActions } from './ChatSelectionActions';
 import { StatusTypewriter } from './StatusTypewriter';
 import { useChatScroll } from './useChatScroll';
 import { Spinner } from '@/components/ui/primitives/Spinner/Spinner';
@@ -317,7 +318,7 @@ export const Chat = memo(function Chat() {
           <>
             <div key={chatId ?? 'chat'} ref={containerRefCallback} className={styles.scroller}>
               {/* Single wrapper so the stick-to-bottom ResizeObserver tracks all content */}
-              <div>
+              <div className={styles.content}>
                 {listHeader}
 
                 {turns.map((turn, turnIndex) => {
@@ -341,6 +342,10 @@ export const Chat = memo(function Chat() {
                 })}
 
                 {turns.length === 0 && listFooter}
+
+                {/* Inside the content wrapper so the selection toolbar / ask
+                    panel anchor in content coordinates and scroll with it */}
+                <ChatSelectionActions chatId={chatId} scrollerRef={scrollerRef} />
               </div>
             </div>
             <MessageTrail messages={messages} scrollerRef={scrollerRef} />

--- a/frontend/src/components/chat/chat-window/ChatSelectionActions.module.scss
+++ b/frontend/src/components/chat/chat-window/ChatSelectionActions.module.scss
@@ -1,0 +1,65 @@
+@use '@/styles/globals/colors' as colors;
+@use '@/styles/globals/typography' as type;
+@use '@/styles/globals/animations' as anim;
+@use '@/styles/globals/responsive' as responsive;
+@use '@/styles/globals/zlayer' as z;
+
+// Covers the message content so children can anchor to selection coordinates;
+// pointer-events pass through everywhere except the toolbar/panel themselves.
+.selection-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.toolbar {
+  @include z.z('raised');
+  position: absolute;
+  display: flex;
+  align-items: center;
+  gap: var(--space-0-5);
+  border: 1px solid var(--theme-border);
+  border-radius: var(--radius-lg);
+  background-color: colors.theme-color('surface', 0.95);
+  box-shadow: var(--shadow-medium);
+  backdrop-filter: blur(24px);
+  padding: var(--space-0-5);
+  pointer-events: auto;
+  // Sit centered above the selection with a small gap.
+  transform: translate(-50%, calc(-100% - var(--space-1-5)));
+  animation: fade-in var(--duration-fast) var(--easing-out);
+}
+
+.action {
+  @include anim.transition-colors;
+  @include type.type-default;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-2);
+  color: var(--theme-text-secondary);
+  white-space: nowrap;
+
+  @include responsive.hover {
+    background-color: var(--theme-surface-hover);
+    color: var(--theme-text-primary);
+  }
+}
+
+.action-icon {
+  height: var(--space-3-5);
+  width: var(--space-3-5);
+}
+
+.divider {
+  width: 1px;
+  height: var(--space-4);
+  background-color: colors.theme-color('border', 0.5);
+}
+
+.ask {
+  @include z.z('raised');
+  position: absolute;
+  pointer-events: auto;
+}

--- a/frontend/src/components/chat/chat-window/ChatSelectionActions.tsx
+++ b/frontend/src/components/chat/chat-window/ChatSelectionActions.tsx
@@ -1,0 +1,187 @@
+import { memo, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
+import { MessageCircleQuestion, MessageSquarePlus } from 'lucide-react';
+import { Button } from '@/components/ui/primitives/Button/Button';
+import { InlineAskPanel } from '@/components/chat/inline-ask/InlineAskPanel';
+import { useUIStore, type ChatTextSelection } from '@/store/uiStore';
+import styles from './ChatSelectionActions.module.scss';
+
+// Must match .inline-ask width/max-width in InlineAskPanel.module.scss so the
+// horizontal clamp keeps the panel inside the overflow-x-hidden scroller.
+const PANEL_WIDTH = 440;
+const PANEL_MAX_VIEWPORT_RATIO = 0.8;
+const EDGE_GAP = 8;
+// Half the toolbar's rendered width — it centers via translateX(-50%).
+const TOOLBAR_HALF_WIDTH = 110;
+// Keeps the toolbar (placed above the selection) from being clipped at the
+// top of the scrollable content.
+const TOOLBAR_CLEARANCE = 44;
+
+// Selection geometry in scroller-content coordinates, so the toolbar and ask
+// panel scroll with the message they anchor to (same feel as the editor's
+// Monaco content widget).
+interface SelectionAnchor {
+  text: string;
+  top: number;
+  bottom: number;
+  center: number;
+  left: number;
+}
+
+interface ChatSelectionActionsProps {
+  chatId: string | undefined;
+  scrollerRef: RefObject<HTMLDivElement | null>;
+}
+
+// Floating "Add to chat" / "Ask" actions over text selected in rendered chat
+// messages — the chat-page counterpart of the editor's selection actions.
+export const ChatSelectionActions = memo(function ChatSelectionActions({
+  chatId,
+  scrollerRef,
+}: ChatSelectionActionsProps) {
+  const [anchor, setAnchor] = useState<SelectionAnchor | null>(null);
+  const [ask, setAsk] = useState<{
+    selection: ChatTextSelection;
+    top: number;
+    left: number;
+    nonce: number;
+  } | null>(null);
+  const askInputRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    // Both actions need a chat to target — without one there's nothing to attach
+    // to or ask against, so don't track selections at all.
+    if (!chatId) return;
+
+    const evaluate = () => {
+      const scroller = scrollerRef.current;
+      const selection = document.getSelection();
+      if (!scroller || !selection || selection.isCollapsed || selection.rangeCount === 0) {
+        setAnchor(null);
+        return;
+      }
+      const range = selection.getRangeAt(0);
+      const node = range.commonAncestorContainer;
+      const element = node instanceof Element ? node : node.parentElement;
+      // Only selections fully inside message content — not the composer, find
+      // bar, or this overlay's own toolbar/ask panel.
+      if (!element || !scroller.contains(element) || element.closest('[data-selection-ui]')) {
+        setAnchor(null);
+        return;
+      }
+      const text = selection.toString().trim();
+      if (!text) {
+        setAnchor(null);
+        return;
+      }
+      const rect = range.getBoundingClientRect();
+      const scrollerRect = scroller.getBoundingClientRect();
+      const center = Math.min(
+        Math.max(rect.left + rect.width / 2 - scrollerRect.left, TOOLBAR_HALF_WIDTH + EDGE_GAP),
+        Math.max(scroller.clientWidth - TOOLBAR_HALF_WIDTH - EDGE_GAP, TOOLBAR_HALF_WIDTH),
+      );
+      setAnchor({
+        text,
+        top: Math.max(rect.top - scrollerRect.top + scroller.scrollTop, TOOLBAR_CLEARANCE),
+        bottom: rect.bottom - scrollerRect.top + scroller.scrollTop,
+        center,
+        left: rect.left - scrollerRect.left,
+      });
+    };
+
+    // Selection is final by pointerup; keyboard selection settles on Shift release.
+    const handlePointerUp = () => evaluate();
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') evaluate();
+    };
+    const handleSelectionChange = () => {
+      const selection = document.getSelection();
+      if (!selection || selection.isCollapsed) setAnchor(null);
+    };
+    document.addEventListener('pointerup', handlePointerUp);
+    document.addEventListener('keyup', handleKeyUp);
+    document.addEventListener('selectionchange', handleSelectionChange);
+    return () => {
+      document.removeEventListener('pointerup', handlePointerUp);
+      document.removeEventListener('keyup', handleKeyUp);
+      document.removeEventListener('selectionchange', handleSelectionChange);
+    };
+  }, [chatId, scrollerRef]);
+
+  // Focus after the panel is in the DOM — keyed on nonce so re-asking from a
+  // new selection refocuses the remounted panel.
+  useLayoutEffect(() => {
+    if (ask) askInputRef.current?.focus();
+  }, [ask]);
+
+  const handleAddToChat = () => {
+    if (!chatId || !anchor) return;
+    useUIStore.getState().addComposerSelection(chatId, { kind: 'chat', text: anchor.text });
+    // Collapse so the chip is clear feedback and the toolbar doesn't linger.
+    document.getSelection()?.removeAllRanges();
+    setAnchor(null);
+  };
+
+  const handleAsk = () => {
+    if (!anchor) return;
+    const scroller = scrollerRef.current;
+    const width = Math.min(PANEL_WIDTH, window.innerWidth * PANEL_MAX_VIEWPORT_RATIO);
+    const maxLeft = scroller
+      ? Math.max(EDGE_GAP, scroller.clientWidth - width - EDGE_GAP)
+      : EDGE_GAP;
+    setAsk((prev) => ({
+      selection: { kind: 'chat', text: anchor.text },
+      top: anchor.bottom,
+      left: Math.min(Math.max(anchor.left, EDGE_GAP), maxLeft),
+      // Nonce remounts the panel so a new selection starts a fresh question/answer.
+      nonce: (prev?.nonce ?? 0) + 1,
+    }));
+    document.getSelection()?.removeAllRanges();
+    setAnchor(null);
+  };
+
+  if (!chatId) return null;
+
+  return (
+    <div className={styles['selection-layer']}>
+      {anchor && (
+        <div
+          className={styles.toolbar}
+          data-selection-ui
+          style={{ top: anchor.top, left: anchor.center }}
+          // Keep the click from collapsing the selection before it lands.
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          <Button
+            type="button"
+            variant="unstyled"
+            onClick={handleAddToChat}
+            className={styles.action}
+          >
+            <MessageSquarePlus className={styles['action-icon']} />
+            Add to chat
+          </Button>
+          <div className={styles.divider} />
+          <Button type="button" variant="unstyled" onClick={handleAsk} className={styles.action}>
+            <MessageCircleQuestion className={styles['action-icon']} />
+            Ask
+          </Button>
+        </div>
+      )}
+      {ask && (
+        <div
+          key={ask.nonce}
+          className={styles.ask}
+          data-selection-ui
+          style={{ top: ask.top, left: ask.left }}
+        >
+          <InlineAskPanel
+            chatId={chatId}
+            selection={ask.selection}
+            inputRef={askInputRef}
+            onClose={() => setAsk(null)}
+          />
+        </div>
+      )}
+    </div>
+  );
+});

--- a/frontend/src/components/chat/inline-ask/InlineAskPanel.module.scss
+++ b/frontend/src/components/chat/inline-ask/InlineAskPanel.module.scss
@@ -3,7 +3,7 @@
 @use '@/styles/globals/animations' as anim;
 @use '@/styles/globals/responsive' as responsive;
 
-.inline-chat {
+.inline-ask {
   // Fixed panel width — never rescales, so px is intentional here.
   width: 440px;
   max-width: 80vw;
@@ -15,7 +15,7 @@
   backdrop-filter: blur(24px);
 }
 
-.inline-chat-header {
+.inline-ask-header {
   display: flex;
   height: var(--space-9);
   align-items: center;
@@ -24,7 +24,7 @@
   padding-inline: var(--space-3);
 }
 
-.inline-chat-location {
+.inline-ask-location {
   @include type.type-mono-meta;
   @include type.type-overflow;
   min-width: 0;
@@ -32,7 +32,7 @@
   color: var(--theme-text-tertiary);
 }
 
-.inline-chat-close {
+.inline-ask-close {
   @include anim.transition-colors;
   color: var(--theme-text-tertiary);
 
@@ -46,14 +46,14 @@
   width: var(--space-3);
 }
 
-.inline-chat-form {
+.inline-ask-form {
   display: flex;
   align-items: center;
   gap: var(--space-1);
   padding: var(--space-1-5) var(--space-2);
 }
 
-.inline-chat-input {
+.inline-ask-input {
   @include type.type-body;
   max-height: var(--space-24);
   flex: 1;
@@ -67,7 +67,7 @@
   }
 }
 
-.inline-chat-submit {
+.inline-ask-submit {
   @include anim.transition-colors;
   border-radius: var(--radius-md);
   padding: var(--space-1-5);
@@ -83,12 +83,12 @@
   }
 }
 
-.inline-chat-submit-icon {
+.inline-ask-submit-icon {
   height: var(--space-3-5);
   width: var(--space-3-5);
 }
 
-.inline-chat-result {
+.inline-ask-result {
   max-height: var(--space-72);
   overflow-y: auto;
   border-top: 1px solid colors.theme-color('border', 0.5);
@@ -97,7 +97,7 @@
   padding: var(--space-2) var(--space-3);
 }
 
-.inline-chat-status {
+.inline-ask-status {
   @include type.type-default;
   display: flex;
   align-items: center;
@@ -106,14 +106,14 @@
   color: var(--theme-text-tertiary);
 }
 
-.inline-chat-spinner {
+.inline-ask-spinner {
   height: var(--space-3);
   width: var(--space-3);
   color: var(--theme-text-quaternary);
   animation: spin 1s linear infinite;
 }
 
-.inline-chat-error {
+.inline-ask-error {
   @include type.type-default;
   color: var(--theme-error-text);
 }

--- a/frontend/src/components/chat/inline-ask/InlineAskPanel.tsx
+++ b/frontend/src/components/chat/inline-ask/InlineAskPanel.tsx
@@ -1,0 +1,131 @@
+import { useState, type RefObject } from 'react';
+import { CornerDownLeft, Loader2, X } from 'lucide-react';
+import { MarkDown } from '@/components/ui/markdown/MarkDown';
+import { Button } from '@/components/ui/primitives/Button/Button';
+import { Textarea } from '@/components/ui/primitives/Textarea/Textarea';
+import { ModelSelector } from '@/components/chat/model-selector/ModelSelector';
+import { useAskAboutCodeMutation } from '@/hooks/queries/useChatQueries';
+import { useChatSessionState } from '@/hooks/useChatSessionContext';
+import type { ComposerSelection } from '@/store/uiStore';
+import styles from './InlineAskPanel.module.scss';
+
+interface InlineAskPanelProps {
+  chatId: string;
+  selection: ComposerSelection;
+  // Owned by the host: Monaco attaches the portal node synchronously and the
+  // chat overlay mounts inline, so each decides when focusing can succeed.
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  onClose: () => void;
+}
+
+// One-off ask panel over a selection — hosted by the editor's Monaco content
+// widget and the chat page's selection overlay.
+export function InlineAskPanel({ chatId, selection, inputRef, onClose }: InlineAskPanelProps) {
+  const [question, setQuestion] = useState('');
+  const { selectedModelId } = useChatSessionState();
+  // Panel-local override falling back to the composer selection (which may
+  // resolve after mount) — picking here shouldn't retarget the main chat.
+  const [modelId, setModelId] = useState('');
+  const effectiveModelId = modelId || selectedModelId;
+  const askMutation = useAskAboutCodeMutation();
+
+  const handleSubmit = () => {
+    const trimmed = question.trim();
+    if (!trimmed || !effectiveModelId || askMutation.isPending) return;
+    askMutation.mutate({ chatId, selection, question: trimmed, modelId: effectiveModelId });
+  };
+
+  const isChatText = 'kind' in selection;
+  const location = isChatText
+    ? 'Selection'
+    : `${selection.path}:${
+        selection.startLine === selection.endLine
+          ? selection.startLine
+          : `${selection.startLine}-${selection.endLine}`
+      }`;
+  const hasResult = askMutation.isPending || askMutation.isError || askMutation.data != null;
+
+  return (
+    <div
+      className={styles['inline-ask']}
+      onKeyDown={(e) => {
+        // Keep panel keys from falling through to the host (Monaco keybindings,
+        // chat-page shortcuts).
+        e.stopPropagation();
+        // defaultPrevented = a descendant already consumed Escape (the model
+        // dropdown's search closes itself) — don't also close the panel.
+        if (e.key === 'Escape' && !e.defaultPrevented) onClose();
+      }}
+    >
+      <div className={styles['inline-ask-header']}>
+        <span className={styles['inline-ask-location']}>{location}</span>
+        <ModelSelector
+          selectedModelId={effectiveModelId}
+          onModelChange={setModelId}
+          dropdownPosition="bottom"
+          dropdownAlign="right"
+          compact={false}
+        />
+        <Button
+          type="button"
+          variant="unstyled"
+          onClick={onClose}
+          aria-label="Close inline ask"
+          className={styles['inline-ask-close']}
+        >
+          <X className={styles['icon-sm']} />
+        </Button>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+        className={styles['inline-ask-form']}
+      >
+        <Textarea
+          ref={inputRef}
+          variant="unstyled"
+          rows={1}
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              handleSubmit();
+            }
+          }}
+          placeholder={isChatText ? 'Ask about this selection…' : 'Ask about this code…'}
+          className={styles['inline-ask-input']}
+        />
+        <Button
+          type="submit"
+          variant="unstyled"
+          disabled={!question.trim() || !effectiveModelId || askMutation.isPending}
+          aria-label="Ask question"
+          className={styles['inline-ask-submit']}
+        >
+          <CornerDownLeft className={styles['inline-ask-submit-icon']} />
+        </Button>
+      </form>
+
+      {hasResult && (
+        <div className={styles['inline-ask-result']}>
+          {askMutation.isPending && (
+            <div className={styles['inline-ask-status']}>
+              <Loader2 className={styles['inline-ask-spinner']} />
+              Thinking…
+            </div>
+          )}
+          {askMutation.isError && (
+            <div className={styles['inline-ask-error']}>{askMutation.error.message}</div>
+          )}
+          {!askMutation.isPending && askMutation.data != null && (
+            <MarkDown content={askMutation.data} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/chat/message-input/InputContext.ts
+++ b/frontend/src/components/chat/message-input/InputContext.ts
@@ -1,6 +1,6 @@
 import { createContext, type RefObject } from 'react';
 import type { MentionItem, SlashCommand } from '@/types/ui.types';
-import type { EditorCodeSelection } from '@/store/uiStore';
+import type { ComposerSelection } from '@/store/uiStore';
 import type { ContextUsageInfo } from './ContextUsageIndicator';
 
 export interface InputState {
@@ -24,7 +24,7 @@ export interface InputState {
   selectedModelId: string;
   dropdownPosition: 'top' | 'bottom';
   attachedFiles: File[] | null;
-  attachedSelections: EditorCodeSelection[];
+  attachedSelections: ComposerSelection[];
   previewUrls: string[];
   editingImageIndex: number | null;
   contextUsage?: ContextUsageInfo;

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useMemo, type ReactNode } from 'react';
 import { useAuthStore } from '@/store/authStore';
-import { useUIStore, type EditorCodeSelection } from '@/store/uiStore';
+import { useUIStore, type ComposerSelection } from '@/store/uiStore';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
 import { useChatContext } from '@/hooks/useChatContext';
 import { useInputAttachments } from '@/hooks/useInputAttachments';
@@ -29,7 +29,7 @@ const AGENTS_WITHOUT_USAGE_UPDATE: ReadonlySet<AgentKind> = new Set([
 ]);
 
 // Stable fallback so chat-less composers (landing page) don't churn the selector.
-const NO_SELECTIONS: EditorCodeSelection[] = [];
+const NO_SELECTIONS: ComposerSelection[] = [];
 
 export function InputProvider({
   message,
@@ -64,7 +64,7 @@ export function InputProvider({
   // the bar is misleading.
   const visibleContextUsage = AGENTS_WITHOUT_USAGE_UPDATE.has(agentKind) ? undefined : contextUsage;
   const storedSelections = useUIStore((s) =>
-    chatId ? s.editorSelectionsByChat[chatId] : undefined,
+    chatId ? s.composerSelectionsByChat[chatId] : undefined,
   );
   const attachedSelections = storedSelections ?? NO_SELECTIONS;
 

--- a/frontend/src/components/chat/message-input/SelectionAttachments.module.scss
+++ b/frontend/src/components/chat/message-input/SelectionAttachments.module.scss
@@ -30,6 +30,12 @@
   color: var(--theme-text-secondary);
 }
 
+// Chat-text selections have no short path:line label — truncate the raw text.
+.label--text {
+  @include type.type-overflow;
+  max-width: var(--space-48);
+}
+
 .remove {
   @include anim.transition-colors;
   // TODO(refactor): bare `rounded` (4px) has no exact token — using sm

--- a/frontend/src/components/chat/message-input/SelectionAttachments.tsx
+++ b/frontend/src/components/chat/message-input/SelectionAttachments.tsx
@@ -1,14 +1,15 @@
 import { memo } from 'react';
-import { X } from 'lucide-react';
+import clsx from 'clsx';
+import { TextQuote, X } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip/FloatingTooltip';
 import { FileIcon } from '@/components/ui/shared/FileIcon/FileIcon';
 import { getFileName } from '@/utils/file';
-import type { EditorCodeSelection } from '@/store/uiStore';
+import type { ComposerSelection } from '@/store/uiStore';
 import styles from './SelectionAttachments.module.scss';
 
 interface SelectionAttachmentsProps {
-  selections: EditorCodeSelection[];
+  selections: ComposerSelection[];
   onRemove: (index: number) => void;
 }
 
@@ -20,31 +21,49 @@ export const SelectionAttachments = memo(function SelectionAttachments({
 
   return (
     <div className={styles['selection-attachments']}>
-      {selections.map((selection, index) => (
-        <FloatingTooltip
-          // Duplicate chips of the same range are allowed, so the index keys them apart.
-          key={`${selection.path}:${selection.startLine}:${index}`}
-          content={selection.comment ? `${selection.path}\n\n${selection.comment}` : selection.path}
-          className={styles.chip}
-        >
-          <FileIcon name={getFileName(selection.path)} className={styles['file-icon']} />
-          <span className={styles.label}>
-            {getFileName(selection.path)}:
-            {selection.startLine === selection.endLine
-              ? selection.startLine
-              : `${selection.startLine}-${selection.endLine}`}
-          </span>
-          <Button
-            type="button"
-            variant="unstyled"
-            onClick={() => onRemove(index)}
-            className={styles.remove}
-            aria-label="Remove code selection"
+      {selections.map((selection, index) => {
+        const isChatText = 'kind' in selection;
+        return (
+          <FloatingTooltip
+            // Duplicate chips of the same range are allowed, so the index keys them apart.
+            key={isChatText ? `chat:${index}` : `${selection.path}:${selection.startLine}:${index}`}
+            content={
+              isChatText
+                ? selection.text
+                : selection.comment
+                  ? `${selection.path}\n\n${selection.comment}`
+                  : selection.path
+            }
+            className={styles.chip}
           >
-            <X className={styles['remove-icon']} />
-          </Button>
-        </FloatingTooltip>
-      ))}
+            {isChatText ? (
+              <>
+                <TextQuote className={styles['file-icon']} />
+                <span className={clsx(styles.label, styles['label--text'])}>{selection.text}</span>
+              </>
+            ) : (
+              <>
+                <FileIcon name={getFileName(selection.path)} className={styles['file-icon']} />
+                <span className={styles.label}>
+                  {getFileName(selection.path)}:
+                  {selection.startLine === selection.endLine
+                    ? selection.startLine
+                    : `${selection.startLine}-${selection.endLine}`}
+                </span>
+              </>
+            )}
+            <Button
+              type="button"
+              variant="unstyled"
+              onClick={() => onRemove(index)}
+              className={styles.remove}
+              aria-label="Remove selection"
+            >
+              <X className={styles['remove-icon']} />
+            </Button>
+          </FloatingTooltip>
+        );
+      })}
     </div>
   );
 });

--- a/frontend/src/components/editor/editor-view/InlineChatWidget.tsx
+++ b/frontend/src/components/editor/editor-view/InlineChatWidget.tsx
@@ -1,15 +1,8 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { CornerDownLeft, Loader2, X } from 'lucide-react';
 import type * as monacoNs from 'monaco-editor';
-import { MarkDown } from '@/components/ui/markdown/MarkDown';
-import { Button } from '@/components/ui/primitives/Button/Button';
-import { Textarea } from '@/components/ui/primitives/Textarea/Textarea';
-import { ModelSelector } from '@/components/chat/model-selector/ModelSelector';
-import { useAskAboutCodeMutation } from '@/hooks/queries/useChatQueries';
-import { useChatSessionState } from '@/hooks/useChatSessionContext';
+import { InlineAskPanel } from '@/components/chat/inline-ask/InlineAskPanel';
 import type { EditorCodeSelection } from '@/store/uiStore';
-import styles from './InlineChatWidget.module.scss';
 
 type Monaco = typeof import('monaco-editor');
 
@@ -32,13 +25,6 @@ export function InlineChatWidget({
   // portals the panel into this node so it stays inside the provider tree.
   const [widgetNode] = useState(() => document.createElement('div'));
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const [question, setQuestion] = useState('');
-  const { selectedModelId } = useChatSessionState();
-  // Widget-local override falling back to the composer selection (which may
-  // resolve after mount) — picking here shouldn't retarget the main chat.
-  const [modelId, setModelId] = useState('');
-  const effectiveModelId = modelId || selectedModelId;
-  const askMutation = useAskAboutCodeMutation();
 
   useLayoutEffect(() => {
     const widget: monacoNs.editor.IContentWidget = {
@@ -77,101 +63,13 @@ export function InlineChatWidget({
     editor.focus();
   };
 
-  const handleSubmit = () => {
-    const trimmed = question.trim();
-    if (!trimmed || !effectiveModelId || askMutation.isPending) return;
-    askMutation.mutate({ chatId, selection, question: trimmed, modelId: effectiveModelId });
-  };
-
-  const lineRef =
-    selection.startLine === selection.endLine
-      ? `${selection.startLine}`
-      : `${selection.startLine}-${selection.endLine}`;
-  const hasResult = askMutation.isPending || askMutation.isError || askMutation.data != null;
-
   return createPortal(
-    <div
-      className={styles['inline-chat']}
-      onKeyDown={(e) => {
-        // Keep widget keys from falling through to Monaco's keybinding service.
-        e.stopPropagation();
-        // defaultPrevented = a descendant already consumed Escape (the model
-        // dropdown's search closes itself) — don't also close the widget.
-        if (e.key === 'Escape' && !e.defaultPrevented) handleClose();
-      }}
-    >
-      <div className={styles['inline-chat-header']}>
-        <span className={styles['inline-chat-location']}>
-          {selection.path}:{lineRef}
-        </span>
-        <ModelSelector
-          selectedModelId={effectiveModelId}
-          onModelChange={setModelId}
-          dropdownPosition="bottom"
-          dropdownAlign="right"
-          compact={false}
-        />
-        <Button
-          type="button"
-          variant="unstyled"
-          onClick={handleClose}
-          aria-label="Close inline chat"
-          className={styles['inline-chat-close']}
-        >
-          <X className={styles['icon-sm']} />
-        </Button>
-      </div>
-
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          handleSubmit();
-        }}
-        className={styles['inline-chat-form']}
-      >
-        <Textarea
-          ref={textareaRef}
-          variant="unstyled"
-          rows={1}
-          value={question}
-          onChange={(e) => setQuestion(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              handleSubmit();
-            }
-          }}
-          placeholder="Ask about this code…"
-          className={styles['inline-chat-input']}
-        />
-        <Button
-          type="submit"
-          variant="unstyled"
-          disabled={!question.trim() || !effectiveModelId || askMutation.isPending}
-          aria-label="Ask question"
-          className={styles['inline-chat-submit']}
-        >
-          <CornerDownLeft className={styles['inline-chat-submit-icon']} />
-        </Button>
-      </form>
-
-      {hasResult && (
-        <div className={styles['inline-chat-result']}>
-          {askMutation.isPending && (
-            <div className={styles['inline-chat-status']}>
-              <Loader2 className={styles['inline-chat-spinner']} />
-              Thinking…
-            </div>
-          )}
-          {askMutation.isError && (
-            <div className={styles['inline-chat-error']}>{askMutation.error.message}</div>
-          )}
-          {!askMutation.isPending && askMutation.data != null && (
-            <MarkDown content={askMutation.data} />
-          )}
-        </div>
-      )}
-    </div>,
+    <InlineAskPanel
+      chatId={chatId}
+      selection={selection}
+      inputRef={textareaRef}
+      onClose={handleClose}
+    />,
     widgetNode,
   );
 }

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -15,7 +15,7 @@ import type {
 import { chatService } from '@/services/chatService';
 import { isCloudChat } from '@/utils/chatOrigin';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
-import { useUIStore, type EditorCodeSelection } from '@/store/uiStore';
+import { useUIStore, type ComposerSelection } from '@/store/uiStore';
 import type { Chat, ChatSearchResponse, ContextUsage, CreateChatRequest } from '@/types/chat.types';
 import type { PaginatedChats } from '@/types/api.types';
 import { logger } from '@/utils/logger';
@@ -399,7 +399,7 @@ export const useEnhancePromptMutation = (
 
 interface AskAboutCodeParams {
   chatId: string;
-  selection: EditorCodeSelection;
+  selection: ComposerSelection;
   question: string;
   modelId: string;
 }

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -16,7 +16,7 @@ import { useStreamCallbacks } from '@/hooks/useStreamCallbacks';
 import { useStreamReconnect } from '@/hooks/useStreamReconnect';
 import { chatService } from '@/services/chatService';
 import { useUIStore } from '@/store/uiStore';
-import { formatEditorSelections } from '@/lib/editorChatActions';
+import { formatComposerSelections } from '@/utils/composerSelections';
 
 interface UseChatStreamingParams {
   chatId: string | undefined;
@@ -329,17 +329,19 @@ export function useChatStreaming({
       event.preventDefault();
       // Selection chips live in the UI store; serialize them into the prompt
       // only now so the visible input text stays clean while they're attached.
-      const selections = chatId ? (useUIStore.getState().editorSelectionsByChat[chatId] ?? []) : [];
+      const selections = chatId
+        ? (useUIStore.getState().composerSelectionsByChat[chatId] ?? [])
+        : [];
       const draftMessage = inputMessageRef.current;
       const draftFiles = inputFiles;
       // Clear optimistically — the send awaits a server round-trip (startStream),
       // and the draft would otherwise linger in the input bar until it resolves.
       clearInput();
       if (chatId && selections.length > 0) {
-        useUIStore.getState().clearEditorSelections(chatId);
+        useUIStore.getState().clearComposerSelections(chatId);
       }
       const result = await handleMessageSendAction(
-        formatEditorSelections(selections, draftMessage),
+        formatComposerSelections(selections, draftMessage),
         draftFiles,
       );
       if (!result?.success) {
@@ -347,7 +349,7 @@ export function useChatStreaming({
         setInputMessageWithRef(draftMessage);
         setInputFiles(draftFiles);
         if (chatId) {
-          selections.forEach((sel) => useUIStore.getState().addEditorSelection(chatId, sel));
+          selections.forEach((sel) => useUIStore.getState().addComposerSelection(chatId, sel));
         }
       }
     },

--- a/frontend/src/hooks/useDiffComments.ts
+++ b/frontend/src/hooks/useDiffComments.ts
@@ -45,7 +45,7 @@ export function useDiffComments(chatId: string | undefined, cwd: string | undefi
       // Attach even when snippet extraction comes up empty — losing the typed
       // comment is worse than an empty code block.
       const snippet = getSelectedDiffText(file, range);
-      useUIStore.getState().addEditorSelection(chatId, {
+      useUIStore.getState().addComposerSelection(chatId, {
         // Same workspace-root basis as "open in editor" and editor selections.
         path: cwd ? `${cwd}/${file.name}` : file.name,
         startLine: range.start,

--- a/frontend/src/hooks/useInputSubmit.ts
+++ b/frontend/src/hooks/useInputSubmit.ts
@@ -1,8 +1,8 @@
 import { useCallback, type RefObject } from 'react';
 import toast from 'react-hot-toast';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
-import { useUIStore, type EditorCodeSelection } from '@/store/uiStore';
-import { formatEditorSelections } from '@/lib/editorChatActions';
+import { useUIStore, type ComposerSelection } from '@/store/uiStore';
+import { formatComposerSelections } from '@/utils/composerSelections';
 import { coercePermissionModeForAgent } from '@/components/chat/permission-mode-selector/permissionModes';
 import { coerceThinkingModeForAgent } from '@/components/chat/thinking-mode-selector/thinkingModes';
 import {
@@ -29,7 +29,7 @@ interface UseInputSubmitOptions {
   selectedModelId: string;
   agentKind: AgentKind;
   personas: Persona[];
-  attachedSelections: EditorCodeSelection[];
+  attachedSelections: ComposerSelection[];
   attachedFiles: File[] | null;
   messageRef: RefObject<string>;
   setMessage: (value: string) => void;
@@ -105,7 +105,7 @@ export function useInputSubmit({
       const storedPersona = settings.personaByChat[chatId] ?? DEFAULT_PERSONA;
       const validPersona = resolvePersona(storedPersona, personas);
       // Queued messages are stored as plain text, so serialize chips here.
-      const fullMessage = formatEditorSelections(attachedSelections, messageRef.current.trim());
+      const fullMessage = formatComposerSelections(attachedSelections, messageRef.current.trim());
       void useMessageQueueStore
         .getState()
         .queueMessage(
@@ -120,7 +120,7 @@ export function useInputSubmit({
         );
       setMessage('');
       onAttach?.([]);
-      if (attachedSelections.length > 0) useUIStore.getState().clearEditorSelections(chatId);
+      if (attachedSelections.length > 0) useUIStore.getState().clearComposerSelections(chatId);
       setPreviewDismissed(true);
       return;
     }
@@ -164,7 +164,7 @@ export function useInputSubmit({
 
   const handleRemoveSelection = useCallback(
     (index: number) => {
-      if (chatId) useUIStore.getState().removeEditorSelection(chatId, index);
+      if (chatId) useUIStore.getState().removeComposerSelection(chatId, index);
     },
     [chatId],
   );

--- a/frontend/src/lib/editorChatActions.ts
+++ b/frontend/src/lib/editorChatActions.ts
@@ -4,8 +4,6 @@ import { useUIStore, type EditorCodeSelection } from '@/store/uiStore';
 
 type Monaco = typeof import('monaco-editor');
 
-const BACKTICK_RUN = /`+/g;
-
 function getSelectionSnippet(ed: monacoNs.editor.ICodeEditor): EditorCodeSelection | null {
   const selection = ed.getSelection();
   const model = ed.getModel();
@@ -48,7 +46,7 @@ export function attachAddSelectionToChat(
       const snippet = getSelectionSnippet(ed);
       const { chatId } = context;
       if (!snippet || !chatId) return;
-      useUIStore.getState().addEditorSelection(chatId, snippet);
+      useUIStore.getState().addComposerSelection(chatId, snippet);
     },
   });
 }
@@ -73,20 +71,4 @@ export function attachAskAboutSelection(
       onOpen(snippet);
     },
   });
-}
-
-export function formatEditorSelections(selections: EditorCodeSelection[], message: string): string {
-  // Chips are UI-only; at send time the code rides in the prompt as fenced
-  // blocks above the user's text.
-  const blocks = selections.map((s) => {
-    const lineRef = s.startLine === s.endLine ? `${s.startLine}` : `${s.startLine}-${s.endLine}`;
-    // Snippets can contain ``` (Markdown, nested fences) which would close a
-    // bare fence early — use one longer than the longest run in the text.
-    const longestRun =
-      s.text.match(BACKTICK_RUN)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
-    const fence = '`'.repeat(Math.max(3, longestRun + 1));
-    const block = `${s.path}:${lineRef}\n${fence}${s.languageId}\n${s.text}\n${fence}`;
-    return s.comment ? `${block}\n${s.comment}` : block;
-  });
-  return [...blocks, message].filter(Boolean).join('\n\n');
 }

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -13,7 +13,7 @@ import type {
 import type { ActiveStreamSnapshot } from '@/types/stream.types';
 import type { GitCommitResult } from '@/types/sandbox.types';
 import type { CursorPaginationParams, PaginatedChats, PaginatedMessages } from '@/types/api.types';
-import type { EditorCodeSelection } from '@/store/uiStore';
+import type { ComposerSelection } from '@/store/uiStore';
 
 export function buildChatFormData(request: ChatRequest): FormData {
   // Single encoding of the /chat/chat multipart contract — shared with
@@ -320,7 +320,7 @@ async function enhancePrompt(prompt: string, modelId: string): Promise<string> {
 
 async function askAboutCode(
   chatId: string,
-  selection: EditorCodeSelection,
+  selection: ComposerSelection,
   question: string,
   modelId: string,
 ): Promise<string> {
@@ -329,16 +329,23 @@ async function askAboutCode(
   validateRequired(modelId, 'Model ID');
 
   return serviceCall(async () => {
+    // Chat-text selections have no file identity — the location fields stay unset.
+    const location =
+      'kind' in selection
+        ? {}
+        : {
+            file_path: selection.path,
+            language: selection.languageId,
+            start_line: selection.startLine,
+            end_line: selection.endLine,
+          };
     const response = await resolveChatClient(chatId).post<{ answer: string }>(
       `/chat/chats/${chatId}/ask-code`,
       {
         question,
         code: selection.text,
-        file_path: selection.path,
-        language: selection.languageId,
-        start_line: selection.startLine,
-        end_line: selection.endLine,
         model_id: modelId,
+        ...location,
       },
     );
 

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -47,6 +47,14 @@ export interface EditorCodeSelection {
   comment?: string;
 }
 
+// Text selected from rendered chat messages — no file/line identity.
+export interface ChatTextSelection {
+  kind: 'chat';
+  text: string;
+}
+
+export type ComposerSelection = EditorCodeSelection | ChatTextSelection;
+
 type UIStoreState = ThemeState &
   Pick<UIState, 'sidebarOpen' | 'sidebarWidth'> &
   Pick<UIActions, 'setSidebarOpen' | 'setSidebarWidth'> &
@@ -77,12 +85,13 @@ type UIStoreState = ThemeState &
     openFileInEditor: (path: string, chatId: string | undefined, line?: number) => void;
     pendingChatMessage: { chatId: string; message: string } | null;
     setPendingChatMessage: (payload: { chatId: string; message: string } | null) => void;
-    // Code snippets attached to a chat's input as removable chips (VS Code
-    // "add selection to chat") — serialized into the prompt only at send time.
-    editorSelectionsByChat: Record<string, EditorCodeSelection[]>;
-    addEditorSelection: (chatId: string, selection: EditorCodeSelection) => void;
-    removeEditorSelection: (chatId: string, index: number) => void;
-    clearEditorSelections: (chatId: string) => void;
+    // Editor snippets / chat-text selections attached to a chat's input as
+    // removable chips (VS Code "add selection to chat") — serialized into the
+    // prompt only at send time.
+    composerSelectionsByChat: Record<string, ComposerSelection[]>;
+    addComposerSelection: (chatId: string, selection: ComposerSelection) => void;
+    removeComposerSelection: (chatId: string, index: number) => void;
+    clearComposerSelections: (chatId: string) => void;
     // Sandbox of the workspace selected on the landing page. Lets context-less
     // consumers (the global git shortcuts) resolve a target before a chat exists.
     workspaceSandboxId: string | null;
@@ -193,24 +202,24 @@ export const useUIStore = create<UIStoreState>()(
       pendingChatMessage: null,
       setPendingChatMessage: (payload) => set({ pendingChatMessage: payload }),
 
-      editorSelectionsByChat: {},
-      addEditorSelection: (chatId, selection) =>
+      composerSelectionsByChat: {},
+      addComposerSelection: (chatId, selection) =>
         set((state) => ({
-          editorSelectionsByChat: {
-            ...state.editorSelectionsByChat,
-            [chatId]: [...(state.editorSelectionsByChat[chatId] ?? []), selection],
+          composerSelectionsByChat: {
+            ...state.composerSelectionsByChat,
+            [chatId]: [...(state.composerSelectionsByChat[chatId] ?? []), selection],
           },
         })),
-      removeEditorSelection: (chatId, index) =>
+      removeComposerSelection: (chatId, index) =>
         set((state) => ({
-          editorSelectionsByChat: {
-            ...state.editorSelectionsByChat,
-            [chatId]: (state.editorSelectionsByChat[chatId] ?? []).filter((_, i) => i !== index),
+          composerSelectionsByChat: {
+            ...state.composerSelectionsByChat,
+            [chatId]: (state.composerSelectionsByChat[chatId] ?? []).filter((_, i) => i !== index),
           },
         })),
-      clearEditorSelections: (chatId) =>
+      clearComposerSelections: (chatId) =>
         set((state) => ({
-          editorSelectionsByChat: { ...state.editorSelectionsByChat, [chatId]: [] },
+          composerSelectionsByChat: { ...state.composerSelectionsByChat, [chatId]: [] },
         })),
 
       workspaceSandboxId: null,

--- a/frontend/src/utils/composerSelections.test.ts
+++ b/frontend/src/utils/composerSelections.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { formatComposerSelections } from './composerSelections';
+import type { ChatTextSelection, EditorCodeSelection } from '@/store/uiStore';
+
+const editorSelection = (over: Partial<EditorCodeSelection> = {}): EditorCodeSelection => ({
+  path: 'src/app.ts',
+  startLine: 3,
+  endLine: 5,
+  languageId: 'typescript',
+  text: 'const a = 1;',
+  ...over,
+});
+
+const chatSelection = (text: string): ChatTextSelection => ({ kind: 'chat', text });
+
+describe('formatComposerSelections', () => {
+  it('returns the bare message when there are no selections', () => {
+    expect(formatComposerSelections([], 'hello')).toBe('hello');
+  });
+
+  it('serializes an editor selection as a fenced block headed by path:range', () => {
+    expect(formatComposerSelections([editorSelection()], 'why?')).toBe(
+      'src/app.ts:3-5\n```typescript\nconst a = 1;\n```\n\nwhy?',
+    );
+  });
+
+  it('collapses single-line ranges to one line number', () => {
+    const result = formatComposerSelections([editorSelection({ startLine: 7, endLine: 7 })], 'q');
+    expect(result.startsWith('src/app.ts:7\n')).toBe(true);
+  });
+
+  it('appends a diff-review comment under the code block', () => {
+    const result = formatComposerSelections([editorSelection({ comment: 'looks wrong' })], '');
+    expect(result).toBe('src/app.ts:3-5\n```typescript\nconst a = 1;\n```\nlooks wrong');
+  });
+
+  it('serializes a chat-text selection as a labeled fenced block without a language', () => {
+    expect(formatComposerSelections([chatSelection('the deploy failed')], 'summarize')).toBe(
+      'Selected from our conversation:\n```\nthe deploy failed\n```\n\nsummarize',
+    );
+  });
+
+  it('lengthens the fence past backtick runs inside the selection', () => {
+    const result = formatComposerSelections([chatSelection('use ```js\ncode\n``` here')], '');
+    expect(result).toBe('Selected from our conversation:\n````\nuse ```js\ncode\n``` here\n````');
+  });
+
+  it('joins multiple selections of both kinds above the message', () => {
+    const result = formatComposerSelections(
+      [editorSelection(), chatSelection('quoted text')],
+      'compare these',
+    );
+    expect(result).toBe(
+      'src/app.ts:3-5\n```typescript\nconst a = 1;\n```\n\n' +
+        'Selected from our conversation:\n```\nquoted text\n```\n\n' +
+        'compare these',
+    );
+  });
+});

--- a/frontend/src/utils/composerSelections.ts
+++ b/frontend/src/utils/composerSelections.ts
@@ -2,10 +2,7 @@ import type { ComposerSelection } from '@/store/uiStore';
 
 const BACKTICK_RUN = /`+/g;
 
-export function formatComposerSelections(
-  selections: ComposerSelection[],
-  message: string,
-): string {
+export function formatComposerSelections(selections: ComposerSelection[], message: string): string {
   // Chips are UI-only; at send time the selections ride in the prompt as
   // fenced blocks above the user's text.
   const blocks = selections.map((s) => {

--- a/frontend/src/utils/composerSelections.ts
+++ b/frontend/src/utils/composerSelections.ts
@@ -1,0 +1,25 @@
+import type { ComposerSelection } from '@/store/uiStore';
+
+const BACKTICK_RUN = /`+/g;
+
+export function formatComposerSelections(
+  selections: ComposerSelection[],
+  message: string,
+): string {
+  // Chips are UI-only; at send time the selections ride in the prompt as
+  // fenced blocks above the user's text.
+  const blocks = selections.map((s) => {
+    // Snippets can contain ``` (Markdown, nested fences) which would close a
+    // bare fence early — use one longer than the longest run in the text.
+    const longestRun =
+      s.text.match(BACKTICK_RUN)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+    const fence = '`'.repeat(Math.max(3, longestRun + 1));
+    if ('kind' in s) {
+      return `Selected from our conversation:\n${fence}\n${s.text}\n${fence}`;
+    }
+    const lineRef = s.startLine === s.endLine ? `${s.startLine}` : `${s.startLine}-${s.endLine}`;
+    const block = `${s.path}:${lineRef}\n${fence}${s.languageId}\n${s.text}\n${fence}`;
+    return s.comment ? `${block}\n${s.comment}` : block;
+  });
+  return [...blocks, message].filter(Boolean).join('\n\n');
+}


### PR DESCRIPTION
## Summary
- Extend the existing editor "add selection to chat" / "ask about selection" actions to text selected within rendered chat messages — a floating toolbar (Add to chat / Ask) now appears over selections inside the chat window (`ChatSelectionActions`).
- Generalize `EditorCodeSelection` into a `ComposerSelection` union (`EditorCodeSelection | ChatTextSelection`) throughout the composer/store/services, since chat-text selections have no file/line identity.
- Extract the ask UI shared by the editor widget and the new chat-selection flow into `InlineAskPanel`, replacing the inline markup that used to live in `InlineChatWidget`.
- Backend: `ask-code` now accepts an optional `file_path`/`language`/`start_line`/`end_line`, and prompts a "Selected text from the conversation" header when they're absent instead of assuming a file selection.

## Test plan
- [x] Backend: `backend/tests/test_chat.py` covers the ask-code endpoint with omitted location fields (chat-text selection path)
- [x] Manual: select text in a chat message, verify "Add to chat" attaches a chip and "Ask" opens the panel and answers correctly
- [x] Manual: verify editor code selections still work unchanged (add to chat, ask about code)