### PR TITLE
feat: sync Claude slash commands with Claude Code 2.1.206+

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -1523,10 +1523,14 @@ MODELS: dict[str, ModelInfo] = {
 }
 
 # Built-in slash commands exposed to the frontend per agent kind.
-# Claude commands sourced from the Claude SDK's supportedCommands(),
-# filtered by what claude-agent-acp exposes via ACP (excludes cost,
-# login, logout, release-notes, todos, and local-only commands like
-# context, heapdump, extra-usage).
+# Claude commands sourced from the Claude SDK's supportedCommands()
+# (Claude Code ~2.1.206+), filtered by what claude-agent-acp exposes via
+# ACP (excludes cost, keybindings-help, login, logout, output-style:new,
+# release-notes, todos, and local-only commands like context, heapdump,
+# extra-usage). Also omit TUI/session chrome that AgentRove already covers
+# or that only affects the Claude CLI UI (model, effort, fast, config, mcp,
+# color, rename, usage, usage-credits). User/plugin skills are discovered at
+# runtime, not listed here.
 # Codex commands sourced from codex-acp's built-in command list (excludes
 # logout — signing out of Codex from a chat autocomplete is too easy to hit).
 BUILTIN_SLASH_COMMANDS: dict[AgentKind, list[dict[str, str]]] = {
@@ -1534,9 +1538,33 @@ BUILTIN_SLASH_COMMANDS: dict[AgentKind, list[dict[str, str]]] = {
         {
             "value": "/compact",
             "label": "Compact",
-            "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+            "description": "Free up context by summarizing the conversation so far. Optional: /compact [instructions for summarization]",
         },
-        {"value": "/review", "label": "Review", "description": "Review a pull request"},
+        {
+            "value": "/clear",
+            "label": "Clear",
+            "description": "Start a new session with empty context; previous session stays on disk (resumable with /resume)",
+        },
+        {
+            "value": "/review",
+            "label": "Review",
+            "description": "Review a GitHub pull request; for your working diff use /code-review",
+        },
+        {
+            "value": "/code-review",
+            "label": "Code Review",
+            "description": "Review the current diff for correctness bugs and reuse/simplification/efficiency cleanups. Optional: /code-review [low|medium|high|xhigh|max] [--fix] [--comment] [target]",
+        },
+        {
+            "value": "/security-review",
+            "label": "Security Review",
+            "description": "Complete a security review of the pending changes on the current branch",
+        },
+        {
+            "value": "/simplify",
+            "label": "Simplify",
+            "description": "Review changed code for reuse, simplification, efficiency, and altitude cleanups, then apply the fixes",
+        },
         {
             "value": "/init",
             "label": "Init",
@@ -1545,12 +1573,12 @@ BUILTIN_SLASH_COMMANDS: dict[AgentKind, list[dict[str, str]]] = {
         {
             "value": "/debug",
             "label": "Debug",
-            "description": "Debug your current Claude Code session",
+            "description": "Enable debug logging for this session and help diagnose issues",
         },
         {
-            "value": "/security-review",
-            "label": "Security Review",
-            "description": "Complete a security review of the pending changes on the current branch",
+            "value": "/doctor",
+            "label": "Doctor",
+            "description": "Health-check the Claude Code setup and fix installation, settings, and configuration issues",
         },
         {
             "value": "/insights",
@@ -1558,9 +1586,9 @@ BUILTIN_SLASH_COMMANDS: dict[AgentKind, list[dict[str, str]]] = {
             "description": "Generate a report analyzing your Claude Code sessions",
         },
         {
-            "value": "/simplify",
-            "label": "Simplify",
-            "description": "Review changed code for reuse, quality and efficiency, then fix any issues found",
+            "value": "/recap",
+            "label": "Recap",
+            "description": "Generate a one-line session recap now",
         },
         {
             "value": "/loop",
@@ -1573,14 +1601,59 @@ BUILTIN_SLASH_COMMANDS: dict[AgentKind, list[dict[str, str]]] = {
             "description": "Research and plan a large-scale change, then execute it in parallel across isolated worktree agents that each open a PR",
         },
         {
+            "value": "/deep-research",
+            "label": "Deep Research",
+            "description": "Fan out web searches, fetch and cross-check sources, and synthesize a cited report",
+        },
+        {
+            "value": "/verify",
+            "label": "Verify",
+            "description": "Verify a code change end-to-end by driving the affected flow, not just tests or typecheck",
+        },
+        {
+            "value": "/run",
+            "label": "Run",
+            "description": "Launch and drive this project's app to see a change working",
+        },
+        {
+            "value": "/run-skill-generator",
+            "label": "Run Skill Generator",
+            "description": "Author or improve a per-project run skill that tells agents how to build, launch, and drive this app",
+        },
+        {
+            "value": "/goal",
+            "label": "Goal",
+            "description": "Set a goal — keep working until the condition is met",
+        },
+        {
             "value": "/update-config",
             "label": "Update Config",
-            "description": "Configure Claude Code settings via settings.json",
+            "description": "Configure Claude Code settings via settings.json (permissions, hooks, env vars)",
         },
         {
             "value": "/claude-api",
             "label": "Claude API",
             "description": "Build apps with the Claude API or Anthropic SDK",
+        },
+        {
+            "value": "/dataviz",
+            "label": "Data Viz",
+            "description": "Design guidance for charts, graphs, and dashboards",
+        },
+        {
+            "value": "/fewer-permission-prompts",
+            "label": "Fewer Permission Prompts",
+            "description": "Scan transcripts for common read-only tool calls and add a project allowlist to reduce permission prompts",
+        },
+        {
+            "value": "/team-onboarding",
+            "label": "Team Onboarding",
+            "description": "Help teammates ramp on Claude Code with a guide from your usage",
+        },
+        {
+            "value": "/reload-skills",
+            "label": "Reload Skills",
+            "description": "Pick up skills added or changed on disk during this session",
         },
     ],
     AgentKind.CODEX: [


### PR DESCRIPTION
## Summary
- Refresh Claude builtin slash commands from the SDK `supportedCommands()` list (Claude Code ~2.1.206+), still filtered for ACP.
- Add missing agent-dispatchable commands (`/code-review`, `/clear`, `/doctor`, `/deep-research`, `/verify`, `/run`, `/goal`, and related skills).
- Omit TUI/session chrome AgentRove already covers or that only affects the Claude CLI (`/model`, `/effort`, `/fast`, `/config`, `/mcp`, `/color`, `/rename`, `/usage`, `/usage-credits`).

## Test plan
- [ ] Open a Claude chat and type `/` — confirm new commands appear (e.g. `/code-review`, `/doctor`, `/deep-research`)
- [ ] Confirm CLI-only entries like `/color` and `/model` are not suggested
- [ ] Select `/compact` and `/code-review` and verify they send as expected