### PR TITLE
feat: add sidebar chat grouping by date

### DIFF
--- a/frontend/src/components/layout/Sidebar/SidebarFilterSubmenu.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarFilterSubmenu.tsx
@@ -30,6 +30,7 @@ export const AGENT_OPTIONS: { value: AgentKind; label: string }[] = [
 
 export const GROUP_BY_OPTIONS: { value: SidebarGroupBy; label: string }[] = [
   { value: 'none', label: 'None' },
+  { value: 'date', label: 'Date' },
   { value: 'workspace', label: 'Workspace' },
   { value: 'status', label: 'Status' },
 ];

--- a/frontend/src/components/layout/Sidebar/sidebarGrouping.test.ts
+++ b/frontend/src/components/layout/Sidebar/sidebarGrouping.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Chat } from '@/types/chat.types';
+import { buildRecentChatSections } from './sidebarGrouping';
+
+const NOW = new Date(2026, 6, 12, 12);
+
+function chat(id: string, updatedAt: Date): Chat {
+  return {
+    id,
+    user_id: 'user',
+    title: id,
+    workspace_id: 'workspace',
+    sandbox_id: 'sandbox',
+    created_at: updatedAt.toISOString(),
+    updated_at: updatedAt.toISOString(),
+    pinned_at: null,
+    worktree_cwd: null,
+    parent_chat_id: null,
+    sub_thread_count: 0,
+    session_agent_kind: null,
+    unread: false,
+  };
+}
+
+function groupByDate(chats: Chat[]) {
+  return buildRecentChatSections({
+    groupBy: 'date',
+    visibleRecentChats: chats,
+    workspaceBadgeById: new Map(),
+    blockedChatIdSet: new Set(),
+    streamingChatIdSet: new Set(),
+    completedChatIds: new Set(),
+  });
+}
+
+describe('buildRecentChatSections date grouping', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('groups chats by local calendar day across the today and yesterday boundary', () => {
+    const sections = groupByDate([
+      chat('today-late', new Date(2026, 6, 12, 23, 59)),
+      chat('today-early', new Date(2026, 6, 12, 0, 1)),
+      chat('yesterday', new Date(2026, 6, 11, 23, 59)),
+    ]);
+
+    expect(sections.map(({ label, chats }) => [label, chats.map(({ id }) => id)])).toEqual([
+      ['Today', ['today-late', 'today-early']],
+      ['Yesterday', ['yesterday']],
+    ]);
+  });
+
+  it('formats older dates and preserves the incoming recency order', () => {
+    const sameYear = new Date(2026, 5, 30, 12);
+    const priorYear = new Date(2025, 11, 31, 12);
+    const sections = groupByDate([
+      chat('same-year-newer', new Date(2026, 5, 30, 18)),
+      chat('same-year-older', sameYear),
+      chat('prior-year', priorYear),
+    ]);
+
+    expect(sections.map(({ label, chats }) => [label, chats.map(({ id }) => id)])).toEqual([
+      [
+        new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(sameYear),
+        ['same-year-newer', 'same-year-older'],
+      ],
+      [
+        new Intl.DateTimeFormat(undefined, {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        }).format(priorYear),
+        ['prior-year'],
+      ],
+    ]);
+  });
+});

--- a/frontend/src/components/layout/Sidebar/sidebarGrouping.ts
+++ b/frontend/src/components/layout/Sidebar/sidebarGrouping.ts
@@ -1,6 +1,7 @@
 import type { Chat } from '@/types/chat.types';
 import type { SidebarGroupBy, SidebarStatusFilter } from '@/store/sidebarFilters';
 import type { WorkspaceBadge } from '@/hooks/queries/useSidebarChatLists';
+import { formatDayLabel } from '@/utils/date';
 
 export interface SidebarChatSection {
   key: string;
@@ -29,8 +30,8 @@ interface GroupingContext {
 
 // Always returns a sections list so the JSX renders one shape — ungrouped is a
 // single headerless section. Groups keep the flat list's recency order:
-// workspace groups appear in order of their most recent chat; status groups
-// follow badge urgency. Pinned stays flat — it's a small, user-curated list.
+// date and workspace groups appear in order of their most recent chat; status
+// groups follow badge urgency. Pinned stays flat — it's a small, curated list.
 export function buildRecentChatSections({
   groupBy,
   visibleRecentChats,
@@ -39,6 +40,32 @@ export function buildRecentChatSections({
   streamingChatIdSet,
   completedChatIds,
 }: GroupingContext): SidebarChatSection[] {
+  if (groupBy === 'date') {
+    const groups = new Map<number, SidebarChatSection>();
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    for (const chat of visibleRecentChats) {
+      const chatDate = new Date(chat.updated_at);
+      chatDate.setHours(0, 0, 0, 0);
+      const key = chatDate.getTime();
+      let group = groups.get(key);
+      if (!group) {
+        const label =
+          key === today.getTime()
+            ? 'Today'
+            : key === yesterday.getTime()
+              ? 'Yesterday'
+              : formatDayLabel(chatDate, today);
+        group = { key: String(key), label, chats: [] };
+        groups.set(key, group);
+      }
+      group.chats.push(chat);
+    }
+    return Array.from(groups.values());
+  }
   if (groupBy === 'workspace') {
     const groups = new Map<string, SidebarChatSection>();
     for (const chat of visibleRecentChats) {

--- a/frontend/src/store/sidebarFilters.ts
+++ b/frontend/src/store/sidebarFilters.ts
@@ -7,7 +7,7 @@ import type { AgentKind } from '@/types/chat.types';
 // running/done/needs-you are session-only stream state that resets on reload.
 export type SidebarStatusFilter = 'unread' | 'running' | 'done' | 'needs-you';
 export type SidebarSourceFilter = 'all' | 'local' | 'cloud';
-export type SidebarGroupBy = 'none' | 'workspace' | 'status';
+export type SidebarGroupBy = 'none' | 'date' | 'workspace' | 'status';
 
 // statuses is an array (not a Set) so the whole object survives JSON
 // persistence in uiStore; it's at most 4 entries.

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,3 +1,11 @@
+export function formatDayLabel(date: Date, referenceDate: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: date.getFullYear() !== referenceDate.getFullYear() ? 'numeric' : undefined,
+  }).format(date);
+}
+
 export const formatRelativeTime = (date: string | Date): string => {
   const targetDate = typeof date === 'string' ? new Date(date) : date;
   const now = new Date();
@@ -27,11 +35,7 @@ export const formatRelativeTime = (date: string | Date): string => {
     return `${diffDays} days ago`;
   }
 
-  return new Intl.DateTimeFormat(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: now.getFullYear() !== targetDate.getFullYear() ? 'numeric' : undefined,
-  }).format(targetDate);
+  return formatDayLabel(targetDate, now);
 };
 
 export function getRelativeTime(dateStr: string): string {


### PR DESCRIPTION
## Summary
- Adds a "Date" option to the sidebar chat group-by filter (alongside Workspace and Status)
- Groups recent chats by local calendar day, labeling today/yesterday and using a formatted date (with year when different from the current year) for older days
- Extracts `formatDayLabel` from `formatRelativeTime` in `utils/date.ts` for reuse in the new grouping logic
- Adds unit tests covering the today/yesterday boundary and older-date formatting/ordering

## Test plan
- [x] Added `sidebarGrouping.test.ts` covering date-grouping boundaries and label formatting
- [x] Manually verify the "Date" option in the sidebar group-by menu