### PR TITLE
polish: improve workspace picker a11y and search UX

### DIFF
--- a/frontend/src/components/chat/workspace-selector/CreateWorkspaceFooter.tsx
+++ b/frontend/src/components/chat/workspace-selector/CreateWorkspaceFooter.tsx
@@ -113,8 +113,8 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
         onClick={() => setCreationMode('menu')}
         className={styles['option-button']}
       >
-        <Plus className={styles['option-icon']} />
-        New workspace
+        <Plus className={styles['option-icon']} aria-hidden="true" />
+        New Workspace
       </Button>
     );
   }
@@ -123,11 +123,14 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
     return (
       <div className={styles.form}>
         <div className={styles['form-label']}>
-          <Box className={styles['option-icon']} />
-          Empty workspace
+          <Box className={styles['option-icon']} aria-hidden="true" />
+          Empty Workspace
         </div>
         <Input
           variant="unstyled"
+          name="workspace-name"
+          aria-label="Workspace name"
+          autoComplete="off"
           value={emptyName}
           onChange={(e) => setEmptyName(e.target.value)}
           onKeyDown={(e) => {
@@ -156,7 +159,7 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
             onClick={() => void handleCreateEmpty()}
             isLoading={createWorkspace.isPending}
           >
-            Create
+            Create Workspace
           </Button>
         </div>
       </div>
@@ -168,8 +171,8 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
       <div className={styles.form}>
         <div className={styles['form-header']}>
           <div className={styles['form-label']}>
-            <GitBranch className={styles['option-icon']} />
-            Clone Git repo
+            <GitBranch className={styles['option-icon']} aria-hidden="true" />
+            Clone Git Repository
           </div>
           {hasGitHubToken && (
             <Button
@@ -190,9 +193,14 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
         {hasGitHubToken && !showUrlInput ? (
           <>
             <div className={styles['search-field']}>
-              <Search className={styles['search-icon']} />
+              <Search className={styles['search-icon']} aria-hidden="true" />
               <Input
                 variant="unstyled"
+                type="search"
+                name="repository-search"
+                aria-label="Search repositories"
+                autoComplete="off"
+                spellCheck={false}
                 value={repoSearchQuery}
                 onChange={(e) => setRepoSearchQuery(e.target.value)}
                 placeholder="Search repositories…"
@@ -203,7 +211,7 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
             <div className={styles['repo-list']}>
               {createWorkspace.isPending ? (
                 <div className={styles['repo-loading']}>
-                  <Loader2 className={styles['repo-loading-icon']} />
+                  <Loader2 className={styles['repo-loading-icon']} aria-hidden="true" />
                   <span className={styles['repo-loading-label']}>Cloning repository…</span>
                 </div>
               ) : reposLoading ? (
@@ -230,6 +238,11 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
           <>
             <Input
               variant="unstyled"
+              type="url"
+              name="git-repository-url"
+              aria-label="Git repository URL"
+              autoComplete="off"
+              spellCheck={false}
               value={gitUrl}
               onChange={(e) => setGitUrl(e.target.value)}
               onKeyDown={(e) => {
@@ -270,7 +283,7 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
               onClick={() => void handleCloneGit()}
               isLoading={createWorkspace.isPending}
             >
-              Clone
+              Clone Repository
             </Button>
           )}
         </div>
@@ -289,8 +302,8 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
         onClick={() => setCreationMode('empty')}
         className={styles['option-button']}
       >
-        <Box className={styles['option-icon']} />
-        Empty workspace
+        <Box className={styles['option-icon']} aria-hidden="true" />
+        Empty Workspace
       </Button>
       {isDesktop && (
         <Button
@@ -300,8 +313,8 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
           disabled={createWorkspace.isPending}
           className={styles['option-button']}
         >
-          <HardDrive className={styles['option-icon']} />
-          Local folder
+          <HardDrive className={styles['option-icon']} aria-hidden="true" />
+          Local Folder
         </Button>
       )}
       <Button
@@ -310,8 +323,8 @@ export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) =
         onClick={() => setCreationMode('git')}
         className={styles['option-button']}
       >
-        <GitBranch className={styles['option-icon']} />
-        Clone Git repo
+        <GitBranch className={styles['option-icon']} aria-hidden="true" />
+        Clone Git Repository
       </Button>
     </div>
   );

--- a/frontend/src/components/chat/workspace-selector/WorkspaceItem.module.scss
+++ b/frontend/src/components/chat/workspace-selector/WorkspaceItem.module.scss
@@ -7,7 +7,8 @@
   @include anim.transition-colors;
   display: flex;
   width: 100%;
-  align-items: flex-start;
+  min-height: var(--space-12);
+  align-items: center;
   gap: var(--space-2-5);
   border-radius: var(--radius-lg);
   padding: var(--space-2) var(--space-2-5);
@@ -15,6 +16,7 @@
 
   &--selected {
     background-color: var(--theme-surface-active);
+    box-shadow: var(--shadow-inset);
   }
 
   &--unselected {
@@ -25,9 +27,8 @@
 }
 
 .source-icon {
-  margin-top: var(--space-0-5);
-  height: var(--space-3-5);
-  width: var(--space-3-5);
+  height: var(--space-4);
+  width: var(--space-4);
   flex-shrink: 0;
   color: var(--theme-text-quaternary);
 }
@@ -49,6 +50,14 @@
   color: var(--theme-text-primary);
 }
 
+.selected-icon {
+  height: var(--space-3-5);
+  width: var(--space-3-5);
+  margin-left: auto;
+  flex-shrink: 0;
+  color: var(--theme-text-secondary);
+}
+
 .badge {
   @include type.type-meta;
   flex-shrink: 0;
@@ -67,8 +76,10 @@
 }
 
 .branches {
-  margin-left: var(--space-6);
+  margin-left: var(--space-5);
   margin-top: var(--space-0-5);
+  padding-left: var(--space-4);
+  border-left: 1px solid colors.theme-color('border', 0.5);
 }
 
 .branch-toggle {

--- a/frontend/src/components/chat/workspace-selector/WorkspaceItem.tsx
+++ b/frontend/src/components/chat/workspace-selector/WorkspaceItem.tsx
@@ -15,11 +15,22 @@ const EMPTY_BRANCHES: string[] = [];
 function sourceIcon(sourceType: string | null | undefined) {
   switch (sourceType) {
     case 'git':
-      return <GitBranch className={styles['source-icon']} />;
+      return <GitBranch className={styles['source-icon']} aria-hidden="true" />;
     case 'local':
-      return <HardDrive className={styles['source-icon']} />;
+      return <HardDrive className={styles['source-icon']} aria-hidden="true" />;
     default:
-      return <Box className={styles['source-icon']} />;
+      return <Box className={styles['source-icon']} aria-hidden="true" />;
+  }
+}
+
+function sourceLabel(sourceType: string | null | undefined) {
+  switch (sourceType) {
+    case 'git':
+      return 'Git repository';
+    case 'local':
+      return 'Local folder';
+    default:
+      return 'Empty workspace';
   }
 }
 
@@ -70,22 +81,25 @@ export function WorkspaceItem({
         variant="unstyled"
         type="button"
         onClick={() => onSelect(ws)}
+        aria-pressed={isSelected}
         className={clsx(styles.item, styles[isSelected ? 'item--selected' : 'item--unselected'])}
       >
         {sourceIcon(ws.source_type)}
         <div className={styles.content}>
           <div className={styles['name-row']}>
             <span className={styles.name}>{ws.name}</span>
-            <span className={styles.badge}>{ws.source_type ?? 'empty'}</span>
             <span className={styles.badge}>
-              {ws.sandbox_provider === 'host' ? 'host' : 'docker'}
+              {ws.sandbox_provider === 'host' ? 'Host' : 'Docker'}
             </span>
+            {isSelected && <Check className={styles['selected-icon']} aria-hidden="true" />}
           </div>
           <div className={styles['meta-row']}>
+            <span>{sourceLabel(ws.source_type)}</span>
+            <span aria-hidden="true">·</span>
             <span>{formatRelativeTime(ws.updated_at)}</span>
             {ws.chat_count > 0 && (
               <>
-                <span>·</span>
+                <span aria-hidden="true">·</span>
                 <span>
                   {ws.chat_count} {ws.chat_count === 1 ? 'chat' : 'chats'}
                 </span>
@@ -104,14 +118,15 @@ export function WorkspaceItem({
               if (branchesExpanded) setBranchSearch('');
               setBranchesExpanded(!branchesExpanded);
             }}
+            aria-expanded={branchesExpanded}
             className={styles['branch-toggle']}
           >
             {branchesExpanded ? (
-              <ChevronDown className={styles['branch-toggle-icon']} />
+              <ChevronDown className={styles['branch-toggle-icon']} aria-hidden="true" />
             ) : (
-              <ChevronRight className={styles['branch-toggle-icon']} />
+              <ChevronRight className={styles['branch-toggle-icon']} aria-hidden="true" />
             )}
-            <GitBranch className={styles['branch-toggle-icon']} />
+            <GitBranch className={styles['branch-toggle-icon']} aria-hidden="true" />
             <span className={styles['branch-toggle-label']}>
               {branchesData?.current_branch || '…'}
             </span>
@@ -120,7 +135,7 @@ export function WorkspaceItem({
             <div className={styles['branch-panel']}>
               {branchesLoading ? (
                 <div className={styles['branch-loading']}>
-                  <Loader2 className={styles['branch-loading-icon']} />
+                  <Loader2 className={styles['branch-loading-icon']} aria-hidden="true" />
                   <span className={styles['branch-loading-label']}>Loading branches…</span>
                 </div>
               ) : !branches.length ? (
@@ -132,6 +147,10 @@ export function WorkspaceItem({
                       <Input
                         variant="unstyled"
                         type="text"
+                        name={`branch-search-${ws.id}`}
+                        aria-label={`Search branches in ${ws.name}`}
+                        autoComplete="off"
+                        spellCheck={false}
                         value={branchSearch}
                         onChange={(e) => setBranchSearch(e.target.value)}
                         onClick={(e) => e.stopPropagation()}
@@ -184,7 +203,10 @@ export function WorkspaceItem({
                                 )}
                               >
                                 {isCurrent ? (
-                                  <Check className={styles['branch-row-check']} />
+                                  <Check
+                                    className={styles['branch-row-check']}
+                                    aria-hidden="true"
+                                  />
                                 ) : (
                                   <span className={styles['branch-row-check']} />
                                 )}

--- a/frontend/src/components/chat/workspace-selector/WorkspacePicker.module.scss
+++ b/frontend/src/components/chat/workspace-selector/WorkspacePicker.module.scss
@@ -39,11 +39,12 @@
 
 .body {
   display: flex;
+  min-height: 0;
   flex-direction: column;
 }
 
 .search-section {
-  padding: var(--space-3) var(--space-4) 0;
+  padding: var(--space-3) var(--space-3) var(--space-2);
 }
 
 .search-field {
@@ -60,6 +61,31 @@
   color: var(--theme-text-quaternary);
 }
 
+.clear-search {
+  @include anim.transition-colors;
+  position: absolute;
+  top: 50%;
+  right: var(--space-1-5);
+  display: flex;
+  height: var(--space-6);
+  width: var(--space-6);
+  transform: translateY(-50%);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  color: var(--theme-text-quaternary);
+
+  svg {
+    height: var(--space-3);
+    width: var(--space-3);
+  }
+
+  @include responsive.hover {
+    background-color: var(--theme-surface-hover);
+    color: var(--theme-text-primary);
+  }
+}
+
 .search-input {
   @include type.type-default;
   height: var(--space-8);
@@ -67,16 +93,24 @@
   border: 1px solid colors.theme-color('border', 0.5);
   border-radius: var(--radius-lg);
   background-color: var(--theme-surface-tertiary);
-  padding: var(--space-2) var(--space-3) var(--space-2) var(--space-8);
+  padding: var(--space-2) var(--space-8);
   color: var(--theme-text-primary);
-  outline: none;
+  box-shadow: var(--shadow-inset);
+
+  &::-webkit-search-cancel-button {
+    appearance: none;
+  }
 
   &::placeholder {
     color: var(--theme-text-quaternary);
   }
 
   &:focus-visible {
+    outline: none;
     border-color: var(--theme-border-hover);
+    box-shadow:
+      var(--shadow-inset),
+      0 0 0 3px colors.theme-color('text-quaternary', 0.15);
   }
 
   // Light reads surface-tertiary, dark reads one step lighter — asymmetric pairing
@@ -89,14 +123,49 @@
 .list {
   max-height: var(--space-80);
   overflow-y: auto;
-  padding: var(--space-2) var(--space-3);
+  overscroll-behavior: contain;
+  padding: 0 var(--space-3) var(--space-2);
 }
 
 .empty {
-  @include type.type-default;
-  padding: var(--space-4) var(--space-2);
+  display: flex;
+  min-height: var(--space-32);
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6) var(--space-4);
   text-align: center;
+}
+
+.empty-icon {
+  height: var(--space-5);
+  width: var(--space-5);
+  margin-bottom: var(--space-2);
   color: var(--theme-text-quaternary);
+}
+
+.empty-title {
+  @include type.type-default(500);
+  color: var(--theme-text-secondary);
+}
+
+.empty-description {
+  @include type.type-meta;
+  margin-top: var(--space-1);
+  color: var(--theme-text-quaternary);
+}
+
+.list-heading {
+  @include type.type-section-header;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-1-5) var(--space-2-5) var(--space-2);
+  color: var(--theme-text-quaternary);
+
+  span:last-child {
+    font-variant-numeric: tabular-nums;
+  }
 }
 
 .list-items {
@@ -107,5 +176,5 @@
 
 .footer {
   border-top: 1px solid colors.theme-color('border', 0.5);
-  padding: var(--space-3) var(--space-4);
+  padding: var(--space-2) var(--space-3);
 }

--- a/frontend/src/components/chat/workspace-selector/WorkspacePicker.tsx
+++ b/frontend/src/components/chat/workspace-selector/WorkspacePicker.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, type ReactNode } from 'react';
-import { FolderOpen, Search, ChevronDown } from 'lucide-react';
+import { FolderOpen, Search, ChevronDown, X } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button/Button';
 import { Input } from '@/components/ui/primitives/Input/Input';
 import { BaseModal } from '@/components/ui/shared/BaseModal/BaseModal';
@@ -7,8 +7,6 @@ import { ModalHeader } from '@/components/ui/shared/ModalHeader/ModalHeader';
 import type { Workspace } from '@/types/workspace.types';
 import { WorkspaceItem } from './WorkspaceItem';
 import styles from './WorkspacePicker.module.scss';
-
-const SEARCH_THRESHOLD = 5;
 
 interface WorkspacePickerProps {
   workspaces: Workspace[];
@@ -38,11 +36,10 @@ export function WorkspacePicker({
   const [searchQuery, setSearchQuery] = useState('');
 
   const selectedWorkspace = workspaces.find((ws) => ws.id === selectedWorkspaceId);
-  const showSearch = workspaces.length > SEARCH_THRESHOLD;
-
+  const hasSearchQuery = searchQuery.trim().length > 0;
   const visibleWorkspaces = useMemo(() => {
-    if (!searchQuery) return workspaces;
-    const query = searchQuery.toLowerCase();
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return workspaces;
     return workspaces.filter((ws) => ws.name.toLowerCase().includes(query));
   }, [workspaces, searchQuery]);
 
@@ -67,39 +64,69 @@ export function WorkspacePicker({
         variant="unstyled"
         type="button"
         disabled={triggerDisabled}
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
         onClick={() => setIsOpen(true)}
         className={styles.trigger}
       >
-        <FolderOpen className={styles['trigger-icon']} />
+        <FolderOpen className={styles['trigger-icon']} aria-hidden="true" />
         <span className={styles['trigger-label']}>{label}</span>
-        <ChevronDown className={styles['trigger-icon']} />
+        <ChevronDown className={styles['trigger-icon']} aria-hidden="true" />
       </Button>
 
       <BaseModal isOpen={isOpen} onClose={close} size="md" ariaLabel="Select workspace">
-        <ModalHeader title="Workspaces" onClose={close} />
+        <ModalHeader title="Select Workspace" onClose={close} />
 
         <div className={styles.body}>
-          {showSearch && (
+          {workspaces.length > 0 && (
             <div className={styles['search-section']}>
               <div className={styles['search-field']}>
-                <Search className={styles['search-icon']} />
+                <Search className={styles['search-icon']} aria-hidden="true" />
                 <Input
                   variant="unstyled"
+                  type="search"
+                  name="workspace-search"
+                  aria-label="Search workspaces"
+                  autoComplete="off"
+                  spellCheck={false}
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Search workspaces…"
                   autoFocus
                   className={styles['search-input']}
                 />
+                {searchQuery && (
+                  <Button
+                    variant="unstyled"
+                    type="button"
+                    aria-label="Clear workspace search"
+                    onClick={() => setSearchQuery('')}
+                    className={styles['clear-search']}
+                  >
+                    <X aria-hidden="true" />
+                  </Button>
+                )}
               </div>
             </div>
           )}
 
           <div className={styles.list}>
+            {visibleWorkspaces.length > 0 && (
+              <div className={styles['list-heading']}>
+                <span>{hasSearchQuery ? 'Search Results' : 'Workspaces'}</span>
+                <span>{visibleWorkspaces.length}</span>
+              </div>
+            )}
             {visibleWorkspaces.length === 0 ? (
-              <p className={styles.empty}>
-                {searchQuery ? 'No workspaces found' : 'No workspaces yet'}
-              </p>
+              <div className={styles.empty}>
+                <FolderOpen className={styles['empty-icon']} aria-hidden="true" />
+                <p className={styles['empty-title']}>
+                  {hasSearchQuery ? 'No matching workspaces' : 'No workspaces yet'}
+                </p>
+                {hasSearchQuery && (
+                  <p className={styles['empty-description']}>Try a different workspace name.</p>
+                )}
+              </div>
             ) : (
               <div className={styles['list-items']}>
                 {visibleWorkspaces.map((ws) => (


### PR DESCRIPTION
## Summary
- Add ARIA labels/roles (aria-hidden on decorative icons, aria-label on inputs, aria-pressed/aria-expanded on toggles) across the workspace picker and workspace creation footer
- Always show the search field in the workspace picker (drop the 5-workspace threshold), add a clear button, and show a result count / list heading
- Show a selected checkmark and a source-type label (Git repository / Local folder / Empty workspace) on each workspace item, plus richer empty and loading states