### PR TITLE
style: color-highlight @mention/command tokens instead of pill bg

### DIFF
--- a/frontend/src/components/chat/message-input/MentionSuggestionsPanel.module.scss
+++ b/frontend/src/components/chat/message-input/MentionSuggestionsPanel.module.scss
@@ -18,7 +18,7 @@
   color: var(--theme-text-secondary);
 
   &--active {
-    color: var(--theme-text-primary);
+    color: var(--theme-token-highlight);
   }
 }
 

--- a/frontend/src/components/chat/message-input/SlashCommandsPanel.module.scss
+++ b/frontend/src/components/chat/message-input/SlashCommandsPanel.module.scss
@@ -11,7 +11,7 @@
   color: var(--theme-text-secondary);
 
   &--active {
-    color: var(--theme-text-primary);
+    color: var(--theme-token-highlight);
   }
 }
 

--- a/frontend/src/components/chat/message-input/Textarea.module.scss
+++ b/frontend/src/components/chat/message-input/Textarea.module.scss
@@ -16,22 +16,15 @@
   line-height: 1.5;
   white-space: pre-wrap;
   overflow-wrap: break-word;
-  color: transparent;
+  color: var(--theme-text-primary);
 
   &--dimmed {
     opacity: 0.5;
   }
 }
 
-// Backdrop pill behind @mention / command tokens — mirrors the textarea glyphs
 .backdrop-token {
-  // TODO(refactor): bare `rounded` (4px) has no exact token — using sm (matches sibling modules)
-  margin-inline: calc(var(--space-0-5) * -1);
-  border-radius: var(--radius-sm);
-  padding: var(--space-0-5);
-  background-color: var(--theme-surface-active);
-  box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
+  color: var(--theme-token-highlight);
 }
 
 .textarea-field {
@@ -50,6 +43,11 @@
 
   &::placeholder {
     color: var(--theme-text-quaternary);
+  }
+
+  &--highlighted {
+    color: transparent;
+    caret-color: var(--theme-text-primary);
   }
 
   &--compact {

--- a/frontend/src/components/chat/message-input/Textarea.tsx
+++ b/frontend/src/components/chat/message-input/Textarea.tsx
@@ -17,8 +17,6 @@ import styles from './Textarea.module.scss';
 
 const THIN_SCROLLBAR_STYLE: CSSProperties = { scrollbarWidth: 'thin' };
 
-// Backdrop variant of the pill: no text colors (the textarea's own glyphs render
-// on top) and negative margins so the painted background doesn't shift the flow.
 const BACKDROP_TOKEN_CLASSNAME = styles['backdrop-token'];
 
 // Invisible scrollbar that still reserves the same thin gutter as the textarea's,
@@ -144,9 +142,7 @@ export function Textarea({
   return (
     <div className={styles.textarea}>
       {hasTokens && (
-        // Paints pill backgrounds behind @mention and /command tokens; the textarea's own
-        // glyphs render on top, so this layer's text is transparent and must mirror the
-        // textarea's typography, padding, and wrapping exactly.
+        // Mirrors the textarea so individual tokens can be colored without changing its value.
         <div
           ref={backdropRef}
           aria-hidden
@@ -176,6 +172,7 @@ export function Textarea({
         rows={1}
         className={clsx(
           styles['textarea-field'],
+          hasTokens && styles['textarea-field--highlighted'],
           isMobile && compact && styles['textarea-field--compact'],
         )}
         style={THIN_SCROLLBAR_STYLE}

--- a/frontend/src/components/ui/shared/HighlightedText/HighlightedText.tsx
+++ b/frontend/src/components/ui/shared/HighlightedText/HighlightedText.tsx
@@ -1,6 +1,6 @@
 import { buildHighlightSegments } from '@/utils/mentionParser';
 
-// Canonical pill look for @mention / /command tokens. Also consumed by
+// Canonical highlight for @mention and /command tokens. Also consumed by
 // MarkDown's rehype transform, which builds hast nodes and can't render
 // this component — so it's a global class (defined in styles/app.scss),
 // not a CSS module.
@@ -8,7 +8,7 @@ export const MENTION_PILL_CLASSNAME = 'mention-pill';
 
 interface HighlightedTextProps {
   text: string;
-  // Override for layers that must not repaint glyphs (the input's transparent backdrop).
+  // The input backdrop overrides this because its styles live in a CSS module.
   tokenClassName?: string;
 }
 

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -87,12 +87,7 @@
   box-shadow: var(--shadow-medium) !important;
 }
 
-// @mention / /command pill (see HighlightedText.MENTION_PILL_CLASSNAME)
+// @mention / /command highlight (see HighlightedText.MENTION_PILL_CLASSNAME)
 .mention-pill {
-  border-radius: var(--radius-sm);
-  background-color: var(--theme-surface-active);
-  box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
-  padding: var(--space-0-5) var(--space-1);
-  color: var(--theme-text-primary);
+  color: var(--theme-token-highlight);
 }

--- a/frontend/src/styles/globals/_colors.scss
+++ b/frontend/src/styles/globals/_colors.scss
@@ -118,6 +118,10 @@ $theme-tokens: (
     --text-quaternary,
     --text-dark-quaternary,
   ),
+  'token-highlight': (
+    --token-highlight,
+    --token-dark-highlight,
+  ),
   // Inverted pair — light theme reads the dark set and vice versa (primary buttons,
   // tooltips: dark-on-light / light-on-dark).
   'surface-inverse': (
@@ -171,6 +175,7 @@ $theme-tokens: (
     --text-secondary: 71 85 105;
     --text-tertiary: 100 116 139;
     --text-quaternary: 128 140 159;
+    --token-highlight: 180 83 9;
 
     --surface-dark: 17 17 17;
     --surface-dark-secondary: 20 20 20;
@@ -184,6 +189,7 @@ $theme-tokens: (
     --text-dark-secondary: 224 224 224;
     --text-dark-tertiary: 192 192 192;
     --text-dark-quaternary: 160 160 160;
+    --token-dark-highlight: 255 184 99;
 
     // macOS traffic lights (desktop title bar only)
     --color-traffic-close: #ff5f57;


### PR DESCRIPTION
## Summary
- Replace the padded pill background behind @mention and /command tokens with a simple colored-text highlight, avoiding `box-decoration-break: clone` issues on wrapped lines
- Add a new `--token-highlight` theme token (light/dark) used consistently across the mention pill, suggestion panels, and the textarea backdrop
- Textarea backdrop now only needs to color individual tokens; the base textarea text is rendered normally, with a `--highlighted` variant making the live input transparent (caret still visible) when tokens are present