### PR TITLE
fix: clean up chat worktrees on deletion

### DIFF
--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -584,7 +584,9 @@ class ChatService(BaseDbService[Chat]):
         # and destroy the workspace container if no other chats reference it.
         async with self.session_factory() as db:
             result = await db.execute(
-                select(Chat).filter(
+                select(Chat)
+                .options(selectinload(Chat.workspace))
+                .filter(
                     Chat.id == chat_id,
                     Chat.user_id == user.id,
                     Chat.deleted_at.is_(None),
@@ -601,17 +603,28 @@ class ChatService(BaseDbService[Chat]):
                 )
 
             workspace_id = chat.workspace_id
+            sandbox_id = chat.sandbox_id
+            sandbox = self.sandbox_for_workspace(chat.workspace)
             now = datetime.now(timezone.utc)
             chat.deleted_at = now
 
             sub_thread_result = await db.execute(
-                select(Chat.id).filter(
+                select(Chat.id, Chat.worktree_cwd).filter(
                     Chat.parent_chat_id == chat_id,
                     Chat.user_id == user.id,
                     Chat.deleted_at.is_(None),
                 )
             )
-            sub_thread_ids = [row[0] for row in sub_thread_result.fetchall()]
+            sub_threads = sub_thread_result.all()
+            sub_thread_ids = [row[0] for row in sub_threads]
+
+            # Only worktrees these chats created themselves — a sub-thread's
+            # inherited worktree_cwd points at the parent's and won't match.
+            owned_worktrees = [
+                cwd
+                for cid, cwd in [(chat.id, chat.worktree_cwd), *sub_threads]
+                if cwd and cwd == GitService.chat_worktree_path(str(cid))
+            ]
 
             if sub_thread_ids:
                 await db.execute(
@@ -641,7 +654,9 @@ class ChatService(BaseDbService[Chat]):
             for sub_id in sub_thread_ids:
                 asyncio.create_task(session_registry.terminate(str(sub_id)))
 
-            # Destroy the workspace container if no chats remain
+            # Destroy the workspace container if no chats remain; the teardown
+            # also removes this chat's worktrees, so only fire standalone
+            # removal when the workspace survives.
             remaining = await db.execute(
                 select(func.count(Chat.id)).filter(
                     Chat.workspace_id == workspace_id,
@@ -662,19 +677,36 @@ class ChatService(BaseDbService[Chat]):
                     if workspace.sandbox_id:
                         ws_sandbox = self.sandbox_for_workspace(workspace)
                         asyncio.create_task(
-                            teardown_workspace_sandbox(workspace.sandbox_id, ws_sandbox)
+                            teardown_workspace_sandbox(
+                                workspace.sandbox_id, ws_sandbox, owned_worktrees
+                            )
                         )
+            elif sandbox_id:
+                git_service = GitService(sandbox)
+                for worktree_cwd in owned_worktrees:
+                    asyncio.create_task(
+                        git_service.remove_worktree(sandbox_id, worktree_cwd)
+                    )
 
     async def delete_all_chats(self, user: User) -> int:
         # Bulk soft-delete all chats, messages, and workspaces for a user,
         # then fire-and-forget session termination and sandbox cleanup.
         async with self.session_factory() as db:
-            chat_query = select(Chat.id).filter(
+            chat_query = select(Chat.id, Chat.workspace_id, Chat.worktree_cwd).filter(
                 Chat.user_id == user.id,
                 Chat.deleted_at.is_(None),
             )
             result = await db.execute(chat_query)
-            chat_ids = [str(row[0]) for row in result.fetchall()]
+            chat_rows = result.all()
+            chat_ids = [str(row[0]) for row in chat_rows]
+
+            # Owned worktrees per workspace, handed to each teardown — host
+            # sandboxes keep the repo files after deletion, so worktrees would
+            # otherwise leak into the user's project.
+            worktrees_by_workspace: dict[UUID, list[str]] = {}
+            for cid, ws_id, cwd in chat_rows:
+                if cwd and cwd == GitService.chat_worktree_path(str(cid)):
+                    worktrees_by_workspace.setdefault(ws_id, []).append(cwd)
 
             ws_result = await db.execute(
                 select(Workspace).filter(
@@ -715,7 +747,11 @@ class ChatService(BaseDbService[Chat]):
                 if ws.sandbox_id:
                     ws_sandbox = self.sandbox_for_workspace(ws)
                     asyncio.create_task(
-                        teardown_workspace_sandbox(ws.sandbox_id, ws_sandbox)
+                        teardown_workspace_sandbox(
+                            ws.sandbox_id,
+                            ws_sandbox,
+                            worktrees_by_workspace.get(ws.id, []),
+                        )
                     )
 
             return len(chat_ids)

--- a/backend/app/services/git.py
+++ b/backend/app/services/git.py
@@ -1,3 +1,4 @@
+import logging
 import posixpath
 import re
 import shlex
@@ -18,6 +19,8 @@ from app.models.schemas.sandbox import (
 from app.services.exceptions import SandboxException
 from app.services.sandbox import SandboxService
 from app.utils.sandbox import BRANCH_NAME_RE, git_cd_prefix
+
+logger = logging.getLogger(__name__)
 
 
 class Checkpoint(NamedTuple):
@@ -71,11 +74,28 @@ GIT_CREATE_BRANCH_FROM_REMOTE_TEMPLATE = Template(
 # Idempotent: a previous attempt may have created the worktree but failed to
 # persist it; the dir-exists check lets us skip `git worktree add` instead of
 # failing on a duplicate branch or path.
+# The info/exclude entry hides .worktrees/ from the parent checkout — status,
+# ls-files, and rg all honor it, so root chats don't surface worktree contents
+# (phantom changed paths, duplicated search results, file-tree noise). Written
+# best-effort: a failed write must not block worktree creation. `--git-path`
+# resolves through the common git dir, so the entry lands in the file git
+# actually reads even when the workspace is itself a linked worktree
+# (`--absolute-git-dir` would point at the per-worktree admin dir).
 GIT_WORKTREE_ADD_TEMPLATE = Template(
-    "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && "
-    "if [ -e '$worktree_dir/.git' ]; then echo 'exists'; exit 0; fi && "
+    "git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 2; "
+    "if [ -e '$worktree_dir/.git' ]; then echo 'exists'; exit 0; fi; "
+    'excl="$$(git rev-parse --git-path info/exclude)"; '
+    '{ mkdir -p "$${excl%/*}" && grep -qxF ".worktrees/" "$$excl" '
+    '|| echo ".worktrees/" >> "$$excl"; } 2>/dev/null; '
     "mkdir -p '$base_worktrees_dir' && "
     "git worktree add '$worktree_dir' -b '$branch_name' 2>&1"
+)
+
+# Chat deletion is best-effort cleanup: `remove` without --force refuses when
+# the worktree has uncommitted changes and `-d` refuses when the branch is
+# unmerged, so dirty trees and unmerged work are never destroyed.
+GIT_WORKTREE_REMOVE_TEMPLATE = Template(
+    "git worktree remove '$worktree_dir' 2>&1 && git branch -d '$branch_name' 2>&1"
 )
 
 GIT_DIFF_STAGED_TEMPLATE = Template("git diff$ctx --cached 2>/dev/null")
@@ -589,6 +609,13 @@ class GitService:
             remote_url=remote_url,
         )
 
+    @staticmethod
+    def chat_worktree_path(chat_id: str) -> str:
+        # Worktrees are keyed by the owning chat's short id, so comparing a
+        # chat's worktree_cwd against this doubles as the ownership test on
+        # deletion — a sub-thread's inherited cwd won't match its own id.
+        return posixpath.join(".worktrees", chat_id[:8])
+
     async def create_worktree(
         self,
         sandbox_id: str,
@@ -601,7 +628,7 @@ class GitService:
         # workspace-relative so it slots straight into chat.worktree_cwd.
         short_id = chat_id[:8]
         rel_base_worktrees = posixpath.join(base_cwd, ".worktrees")
-        rel_worktree = posixpath.join(rel_base_worktrees, short_id)
+        rel_worktree = posixpath.join(base_cwd, self.chat_worktree_path(chat_id))
         branch_name = f"worktree-{short_id}"
         git_prefix = self.git_command_prefix(base_cwd)
         cmd = git_prefix + GIT_WORKTREE_ADD_TEMPLATE.substitute(
@@ -621,6 +648,30 @@ class GitService:
         if not error_output:
             error_output = "Worktree mode requires a git workspace"
         raise SandboxException(error_output)
+
+    async def remove_worktree(self, sandbox_id: str, worktree_cwd: str) -> None:
+        # Best-effort: a refusal (dirty worktree, unmerged branch, sandbox
+        # already torn down) just leaves the worktree behind, hidden from the
+        # parent checkout by the info/exclude entry. Runs fire-and-forget from
+        # chat deletion, so failures are logged instead of raised.
+        short_id = posixpath.basename(worktree_cwd)
+        cmd = GIT_DISCOVERY_ENV + GIT_WORKTREE_REMOVE_TEMPLATE.substitute(
+            worktree_dir=worktree_cwd,
+            branch_name=f"worktree-{short_id}",
+        )
+        try:
+            result = await self.sandbox_service.provider.execute_command(
+                sandbox_id, cmd
+            )
+        except (SandboxException, TimeoutError, OSError) as exc:
+            logger.info("Worktree cleanup skipped for %s: %s", worktree_cwd, exc)
+            return
+        if result.exit_code != 0:
+            logger.info(
+                "Worktree cleanup skipped for %s: %s",
+                worktree_cwd,
+                (result.stdout or result.stderr).strip(),
+            )
 
     @staticmethod
     def _validate_branch_name(name: str, label: str = "branch") -> None:

--- a/backend/app/services/session_registry.py
+++ b/backend/app/services/session_registry.py
@@ -144,10 +144,14 @@ class SessionRegistry:
 
     @staticmethod
     def _compute_fingerprint(config: AcpSessionConfig) -> str:
-        # cwd is excluded: it drifts during a session when the agent
-        # reports sub-paths via SessionInfoUpdate.
+        # cwd is stable per chat (workspace root or the chat's worktree, never
+        # agent-reported paths), so including it respawns the agent process in
+        # the worktree when worktree mode is enabled mid-chat — otherwise the
+        # reused session keeps editing the workspace root while the UI targets
+        # the worktree. resume_session_id carries context across the respawn.
         fingerprint_dict: dict[str, Any] = {
             "agent_kind": config.agent_kind.value,
+            "cwd": config.cwd,
             "env": config.env,
             "mcp_servers": config.mcp_servers,
             "system_prompt": config.system_prompt,

--- a/backend/app/services/terminal.py
+++ b/backend/app/services/terminal.py
@@ -12,6 +12,7 @@ from fastapi import WebSocket
 
 from app.constants import PTY_INPUT_QUEUE_SIZE, PTY_OUTPUT_QUEUE_SIZE
 from app.services.exceptions import SandboxException
+from app.services.git import GitService
 from app.services.sandbox import SandboxService
 from app.services.sandbox_providers import SandboxProviderType
 from app.services.sandbox_providers.base import SandboxProvider
@@ -349,10 +350,20 @@ terminal_session_registry = TerminalSessionRegistry()
 
 
 async def teardown_workspace_sandbox(
-    sandbox_id: str, sandbox_service: SandboxService
+    sandbox_id: str,
+    sandbox_service: SandboxService,
+    worktree_cwds: list[str],
 ) -> None:
     # Every workspace-sandbox deletion funnels through here so the ordering
     # can't drift: terminals must die while the sandbox still exists (tmux
-    # kill-session runs inside it), then the sandbox itself is deleted.
+    # kill-session runs inside it), then chat worktrees are removed (host
+    # sandboxes keep the repo files after deletion, so worktrees would leak),
+    # then the sandbox itself is deleted.
     await terminal_session_registry.terminate_for_sandbox(sandbox_id)
+    if worktree_cwds:
+        git_service = GitService(sandbox_service)
+        await asyncio.gather(
+            *[git_service.remove_worktree(sandbox_id, cwd) for cwd in worktree_cwds],
+            return_exceptions=True,
+        )
     await sandbox_service.delete_sandbox(sandbox_id)

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -29,6 +29,7 @@ from app.models.schemas.workspace import (
 from app.services.acp.adapters import AgentKind
 from app.services.db import BaseDbService, SessionFactoryType
 from app.services.exceptions import ErrorCode, WorkspaceException
+from app.services.git import GitService
 from app.services.sandbox import SandboxService
 from app.services.sandbox_providers.base import SandboxProvider
 from app.services.session_registry import session_registry
@@ -282,11 +283,21 @@ class WorkspaceService(BaseDbService[Workspace]):
             workspace.deleted_at = now
 
             # Soft-delete all chats in this workspace
-            chat_ids_query = select(Chat.id).filter(
+            chat_ids_query = select(Chat.id, Chat.worktree_cwd).filter(
                 Chat.workspace_id == workspace_id, Chat.deleted_at.is_(None)
             )
             chat_ids_result = await db.execute(chat_ids_query)
-            chat_ids = [row[0] for row in chat_ids_result.fetchall()]
+            chat_rows = chat_ids_result.all()
+            chat_ids = [row[0] for row in chat_rows]
+
+            # Owned worktrees only (a sub-thread's inherited cwd won't match
+            # its own id) — teardown removes them before the sandbox goes away,
+            # since host sandboxes keep the repo files after deletion.
+            owned_worktrees = [
+                cwd
+                for cid, cwd in chat_rows
+                if cwd and cwd == GitService.chat_worktree_path(str(cid))
+            ]
 
             await db.execute(
                 update(Chat)
@@ -318,7 +329,9 @@ class WorkspaceService(BaseDbService[Workspace]):
                 )
                 sandbox_service = SandboxService(provider)
                 asyncio.create_task(
-                    teardown_workspace_sandbox(workspace.sandbox_id, sandbox_service)
+                    teardown_workspace_sandbox(
+                        workspace.sandbox_id, sandbox_service, owned_worktrees
+                    )
                 )
 
     async def _clone_git_workspace(


### PR DESCRIPTION
## Summary
- Chat/workspace/bulk-chat deletion now removes each chat's owned git worktree (`.worktrees/<short_id>`) before or as part of sandbox teardown — previously only the sandbox container was destroyed, leaving orphaned worktree directories behind in host sandboxes that keep repo files after deletion.
- Worktree creation writes `.worktrees/` to `info/exclude` (best-effort) so it stays hidden from the parent checkout's status/search/file-tree output.
- `SessionRegistry._compute_fingerprint` now includes `cwd`, so an existing ACP session respawns when worktree mode changes a chat's cwd mid-session instead of continuing to edit the workspace root while the UI targets the worktree.

## Test plan
- [ ] Create a chat with worktree mode enabled, delete the chat, and confirm `.worktrees/<id>` is removed from the sandbox
- [ ] Delete a workspace with multiple worktree chats and confirm all owned worktrees are cleaned up, sub-thread worktrees aren't double-removed
- [ ] Enable worktree mode mid-chat and confirm the agent session respawns targeting the worktree cwd