### PR TITLE
Add search button to TitleBar when sidebar is collapsed

### DIFF
--- a/frontend/src/components/layout/TitleBar/TitleBar.module.scss
+++ b/frontend/src/components/layout/TitleBar/TitleBar.module.scss
@@ -94,6 +94,18 @@
   margin-left: var(--space-3);
   display: flex;
   align-items: center;
+  gap: var(--space-1);
+}
+
+.search-button {
+  height: var(--space-8);
+  width: var(--space-8);
+}
+
+.search-icon {
+  height: var(--space-4);
+  width: var(--space-4);
+  color: var(--theme-text-secondary);
 }
 
 .spacer {

--- a/frontend/src/components/layout/TitleBar/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar/TitleBar.tsx
@@ -1,9 +1,11 @@
 import { useCallback } from 'react';
+import { Search } from 'lucide-react';
 import { useMatch } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
 import { Button } from '@/components/ui/primitives/Button/Button';
 import { ToggleButton } from '@/components/ui/ToggleButton/ToggleButton';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip/FloatingTooltip';
 import { ViewSwitcher } from '@/components/layout/ViewSwitcher/ViewSwitcher';
 import { ChatTabs } from '@/components/layout/ChatTabs/ChatTabs';
 import clsx from 'clsx';
@@ -159,6 +161,20 @@ export function TitleBar() {
               position="left"
               ariaLabel="Toggle sidebar"
             />
+            {!sidebarOpen && (
+              <FloatingTooltip content="Search">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className={styles['search-button']}
+                  onClick={() => useUIStore.getState().setCommandMenuOpen(true)}
+                  aria-label="Search"
+                >
+                  <Search className={styles['search-icon']} />
+                </Button>
+              </FloatingTooltip>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Adds a search icon button to the TitleBar, shown only when the sidebar is collapsed
- Clicking it opens the command menu, restoring quick access to search since the sidebar's search entry point is hidden while collapsed
- Wrapped in a `FloatingTooltip` labeled "Search" for discoverability