### PR TITLE
fix: restore SCSS module animations after Tailwind migration

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -161,7 +161,7 @@ Reference implementations: `ui/primitives/Button` (variants/sizes via BEM modifi
 | `_typography.scss`    | `type-meta/default/body/large/title/page-title/section-header/mono` + `type-overflow`, `type-lineclamp($n)`, `type-noselect` | ALL font sizing                         |
 | `_responsive.scss`    | `media($query)`, `hover`, `active`, `hide`, `show`                                                                           | ALL breakpoints + hover/active          |
 | `_elevation.scss`     | `--radius-*`, `--shadow-sm/medium/strong/inset`                                                                              | ALL radius/shadows                      |
-| `_animations.scss`    | `--duration-*`, `--easing-*`, global keyframes, `transition-colors`                                                          | ALL motion                              |
+| `_animations.scss`    | `--duration-*`, `--easing-*`, animation mixins (`spin`, `pulse`, `fade-in`, ...), `transition-colors`                        | ALL motion                              |
 | `_zlayer.scss`        | `z($layer)` (`raised/sticky/sidebar/titlebar/dropdown/modal/command-menu/tooltip/toast`)                                     | ALL z-index                             |
 | `_state-classes.scss` | `$state-*` names (mirrored in `src/config/stateClasses.ts` — keep in sync)                                                   | JS-driven state styling                 |
 | `_controls.scss`      | `focus-ring`, `button-base/size/variant`, `input-base/error`                                                                 | new controls (prefer primitives)        |
@@ -213,7 +213,7 @@ token and leave a `// TODO(refactor):` comment — don't invent new global token
 
 ### Animations & Transitions
 
-- Global keyframes live in `_animations.scss` (`fade-in`, `fade-in-up`, `spin`, `pulse`, `shimmer`, ...) — no framer-motion or other JS animation libs
+- Animate via the `_animations.scss` mixins (`anim.fade-in`, `anim.spin`, `anim.pulse`, ...) — they emit module-local keyframes (CSS modules hash bare names); no framer-motion or other JS animation libs
 - `@include anim.transition-colors;` for hover/focus; durations/easings only via `--duration-*` / `--easing-*` vars
 - Loading: `spin` for circular spinners only; `pulse` for non-circular loading icons and skeletons
 - Delay-reveal loading indicators for data that usually resolves fast (opacity 0 + `animationDelay` ~300ms + explicit `animationFillMode: 'forwards'`) so fast loads render nothing (see `ListManagementTab`)

--- a/frontend/src/components/chat/chat-search/ChatSearchPanel.module.scss
+++ b/frontend/src/components/chat/chat-search/ChatSearchPanel.module.scss
@@ -105,9 +105,9 @@
 }
 
 .spin-icon {
+  @include anim.spin;
   height: var(--space-3);
   width: var(--space-3);
-  animation: spin 1s linear infinite;
 }
 
 .error-message {

--- a/frontend/src/components/chat/chat-window/ChatSelectionActions.module.scss
+++ b/frontend/src/components/chat/chat-window/ChatSelectionActions.module.scss
@@ -14,6 +14,7 @@
 
 .toolbar {
   @include z.z('raised');
+  @include anim.fade-in(var(--duration-fast));
   position: absolute;
   display: flex;
   align-items: center;
@@ -27,7 +28,6 @@
   pointer-events: auto;
   // Sit centered above the selection with a small gap.
   transform: translate(-50%, calc(-100% - var(--space-1-5)));
-  animation: fade-in var(--duration-fast) var(--easing-out);
 }
 
 .action {

--- a/frontend/src/components/chat/chat-window/ChatSkeleton.module.scss
+++ b/frontend/src/components/chat/chat-window/ChatSkeleton.module.scss
@@ -1,4 +1,5 @@
 @use '@/styles/globals/responsive' as responsive;
+@use '@/styles/globals/animations' as anim;
 
 .chat-skeleton {
   margin-left: auto;
@@ -38,7 +39,7 @@
 
 // Shared pulsing placeholder fill — light surface-hover, dark surface-tertiary
 .pulse-block {
-  animation: pulse 2s var(--easing-in-out) infinite;
+  @include anim.pulse;
   background-color: var(--theme-surface-hover);
 
   :global([data-theme='dark']) & {

--- a/frontend/src/components/chat/chat-window/QueueMessageCard.module.scss
+++ b/frontend/src/components/chat/chat-window/QueueMessageCard.module.scss
@@ -74,11 +74,11 @@
 }
 
 .thumb-loading {
+  @include anim.pulse;
   height: var(--space-3);
   width: var(--space-3);
   border-radius: var(--radius-full);
   background-color: var(--theme-text-quaternary);
-  animation: pulse 2s var(--easing-in-out) infinite;
 }
 
 .thumb-error {

--- a/frontend/src/components/chat/chat-window/StatusTypewriter.module.scss
+++ b/frontend/src/components/chat/chat-window/StatusTypewriter.module.scss
@@ -34,7 +34,7 @@
   background-color: var(--theme-text-tertiary);
 
   &--blinking {
-    animation: caret-blink 1.1s step-end infinite;
+    @include anim.caret-blink;
   }
 }
 

--- a/frontend/src/components/chat/github/CreateCommitDialog.module.scss
+++ b/frontend/src/components/chat/github/CreateCommitDialog.module.scss
@@ -85,7 +85,7 @@
   width: var(--space-3);
 
   &--pulsing {
-    animation: pulse 2s var(--easing-in-out) infinite;
+    @include anim.pulse;
   }
 }
 

--- a/frontend/src/components/chat/github/CreatePRDialog.module.scss
+++ b/frontend/src/components/chat/github/CreatePRDialog.module.scss
@@ -115,7 +115,7 @@
   width: var(--space-3);
 
   &--pulsing {
-    animation: pulse 2s var(--easing-in-out) infinite;
+    @include anim.pulse;
   }
 }
 

--- a/frontend/src/components/chat/inline-ask/InlineAskPanel.module.scss
+++ b/frontend/src/components/chat/inline-ask/InlineAskPanel.module.scss
@@ -107,10 +107,10 @@
 }
 
 .inline-ask-spinner {
+  @include anim.spin;
   height: var(--space-3);
   width: var(--space-3);
   color: var(--theme-text-quaternary);
-  animation: spin 1s linear infinite;
 }
 
 .inline-ask-error {

--- a/frontend/src/components/chat/message-bubble/ThinkingBlock.module.scss
+++ b/frontend/src/components/chat/message-bubble/ThinkingBlock.module.scss
@@ -33,11 +33,11 @@
 }
 
 .thinking-dot {
+  @include anim.bounce;
   height: var(--space-0-5);
   width: var(--space-0-5);
   border-radius: var(--radius-full);
   background-color: var(--theme-text-quaternary);
-  animation: bounce 1s infinite;
 }
 
 .thinking-preview {

--- a/frontend/src/components/chat/message-input/DropIndicator.module.scss
+++ b/frontend/src/components/chat/message-input/DropIndicator.module.scss
@@ -31,12 +31,12 @@
 }
 
 .glow {
+  @include anim.pulse;
   position: absolute;
   inset: 0;
   border-radius: var(--radius-full);
   background-color: colors.theme-color('text-quaternary', 0.2);
   filter: blur(24px);
-  animation: pulse 2s var(--easing-in-out) infinite;
 }
 
 .icon-badge {

--- a/frontend/src/components/chat/message-input/EnhanceButton.module.scss
+++ b/frontend/src/components/chat/message-input/EnhanceButton.module.scss
@@ -37,6 +37,6 @@
   width: var(--space-3);
 
   &--spinning {
-    animation: spin 1s linear infinite;
+    @include anim.spin;
   }
 }

--- a/frontend/src/components/chat/message-input/SendButton.module.scss
+++ b/frontend/src/components/chat/message-input/SendButton.module.scss
@@ -34,17 +34,17 @@
 }
 
 .icon-spinner {
+  @include anim.spin;
   height: var(--space-3-5);
   width: var(--space-3-5);
   color: var(--theme-text-inverse);
-  animation: spin 1s linear infinite;
 }
 
 .icon-stop {
+  @include anim.pulse;
   height: var(--space-3);
   width: var(--space-3);
   color: var(--theme-surface);
-  animation: pulse 2s var(--easing-in-out) infinite;
 }
 
 .icon-send {

--- a/frontend/src/components/chat/model-selector/ModelSelector.module.scss
+++ b/frontend/src/components/chat/model-selector/ModelSelector.module.scss
@@ -13,11 +13,11 @@
 }
 
 .status-pill {
+  @include anim.pulse;
   height: var(--space-3-5);
   width: var(--space-16);
   border-radius: var(--radius-full);
   background-color: colors.theme-color('text-quaternary', 0.2);
-  animation: pulse 2s var(--easing-in-out) infinite;
 }
 
 .status-text {

--- a/frontend/src/components/chat/tools/common/SearchLoadingDots/SearchLoadingDots.module.scss
+++ b/frontend/src/components/chat/tools/common/SearchLoadingDots/SearchLoadingDots.module.scss
@@ -1,4 +1,5 @@
 @use '@/styles/globals/typography' as type;
+@use '@/styles/globals/animations' as anim;
 
 .dots {
   margin-top: var(--space-0-5);
@@ -13,11 +14,11 @@
 }
 
 .dot {
+  @include anim.bounce;
   height: var(--space-1);
   width: var(--space-1);
   border-radius: var(--radius-full);
   background-color: var(--theme-text-tertiary);
-  animation: bounce 1s infinite;
 }
 
 .label {

--- a/frontend/src/components/chat/tools/common/statusIndicator.module.scss
+++ b/frontend/src/components/chat/tools/common/statusIndicator.module.scss
@@ -14,6 +14,6 @@
 }
 
 .icon--started {
-  animation: pulse 2s var(--easing-in-out) infinite;
+  @include anim.pulse;
   color: var(--theme-text-quaternary);
 }

--- a/frontend/src/components/chat/workspace-selector/CreateWorkspaceFooter.module.scss
+++ b/frontend/src/components/chat/workspace-selector/CreateWorkspaceFooter.module.scss
@@ -133,10 +133,10 @@
 }
 
 .repo-loading-icon {
+  @include anim.spin;
   height: var(--space-3-5);
   width: var(--space-3-5);
   color: var(--theme-text-quaternary);
-  animation: spin 1s linear infinite;
 }
 
 .repo-loading-label {

--- a/frontend/src/components/chat/workspace-selector/CreateWorkspaceRepoListSkeleton.module.scss
+++ b/frontend/src/components/chat/workspace-selector/CreateWorkspaceRepoListSkeleton.module.scss
@@ -1,3 +1,5 @@
+@use '@/styles/globals/animations' as anim;
+
 .repo-list-skeleton {
   display: flex;
   flex-direction: column;
@@ -14,13 +16,13 @@
 // Bare Tailwind `rounded` (0.25rem) has no exact token match; --radius-sm is closest.
 // TODO(refactor): confirm intended radius once design tokens add a 0.25rem step.
 .icon {
+  @include anim.pulse;
   margin-top: var(--space-0-5);
   height: var(--space-3-5);
   width: var(--space-3-5);
   flex-shrink: 0;
   border-radius: var(--radius-sm);
   background-color: var(--theme-surface-tertiary);
-  animation: pulse 2s var(--easing-in-out) infinite;
 }
 
 .content {
@@ -31,11 +33,11 @@
 }
 
 .line {
+  @include anim.pulse;
   height: var(--space-3);
   width: 66.6667%;
   border-radius: var(--radius-sm);
   background-color: var(--theme-surface-tertiary);
-  animation: pulse 2s var(--easing-in-out) infinite;
 
   &--full {
     height: var(--space-2-5);

--- a/frontend/src/components/chat/workspace-selector/WorkspaceItem.module.scss
+++ b/frontend/src/components/chat/workspace-selector/WorkspaceItem.module.scss
@@ -115,10 +115,10 @@
 }
 
 .branch-loading-icon {
+  @include anim.spin;
   height: var(--space-3);
   width: var(--space-3);
   color: var(--theme-text-quaternary);
-  animation: spin 1s linear infinite;
 }
 
 .branch-loading-label {

--- a/frontend/src/components/editor/code-sidebar/CodeSidebar.module.scss
+++ b/frontend/src/components/editor/code-sidebar/CodeSidebar.module.scss
@@ -39,7 +39,7 @@
   flex-shrink: 0;
 
   &--spinning {
-    animation: spin 1s linear infinite;
+    @include anim.spin;
   }
 }
 

--- a/frontend/src/components/editor/editor-view/Content.module.scss
+++ b/frontend/src/components/editor/editor-view/Content.module.scss
@@ -1,4 +1,5 @@
 @use '@/styles/globals/typography' as type;
+@use '@/styles/globals/animations' as anim;
 
 .content {
   height: 100%;
@@ -16,7 +17,7 @@
 }
 
 .content-loading-pulse {
-  animation: pulse 2s var(--easing-in-out) infinite;
+  @include anim.pulse;
 }
 
 .content-editor {

--- a/frontend/src/components/editor/editor-view/DiffContent.module.scss
+++ b/frontend/src/components/editor/editor-view/DiffContent.module.scss
@@ -19,7 +19,7 @@
 
 .diff-loading-text {
   @include type.type-default;
-  animation: pulse 2s var(--easing-in-out) infinite;
+  @include anim.pulse;
   color: var(--theme-text-quaternary);
 }
 

--- a/frontend/src/components/editor/file-search/SearchPanel.module.scss
+++ b/frontend/src/components/editor/file-search/SearchPanel.module.scss
@@ -116,9 +116,9 @@
 }
 
 .spin-icon {
+  @include anim.spin;
   height: var(--space-3);
   width: var(--space-3);
-  animation: spin 1s linear infinite;
 }
 
 .error-message {

--- a/frontend/src/components/layout/UserProfileMenu/UserProfileMenu.module.scss
+++ b/frontend/src/components/layout/UserProfileMenu/UserProfileMenu.module.scss
@@ -48,6 +48,7 @@
 
 .panel {
   @include z.z('dropdown');
+  @include anim.fade-in(var(--duration-base), forwards);
   position: absolute;
   bottom: 100%;
   left: 0;
@@ -57,7 +58,6 @@
   border-radius: var(--radius-xl);
   background-color: var(--theme-surface-secondary);
   box-shadow: var(--shadow-medium);
-  animation: fade-in var(--duration-base) var(--easing-out) forwards;
 }
 
 .update-section {
@@ -108,7 +108,7 @@
   }
 
   &--spin {
-    animation: spin 1s linear infinite;
+    @include anim.spin;
   }
 
   &--primary {

--- a/frontend/src/components/sandbox/git/DiffView/DiffToolbar.module.scss
+++ b/frontend/src/components/sandbox/git/DiffView/DiffToolbar.module.scss
@@ -40,7 +40,7 @@
   width: var(--space-3);
 
   &--spinning {
-    animation: spin 1s linear infinite;
+    @include anim.spin;
   }
 }
 

--- a/frontend/src/components/ui/ListManagementTab/ListManagementTab.module.scss
+++ b/frontend/src/components/ui/ListManagementTab/ListManagementTab.module.scss
@@ -58,10 +58,10 @@
 }
 
 .loading-icon {
+  @include anim.spin;
   height: var(--space-4);
   width: var(--space-4);
   color: var(--theme-text-quaternary);
-  animation: spin 1s linear infinite;
 }
 
 .empty {
@@ -136,5 +136,5 @@
 }
 
 .spin {
-  animation: spin 1s linear infinite;
+  @include anim.spin;
 }

--- a/frontend/src/components/ui/LoadingScreen/LoadingScreen.module.scss
+++ b/frontend/src/components/ui/LoadingScreen/LoadingScreen.module.scss
@@ -1,3 +1,5 @@
+@use '@/styles/globals/animations' as anim;
+
 .loading-screen {
   min-height: 100vh;
   min-height: 100dvh;
@@ -21,10 +23,10 @@
 }
 
 .spinner {
+  @include anim.spin;
   height: var(--space-8);
   width: var(--space-8);
   color: var(--theme-text-quaternary);
-  animation: spin 1s linear infinite;
 }
 
 .label {

--- a/frontend/src/components/ui/Mermaid/Mermaid.module.scss
+++ b/frontend/src/components/ui/Mermaid/Mermaid.module.scss
@@ -65,9 +65,9 @@
 }
 
 .loading-icon {
+  @include anim.spin;
   height: var(--space-5);
   width: var(--space-5);
-  animation: spin 1s linear infinite;
 }
 
 .loading-text {

--- a/frontend/src/components/ui/RenameModal/RenameModal.module.scss
+++ b/frontend/src/components/ui/RenameModal/RenameModal.module.scss
@@ -39,7 +39,7 @@
   width: var(--space-3-5);
 
   &--spinning {
-    animation: spin 1s linear infinite;
+    @include anim.spin;
   }
 }
 

--- a/frontend/src/components/ui/primitives/Spinner/Spinner.module.scss
+++ b/frontend/src/components/ui/primitives/Spinner/Spinner.module.scss
@@ -1,9 +1,11 @@
+@use '@/styles/globals/animations' as anim;
+
 .spinner {
+  @include anim.spin;
   display: inline-flex;
   border-radius: var(--radius-full);
   border: 2px solid currentColor;
   border-top-color: transparent;
-  animation: spin 1s linear infinite;
 
   &--xs {
     height: var(--space-3);

--- a/frontend/src/components/ui/shared/RefreshButton/RefreshButton.module.scss
+++ b/frontend/src/components/ui/shared/RefreshButton/RefreshButton.module.scss
@@ -22,7 +22,7 @@
   width: var(--space-3);
 
   &--spin {
-    animation: spin 1s linear infinite;
+    @include anim.spin;
   }
 }
 

--- a/frontend/src/components/ui/shared/SaveButton/SaveButton.module.scss
+++ b/frontend/src/components/ui/shared/SaveButton/SaveButton.module.scss
@@ -33,6 +33,6 @@
   width: var(--space-3);
 
   &--spin {
-    animation: spin 1s linear infinite;
+    @include anim.spin;
   }
 }

--- a/frontend/src/pages/EmailVerificationPage/VerificationStatus.module.scss
+++ b/frontend/src/pages/EmailVerificationPage/VerificationStatus.module.scss
@@ -1,6 +1,7 @@
 @use '@/styles/globals/colors' as colors;
 @use '@/styles/globals/typography' as type;
 @use '@/styles/globals/zlayer' as z;
+@use '@/styles/globals/animations' as anim;
 
 .page {
   display: flex;
@@ -56,10 +57,10 @@
 }
 
 .status-icon--spinning {
+  @include anim.spin;
   height: var(--space-5);
   width: var(--space-5);
   color: var(--theme-text-tertiary);
-  animation: spin 1s linear infinite;
 }
 
 .card {
@@ -135,7 +136,7 @@
 }
 
 .spinner-icon {
+  @include anim.spin;
   height: var(--space-3-5);
   width: var(--space-3-5);
-  animation: spin 1s linear infinite;
 }

--- a/frontend/src/pages/ForgotPasswordPage/ForgotPasswordPage.module.scss
+++ b/frontend/src/pages/ForgotPasswordPage/ForgotPasswordPage.module.scss
@@ -73,7 +73,7 @@
 }
 
 .spinner-icon {
+  @include anim.spin;
   height: var(--space-3-5);
   width: var(--space-3-5);
-  animation: spin 1s linear infinite;
 }

--- a/frontend/src/pages/LoginPage/LoginPage.module.scss
+++ b/frontend/src/pages/LoginPage/LoginPage.module.scss
@@ -1,4 +1,5 @@
 @use '@/styles/globals/typography' as type;
+@use '@/styles/globals/animations' as anim;
 
 .form {
   > * + * {
@@ -54,7 +55,7 @@
 }
 
 .spinner-icon {
+  @include anim.spin;
   height: var(--space-3-5);
   width: var(--space-3-5);
-  animation: spin 1s linear infinite;
 }

--- a/frontend/src/pages/ResetPasswordPage/ResetPasswordPage.module.scss
+++ b/frontend/src/pages/ResetPasswordPage/ResetPasswordPage.module.scss
@@ -1,6 +1,7 @@
 @use '@/styles/globals/colors' as colors;
 @use '@/styles/globals/typography' as type;
 @use '@/styles/globals/responsive' as responsive;
+@use '@/styles/globals/animations' as anim;
 
 .form {
   > * + * {
@@ -97,7 +98,7 @@
 }
 
 .spinner-icon {
+  @include anim.spin;
   height: var(--space-3-5);
   width: var(--space-3-5);
-  animation: spin 1s linear infinite;
 }

--- a/frontend/src/pages/SignupPage/SignupPage.module.scss
+++ b/frontend/src/pages/SignupPage/SignupPage.module.scss
@@ -1,4 +1,5 @@
 @use '@/styles/globals/typography' as type;
+@use '@/styles/globals/animations' as anim;
 
 .form {
   > * + * {
@@ -48,7 +49,7 @@
 }
 
 .spinner-icon {
+  @include anim.spin;
   height: var(--space-3-5);
   width: var(--space-3-5);
-  animation: spin 1s linear infinite;
 }

--- a/frontend/src/styles/globals/_animations.scss
+++ b/frontend/src/styles/globals/_animations.scss
@@ -14,32 +14,12 @@
     --easing-in-out: cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  @keyframes fade-in {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-
   @keyframes fade-out {
     from {
       opacity: 1;
     }
     to {
       opacity: 0;
-    }
-  }
-
-  @keyframes fade-in-up {
-    from {
-      opacity: 0;
-      transform: translateY(4px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
     }
   }
 
@@ -81,50 +61,12 @@
     }
   }
 
-  @keyframes pulse {
-    0%,
-    100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.5;
-    }
-  }
-
-  @keyframes spin {
-    to {
-      transform: rotate(360deg);
-    }
-  }
-
-  @keyframes bounce {
-    0%,
-    100% {
-      transform: translateY(-25%);
-      animation-timing-function: var(--easing-in);
-    }
-    50% {
-      transform: translateY(0);
-      animation-timing-function: var(--easing-out);
-    }
-  }
-
   @keyframes progress-bar {
     from {
       width: 0%;
     }
     to {
       width: 100%;
-    }
-  }
-
-  @keyframes caret-blink {
-    0%,
-    100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0;
     }
   }
 }
@@ -136,10 +78,66 @@
   transition-timing-function: var(--easing-in-out);
 }
 
-@mixin fade-in($duration: var(--duration-slow)) {
-  animation: fade-in $duration var(--easing-out);
+// CSS modules hash animation names, so these mixins re-emit their @keyframes into the
+// consuming module (Sass hoists them to root) so the name and @keyframes share one hash.
+@mixin fade-in($duration: var(--duration-slow), $fill: null) {
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  animation: fade-in $duration var(--easing-out) $fill;
 }
 
-@mixin fade-in-up($duration: 350ms) {
-  animation: fade-in-up $duration var(--easing-out) forwards;
+@mixin spin {
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  animation: spin 1s linear infinite;
+}
+
+@mixin pulse {
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.5;
+    }
+  }
+  animation: pulse 2s var(--easing-in-out) infinite;
+}
+
+@mixin bounce {
+  @keyframes bounce {
+    0%,
+    100% {
+      transform: translateY(-25%);
+      animation-timing-function: var(--easing-in);
+    }
+    50% {
+      transform: translateY(0);
+      animation-timing-function: var(--easing-out);
+    }
+  }
+  animation: bounce 1s infinite;
+}
+
+@mixin caret-blink {
+  @keyframes caret-blink {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0;
+    }
+  }
+  animation: caret-blink 1.1s step-end infinite;
 }


### PR DESCRIPTION
## Summary
- CSS modules hash bare animation names, so post-Tailwind SCSS modules referenced global `@keyframes spin`/`pulse`/`bounce` that never matched
- Animation mixins in `_animations.scss` now re-emit keyframes into the consuming module so the name and `@keyframes` share one hash
- Updated spinners, thinking dots, skeletons, caret blink, and related loaders to use `anim.spin` / `pulse` / `bounce` / `fade-in` / `caret-blink`
- Documented the module-local keyframe convention in `frontend/CLAUDE.md`