### PR TITLE
fix: keep FloatingTooltip within the viewport

### DIFF
--- a/frontend/src/components/ui/FloatingTooltip/FloatingTooltip.module.scss
+++ b/frontend/src/components/ui/FloatingTooltip/FloatingTooltip.module.scss
@@ -13,7 +13,8 @@
   pointer-events: none;
   position: fixed;
   // arbitrary Tailwind value (280px), not in the spacing scale
-  max-width: 280px;
+  width: max-content;
+  max-width: min(280px, calc(100vw - var(--space-4)));
   white-space: pre-line;
   overflow-wrap: break-word;
   // TODO(refactor): bare "rounded" (4px) has no exact token; radius-sm is closest

--- a/frontend/src/components/ui/FloatingTooltip/FloatingTooltip.test.tsx
+++ b/frontend/src/components/ui/FloatingTooltip/FloatingTooltip.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FloatingTooltip } from './FloatingTooltip';
+
+const TOOLTIP_HEIGHT = 30;
+const TOOLTIP_WIDTH = 100;
+
+function showTooltip(rect: Pick<DOMRect, 'bottom' | 'left' | 'top'>) {
+  render(
+    <FloatingTooltip content="Tooltip content">
+      <span>Trigger</span>
+    </FloatingTooltip>,
+  );
+  const trigger = screen.getByText('Trigger').parentElement;
+  if (trigger == null) throw new Error('Tooltip trigger was not rendered');
+
+  vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue(rect as DOMRect);
+  vi.spyOn(trigger, 'matches').mockImplementation((selector) => selector === ':hover');
+  fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+  act(() => {
+    vi.advanceTimersByTime(500);
+  });
+
+  return screen.getByRole('tooltip');
+}
+
+describe('FloatingTooltip', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(TOOLTIP_HEIGHT);
+    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(TOOLTIP_WIDTH);
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(500);
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(300);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('flips above a trigger when the tooltip would cross the bottom edge', () => {
+    const tooltip = showTooltip({ top: 470, bottom: 490, left: 20 });
+
+    expect(tooltip.style.top).toBe('436px');
+    expect(tooltip.style.left).toBe('20px');
+  });
+
+  it('shifts left when the tooltip would cross the right edge', () => {
+    const tooltip = showTooltip({ top: 100, bottom: 120, left: 280 });
+
+    expect(tooltip.style.top).toBe('124px');
+    expect(tooltip.style.left).toBe('192px');
+  });
+});

--- a/frontend/src/components/ui/FloatingTooltip/FloatingTooltip.tsx
+++ b/frontend/src/components/ui/FloatingTooltip/FloatingTooltip.tsx
@@ -2,6 +2,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react';
@@ -12,6 +13,15 @@ import styles from './FloatingTooltip.module.scss';
 // Matches the native title-attribute hover delay so tooltips don't flash while scanning a list
 const SHOW_DELAY_MS = 500;
 const HOVER_CHECK_MS = 100;
+const TOOLTIP_GAP = 4;
+const VIEWPORT_PADDING = 8;
+
+interface TooltipPosition {
+  top: number;
+  left: number;
+  triggerTop: number;
+  triggerBottom: number;
+}
 
 interface FloatingTooltipProps {
   content: string;
@@ -23,11 +33,12 @@ interface FloatingTooltipProps {
 // absolute), it renders position:fixed so triggers inside overflow-y-auto lists
 // (e.g. the sidebar) don't clip the bubble or add phantom scroll space.
 export function FloatingTooltip({ content, children, className }: FloatingTooltipProps) {
-  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+  const [position, setPosition] = useState<TooltipPosition | null>(null);
   // Tracks the whole hover interaction (show delay + visible) so the scroll
   // listener can also cancel a pending show timer, not just an open tooltip
   const [hovering, setHovering] = useState(false);
   const triggerRef = useRef<HTMLDivElement>(null);
+  const bubbleRef = useRef<HTMLDivElement>(null);
   const showTimerRef = useRef<number | null>(null);
 
   const handlePointerEnter = (e: ReactPointerEvent<HTMLDivElement>) => {
@@ -37,7 +48,12 @@ export function FloatingTooltip({ content, children, className }: FloatingToolti
       // Measure at show time, not pointer-enter — the list may scroll during the delay
       const rect = triggerRef.current?.getBoundingClientRect();
       if (rect && triggerRef.current?.matches(':hover')) {
-        setPosition({ top: rect.bottom + 4, left: rect.left });
+        setPosition({
+          top: rect.bottom + TOOLTIP_GAP,
+          left: rect.left,
+          triggerTop: rect.top,
+          triggerBottom: rect.bottom,
+        });
       }
     }, SHOW_DELAY_MS);
   };
@@ -48,6 +64,31 @@ export function FloatingTooltip({ content, children, className }: FloatingToolti
     setHovering(false);
     setPosition(null);
   };
+
+  useLayoutEffect(() => {
+    if (position == null || bubbleRef.current == null) return;
+
+    const { offsetHeight: height, offsetWidth: width } = bubbleRef.current;
+    const fitsAbove = position.triggerTop - TOOLTIP_GAP - height >= VIEWPORT_PADDING;
+    const fitsBelow =
+      position.triggerBottom + TOOLTIP_GAP + height <= window.innerHeight - VIEWPORT_PADDING;
+    const openAbove = !fitsBelow && fitsAbove;
+    const desiredTop = openAbove
+      ? position.triggerTop - TOOLTIP_GAP - height
+      : position.triggerBottom + TOOLTIP_GAP;
+    const top = Math.max(
+      VIEWPORT_PADDING,
+      Math.min(desiredTop, window.innerHeight - VIEWPORT_PADDING - height),
+    );
+    const left = Math.max(
+      VIEWPORT_PADDING,
+      Math.min(position.left, window.innerWidth - VIEWPORT_PADDING - width),
+    );
+
+    if (top !== position.top || left !== position.left) {
+      setPosition({ ...position, top, left });
+    }
+  }, [position]);
 
   // pointerleave alone is unreliable: WKWebView (Tauri) can drop it on fast
   // window exits, native title-bar transitions, and focus changes.
@@ -87,6 +128,7 @@ export function FloatingTooltip({ content, children, className }: FloatingToolti
         content &&
         createPortal(
           <div
+            ref={bubbleRef}
             role="tooltip"
             style={{ top: position.top, left: position.left }}
             className={styles.bubble}


### PR DESCRIPTION
## Summary
- Clamp tooltip left/top to stay within the viewport instead of overflowing past the right/bottom edges
- Flip the tooltip above its trigger when there isn't room to render below
- Cap tooltip width against `calc(100vw - var(--space-4))` so it can't overflow narrow viewports
- Add tests covering the flip-above and shift-left clamping behavior