### PR TITLE
fix: keep plan segments anchored to their stream position

### DIFF
--- a/frontend/src/components/chat/message-bubble/segmentBuilder.test.ts
+++ b/frontend/src/components/chat/message-bubble/segmentBuilder.test.ts
@@ -5,7 +5,7 @@ import {
   type MessageSegment,
   type ToolSegment,
 } from './segmentBuilder';
-import type { AssistantStreamEvent } from '@/types/chat.types';
+import type { AssistantStreamEvent, PlanEntry } from '@/types/chat.types';
 import type { ToolEventPayload } from '@/types/tools.types';
 
 // Minimal tool payload factory — only the fields buildSegments reads.
@@ -263,6 +263,53 @@ describe('buildSegments — ordering across kinds', () => {
       { type: 'tool_started', tool: toolPayload({ id: 't1' }) },
     ]);
     expect(segments.map((s) => s.kind)).toEqual(['thinking', 'text', 'tool']);
+  });
+});
+
+describe('buildSegments — plan translation', () => {
+  const entry = (content: string, status: PlanEntry['status'] = 'pending'): PlanEntry => ({
+    content,
+    status,
+  });
+
+  it('flushes pending text before emitting a plan segment', () => {
+    const segments = buildSegments([
+      { type: 'assistant_text', text: 'working' },
+      { type: 'plan', data: { entries: [entry('a')] } },
+    ]);
+    expect(segments).toEqual([
+      { kind: 'text', id: 'text-0', text: 'working' },
+      { kind: 'plan', id: 'plan-0', entries: [entry('a')] },
+    ]);
+  });
+
+  it('re-renders the plan at the current position when content arrives in between', () => {
+    const first = [entry('a', 'in_progress')];
+    const second = [entry('a', 'completed')];
+    const segments = buildSegments([
+      { type: 'plan', data: { entries: first } },
+      { type: 'assistant_text', text: 'step done' },
+      { type: 'plan', data: { entries: second } },
+    ]);
+    expect(segments).toEqual([
+      { kind: 'plan', id: 'plan-0', entries: first },
+      { kind: 'text', id: 'text-0', text: 'step done' },
+      { kind: 'plan', id: 'plan-1', entries: second },
+    ]);
+  });
+
+  it('collapses back-to-back plan snapshots into one segment', () => {
+    const second = [entry('a', 'completed'), entry('b', 'in_progress')];
+    const segments = buildSegments([
+      { type: 'plan', data: { entries: [entry('a', 'completed')] } },
+      { type: 'plan', data: { entries: second } },
+    ]);
+    expect(segments).toEqual([{ kind: 'plan', id: 'plan-0', entries: second }]);
+  });
+
+  it('ignores plan events with missing or empty entries', () => {
+    expect(buildSegments([{ type: 'plan' }])).toEqual([]);
+    expect(buildSegments([{ type: 'plan', data: { entries: [] } }])).toEqual([]);
   });
 });
 

--- a/frontend/src/components/chat/message-bubble/segmentBuilder.ts
+++ b/frontend/src/components/chat/message-bubble/segmentBuilder.ts
@@ -363,6 +363,7 @@ export const buildSegments = (events: AssistantStreamEvent[]): MessageSegment[] 
   let textSegmentCount = 0;
   let thinkingSegmentCount = 0;
   let suggestionsSegmentCount = 0;
+  let planSegmentCount = 0;
 
   const flushText = () => {
     if (!pendingText) return;
@@ -433,16 +434,17 @@ export const buildSegments = (events: AssistantStreamEvent[]): MessageSegment[] 
       case 'plan': {
         const entries = event.data?.entries;
         if (!Array.isArray(entries) || entries.length === 0) break;
-        // Each plan event is a full snapshot — update the existing segment in
-        // place so the checklist stays at the position planning started.
-        // Scan instead of caching an index: tool reparenting can splice segments.
-        const planIndex = segments.findIndex((segment) => segment.kind === 'plan');
-        if (planIndex === -1) {
+        // Each plan event is a full snapshot. Render it at the current stream
+        // position so updates stay visible as the chat scrolls; collapse
+        // back-to-back snapshots into one card instead of stacking duplicates.
+        const last = segments[segments.length - 1];
+        if (last?.kind === 'plan' && !pendingText && !pendingThinking) {
+          segments[segments.length - 1] = { kind: 'plan', id: last.id, entries };
+        } else {
           flushText();
           flushThinking();
-          segments.push({ kind: 'plan', id: 'plan', entries });
-        } else {
-          segments[planIndex] = { kind: 'plan', id: 'plan', entries };
+          segments.push({ kind: 'plan', id: `plan-${planSegmentCount}`, entries });
+          planSegmentCount++;
         }
         break;
       }


### PR DESCRIPTION
## Summary
- Plan snapshots previously always overwrote a single fixed segment, snapping the checklist back to its original position even after more content streamed in.
- New plan events now render at the current stream position, collapsing into the prior segment only when it directly follows another plan snapshot with no intervening text/thinking.
- Added test coverage for flushing pending text before a plan segment, re-rendering at the new position when content arrives between snapshots, collapsing back-to-back snapshots, and ignoring empty/missing entries.