### PR TITLE
test: expand frontend unit test coverage

### DIFF
--- a/frontend/src/components/chat/chat-window/ChatInlinePermission.test.tsx
+++ b/frontend/src/components/chat/chat-window/ChatInlinePermission.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ChatInlinePermission } from './ChatInlinePermission';
+import type { PermissionRequest } from '@/types/chat.types';
+
+vi.mock('@/components/ui/markdown/LazyMarkDown', () => ({
+  LazyMarkDown: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+const hooks = vi.hoisted(() => ({
+  state: {
+    pendingPermissionRequest: null as PermissionRequest | null,
+    isPermissionLoading: false,
+    permissionError: null as string | null,
+  },
+  actions: {
+    onPermissionApprove: vi.fn(),
+    onPermissionReject: vi.fn(),
+  },
+}));
+
+// ChatInlinePermission reads the live request and the approve/reject actions
+// straight off the chat-session context; mock at that boundary so the test
+// drives the same wiring the real provider supplies.
+vi.mock('@/hooks/useChatSessionContext', () => ({
+  useChatSessionState: () => hooks.state,
+  useChatSessionActions: () => hooks.actions,
+}));
+
+function makeRequest(over: Partial<PermissionRequest> = {}): PermissionRequest {
+  return {
+    request_id: 'req-1',
+    tool_name: 'Bash',
+    tool_input: { command: 'ls' },
+    seq: 1,
+    options: [
+      { kind: 'allow_once', name: 'Allow', option_id: 'opt-allow' },
+      { kind: 'reject_once', name: 'Reject', option_id: 'opt-reject' },
+    ],
+    ...over,
+  };
+}
+
+describe('ChatInlinePermission', () => {
+  afterEach(() => {
+    cleanup();
+    hooks.state.pendingPermissionRequest = null;
+    hooks.state.isPermissionLoading = false;
+    hooks.state.permissionError = null;
+    hooks.actions.onPermissionApprove.mockReset();
+    hooks.actions.onPermissionReject.mockReset();
+  });
+
+  it('renders nothing when there is no pending request', () => {
+    const { container } = render(<ChatInlinePermission />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for an ExitPlanMode request', () => {
+    hooks.state.pendingPermissionRequest = makeRequest({ tool_name: 'ExitPlanMode' });
+    const { container } = render(<ChatInlinePermission />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('forwards the approve action with the selected option id', () => {
+    hooks.state.pendingPermissionRequest = makeRequest();
+    render(<ChatInlinePermission />);
+
+    fireEvent.click(screen.getByText('Allow'));
+
+    expect(hooks.actions.onPermissionApprove).toHaveBeenCalledWith('opt-allow');
+    expect(hooks.actions.onPermissionReject).not.toHaveBeenCalled();
+  });
+
+  it('forwards the reject action with the selected option id', () => {
+    hooks.state.pendingPermissionRequest = makeRequest();
+    render(<ChatInlinePermission />);
+
+    fireEvent.click(screen.getByText('Reject'));
+
+    expect(hooks.actions.onPermissionReject).toHaveBeenCalledWith('opt-reject');
+    expect(hooks.actions.onPermissionApprove).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/chat/chat-window/QueueMessageCard.test.tsx
+++ b/frontend/src/components/chat/chat-window/QueueMessageCard.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { QueueMessageCard } from './QueueMessageCard';
+import type { LocalQueuedMessage } from '@/types/queue.types';
+
+function makeMessage(over: Partial<LocalQueuedMessage> = {}): LocalQueuedMessage {
+  return {
+    id: 'msg-1',
+    content: 'queued text',
+    model_id: 'claude-x',
+    queuedAt: 0,
+    synced: true,
+    sendingNow: false,
+    ...over,
+  };
+}
+
+function renderCard(over: Partial<LocalQueuedMessage> = {}) {
+  const onCancel = vi.fn();
+  const onEdit = vi.fn();
+  const onSendNow = vi.fn();
+  render(
+    <QueueMessageCard
+      message={makeMessage(over)}
+      onCancel={onCancel}
+      onEdit={onEdit}
+      onSendNow={onSendNow}
+    />,
+  );
+  return { onCancel, onEdit, onSendNow };
+}
+
+describe('QueueMessageCard', () => {
+  afterEach(cleanup);
+
+  it('renders the queued message content', () => {
+    renderCard({ content: 'deploy the app' });
+    expect(screen.getByText('deploy the app')).toBeTruthy();
+  });
+
+  it('cancels the queued message when the cancel action is clicked', () => {
+    const { onCancel } = renderCard();
+    fireEvent.click(screen.getByLabelText('Cancel message'));
+    expect(onCancel).toHaveBeenCalledWith('msg-1');
+  });
+
+  it('sends now only for a synced message and dispatches the id', () => {
+    const { onSendNow } = renderCard({ synced: true });
+    fireEvent.click(screen.getByLabelText('Send now'));
+    expect(onSendNow).toHaveBeenCalledWith('msg-1');
+  });
+
+  it('hides the send-now action for an unsynced (still uploading) message', () => {
+    renderCard({ synced: false });
+    expect(screen.queryByLabelText('Send now')).toBeNull();
+  });
+
+  it('shows a sending state instead of actions while dispatching', () => {
+    renderCard({ sendingNow: true });
+    expect(screen.getByText('Sending...')).toBeTruthy();
+    expect(screen.queryByLabelText('Cancel message')).toBeNull();
+    expect(screen.queryByLabelText('Edit message')).toBeNull();
+  });
+
+  it('persists an edited message via onEdit with trimmed content', () => {
+    const { onEdit, onCancel } = renderCard({ content: 'old' });
+    fireEvent.click(screen.getByLabelText('Edit message'));
+
+    const input = screen.getByLabelText('Edit message') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '  new text  ' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(onEdit).toHaveBeenCalledWith('msg-1', 'new text');
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('cancels rather than persisting an empty edit — a blank message must never be queued', () => {
+    const { onEdit, onCancel } = renderCard({ content: 'old' });
+    fireEvent.click(screen.getByLabelText('Edit message'));
+
+    const input = screen.getByLabelText('Edit message') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(onCancel).toHaveBeenCalledWith('msg-1');
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+
+  it('saves an edit on Enter and abandons it on Escape', () => {
+    const { onEdit } = renderCard({ content: 'first' });
+
+    // Enter commits.
+    fireEvent.click(screen.getByLabelText('Edit message'));
+    let input = screen.getByLabelText('Edit message') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'committed' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onEdit).toHaveBeenCalledWith('msg-1', 'committed');
+
+    // Escape discards: the original preview is restored and no further edit fires.
+    onEdit.mockReset();
+    fireEvent.click(screen.getByLabelText('Edit message'));
+    input = screen.getByLabelText('Edit message') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'discarded' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(screen.getByText('first')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/chat/message-bubble/MessageRenderer.test.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageRenderer.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from 'react';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MessageRenderer } from './MessageRenderer';
+import type { AssistantStreamEvent } from '@/types/chat.types';
+import type { ToolEventPayload } from '@/types/tools.types';
+
+// Stub the leaf renderer so the test observes MessageRenderer's wiring — segment
+// order and the per-segment active-thinking/active-text flags — without pulling
+// in markdown, tool registries, or the smooth-text animation.
+vi.mock('./SegmentView', () => ({
+  SegmentView: ({
+    segment,
+    isActiveThinking,
+    isActiveText,
+  }: {
+    segment: { id: string; kind: string; text?: string };
+    isActiveThinking: boolean;
+    isActiveText: boolean;
+  }) => (
+    <div
+      data-testid="segment"
+      data-id={segment.id}
+      data-kind={segment.kind}
+      data-active-thinking={String(isActiveThinking)}
+      data-active-text={String(isActiveText)}
+    >
+      {segment.text ?? ''}
+    </div>
+  ),
+}));
+
+// The completed-turn work trace collapses into WorkedRollup; expose it as a
+// boundary so the trace/tail split is assertable.
+vi.mock('./WorkedRollup', () => ({
+  WorkedRollup: ({ children }: { children: ReactNode }) => (
+    <div data-testid="rollup">{children}</div>
+  ),
+}));
+
+const tool = (over: Partial<ToolEventPayload> & { id: string }): ToolEventPayload => ({
+  name: 'Bash',
+  title: 'run',
+  status: 'started',
+  ...over,
+});
+
+function renderedOrder() {
+  return screen.getAllByTestId('segment').map((el) => el.getAttribute('data-id'));
+}
+
+describe('MessageRenderer streaming wiring', () => {
+  afterEach(cleanup);
+
+  it('renders segments in emission order', () => {
+    const events: AssistantStreamEvent[] = [
+      { type: 'assistant_text', text: 'intro' },
+      { type: 'tool_started', tool: tool({ id: 't1' }) },
+      { type: 'assistant_text', text: 'outro' },
+    ];
+    render(<MessageRenderer events={events} isStreaming />);
+    expect(renderedOrder()).toEqual(['text-0', 'tool-t1', 'text-1']);
+  });
+
+  it('marks only the trailing text segment active while its text streams in', () => {
+    const events: AssistantStreamEvent[] = [
+      { type: 'assistant_text', text: 'first' },
+      { type: 'tool_started', tool: tool({ id: 't1' }) },
+      { type: 'assistant_text', text: 'live tail' },
+    ];
+    render(<MessageRenderer events={events} isStreaming />);
+
+    const segments = screen.getAllByTestId('segment');
+    const byId = Object.fromEntries(segments.map((el) => [el.getAttribute('data-id'), el]));
+    expect(byId['text-1'].getAttribute('data-active-text')).toBe('true');
+    expect(byId['text-0'].getAttribute('data-active-text')).toBe('false');
+    expect(byId['tool-t1'].getAttribute('data-active-thinking')).toBe('false');
+  });
+
+  it('marks the trailing thinking segment active while thinking streams', () => {
+    render(
+      <MessageRenderer
+        events={[{ type: 'assistant_thinking', thinking: 'pondering' }]}
+        isStreaming
+      />,
+    );
+    const segment = screen.getByTestId('segment');
+    expect(segment.getAttribute('data-kind')).toBe('thinking');
+    expect(segment.getAttribute('data-active-thinking')).toBe('true');
+  });
+
+  it('never marks a segment active once the turn is no longer streaming', () => {
+    const events: AssistantStreamEvent[] = [
+      { type: 'assistant_thinking', thinking: 'done thinking' },
+      { type: 'assistant_text', text: 'final answer' },
+    ];
+    render(<MessageRenderer events={events} isStreaming={false} />);
+    for (const el of screen.getAllByTestId('segment')) {
+      expect(el.getAttribute('data-active-thinking')).toBe('false');
+      expect(el.getAttribute('data-active-text')).toBe('false');
+    }
+  });
+
+  it('collapses the completed work trace into the rollup and leaves the final answer outside it', () => {
+    const events: AssistantStreamEvent[] = [
+      { type: 'assistant_thinking', thinking: 'plan' },
+      { type: 'tool_started', tool: tool({ id: 't1' }) },
+      { type: 'tool_completed', tool: tool({ id: 't1', status: 'completed' }) },
+      { type: 'assistant_text', text: 'the answer' },
+    ];
+    render(<MessageRenderer events={events} isStreaming={false} />);
+
+    const rollup = screen.getByTestId('rollup');
+    const rollupIds = within(rollup)
+      .getAllByTestId('segment')
+      .map((el) => el.getAttribute('data-id'));
+    expect(rollupIds).toEqual(['thinking-0', 'tool-t1']);
+
+    // The final text segment renders after the rollup, not inside it.
+    expect(within(rollup).queryByText('the answer')).toBeNull();
+    expect(screen.getByText('the answer')).toBeTruthy();
+  });
+
+  it('keeps live segments flat (no rollup) while streaming', () => {
+    const events: AssistantStreamEvent[] = [
+      { type: 'assistant_thinking', thinking: 'plan' },
+      { type: 'tool_started', tool: tool({ id: 't1' }) },
+      { type: 'assistant_text', text: 'streaming answer' },
+    ];
+    render(<MessageRenderer events={events} isStreaming />);
+    expect(screen.queryByTestId('rollup')).toBeNull();
+    expect(renderedOrder()).toEqual(['thinking-0', 'tool-t1', 'text-0']);
+  });
+});

--- a/frontend/src/components/chat/message-input/Input.test.tsx
+++ b/frontend/src/components/chat/message-input/Input.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Input, type InputProps } from './Input';
+
+// The composer's send/queue decision lives in the real useInputSubmit hook,
+// which Input wires up through InputProvider. Keep that hook real and mock only
+// the surrounding data sources so the test exercises the actual dispatch logic.
+const mocks = vi.hoisted(() => ({
+  queueMessage: vi.fn<(...args: unknown[]) => Promise<string>>(() => Promise.resolve('queued-id')),
+  clearComposerSelections: vi.fn(),
+  removeComposerSelection: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('@/hooks/useChatContext', () => ({
+  useChatContext: () => ({
+    fileStructure: null,
+    customSkills: [],
+    builtinSlashCommands: [],
+    personas: [],
+  }),
+}));
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: (selector: (s: { isAuthenticated: boolean }) => unknown) =>
+    selector({ isAuthenticated: true }),
+}));
+
+vi.mock('@/hooks/queries/useModelQueries', () => ({
+  useModelMap: () => new Map(),
+}));
+
+const uiState = { composerSelectionsByChat: {} as Record<string, unknown[]> };
+vi.mock('@/store/uiStore', () => {
+  const useUIStore = (selector: (s: typeof uiState) => unknown) => selector(uiState);
+  useUIStore.getState = () => ({
+    clearComposerSelections: mocks.clearComposerSelections,
+    removeComposerSelection: mocks.removeComposerSelection,
+  });
+  return { useUIStore };
+});
+
+vi.mock('@/store/messageQueueStore', () => ({
+  useMessageQueueStore: { getState: () => ({ queueMessage: mocks.queueMessage }) },
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { error: mocks.toastError },
+}));
+
+// Heavy composer sub-trees that don't participate in submit/queue logic.
+vi.mock('./InputControls', () => ({ InputControls: () => null }));
+vi.mock('@/components/ui/FileUploadDialog/FileUploadDialog', () => ({
+  FileUploadDialog: () => null,
+}));
+vi.mock('@/components/ui/drawing-modal/DrawingModal', () => ({ DrawingModal: () => null }));
+
+// Suggestion/attachment/enhance hooks are unrelated to the send path — stub
+// them so InputProvider renders without their real dependencies.
+vi.mock('@/hooks/useInputAttachments', () => ({
+  useInputAttachments: () => ({
+    previewUrls: [],
+    showFileUpload: false,
+    setShowFileUpload: vi.fn(),
+    showDrawingModal: false,
+    editingImageIndex: null,
+    handleFileSelect: vi.fn(),
+    handleRemoveFile: vi.fn(),
+    handleDrawClick: vi.fn(),
+    handleDrawingSave: vi.fn(),
+    closeDrawingModal: vi.fn(),
+    isDragging: false,
+    dragHandlers: {},
+    resetDragState: vi.fn(),
+    handlePaste: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useInputEnhance', () => ({
+  useInputEnhance: () => ({ isEnhancing: false, handleEnhancePrompt: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useInputSuggestions', () => ({
+  useInputSuggestions: () => ({
+    slashCommandSuggestions: [],
+    highlightedSlashCommandIndex: -1,
+    selectSlashCommand: vi.fn(),
+    handleSlashCommandKeyDown: () => false,
+    filteredFiles: [],
+    highlightedMentionIndex: -1,
+    selectMention: vi.fn(),
+    handleMentionKeyDown: () => false,
+    isMentionActive: false,
+  }),
+}));
+
+function renderInput(over: Partial<InputProps> = {}) {
+  const onSubmit = vi.fn();
+  const setMessage = vi.fn();
+  const props: InputProps = {
+    message: 'hello world',
+    setMessage,
+    onSubmit,
+    isLoading: false,
+    selectedModelId: 'claude-x',
+    onModelChange: vi.fn(),
+    chatId: 'chat-1',
+    ...over,
+  };
+  render(<Input {...props} />);
+  return { onSubmit, setMessage };
+}
+
+function pressEnter() {
+  fireEvent.keyDown(screen.getByLabelText('Message input'), { key: 'Enter' });
+}
+
+describe('Input send/queue path', () => {
+  beforeEach(() => {
+    uiState.composerSelectionsByChat = {};
+    vi.clearAllMocks();
+  });
+  afterEach(cleanup);
+
+  it('submits the message on Enter when the agent is idle', () => {
+    const { onSubmit } = renderInput({ isStreaming: false });
+    pressEnter();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(mocks.queueMessage).not.toHaveBeenCalled();
+  });
+
+  it('queues the message and clears the draft while a response is streaming', () => {
+    const { onSubmit, setMessage } = renderInput({ isStreaming: true });
+    pressEnter();
+
+    expect(mocks.queueMessage).toHaveBeenCalledTimes(1);
+    const [chatId, content, modelId] = mocks.queueMessage.mock.calls[0];
+    expect(chatId).toBe('chat-1');
+    expect(content).toBe('hello world');
+    expect(modelId).toBe('claude-x');
+    // The queued draft only clears because the dispatch was accepted.
+    expect(setMessage).toHaveBeenCalledWith('');
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('drops nothing: with no model selected it errors and keeps the draft instead of queuing', () => {
+    const { onSubmit, setMessage } = renderInput({ isStreaming: true, selectedModelId: '' });
+    pressEnter();
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(1);
+    expect(mocks.queueMessage).not.toHaveBeenCalled();
+    // Draft must survive — clearing without a successful queue would silently
+    // lose the user's message.
+    expect(setMessage).not.toHaveBeenCalledWith('');
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not submit or queue an empty draft', () => {
+    const { onSubmit } = renderInput({ isStreaming: false, message: '   ' });
+    pressEnter();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(mocks.queueMessage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/chat/tools/ToolPermissionInline.test.tsx
+++ b/frontend/src/components/chat/tools/ToolPermissionInline.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ToolPermissionInline } from './ToolPermissionInline';
+import type { PermissionRequest } from '@/types/chat.types';
+
+// DetailsList renders diagnostics through the lazy markdown component; swap it
+// for a plain passthrough so the disclosure assertions don't depend on the
+// async chunk resolving.
+vi.mock('@/components/ui/markdown/LazyMarkDown', () => ({
+  LazyMarkDown: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+function makeRequest(over: Partial<PermissionRequest> = {}): PermissionRequest {
+  return {
+    request_id: 'req-1',
+    tool_name: 'Bash',
+    tool_input: { reason: 'Run the test suite', command: 'npm test' },
+    seq: 1,
+    options: [
+      { kind: 'allow_once', name: 'Allow', option_id: 'opt-allow' },
+      { kind: 'reject_once', name: 'Reject', option_id: 'opt-reject' },
+    ],
+    ...over,
+  };
+}
+
+describe('ToolPermissionInline', () => {
+  afterEach(cleanup);
+
+  it('dispatches the allow option id when the allow choice is clicked', () => {
+    const onApprove = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <ToolPermissionInline request={makeRequest()} onApprove={onApprove} onReject={onReject} />,
+    );
+
+    fireEvent.click(screen.getByText('Allow'));
+
+    expect(onApprove).toHaveBeenCalledTimes(1);
+    expect(onApprove).toHaveBeenCalledWith('opt-allow');
+    expect(onReject).not.toHaveBeenCalled();
+  });
+
+  it('dispatches the reject option id when the reject choice is clicked', () => {
+    const onApprove = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <ToolPermissionInline request={makeRequest()} onApprove={onApprove} onReject={onReject} />,
+    );
+
+    fireEvent.click(screen.getByText('Reject'));
+
+    expect(onReject).toHaveBeenCalledTimes(1);
+    expect(onReject).toHaveBeenCalledWith('opt-reject');
+    expect(onApprove).not.toHaveBeenCalled();
+  });
+
+  it('routes each allow/reject variant to the matching handler', () => {
+    const onApprove = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <ToolPermissionInline
+        request={makeRequest({
+          options: [
+            { kind: 'allow_once', name: 'Allow once', option_id: 'a1' },
+            { kind: 'allow_always', name: 'Always allow', option_id: 'a2' },
+            { kind: 'reject_always', name: 'Never allow', option_id: 'r2' },
+          ],
+        })}
+        onApprove={onApprove}
+        onReject={onReject}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Always allow'));
+    fireEvent.click(screen.getByText('Never allow'));
+
+    expect(onApprove).toHaveBeenCalledWith('a2');
+    expect(onReject).toHaveBeenCalledWith('r2');
+  });
+
+  it('renders the tool name and command headline', () => {
+    render(<ToolPermissionInline request={makeRequest()} onApprove={vi.fn()} onReject={vi.fn()} />);
+
+    expect(screen.getByText('Bash')).toBeTruthy();
+    expect(screen.getByText('Run the test suite')).toBeTruthy();
+    expect(screen.getByText('npm test')).toBeTruthy();
+  });
+
+  it('renders nothing when there is no request', () => {
+    const { container } = render(
+      <ToolPermissionInline request={null} onApprove={vi.fn()} onReject={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for an ExitPlanMode request (handled by the plan-mode UI)', () => {
+    const { container } = render(
+      <ToolPermissionInline
+        request={makeRequest({ tool_name: 'ExitPlanMode' })}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('disables the option buttons while a response is in flight', () => {
+    const onApprove = vi.fn();
+    render(
+      <ToolPermissionInline
+        request={makeRequest()}
+        onApprove={onApprove}
+        onReject={vi.fn()}
+        isLoading
+      />,
+    );
+
+    const allowButton = screen.getByText('Allow').closest('button');
+    expect(allowButton).not.toBeNull();
+    expect(allowButton!.disabled).toBe(true);
+    fireEvent.click(allowButton!);
+    expect(onApprove).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the permission error text', () => {
+    render(
+      <ToolPermissionInline
+        request={makeRequest()}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        error="Backend rejected the response"
+      />,
+    );
+    expect(screen.getByText('Backend rejected the response')).toBeTruthy();
+  });
+
+  it('collapses an expanded details disclosure when a new request arrives', () => {
+    const diagnosticInput = { reason: 'do it', call_id: 'call-123' };
+    const { rerender } = render(
+      <ToolPermissionInline
+        request={makeRequest({ request_id: 'req-1', tool_input: diagnosticInput })}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Show details'));
+    expect(screen.getByText('Hide details')).toBeTruthy();
+
+    // A different request_id must reset the disclosure — the component stays
+    // mounted across requests, so a leaked expansion would show stale details.
+    rerender(
+      <ToolPermissionInline
+        request={makeRequest({ request_id: 'req-2', tool_input: diagnosticInput })}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Show details')).toBeTruthy();
+    expect(screen.queryByText('Hide details')).toBeNull();
+  });
+});

--- a/frontend/src/components/layout/Sidebar/sidebarGrouping.test.ts
+++ b/frontend/src/components/layout/Sidebar/sidebarGrouping.test.ts
@@ -4,7 +4,7 @@ import { buildRecentChatSections } from './sidebarGrouping';
 
 const NOW = new Date(2026, 6, 12, 12);
 
-function chat(id: string, updatedAt: Date): Chat {
+function chat(id: string, updatedAt: Date, over: Partial<Chat> = {}): Chat {
   return {
     id,
     user_id: 'user',
@@ -19,6 +19,7 @@ function chat(id: string, updatedAt: Date): Chat {
     sub_thread_count: 0,
     session_agent_kind: null,
     unread: false,
+    ...over,
   };
 }
 
@@ -77,5 +78,102 @@ describe('buildRecentChatSections date grouping', () => {
         ['prior-year'],
       ],
     ]);
+  });
+});
+
+const DAY = new Date(2026, 6, 12, 12);
+
+describe('buildRecentChatSections workspace grouping', () => {
+  it('groups by workspace in most-recent order, resolving badge names', () => {
+    const sections = buildRecentChatSections({
+      groupBy: 'workspace',
+      visibleRecentChats: [
+        chat('a', DAY, { workspace_id: 'ws-1' }),
+        chat('b', DAY, { workspace_id: 'ws-2' }),
+        chat('c', DAY, { workspace_id: 'ws-1' }),
+      ],
+      workspaceBadgeById: new Map([
+        ['ws-1', { name: 'Alpha', isCloud: false }],
+        ['ws-2', { name: 'Beta', isCloud: true }],
+      ]),
+      blockedChatIdSet: new Set(),
+      streamingChatIdSet: new Set(),
+      completedChatIds: new Set(),
+    });
+
+    expect(sections.map(({ label, chats }) => [label, chats.map(({ id }) => id)])).toEqual([
+      ['Alpha', ['a', 'c']],
+      ['Beta', ['b']],
+    ]);
+  });
+
+  it('falls back to "Unknown workspace" while the badge is unresolved', () => {
+    const sections = buildRecentChatSections({
+      groupBy: 'workspace',
+      visibleRecentChats: [chat('a', DAY, { workspace_id: 'ws-x' })],
+      workspaceBadgeById: new Map(),
+      blockedChatIdSet: new Set(),
+      streamingChatIdSet: new Set(),
+      completedChatIds: new Set(),
+    });
+    expect(sections.map(({ label }) => label)).toEqual(['Unknown workspace']);
+  });
+});
+
+describe('buildRecentChatSections status grouping', () => {
+  it('assigns each chat to its highest-precedence status group and orders by urgency', () => {
+    const sections = buildRecentChatSections({
+      groupBy: 'status',
+      visibleRecentChats: [
+        chat('plain', DAY),
+        chat('unread', DAY, { unread: true }),
+        chat('done', DAY),
+        chat('running', DAY),
+        chat('blocked', DAY),
+        // blocked wins over streaming/completed/unread precedence
+        chat('blocked-and-streaming', DAY, { unread: true }),
+      ],
+      workspaceBadgeById: new Map(),
+      blockedChatIdSet: new Set(['blocked', 'blocked-and-streaming']),
+      streamingChatIdSet: new Set(['running', 'blocked-and-streaming']),
+      completedChatIds: new Set(['done']),
+    });
+
+    expect(sections.map(({ label, chats }) => [label, chats.map(({ id }) => id)])).toEqual([
+      ['Needs you', ['blocked', 'blocked-and-streaming']],
+      ['Running', ['running']],
+      ['Done', ['done']],
+      ['Unread', ['unread']],
+      ['Other', ['plain']],
+    ]);
+  });
+
+  it('omits status groups that have no chats', () => {
+    const sections = buildRecentChatSections({
+      groupBy: 'status',
+      visibleRecentChats: [chat('only', DAY, { unread: true })],
+      workspaceBadgeById: new Map(),
+      blockedChatIdSet: new Set(),
+      streamingChatIdSet: new Set(),
+      completedChatIds: new Set(),
+    });
+    expect(sections.map(({ label }) => label)).toEqual(['Unread']);
+  });
+});
+
+describe('buildRecentChatSections ungrouped', () => {
+  it('returns a single headerless section preserving order', () => {
+    const chats = [chat('a', DAY), chat('b', DAY)];
+    const sections = buildRecentChatSections({
+      groupBy: 'none',
+      visibleRecentChats: chats,
+      workspaceBadgeById: new Map(),
+      blockedChatIdSet: new Set(),
+      streamingChatIdSet: new Set(),
+      completedChatIds: new Set(),
+    });
+    expect(sections).toHaveLength(1);
+    expect(sections[0].label).toBeNull();
+    expect(sections[0].chats.map(({ id }) => id)).toEqual(['a', 'b']);
   });
 });

--- a/frontend/src/hooks/createContextHook.test.tsx
+++ b/frontend/src/hooks/createContextHook.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import { createContext } from 'react';
+import type { ReactNode } from 'react';
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { createContextHook } from './createContextHook';
+
+interface Value {
+  label: string;
+}
+
+describe('createContextHook', () => {
+  it('returns the context value when rendered inside a provider', () => {
+    const Ctx = createContext<Value | null>(null);
+    const useValue = createContextHook(Ctx, 'useValue', 'ValueProvider');
+    const value: Value = { label: 'hi' };
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Ctx.Provider value={value}>{children}</Ctx.Provider>
+    );
+
+    const { result } = renderHook(() => useValue(), { wrapper });
+    expect(result.current).toBe(value);
+  });
+
+  it('throws a named error when used outside a provider', () => {
+    const Ctx = createContext<Value | null>(null);
+    const useValue = createContextHook(Ctx, 'useValue', 'ValueProvider');
+    // The hook throws during render; renderHook re-raises it to the caller.
+    expect(() => renderHook(() => useValue())).toThrow(
+      'useValue must be used within a ValueProvider',
+    );
+  });
+});

--- a/frontend/src/hooks/useAsyncEffect.test.tsx
+++ b/frontend/src/hooks/useAsyncEffect.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useAsyncEffect } from './useAsyncEffect';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Resolve microtasks so the effect's async body runs to completion.
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('useAsyncEffect', () => {
+  it('runs the effect on mount with a cancelled() probe that reads false', async () => {
+    const seen: boolean[] = [];
+    renderHook(() =>
+      useAsyncEffect(async (cancelled) => {
+        seen.push(cancelled());
+      }, []),
+    );
+    await flush();
+    expect(seen).toEqual([false]);
+  });
+
+  it('re-runs only when deps change', async () => {
+    const effect = vi.fn(async () => {});
+    const { rerender } = renderHook(({ dep }) => useAsyncEffect(effect, [dep]), {
+      initialProps: { dep: 1 },
+    });
+    await flush();
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    rerender({ dep: 1 });
+    await flush();
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    rerender({ dep: 2 });
+    await flush();
+    expect(effect).toHaveBeenCalledTimes(2);
+  });
+
+  it('flips cancelled() to true after unmount so post-await work can bail', async () => {
+    let probe: (() => boolean) | null = null;
+    let resolveGate: () => void = () => {};
+    const gate = new Promise<void>((r) => {
+      resolveGate = r;
+    });
+
+    const { unmount } = renderHook(() =>
+      useAsyncEffect(async (cancelled) => {
+        probe = cancelled;
+        await gate;
+      }, []),
+    );
+
+    expect(probe!()).toBe(false);
+    unmount();
+    resolveGate();
+    await flush();
+    expect(probe!()).toBe(true);
+  });
+
+  it('logs rejections only when the effect is still active', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    renderHook(() =>
+      useAsyncEffect(async () => {
+        throw new Error('boom');
+      }, []),
+    );
+    await flush();
+    expect(errorSpy).toHaveBeenCalledWith('useAsyncEffect error:', expect.any(Error));
+  });
+
+  it('swallows a rejection that surfaces after unmount', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let reject: (e: unknown) => void = () => {};
+    const gate = new Promise<void>((_, rej) => {
+      reject = rej;
+    });
+
+    const { unmount } = renderHook(() => useAsyncEffect(async () => gate, []));
+    unmount();
+    reject(new Error('late'));
+    await flush();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useCloudStreamRestoration.test.tsx
+++ b/frontend/src/hooks/useCloudStreamRestoration.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { getActiveStreams, addStreamMetadataIfAbsent, loggerError, state } = vi.hoisted(() => ({
+  getActiveStreams: vi.fn(),
+  addStreamMetadataIfAbsent: vi.fn(),
+  loggerError: vi.fn(),
+  state: { cloudUrl: 'https://cloud.example' as string | null },
+}));
+
+vi.mock('@/services/cloudChatService', () => ({ cloudChatService: { getActiveStreams } }));
+vi.mock('@/store/streamStore', () => ({
+  useStreamStore: { getState: () => ({ addStreamMetadataIfAbsent }) },
+}));
+vi.mock('@/store/cloudSettingsStore', () => ({
+  // Match the real selector-hook shape the source consumes.
+  useCloudSettingsStore: (selector: (s: typeof state) => unknown) => selector(state),
+}));
+vi.mock('@/utils/logger', () => ({ logger: { error: loggerError } }));
+
+import { useCloudStreamRestoration } from './useCloudStreamRestoration';
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.cloudUrl = 'https://cloud.example';
+  getActiveStreams.mockResolvedValue([]);
+});
+
+describe('useCloudStreamRestoration', () => {
+  it('does nothing while disabled', async () => {
+    renderHook(() => useCloudStreamRestoration({ enabled: false }));
+    await flush();
+    expect(getActiveStreams).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no cloudUrl is configured', async () => {
+    state.cloudUrl = null;
+    renderHook(() => useCloudStreamRestoration({ enabled: true }));
+    await flush();
+    expect(getActiveStreams).not.toHaveBeenCalled();
+  });
+
+  it('seeds metadata for each active cloud stream', async () => {
+    getActiveStreams.mockResolvedValue([{ chat_id: 'c1', message_id: 'm1' }]);
+    renderHook(() => useCloudStreamRestoration({ enabled: true }));
+    await flush();
+    expect(addStreamMetadataIfAbsent).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId: 'c1', messageId: 'm1' }),
+    );
+  });
+
+  it('re-restores when the cloudUrl changes (new connection)', async () => {
+    const { rerender } = renderHook(() => useCloudStreamRestoration({ enabled: true }));
+    await flush();
+    expect(getActiveStreams).toHaveBeenCalledTimes(1);
+
+    state.cloudUrl = 'https://other.example';
+    rerender();
+    await flush();
+    expect(getActiveStreams).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs and swallows a restoration failure', async () => {
+    const err = new Error('unreachable');
+    getActiveStreams.mockRejectedValue(err);
+    renderHook(() => useCloudStreamRestoration({ enabled: true }));
+    await flush();
+    expect(loggerError).toHaveBeenCalledWith(
+      'Cloud stream restoration failed',
+      'useCloudStreamRestoration',
+      err,
+    );
+  });
+});

--- a/frontend/src/hooks/useInputSubmit.test.tsx
+++ b/frontend/src/hooks/useInputSubmit.test.tsx
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ComposerSelection } from '@/store/uiStore';
+import type { AgentKind } from '@/types/chat.types';
+
+const h = vi.hoisted(() => ({
+  queueMessage: vi.fn<(...args: unknown[]) => Promise<void>>(() => Promise.resolve()),
+  clearComposerSelections: vi.fn(),
+  removeComposerSelection: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('react-hot-toast', () => ({ default: { error: h.toastError } }));
+vi.mock('@/store/messageQueueStore', () => ({
+  useMessageQueueStore: { getState: () => ({ queueMessage: h.queueMessage }) },
+}));
+vi.mock('@/store/uiStore', () => ({
+  useUIStore: {
+    getState: () => ({
+      clearComposerSelections: h.clearComposerSelections,
+      removeComposerSelection: h.removeComposerSelection,
+    }),
+  },
+}));
+vi.mock('@/store/chatSettingsStore', () => ({
+  useChatSettingsStore: {
+    getState: () => ({
+      permissionModeByChat: {},
+      thinkingModeByChat: {},
+      worktreeByChat: {},
+      personaByChat: {},
+    }),
+  },
+  DEFAULT_PERMISSION_MODE: 'bypassPermissions',
+  DEFAULT_THINKING_MODE: 'high',
+  DEFAULT_WORKTREE: false,
+  DEFAULT_PERSONA: 'Default',
+}));
+
+import { useInputSubmit } from './useInputSubmit';
+
+function makeOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    disabled: false,
+    hasContent: true,
+    onSubmit: vi.fn(),
+    setPreviewDismissed: vi.fn(),
+    isStreaming: false,
+    onStopStream: vi.fn(),
+    isLoading: false,
+    chatId: 'chat-1',
+    selectedModelId: 'model-1',
+    agentKind: 'claude' as AgentKind,
+    personas: [],
+    attachedSelections: [] as ComposerSelection[],
+    attachedFiles: null,
+    messageRef: { current: 'hello' },
+    setMessage: vi.fn(),
+    onAttach: vi.fn(),
+    formRef: { current: null } as React.RefObject<HTMLFormElement | null>,
+    textareaRef: { current: null } as React.RefObject<HTMLTextAreaElement | null>,
+    handleMentionKeyDown: vi.fn(() => false),
+    handleSlashCommandKeyDown: vi.fn(() => false),
+    ...overrides,
+  } as Parameters<typeof useInputSubmit>[0];
+}
+
+function formEvent() {
+  return { preventDefault: vi.fn() } as unknown as React.FormEvent;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useInputSubmit — handleSubmit', () => {
+  it('submits content and dismisses the preview', () => {
+    const opts = makeOptions();
+    const { result } = renderHook(() => useInputSubmit(opts));
+    const e = formEvent();
+    act(() => result.current.handleSubmit(e));
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(opts.setPreviewDismissed).toHaveBeenCalledWith(true);
+    expect(opts.onSubmit).toHaveBeenCalledWith(e);
+  });
+
+  it('bails when disabled', () => {
+    const opts = makeOptions({ disabled: true });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.handleSubmit(formEvent()));
+    expect(opts.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('bails when there is no content', () => {
+    const opts = makeOptions({ hasContent: false });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.handleSubmit(formEvent()));
+    expect(opts.onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('useInputSubmit — submitOrStop stop paths', () => {
+  it('stops the stream when streaming with an empty composer', () => {
+    const opts = makeOptions({ isStreaming: true, hasContent: false });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.submitOrStop());
+    expect(opts.onStopStream).toHaveBeenCalledTimes(1);
+    expect(h.queueMessage).not.toHaveBeenCalled();
+  });
+
+  it('stops the pending start when loading', () => {
+    const opts = makeOptions({ isLoading: true, hasContent: false });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.submitOrStop());
+    expect(opts.onStopStream).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useInputSubmit — submitOrStop queue path', () => {
+  it('queues the message, clears the draft, and dismisses the preview', () => {
+    const opts = makeOptions({ isStreaming: true, hasContent: true });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.submitOrStop());
+
+    expect(h.queueMessage).toHaveBeenCalledTimes(1);
+    const [chatId, message, modelId] = h.queueMessage.mock.calls[0];
+    expect(chatId).toBe('chat-1');
+    expect(message).toBe('hello');
+    expect(modelId).toBe('model-1');
+    expect(opts.setMessage).toHaveBeenCalledWith('');
+    expect(opts.onAttach).toHaveBeenCalledWith([]);
+    expect(opts.setPreviewDismissed).toHaveBeenCalledWith(true);
+  });
+
+  it('refuses to queue and warns when no model is selected — the draft survives', () => {
+    const opts = makeOptions({ isStreaming: true, hasContent: true, selectedModelId: '' });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.submitOrStop());
+
+    expect(h.toastError).toHaveBeenCalledWith('Please select an AI model');
+    expect(h.queueMessage).not.toHaveBeenCalled();
+    expect(opts.setMessage).not.toHaveBeenCalled();
+  });
+
+  it('clears composer selections only when some are attached', () => {
+    const selections = [{ text: 'foo.ts', kind: 'file' }] as unknown as ComposerSelection[];
+    const opts = makeOptions({
+      isStreaming: true,
+      hasContent: true,
+      attachedSelections: selections,
+    });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.submitOrStop());
+    expect(h.clearComposerSelections).toHaveBeenCalledWith('chat-1');
+  });
+});
+
+describe('useInputSubmit — submitOrStop send path', () => {
+  it('requestSubmits the form when idle with content', () => {
+    const requestSubmit = vi.fn();
+    const form = { requestSubmit } as unknown as HTMLFormElement;
+    const opts = makeOptions({ formRef: { current: form } });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.submitOrStop());
+    expect(requestSubmit).toHaveBeenCalledTimes(1);
+    expect(opts.setPreviewDismissed).toHaveBeenCalledWith(true);
+  });
+
+  it('falls back to a synthetic submit event when the form lacks requestSubmit', () => {
+    const opts = makeOptions({ formRef: { current: null } });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.submitOrStop());
+    expect(opts.onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when disabled and not streaming', () => {
+    const opts = makeOptions({ disabled: true });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.submitOrStop());
+    expect(opts.onSubmit).not.toHaveBeenCalled();
+    expect(opts.onStopStream).not.toHaveBeenCalled();
+  });
+});
+
+describe('useInputSubmit — keyboard handling', () => {
+  it('Enter without shift submits; suggestion handlers get first refusal', () => {
+    const opts = makeOptions({
+      formRef: { current: { requestSubmit: vi.fn() } as unknown as HTMLFormElement },
+    });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    const e = {
+      key: 'Enter',
+      shiftKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent<Element>;
+    act(() => result.current.handleKeyDown(e));
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(opts.handleMentionKeyDown).toHaveBeenCalled();
+    expect(opts.handleSlashCommandKeyDown).toHaveBeenCalled();
+  });
+
+  it('lets a mention-menu handler swallow Enter without submitting', () => {
+    const opts = makeOptions({ handleMentionKeyDown: vi.fn(() => true) });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    const e = {
+      key: 'Enter',
+      shiftKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent<Element>;
+    act(() => result.current.handleKeyDown(e));
+    expect(opts.handleSlashCommandKeyDown).not.toHaveBeenCalled();
+    expect(opts.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('Shift+Enter inserts a newline (no submit)', () => {
+    const opts = makeOptions();
+    const { result } = renderHook(() => useInputSubmit(opts));
+    const e = {
+      key: 'Enter',
+      shiftKey: true,
+      preventDefault: vi.fn(),
+    } as unknown as React.KeyboardEvent<Element>;
+    act(() => result.current.handleKeyDown(e));
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(opts.onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('useInputSubmit — selection removal', () => {
+  it('removes a selection by index for the active chat', () => {
+    const opts = makeOptions();
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.handleRemoveSelection(2));
+    expect(h.removeComposerSelection).toHaveBeenCalledWith('chat-1', 2);
+  });
+
+  it('is a no-op without a chatId', () => {
+    const opts = makeOptions({ chatId: undefined });
+    const { result } = renderHook(() => useInputSubmit(opts));
+    act(() => result.current.handleRemoveSelection(0));
+    expect(h.removeComposerSelection).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useLocalStreamRestoration.test.tsx
+++ b/frontend/src/hooks/useLocalStreamRestoration.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { getActiveStreams, addStreamMetadataIfAbsent, loggerError } = vi.hoisted(() => ({
+  getActiveStreams: vi.fn(),
+  addStreamMetadataIfAbsent: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+vi.mock('@/services/chatService', () => ({ chatService: { getActiveStreams } }));
+vi.mock('@/store/streamStore', () => ({
+  useStreamStore: { getState: () => ({ addStreamMetadataIfAbsent }) },
+}));
+vi.mock('@/utils/logger', () => ({ logger: { error: loggerError } }));
+
+import { useLocalStreamRestoration } from './useLocalStreamRestoration';
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getActiveStreams.mockResolvedValue([]);
+});
+
+describe('useLocalStreamRestoration', () => {
+  it('does nothing while disabled', async () => {
+    renderHook(() => useLocalStreamRestoration({ enabled: false }));
+    await flush();
+    expect(getActiveStreams).not.toHaveBeenCalled();
+  });
+
+  it('seeds stream metadata for each active stream once enabled', async () => {
+    getActiveStreams.mockResolvedValue([
+      { chat_id: 'c1', message_id: 'm1' },
+      { chat_id: 'c2', message_id: 'm2' },
+    ]);
+    renderHook(() => useLocalStreamRestoration({ enabled: true }));
+    await flush();
+
+    expect(getActiveStreams).toHaveBeenCalledTimes(1);
+    expect(addStreamMetadataIfAbsent).toHaveBeenCalledTimes(2);
+    expect(addStreamMetadataIfAbsent).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId: 'c1', messageId: 'm1' }),
+    );
+  });
+
+  it('restores at most once even across re-renders', async () => {
+    const { rerender } = renderHook(({ enabled }) => useLocalStreamRestoration({ enabled }), {
+      initialProps: { enabled: true },
+    });
+    await flush();
+    rerender({ enabled: true });
+    await flush();
+    expect(getActiveStreams).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs and swallows a restoration failure', async () => {
+    const err = new Error('offline');
+    getActiveStreams.mockRejectedValue(err);
+    renderHook(() => useLocalStreamRestoration({ enabled: true }));
+    await flush();
+    expect(loggerError).toHaveBeenCalledWith(
+      'Stream restoration failed',
+      'useLocalStreamRestoration',
+      err,
+    );
+    expect(addStreamMetadataIfAbsent).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useMessageInitialization.test.tsx
+++ b/frontend/src/hooks/useMessageInitialization.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Message } from '@/types/chat.types';
+
+const { setEventId } = vi.hoisted(() => ({ setEventId: vi.fn() }));
+
+// Only the persistence boundary is mocked; message/fileType normalization stays real.
+vi.mock('@/utils/storage', () => ({ chatStorage: { setEventId } }));
+
+import { useMessageInitialization } from './useMessageInitialization';
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'm1',
+    chat_id: 'c1',
+    content_text: 'hi',
+    content_render: null,
+    last_seq: 5,
+    active_stream_id: null,
+    stream_status: 'completed',
+    role: 'assistant',
+    attachments: [],
+    created_at: '2026-01-01T00:00:00Z',
+    model_id: 'model-1',
+    duration_ms: null,
+    checkpoint_id: null,
+    ...overrides,
+  } as Message;
+}
+
+function makeParams(overrides: Record<string, unknown> = {}) {
+  return {
+    fetchedMessages: [] as Message[],
+    chatId: 'c1',
+    selectedModelId: 'model-1',
+    initialPromptFromRoute: null,
+    initialPromptSent: false,
+    wasAborted: false,
+    attachedFiles: [] as File[],
+    isLoading: false,
+    isStreaming: false,
+    setMessages: vi.fn(),
+    setInitialPrompt: vi.fn(),
+    ...overrides,
+  } as Parameters<typeof useMessageInitialization>[0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useMessageInitialization', () => {
+  it('normalizes fetched messages and seeds local state', () => {
+    const params = makeParams({
+      fetchedMessages: [makeMessage({ role: 'assistant' })],
+    });
+    renderHook(() => useMessageInitialization(params));
+
+    expect(params.setMessages).toHaveBeenCalledTimes(1);
+    const seeded = (params.setMessages as ReturnType<typeof vi.fn>).mock.calls[0][0] as Message[];
+    expect(seeded[0].id).toBe('m1');
+    // is_bot is derived from role, not trusted from the payload.
+    expect(seeded[0].is_bot).toBe(true);
+  });
+
+  it('persists the highest last_seq for stream-reconnect resumption', () => {
+    const params = makeParams({
+      fetchedMessages: [
+        makeMessage({ id: 'a', last_seq: 3 }),
+        makeMessage({ id: 'b', last_seq: 8 }),
+      ],
+    });
+    renderHook(() => useMessageInitialization(params));
+    expect(setEventId).toHaveBeenCalledWith('c1', '8');
+  });
+
+  it('does not touch state while messages are still loading', () => {
+    const params = makeParams({ fetchedMessages: [makeMessage()], isLoading: true });
+    renderHook(() => useMessageInitialization(params));
+    expect(params.setMessages).not.toHaveBeenCalled();
+    expect(setEventId).not.toHaveBeenCalled();
+  });
+
+  it('does not re-seed after an abort', () => {
+    const params = makeParams({ fetchedMessages: [makeMessage()], wasAborted: true });
+    renderHook(() => useMessageInitialization(params));
+    expect(params.setMessages).not.toHaveBeenCalled();
+  });
+
+  it('injects a synthetic user message for the initial-prompt flow', () => {
+    const params = makeParams({
+      fetchedMessages: [],
+      initialPromptFromRoute: 'draft an email',
+      initialPromptSent: false,
+    });
+    renderHook(() => useMessageInitialization(params));
+
+    const seeded = (params.setMessages as ReturnType<typeof vi.fn>).mock.calls[0][0] as Message[];
+    expect(seeded).toHaveLength(1);
+    expect(seeded[0].role).toBe('user');
+    expect(seeded[0].content_text).toBe('draft an email');
+    expect(params.setInitialPrompt).toHaveBeenCalledWith('draft an email');
+  });
+
+  it('skips the initial-prompt injection until a model is selected', () => {
+    const params = makeParams({
+      fetchedMessages: [],
+      initialPromptFromRoute: 'draft an email',
+      selectedModelId: null,
+    });
+    renderHook(() => useMessageInitialization(params));
+    expect(params.setMessages).not.toHaveBeenCalled();
+    expect(params.setInitialPrompt).not.toHaveBeenCalled();
+  });
+
+  it('does not re-inject once the initial prompt was already sent', () => {
+    const params = makeParams({
+      fetchedMessages: [],
+      initialPromptFromRoute: 'draft an email',
+      initialPromptSent: true,
+    });
+    renderHook(() => useMessageInitialization(params));
+    expect(params.setMessages).not.toHaveBeenCalled();
+  });
+
+  it('stops reprocessing the same chat while a stream is live', () => {
+    const params = makeParams({ fetchedMessages: [makeMessage()] });
+    const { rerender } = renderHook((p) => useMessageInitialization(p), { initialProps: params });
+    expect(params.setMessages).toHaveBeenCalledTimes(1);
+
+    // Same chat, now streaming with a changed payload — must not clobber live state.
+    const streamingParams = makeParams({
+      fetchedMessages: [makeMessage({ id: 'm2' })],
+      isStreaming: true,
+      setMessages: params.setMessages,
+    });
+    rerender(streamingParams);
+    expect(params.setMessages).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useMountEffect.test.tsx
+++ b/frontend/src/hooks/useMountEffect.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useMountEffect } from './useMountEffect';
+
+describe('useMountEffect', () => {
+  it('runs the effect exactly once, ignoring re-renders', () => {
+    const effect = vi.fn();
+    const { rerender } = renderHook(() => useMountEffect(effect));
+    rerender();
+    rerender();
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the cleanup on unmount', () => {
+    const cleanup = vi.fn();
+    const { unmount } = renderHook(() => useMountEffect(() => cleanup));
+    expect(cleanup).not.toHaveBeenCalled();
+    unmount();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-run even when the passed effect identity changes', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ fn }) => useMountEffect(fn), {
+      initialProps: { fn: first },
+    });
+    rerender({ fn: second });
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/usePermissionRequest.test.tsx
+++ b/frontend/src/hooks/usePermissionRequest.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PermissionRequest } from '@/types/chat.types';
+
+const h = vi.hoisted(() => ({
+  storeState: {
+    pendingRequests: new Map<string, PermissionRequest[]>(),
+    enqueuePermissionRequest: vi.fn(() => true),
+  },
+  respondToPermission: vi.fn(() => Promise.resolve()),
+  isPermissionResolved: vi.fn(() => false),
+  notifyPermissionRequest: vi.fn(),
+  settings: { data: undefined as { notifications_enabled?: boolean } | undefined },
+  executePermissionResponse: vi.fn<
+    (
+      serviceFn: () => unknown,
+      opts: { errorMessage: string; clearRequest: () => void },
+    ) => Promise<string>
+  >(() => Promise.resolve('success')),
+  clearPermissionRequest: vi.fn(),
+}));
+
+vi.mock('@/services/permissionService', () => ({
+  permissionService: { respondToPermission: h.respondToPermission },
+}));
+vi.mock('@/store/permissionStore', () => ({
+  usePermissionStore: Object.assign(
+    (selector: (s: typeof h.storeState) => unknown) => selector(h.storeState),
+    { getState: () => h.storeState },
+  ),
+}));
+vi.mock('@/utils/permissionStorage', () => ({ isPermissionResolved: h.isPermissionResolved }));
+vi.mock('@/utils/notifications', () => ({ notifyPermissionRequest: h.notifyPermissionRequest }));
+vi.mock('@/hooks/queries/useSettingsQueries', () => ({ useSettingsQuery: () => h.settings }));
+vi.mock('@/utils/permissionResponse', () => ({
+  executePermissionResponse: h.executePermissionResponse,
+  clearPermissionRequest: h.clearPermissionRequest,
+}));
+
+import { usePermissionRequest } from './usePermissionRequest';
+
+function makeRequest(overrides: Partial<PermissionRequest> = {}): PermissionRequest {
+  return {
+    request_id: 'req-1',
+    seq: 7,
+    ...overrides,
+  } as PermissionRequest;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.storeState.pendingRequests = new Map();
+  h.storeState.enqueuePermissionRequest.mockReturnValue(true);
+  h.isPermissionResolved.mockReturnValue(false);
+  h.settings.data = undefined;
+});
+
+describe('usePermissionRequest', () => {
+  it('surfaces the head of the chat queue as pendingRequest', () => {
+    const first = makeRequest({ request_id: 'a' });
+    h.storeState.pendingRequests.set('chat-1', [first, makeRequest({ request_id: 'b' })]);
+    const { result } = renderHook(() => usePermissionRequest('chat-1'));
+    expect(result.current.pendingRequest).toBe(first);
+  });
+
+  it('reports no pending request when chatId is undefined', () => {
+    h.storeState.pendingRequests.set('chat-1', [makeRequest()]);
+    const { result } = renderHook(() => usePermissionRequest(undefined));
+    expect(result.current.pendingRequest).toBeNull();
+  });
+
+  it('enqueues and notifies for a genuinely new request', () => {
+    const { result } = renderHook(() => usePermissionRequest('chat-1'));
+    const req = makeRequest();
+    act(() => result.current.handlePermissionRequest(req));
+    expect(h.storeState.enqueuePermissionRequest).toHaveBeenCalledWith('chat-1', req);
+    expect(h.notifyPermissionRequest).toHaveBeenCalledWith(req);
+  });
+
+  it('drops requests the user already resolved (no enqueue, no notify)', () => {
+    h.isPermissionResolved.mockReturnValue(true);
+    const { result } = renderHook(() => usePermissionRequest('chat-1'));
+    act(() => result.current.handlePermissionRequest(makeRequest()));
+    expect(h.storeState.enqueuePermissionRequest).not.toHaveBeenCalled();
+    expect(h.notifyPermissionRequest).not.toHaveBeenCalled();
+  });
+
+  it('does not notify when the store dedupes the request (added=false)', () => {
+    h.storeState.enqueuePermissionRequest.mockReturnValue(false);
+    const { result } = renderHook(() => usePermissionRequest('chat-1'));
+    act(() => result.current.handlePermissionRequest(makeRequest()));
+    expect(h.notifyPermissionRequest).not.toHaveBeenCalled();
+  });
+
+  it('does not notify when notifications are disabled in settings', () => {
+    h.settings.data = { notifications_enabled: false };
+    const { result } = renderHook(() => usePermissionRequest('chat-1'));
+    act(() => result.current.handlePermissionRequest(makeRequest()));
+    expect(h.storeState.enqueuePermissionRequest).toHaveBeenCalled();
+    expect(h.notifyPermissionRequest).not.toHaveBeenCalled();
+  });
+
+  it('wires approve to the service and cleanup with the pending request ids', async () => {
+    h.storeState.pendingRequests.set('chat-1', [makeRequest({ request_id: 'req-9', seq: 42 })]);
+    const { result } = renderHook(() => usePermissionRequest('chat-1'));
+
+    await act(async () => {
+      await result.current.handleApprove('allow');
+    });
+
+    expect(h.executePermissionResponse).toHaveBeenCalledTimes(1);
+    const [serviceFn, opts] = h.executePermissionResponse.mock.calls[0];
+    // Invoke the captured closures to confirm they target the right request.
+    serviceFn();
+    expect(h.respondToPermission).toHaveBeenCalledWith('chat-1', 'req-9', 'allow');
+    opts.clearRequest();
+    expect(h.clearPermissionRequest).toHaveBeenCalledWith('chat-1', 'req-9', 42);
+    expect(opts.errorMessage).toBe('Failed to approve permission');
+  });
+
+  it('reject uses its own error message but the same request target', async () => {
+    h.storeState.pendingRequests.set('chat-1', [makeRequest({ request_id: 'req-9', seq: 42 })]);
+    const { result } = renderHook(() => usePermissionRequest('chat-1'));
+
+    await act(async () => {
+      await result.current.handleReject('deny');
+    });
+
+    const [serviceFn, opts] = h.executePermissionResponse.mock.calls[0];
+    serviceFn();
+    expect(h.respondToPermission).toHaveBeenCalledWith('chat-1', 'req-9', 'deny');
+    expect(opts.errorMessage).toBe('Failed to reject permission');
+  });
+
+  it('approve is a no-op without a pending request', async () => {
+    const { result } = renderHook(() => usePermissionRequest('chat-1'));
+    await act(async () => {
+      await result.current.handleApprove('allow');
+    });
+    expect(h.executePermissionResponse).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useToggleSet.test.tsx
+++ b/frontend/src/hooks/useToggleSet.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useToggleSet } from './useToggleSet';
+
+describe('useToggleSet', () => {
+  it('seeds the set from the initial iterable', () => {
+    const { result } = renderHook(() => useToggleSet<string>(['a', 'b']));
+    const [set] = result.current;
+    expect([...set].sort()).toEqual(['a', 'b']);
+  });
+
+  it('starts empty when no initial value is given', () => {
+    const { result } = renderHook(() => useToggleSet<string>());
+    expect(result.current[0].size).toBe(0);
+  });
+
+  it('toggle adds an absent item and removes a present one', () => {
+    const { result } = renderHook(() => useToggleSet<string>());
+
+    act(() => result.current[1]('x'));
+    expect(result.current[0].has('x')).toBe(true);
+
+    act(() => result.current[1]('x'));
+    expect(result.current[0].has('x')).toBe(false);
+  });
+
+  it('returns a new Set instance on toggle (no in-place mutation)', () => {
+    const { result } = renderHook(() => useToggleSet<string>(['a']));
+    const before = result.current[0];
+
+    act(() => result.current[1]('b'));
+    expect(result.current[0]).not.toBe(before);
+    // The previous snapshot is left untouched.
+    expect(before.has('b')).toBe(false);
+  });
+
+  it('keeps a stable toggle identity across renders', () => {
+    const { result, rerender } = renderHook(() => useToggleSet<string>());
+    const toggle = result.current[1];
+    act(() => result.current[1]('a'));
+    rerender();
+    expect(result.current[1]).toBe(toggle);
+  });
+
+  it('exposes the raw setter for direct replacement', () => {
+    const { result } = renderHook(() => useToggleSet<number>([1]));
+    act(() => result.current[2](new Set([9, 10])));
+    expect([...result.current[0]]).toEqual([9, 10]);
+  });
+});

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  getToken: vi.fn<() => string | null>(() => 'access'),
+  getRefreshToken: vi.fn<() => string | null>(() => null),
+  setToken: vi.fn(),
+  setRefreshToken: vi.fn(),
+  onSessionExpired: vi.fn(),
+  isCloudChat: vi.fn<(id: string) => boolean>(() => false),
+  isCloudSandbox: vi.fn<(id: string) => boolean>(() => false),
+  clearCloudOrigins: vi.fn(),
+}));
+
+vi.mock('@/utils/storage', () => ({
+  authStorage: {
+    getToken: h.getToken,
+    getRefreshToken: h.getRefreshToken,
+    setToken: h.setToken,
+    setRefreshToken: h.setRefreshToken,
+  },
+  cloudAuthStorage: {
+    getAccessToken: () => null,
+    getRefreshToken: () => null,
+    setAccessToken: vi.fn(),
+    setRefreshToken: vi.fn(),
+    clear: vi.fn(),
+  },
+}));
+vi.mock('@/utils/authSession', () => ({ invalidateSessionAndRedirect: h.onSessionExpired }));
+vi.mock('@/utils/chatOrigin', () => ({
+  isCloudChat: h.isCloudChat,
+  isCloudSandbox: h.isCloudSandbox,
+  clearCloudOrigins: h.clearCloudOrigins,
+}));
+vi.mock('@/store/cloudSettingsStore', () => ({
+  useCloudSettingsStore: { getState: () => ({ cloudUrl: '', clearCloud: vi.fn() }) },
+}));
+
+import {
+  trimTrailingSlash,
+  apiClient,
+  remoteApiClient,
+  resolveChatClient,
+  resolveSandboxClient,
+} from './api';
+
+const json = (body: unknown, status = 200, statusText?: string) =>
+  new Response(body == null ? '' : JSON.stringify(body), { status, statusText });
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getToken.mockReturnValue('access');
+  h.getRefreshToken.mockReturnValue(null);
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+describe('trimTrailingSlash', () => {
+  it('strips one or more trailing slashes', () => {
+    expect(trimTrailingSlash('http://x/api/v1///')).toBe('http://x/api/v1');
+  });
+
+  it('leaves a slash-free url untouched', () => {
+    expect(trimTrailingSlash('http://x/api/v1')).toBe('http://x/api/v1');
+  });
+});
+
+describe('APIClient success + error shaping', () => {
+  it('parses a JSON body on success', async () => {
+    fetchMock.mockResolvedValueOnce(json({ id: 7 }));
+    await expect(apiClient.get('/thing')).resolves.toEqual({ id: 7 });
+  });
+
+  it('returns null for an empty 200 body', async () => {
+    fetchMock.mockResolvedValueOnce(json(null, 200));
+    await expect(apiClient.get('/thing')).resolves.toBeNull();
+  });
+
+  it('throws with the JSON `message` and attaches the status', async () => {
+    fetchMock.mockResolvedValueOnce(json({ message: 'boom' }, 500));
+    await expect(apiClient.get('/thing')).rejects.toMatchObject({ message: 'boom', status: 500 });
+  });
+
+  it('falls back to `detail` then statusText for the error message', async () => {
+    fetchMock.mockResolvedValueOnce(json({ detail: 'nope' }, 422));
+    await expect(apiClient.get('/thing')).rejects.toMatchObject({ message: 'nope' });
+
+    fetchMock.mockResolvedValueOnce(
+      new Response('plain text', { status: 500, statusText: 'Boom' }),
+    );
+    await expect(apiClient.get('/thing')).rejects.toMatchObject({ message: 'Boom' });
+  });
+
+  it('uses a status placeholder when the error body is empty', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 503 }));
+    await expect(apiClient.get('/thing')).rejects.toMatchObject({
+      message: 'HTTP error! status: 503',
+    });
+  });
+});
+
+describe('APIClient 401 handling', () => {
+  it('refreshes the token and retries once on 401', async () => {
+    h.getRefreshToken.mockReturnValue('refresh-tok');
+    fetchMock
+      .mockResolvedValueOnce(json({ message: 'unauth' }, 401)) // original request
+      .mockResolvedValueOnce(
+        json({ access_token: 'a2', refresh_token: 'r2', token_type: 'bearer' }),
+      ) // refresh
+      .mockResolvedValueOnce(json({ ok: true })); // retried request
+
+    await expect(apiClient.get('/thing')).resolves.toEqual({ ok: true });
+    expect(h.setToken).toHaveBeenCalledWith('a2');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('tears down the session on a 401 with no refresh token', async () => {
+    h.getRefreshToken.mockReturnValue(null);
+    fetchMock.mockResolvedValueOnce(json({ message: 'unauth' }, 401));
+
+    await expect(apiClient.get('/thing')).rejects.toThrow('Session expired');
+    expect(h.onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears down the session when the refresh itself returns 401', async () => {
+    h.getRefreshToken.mockReturnValue('refresh-tok');
+    fetchMock
+      .mockResolvedValueOnce(json({ message: 'unauth' }, 401)) // original request
+      .mockResolvedValueOnce(json({ message: 'dead' }, 401)); // refresh -> terminal
+
+    await expect(apiClient.get('/thing')).rejects.toThrow('Session expired');
+    expect(h.onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('client routing', () => {
+  it('routes cloud chats to the remote client and local chats to the local client', () => {
+    h.isCloudChat.mockImplementation((id) => id === 'cloud-chat');
+    expect(resolveChatClient('cloud-chat')).toBe(remoteApiClient);
+    expect(resolveChatClient('local-chat')).toBe(apiClient);
+    expect(resolveChatClient(undefined)).toBe(apiClient);
+  });
+
+  it('routes cloud sandboxes to the remote client', () => {
+    h.isCloudSandbox.mockImplementation((id) => id === 'cloud-sbx');
+    expect(resolveSandboxClient('cloud-sbx')).toBe(remoteApiClient);
+    expect(resolveSandboxClient('local-sbx')).toBe(apiClient);
+    expect(resolveSandboxClient(undefined)).toBe(apiClient);
+  });
+});

--- a/frontend/src/lib/editorChatActions.test.ts
+++ b/frontend/src/lib/editorChatActions.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { addComposerSelection } = vi.hoisted(() => ({ addComposerSelection: vi.fn() }));
+
+vi.mock('@/store/uiStore', () => ({
+  useUIStore: { getState: () => ({ addComposerSelection }) },
+}));
+
+import { attachAddSelectionToChat, attachAskAboutSelection } from './editorChatActions';
+
+// Minimal Monaco keybinding stand-in — the action factory only reads these to
+// build its keybinding array.
+const monaco = { KeyMod: { CtrlCmd: 1 }, KeyCode: { KeyL: 2, KeyI: 3 } };
+
+interface FakeSelection {
+  isEmpty: () => boolean;
+  startLineNumber: number;
+  endLineNumber: number;
+  startColumn: number;
+  endColumn: number;
+}
+
+// Builds a fake editor plus a handle to invoke whatever action the module
+// registers, mimicking Monaco firing the command.
+function makeEditor(opts: {
+  selection: FakeSelection | null;
+  value?: string;
+  path?: string;
+  languageId?: string;
+}) {
+  const model =
+    opts.selection == null && opts.value === undefined
+      ? null
+      : {
+          getValueInRange: () => opts.value ?? '',
+          uri: { path: opts.path ?? '/src/index.ts' },
+          getLanguageId: () => opts.languageId ?? 'typescript',
+        };
+
+  const registered: { run: (ed: unknown) => void }[] = [];
+  const editor = {
+    addAction: (descriptor: { run: (ed: unknown) => void }) => {
+      registered.push(descriptor);
+    },
+    getSelection: () => opts.selection,
+    getModel: () => model,
+  };
+  return {
+    editor,
+    fire: () => registered[0].run(editor),
+  };
+}
+
+const selection = (over: Partial<FakeSelection> = {}): FakeSelection => ({
+  isEmpty: () => false,
+  startLineNumber: 3,
+  endLineNumber: 5,
+  startColumn: 1,
+  endColumn: 10,
+  ...over,
+});
+
+beforeEach(() => {
+  addComposerSelection.mockClear();
+});
+
+describe('attachAddSelectionToChat', () => {
+  it('adds the captured snippet to the target chat', () => {
+    const { editor, fire } = makeEditor({
+      selection: selection(),
+      value: 'const x = 1;',
+      path: '/src/foo.ts',
+      languageId: 'typescript',
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    attachAddSelectionToChat(monaco as any, editor as any, { chatId: 'chat-1' } as any);
+
+    fire();
+
+    expect(addComposerSelection).toHaveBeenCalledWith('chat-1', {
+      // Leading slash is stripped from the model URI path.
+      path: 'src/foo.ts',
+      startLine: 3,
+      endLine: 5,
+      languageId: 'typescript',
+      text: 'const x = 1;',
+    });
+  });
+
+  it('trims the trailing empty line for a full-line drag selection', () => {
+    const { editor, fire } = makeEditor({
+      // Full-line drag ends at column 1 of the line below.
+      selection: selection({ startLineNumber: 3, endLineNumber: 6, endColumn: 1 }),
+      value: 'line3\nline4\nline5\n',
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    attachAddSelectionToChat(monaco as any, editor as any, { chatId: 'c' } as any);
+
+    fire();
+
+    const snippet = addComposerSelection.mock.calls[0][1];
+    expect(snippet.endLine).toBe(5);
+    expect(snippet.text).toBe('line3\nline4\nline5');
+  });
+
+  it('does nothing when there is no selection', () => {
+    const { editor, fire } = makeEditor({ selection: null });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    attachAddSelectionToChat(monaco as any, editor as any, { chatId: 'c' } as any);
+
+    fire();
+
+    expect(addComposerSelection).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the context has no chatId', () => {
+    const { editor, fire } = makeEditor({ selection: selection(), value: 'x' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    attachAddSelectionToChat(monaco as any, editor as any, { chatId: undefined } as any);
+
+    fire();
+
+    expect(addComposerSelection).not.toHaveBeenCalled();
+  });
+});
+
+describe('attachAskAboutSelection', () => {
+  it('reports the captured selection to the onOpen callback', () => {
+    const onOpen = vi.fn();
+    const { editor, fire } = makeEditor({ selection: selection(), value: 'y', path: '/a/b.ts' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    attachAskAboutSelection(monaco as any, editor as any, onOpen);
+
+    fire();
+
+    expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ path: 'a/b.ts', text: 'y' }));
+  });
+
+  it('does not fire onOpen without a selection', () => {
+    const onOpen = vi.fn();
+    const { editor, fire } = makeEditor({ selection: null });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    attachAskAboutSelection(monaco as any, editor as any, onOpen);
+
+    fire();
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/queryClient.test.ts
+++ b/frontend/src/lib/queryClient.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { QueryClient, type Query } from '@tanstack/react-query';
+import { persistOptions } from './queryClient';
+
+const shouldPersist = persistOptions.dehydrateOptions!.shouldDehydrateQuery!;
+
+// Builds a real, successful Query for `key` so defaultShouldDehydrateQuery (which
+// gates on status === 'success') passes and only the key-matching branch decides.
+function query(key: readonly unknown[]): Query {
+  const client = new QueryClient();
+  client.setQueryData(key, { ok: true });
+  return client.getQueryCache().find({ queryKey: key })!;
+}
+
+describe('shouldPersistQuery', () => {
+  it('persists the infinite chats list', () => {
+    expect(shouldPersist(query(['chats', 'infinite']))).toBe(true);
+  });
+
+  it('persists the auth user query', () => {
+    expect(shouldPersist(query(['auth-user']))).toBe(true);
+  });
+
+  it('persists the top-level workspaces query', () => {
+    expect(shouldPersist(query(['workspaces']))).toBe(true);
+  });
+
+  it('persists the cloud chats list', () => {
+    expect(shouldPersist(query(['cloud', 'chats']))).toBe(true);
+  });
+
+  it('does not persist messages', () => {
+    expect(shouldPersist(query(['messages', 'chat-1']))).toBe(false);
+  });
+
+  it('does not persist settings (carries secrets)', () => {
+    expect(shouldPersist(query(['settings']))).toBe(false);
+  });
+
+  it('does not persist a nested workspaces resource query', () => {
+    // Only the length-1 workspaces key is whitelisted.
+    expect(shouldPersist(query(['workspaces', 'ws-1', 'resources', 'chat-1']))).toBe(false);
+  });
+});

--- a/frontend/src/store/chatSettingsStore.test.ts
+++ b/frontend/src/store/chatSettingsStore.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  useChatSettingsStore,
+  DEFAULT_CHAT_SETTINGS_KEY,
+  type PermissionMode,
+} from './chatSettingsStore';
+
+const state = () => useChatSettingsStore.getState();
+
+beforeEach(() => {
+  localStorage.clear();
+  useChatSettingsStore.setState({
+    permissionModeByChat: {},
+    thinkingModeByChat: {},
+    worktreeByChat: {},
+    runOnCloud: false,
+    personaByChat: {},
+  });
+});
+
+describe('per-chat setters', () => {
+  it('records permission, thinking, worktree, and persona keyed by chat', () => {
+    state().setPermissionMode('c1', 'plan');
+    state().setThinkingMode('c1', 'low');
+    state().setWorktree('c1', true);
+    state().setPersona('c1', 'Reviewer');
+
+    expect(state().permissionModeByChat.c1).toBe('plan');
+    expect(state().thinkingModeByChat.c1).toBe('low');
+    expect(state().worktreeByChat.c1).toBe(true);
+    expect(state().personaByChat.c1).toBe('Reviewer');
+  });
+
+  it('keeps per-chat entries independent', () => {
+    state().setPermissionMode('c1', 'plan');
+    state().setPermissionMode('c2', 'acceptEdits');
+    expect(state().permissionModeByChat).toEqual({ c1: 'plan', c2: 'acceptEdits' });
+  });
+
+  it('overwrites an existing chat entry in place', () => {
+    state().setWorktree('c1', true);
+    state().setWorktree('c1', false);
+    expect(state().worktreeByChat.c1).toBe(false);
+  });
+});
+
+describe('setRunOnCloud', () => {
+  it('flips the global cloud flag without touching per-chat maps', () => {
+    state().setPermissionMode('c1', 'plan');
+    state().setRunOnCloud(true);
+    expect(state().runOnCloud).toBe(true);
+    expect(state().permissionModeByChat).toEqual({ c1: 'plan' });
+  });
+});
+
+describe('initChatFromDefaults', () => {
+  const seedDefaults = (over: {
+    permission?: PermissionMode;
+    thinking?: string;
+    worktree?: boolean;
+    persona?: string;
+  }) => {
+    if (over.permission !== undefined)
+      state().setPermissionMode(DEFAULT_CHAT_SETTINGS_KEY, over.permission);
+    if (over.thinking !== undefined)
+      state().setThinkingMode(DEFAULT_CHAT_SETTINGS_KEY, over.thinking);
+    if (over.worktree !== undefined) state().setWorktree(DEFAULT_CHAT_SETTINGS_KEY, over.worktree);
+    if (over.persona !== undefined) state().setPersona(DEFAULT_CHAT_SETTINGS_KEY, over.persona);
+  };
+
+  it('copies every set default onto the new chat', () => {
+    seedDefaults({ permission: 'plan', thinking: 'low', worktree: true, persona: 'Reviewer' });
+    state().initChatFromDefaults('c1');
+
+    expect(state().permissionModeByChat.c1).toBe('plan');
+    expect(state().thinkingModeByChat.c1).toBe('low');
+    expect(state().worktreeByChat.c1).toBe(true);
+    expect(state().personaByChat.c1).toBe('Reviewer');
+  });
+
+  it('only seeds the dimensions that have a default set', () => {
+    // Just a permission default exists — the other maps stay untouched for c1.
+    seedDefaults({ permission: 'plan' });
+    state().initChatFromDefaults('c1');
+
+    expect(state().permissionModeByChat.c1).toBe('plan');
+    expect('c1' in state().thinkingModeByChat).toBe(false);
+    expect('c1' in state().worktreeByChat).toBe(false);
+    expect('c1' in state().personaByChat).toBe(false);
+  });
+
+  it('is a no-op when no defaults have been set', () => {
+    const before = state();
+    state().initChatFromDefaults('c1');
+    // No updates object built, so set() never fires and the reference is stable.
+    expect(useChatSettingsStore.getState()).toBe(before);
+  });
+
+  it('preserves the false worktree default (distinct from unset)', () => {
+    // worktree=false is a real default that must copy — the guard keys on
+    // `undefined`, not falsiness.
+    seedDefaults({ worktree: false });
+    state().initChatFromDefaults('c1');
+    expect(state().worktreeByChat.c1).toBe(false);
+  });
+
+  it('does not disturb other chats when seeding a new one', () => {
+    state().setPermissionMode('existing', 'acceptEdits');
+    seedDefaults({ permission: 'plan' });
+    state().initChatFromDefaults('c1');
+    expect(state().permissionModeByChat.existing).toBe('acceptEdits');
+    expect(state().permissionModeByChat.c1).toBe('plan');
+  });
+});

--- a/frontend/src/store/cloudSettingsStore.test.ts
+++ b/frontend/src/store/cloudSettingsStore.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCloudSettingsStore } from './cloudSettingsStore';
+
+const state = () => useCloudSettingsStore.getState();
+
+beforeEach(() => {
+  localStorage.clear();
+  useCloudSettingsStore.setState({ cloudUrl: '', connectedEmail: null });
+});
+
+describe('setCloud', () => {
+  it('records the VPS url and connected email together', () => {
+    state().setCloud('https://vps.example.com', 'user@example.com');
+    expect(state().cloudUrl).toBe('https://vps.example.com');
+    expect(state().connectedEmail).toBe('user@example.com');
+  });
+});
+
+describe('clearCloud', () => {
+  it('resets both fields to the disconnected state', () => {
+    state().setCloud('https://vps.example.com', 'user@example.com');
+    state().clearCloud();
+    expect(state().cloudUrl).toBe('');
+    expect(state().connectedEmail).toBeNull();
+  });
+});

--- a/frontend/src/store/streamStore.test.ts
+++ b/frontend/src/store/streamStore.test.ts
@@ -54,6 +54,14 @@ describe('getStreamByChat', () => {
     useStreamStore.getState().addStream(makeStream('s1', 'c1', 'm1', false));
     expect(useStreamStore.getState().getStreamByChat('c1')).toBeUndefined();
   });
+
+  it('returns the first active stream when several exist for the chat', () => {
+    const inactive = makeStream('s1', 'c1', 'm1', false);
+    const active = makeStream('s2', 'c1', 'm2');
+    useStreamStore.getState().addStream(inactive);
+    useStreamStore.getState().addStream(active);
+    expect(useStreamStore.getState().getStreamByChat('c1')).toBe(active);
+  });
 });
 
 describe('removeStream', () => {
@@ -76,6 +84,14 @@ describe('removeStream', () => {
     useStreamStore.getState().removeStream('s2');
     // s1 is still active for c1, so its rollup metadata must survive.
     expect(useStreamStore.getState().activeStreamMetadata).toHaveLength(1);
+  });
+
+  it('drops chat metadata when the only remaining sibling stream is inactive', () => {
+    useStreamStore.getState().addStream(makeStream('s1', 'c1', 'm1'));
+    useStreamStore.getState().addStream(makeStream('s2', 'c1', 'm2', false));
+    useStreamStore.getState().removeStream('s1');
+    // Only an inactive stream is left, so the "running" rollup must clear.
+    expect(useStreamStore.getState().activeStreamMetadata).toEqual([]);
   });
 
   it('is a no-op for an unknown stream id', () => {

--- a/frontend/src/store/uiStore.test.ts
+++ b/frontend/src/store/uiStore.test.ts
@@ -1,0 +1,249 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  useUIStore,
+  clampSidebarWidth,
+  MIN_SIDEBAR_WIDTH,
+  MAX_SIDEBAR_WIDTH,
+  DEFAULT_SIDEBAR_WIDTH,
+} from './uiStore';
+import { THEME_CYCLE } from '@/utils/theme';
+
+const state = () => useUIStore.getState();
+
+// jsdom's default innerWidth (1024) is above MOBILE_BREAKPOINT, so isDesktop()
+// is true here — the split/layout paths take their desktop branches.
+beforeEach(() => {
+  localStorage.clear();
+  useUIStore.setState({
+    theme: 'dark',
+    sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
+    openTabs: ['agent:primary'],
+    visibleLayout: [['agent:primary']],
+    secondaryChatId: null,
+    activeAgentTile: 'agent:primary',
+    focusedTile: null,
+    layoutsByChat: {},
+    editorByChat: {},
+    currentWorkspaceChatId: null,
+    chatTabs: [],
+    pendingFileOpen: null,
+    composerSelectionsByChat: {},
+  });
+});
+
+describe('clampSidebarWidth', () => {
+  it('clamps below the minimum and above the maximum', () => {
+    expect(clampSidebarWidth(0)).toBe(MIN_SIDEBAR_WIDTH);
+    expect(clampSidebarWidth(9999)).toBe(MAX_SIDEBAR_WIDTH);
+  });
+
+  it('rounds fractional widths within range', () => {
+    expect(clampSidebarWidth(300.6)).toBe(301);
+  });
+});
+
+describe('setSidebarWidth', () => {
+  it('stores the clamped width', () => {
+    state().setSidebarWidth(10_000);
+    expect(state().sidebarWidth).toBe(MAX_SIDEBAR_WIDTH);
+  });
+
+  it('is a no-op (stable reference) when the clamped width is unchanged', () => {
+    state().setSidebarWidth(MAX_SIDEBAR_WIDTH);
+    const before = state();
+    // A larger value clamps back to the same MAX — the guard must skip the set.
+    state().setSidebarWidth(MAX_SIDEBAR_WIDTH + 50);
+    expect(useUIStore.getState()).toBe(before);
+  });
+});
+
+describe('theme', () => {
+  it('cycles to the next theme and wraps around', () => {
+    useUIStore.setState({ theme: THEME_CYCLE[THEME_CYCLE.length - 1] });
+    state().toggleTheme();
+    expect(state().theme).toBe(THEME_CYCLE[0]);
+  });
+
+  it('setTheme jumps directly to a theme', () => {
+    state().setTheme('nord');
+    expect(state().theme).toBe('nord');
+  });
+});
+
+describe('composer selections', () => {
+  const chatSel = (text: string) => ({ kind: 'chat' as const, text });
+
+  it('appends selections per chat, keeping order', () => {
+    state().addComposerSelection('c1', chatSel('a'));
+    state().addComposerSelection('c1', chatSel('b'));
+    expect(state().composerSelectionsByChat.c1.map((s) => 'text' in s && s.text)).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('removes a selection by index', () => {
+    state().addComposerSelection('c1', chatSel('a'));
+    state().addComposerSelection('c1', chatSel('b'));
+    state().removeComposerSelection('c1', 0);
+    expect(state().composerSelectionsByChat.c1).toEqual([chatSel('b')]);
+  });
+
+  it('clears a chat bucket to an empty array', () => {
+    state().addComposerSelection('c1', chatSel('a'));
+    state().clearComposerSelections('c1');
+    expect(state().composerSelectionsByChat.c1).toEqual([]);
+  });
+
+  it('keeps selections isolated per chat', () => {
+    state().addComposerSelection('c1', chatSel('a'));
+    state().addComposerSelection('c2', chatSel('z'));
+    expect(state().composerSelectionsByChat.c1).toEqual([chatSel('a')]);
+    expect(state().composerSelectionsByChat.c2).toEqual([chatSel('z')]);
+  });
+});
+
+describe('chatTabs', () => {
+  it('opens a tab once, ignoring duplicates', () => {
+    state().openChatTab('c1');
+    const before = state();
+    state().openChatTab('c1');
+    // Idempotent — a second open must not re-write the array.
+    expect(useUIStore.getState()).toBe(before);
+    expect(state().chatTabs).toEqual(['c1']);
+  });
+
+  it('closes an open tab and no-ops an unknown one', () => {
+    state().openChatTab('c1');
+    state().closeChatTab('c1');
+    expect(state().chatTabs).toEqual([]);
+    const before = state();
+    state().closeChatTab('missing');
+    expect(useUIStore.getState()).toBe(before);
+  });
+});
+
+describe('openFileInEditor', () => {
+  it('records the pending open, adds the editor tab, and bumps the nonce on re-open', () => {
+    state().openFileInEditor('a.ts', 'c1', 12);
+    expect(state().pendingFileOpen).toMatchObject({
+      path: 'a.ts',
+      chatId: 'c1',
+      line: 12,
+      nonce: 1,
+    });
+    expect(state().openTabs).toContain('editor');
+
+    state().openFileInEditor('a.ts', 'c1', 12);
+    // Same path/line re-opens must still register (nonce increments) so the
+    // editor re-focuses after the user scrolled away.
+    expect(state().pendingFileOpen?.nonce).toBe(2);
+  });
+
+  it('omits the line field when none is given', () => {
+    state().openFileInEditor('a.ts', 'c1');
+    expect(state().pendingFileOpen).not.toHaveProperty('line');
+  });
+});
+
+describe('loadWorkspaceForChat', () => {
+  it('adds the chat tab and defaults to a lone agent view on first visit', () => {
+    state().loadWorkspaceForChat('c1');
+    expect(state().currentWorkspaceChatId).toBe('c1');
+    expect(state().chatTabs).toContain('c1');
+    expect(state().visibleLayout).toEqual([['agent:primary']]);
+  });
+
+  it('stashes the outgoing chat layout and restores it on return', () => {
+    state().loadWorkspaceForChat('c1');
+    // Open the editor view for c1 so its layout is non-default.
+    state().toggleView('editor', false);
+    expect(state().visibleLayout.flat()).toContain('editor');
+
+    state().loadWorkspaceForChat('c2');
+    // c2 starts fresh...
+    expect(state().visibleLayout).toEqual([['agent:primary']]);
+
+    state().loadWorkspaceForChat('c1');
+    // ...and c1's stashed editor layout comes back.
+    expect(state().visibleLayout.flat()).toContain('editor');
+  });
+});
+
+describe('cleanupChat', () => {
+  it('drops the chat tab, saved layout, and clears the live pointer when it is current', () => {
+    state().loadWorkspaceForChat('c1');
+    state().toggleView('editor', false);
+    state().cleanupChat('c1');
+
+    expect(state().chatTabs).not.toContain('c1');
+    expect('c1' in state().layoutsByChat).toBe(false);
+    expect(state().currentWorkspaceChatId).toBeNull();
+  });
+});
+
+describe('cleanupAllChats', () => {
+  it('resets the workspace and wipes all per-chat maps', () => {
+    state().loadWorkspaceForChat('c1');
+    state().toggleView('editor', false);
+    state().cleanupAllChats();
+
+    expect(state().chatTabs).toEqual([]);
+    expect(state().layoutsByChat).toEqual({});
+    expect(state().editorByChat).toEqual({});
+    expect(state().visibleLayout).toEqual([['agent:primary']]);
+    expect(state().currentWorkspaceChatId).toBeNull();
+  });
+});
+
+describe('split chat', () => {
+  it('opens a secondary chat side by side and tears it down on close', () => {
+    state().openChatInSplit('c2');
+    expect(state().secondaryChatId).toBe('c2');
+    expect(state().visibleLayout).toEqual([['agent:primary', 'agent:secondary']]);
+    expect(state().chatTabs).toContain('c2');
+
+    state().closeSplitChat();
+    expect(state().secondaryChatId).toBeNull();
+    expect(state().openTabs).not.toContain('agent:secondary');
+    expect(state().visibleLayout).toEqual([['agent:primary']]);
+    expect(state().activeAgentTile).toBe('agent:primary');
+  });
+
+  it('drops a pending jump aimed at the replaced secondary chat', () => {
+    state().openChatInSplit('c2');
+    // A jump bound to c2 (the secondary) becomes stale once c2 leaves the split.
+    state().openFileInEditor('a.ts', 'c2');
+    state().closeSplitChat();
+    expect(state().pendingFileOpen).toBeNull();
+  });
+});
+
+describe('removeTab', () => {
+  it('never closes the base agent tab', () => {
+    const before = state();
+    state().removeTab('agent:primary');
+    expect(useUIStore.getState()).toBe(before);
+  });
+
+  it('closes a view and lands focus back on an agent pane', () => {
+    state().toggleView('editor', false);
+    expect(state().visibleLayout.flat()).toContain('editor');
+    state().removeTab('editor');
+    expect(state().openTabs).not.toContain('editor');
+    expect(state().visibleLayout).toEqual([['agent:primary']]);
+  });
+});
+
+describe('resetWorkspace', () => {
+  it('collapses to a single agent view and detaches from the chat', () => {
+    state().openChatInSplit('c2');
+    state().loadWorkspaceForChat('c1');
+    state().resetWorkspace();
+    expect(state().visibleLayout).toEqual([['agent:primary']]);
+    expect(state().secondaryChatId).toBeNull();
+    expect(state().currentWorkspaceChatId).toBeNull();
+    expect(state().focusedTile).toBeNull();
+  });
+});

--- a/frontend/src/store/updateStore.test.ts
+++ b/frontend/src/store/updateStore.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useDesktopUpdateStore } from './updateStore';
+
+const state = () => useDesktopUpdateStore.getState();
+
+const availableInfo = {
+  version: '2.0.0',
+  currentVersion: '1.0.0',
+  body: 'notes',
+  date: '2020-01-01',
+};
+
+beforeEach(() => {
+  useDesktopUpdateStore.setState({
+    status: 'idle',
+    version: null,
+    currentVersion: null,
+    releaseNotes: null,
+    releaseDate: null,
+    downloadedBytes: 0,
+    totalBytes: null,
+    errorMessage: null,
+    triggerInstall: null,
+  });
+});
+
+describe('setAvailable', () => {
+  it('populates release info and stores the install trigger', () => {
+    const trigger = vi.fn(async () => {});
+    state().setAvailable(availableInfo, trigger);
+
+    expect(state().status).toBe('available');
+    expect(state().version).toBe('2.0.0');
+    expect(state().currentVersion).toBe('1.0.0');
+    expect(state().releaseNotes).toBe('notes');
+    expect(state().releaseDate).toBe('2020-01-01');
+    expect(state().triggerInstall).toBe(trigger);
+  });
+
+  it('clears any prior progress and error when a new update appears', () => {
+    useDesktopUpdateStore.setState({
+      downloadedBytes: 500,
+      totalBytes: 1000,
+      errorMessage: 'old failure',
+    });
+    state().setAvailable(
+      availableInfo,
+      vi.fn(async () => {}),
+    );
+
+    expect(state().downloadedBytes).toBe(0);
+    expect(state().totalBytes).toBeNull();
+    expect(state().errorMessage).toBeNull();
+  });
+});
+
+describe('download progress', () => {
+  it('resets counters when downloading starts', () => {
+    useDesktopUpdateStore.setState({ downloadedBytes: 42, totalBytes: 100, errorMessage: 'x' });
+    state().setDownloading();
+
+    expect(state().status).toBe('downloading');
+    expect(state().downloadedBytes).toBe(0);
+    expect(state().totalBytes).toBeNull();
+    expect(state().errorMessage).toBeNull();
+  });
+
+  it('records the total size once the response headers arrive', () => {
+    state().setDownloadStarted(2048);
+    expect(state().totalBytes).toBe(2048);
+  });
+
+  it('leaves totalBytes null when Content-Length is absent', () => {
+    state().setDownloadStarted(null);
+    expect(state().totalBytes).toBeNull();
+  });
+
+  it('accumulates chunk lengths across calls', () => {
+    state().addDownloadChunk(100);
+    state().addDownloadChunk(250);
+    expect(state().downloadedBytes).toBe(350);
+  });
+});
+
+describe('terminal transitions', () => {
+  it('moves to installing without disturbing download counters', () => {
+    state().setDownloadStarted(1000);
+    state().addDownloadChunk(1000);
+    state().setInstalling();
+    expect(state().status).toBe('installing');
+    expect(state().downloadedBytes).toBe(1000);
+  });
+
+  it('records an error status and message', () => {
+    state().setError('disk full');
+    expect(state().status).toBe('error');
+    expect(state().errorMessage).toBe('disk full');
+  });
+});
+
+describe('full update lifecycle', () => {
+  it('walks available -> downloading -> started -> chunks -> installing', () => {
+    state().setAvailable(
+      availableInfo,
+      vi.fn(async () => {}),
+    );
+    state().setDownloading();
+    state().setDownloadStarted(300);
+    state().addDownloadChunk(100);
+    state().addDownloadChunk(200);
+    state().setInstalling();
+
+    expect(state().status).toBe('installing');
+    expect(state().downloadedBytes).toBe(300);
+    expect(state().totalBytes).toBe(300);
+  });
+});

--- a/frontend/src/utils/authSession.test.ts
+++ b/frontend/src/utils/authSession.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { clearAuth } = vi.hoisted(() => ({ clearAuth: vi.fn() }));
+
+vi.mock('@/utils/storage', () => ({ authStorage: { clearAuth } }));
+
+// Fresh module per test so the module-level `redirectInProgress` latch resets.
+async function load() {
+  vi.resetModules();
+  return import('./authSession');
+}
+
+function stubLocation(pathname: string) {
+  const replace = vi.fn();
+  Object.defineProperty(window, 'location', {
+    value: { pathname, replace },
+    writable: true,
+    configurable: true,
+  });
+  return replace;
+}
+
+beforeEach(() => {
+  clearAuth.mockClear();
+});
+
+describe('invalidateSessionAndRedirect', () => {
+  it('clears auth and redirects to /login from a normal route', async () => {
+    const replace = stubLocation('/dashboard');
+    const { invalidateSessionAndRedirect } = await load();
+
+    invalidateSessionAndRedirect();
+
+    expect(clearAuth).toHaveBeenCalledTimes(1);
+    expect(replace).toHaveBeenCalledWith('/login');
+  });
+
+  it('clears auth but does not redirect when already on /login', async () => {
+    const replace = stubLocation('/login');
+    const { invalidateSessionAndRedirect } = await load();
+
+    invalidateSessionAndRedirect();
+
+    expect(clearAuth).toHaveBeenCalledTimes(1);
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('redirects only once even when called repeatedly', async () => {
+    const replace = stubLocation('/dashboard');
+    const { invalidateSessionAndRedirect } = await load();
+
+    invalidateSessionAndRedirect();
+    invalidateSessionAndRedirect();
+    invalidateSessionAndRedirect();
+
+    // The redirectInProgress latch guards against a redirect storm.
+    expect(replace).toHaveBeenCalledTimes(1);
+    // clearAuth still runs on every call.
+    expect(clearAuth).toHaveBeenCalledTimes(3);
+  });
+});

--- a/frontend/src/utils/logger.test.ts
+++ b/frontend/src/utils/logger.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logger } from './logger';
+
+const ISO_TIMESTAMP = /^\[\d{4}-\d{2}-\d{2}T[\d:.]+Z\]/;
+
+beforeEach(() => {
+  vi.spyOn(console, 'debug').mockImplementation(() => {});
+  vi.spyOn(console, 'info').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('logger message formatting', () => {
+  it('prefixes an ISO timestamp and the level, then the message', () => {
+    logger.info('hello');
+    const [line] = vi.mocked(console.info).mock.calls[0];
+    expect(line).toMatch(ISO_TIMESTAMP);
+    expect(line).toContain('[INFO]');
+    expect(line).toContain('hello');
+  });
+
+  it('includes the context segment only when provided', () => {
+    logger.warn('with ctx', 'my.context');
+    expect(vi.mocked(console.warn).mock.calls[0][0]).toContain('[my.context]');
+
+    logger.warn('no ctx');
+    expect(vi.mocked(console.warn).mock.calls[1][0]).not.toContain('[undefined]');
+  });
+
+  it('forwards the data payload as a trailing argument', () => {
+    const data = { id: 1 };
+    logger.error('boom', 'ctx', data);
+    const call = vi.mocked(console.error).mock.calls[0];
+    expect(call[1]).toBe(data);
+  });
+});
+
+describe('logger.debug DEV gating', () => {
+  it('logs when running in DEV', () => {
+    vi.stubEnv('DEV', true);
+    logger.debug('dev only');
+    expect(console.debug).toHaveBeenCalledTimes(1);
+  });
+
+  it('is silent outside DEV', () => {
+    vi.stubEnv('DEV', false);
+    logger.debug('prod noise');
+    expect(console.debug).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/notifications.test.ts
+++ b/frontend/src/utils/notifications.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PermissionRequest } from '@/types/chat.types';
+
+const { isTauri, isPermissionGranted, requestPermission, sendNotification, debug } = vi.hoisted(
+  () => ({
+    isTauri: vi.fn(() => true),
+    isPermissionGranted: vi.fn(async () => true),
+    requestPermission: vi.fn(async () => 'granted'),
+    sendNotification: vi.fn(),
+    debug: vi.fn(),
+  }),
+);
+
+vi.mock('@tauri-apps/api/core', () => ({ isTauri }));
+vi.mock('@tauri-apps/plugin-notification', () => ({
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+}));
+vi.mock('@/utils/logger', () => ({ logger: { debug } }));
+
+// Fresh module per test so the module-level dedup Set resets.
+async function load() {
+  vi.resetModules();
+  return import('./notifications');
+}
+
+const request = (overrides: Partial<PermissionRequest> = {}): PermissionRequest =>
+  ({ request_id: 'r1', tool_name: 'Bash', ...overrides }) as PermissionRequest;
+
+beforeEach(() => {
+  isTauri.mockReturnValue(true);
+  isPermissionGranted.mockResolvedValue(true);
+  requestPermission.mockResolvedValue('granted');
+  sendNotification.mockClear();
+  debug.mockClear();
+});
+
+describe('notifyPermissionRequest', () => {
+  it('sends a generic permission notification for an arbitrary tool', async () => {
+    const { notifyPermissionRequest } = await load();
+    await notifyPermissionRequest(request({ tool_name: 'Bash' }));
+
+    expect(sendNotification).toHaveBeenCalledWith({
+      title: 'Permission needed',
+      body: 'Tool "Bash" is waiting for your approval.',
+    });
+  });
+
+  it('uses plan-specific copy for ExitPlanMode', async () => {
+    const { notifyPermissionRequest } = await load();
+    await notifyPermissionRequest(request({ tool_name: 'ExitPlanMode' }));
+
+    expect(sendNotification).toHaveBeenCalledWith({
+      title: 'Plan ready for approval',
+      body: 'Review the plan and approve or reject it.',
+    });
+  });
+
+  it('deduplicates repeat notifications for the same request id', async () => {
+    const { notifyPermissionRequest } = await load();
+    await notifyPermissionRequest(request({ request_id: 'dup' }));
+    await notifyPermissionRequest(request({ request_id: 'dup' }));
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('requests OS permission when not already granted', async () => {
+    isPermissionGranted.mockResolvedValueOnce(false);
+    const { notifyPermissionRequest } = await load();
+    await notifyPermissionRequest(request());
+
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send when permission is denied', async () => {
+    isPermissionGranted.mockResolvedValueOnce(false);
+    requestPermission.mockResolvedValueOnce('denied');
+    const { notifyPermissionRequest } = await load();
+    await notifyPermissionRequest(request());
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('swallows notification errors and logs them', async () => {
+    isPermissionGranted.mockRejectedValueOnce(new Error('nope'));
+    const { notifyPermissionRequest } = await load();
+
+    await expect(notifyPermissionRequest(request())).resolves.toBeUndefined();
+    expect(debug).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('notifyStreamComplete', () => {
+  it('sends a completion notification', async () => {
+    const { notifyStreamComplete } = await load();
+    await notifyStreamComplete();
+
+    expect(sendNotification).toHaveBeenCalledWith({
+      title: 'Task completed',
+      body: 'The assistant has finished responding.',
+    });
+  });
+});

--- a/frontend/src/utils/openExternal.test.ts
+++ b/frontend/src/utils/openExternal.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { openUrl } = vi.hoisted(() => ({ openUrl: vi.fn() }));
+
+vi.mock('@tauri-apps/plugin-opener', () => ({ openUrl }));
+
+import { openExternalUrl } from './openExternal';
+
+beforeEach(() => {
+  openUrl.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe('openExternalUrl', () => {
+  it('opens via the Tauri opener when available', async () => {
+    openUrl.mockResolvedValue(undefined);
+    const win = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    await openExternalUrl('https://example.com');
+
+    expect(openUrl).toHaveBeenCalledWith('https://example.com');
+    expect(win).not.toHaveBeenCalled();
+  });
+
+  it('falls back to window.open when the opener rejects', async () => {
+    openUrl.mockRejectedValue(new Error('not tauri'));
+    const win = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    await openExternalUrl('https://example.com');
+
+    expect(win).toHaveBeenCalledWith('https://example.com', '_blank');
+  });
+});

--- a/frontend/src/utils/storage.test.ts
+++ b/frontend/src/utils/storage.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Force the browser (localStorage) backend — the Tauri secure-store path is a
+// thin plugin wrapper and not the logic under test.
+vi.mock('@tauri-apps/api/core', () => ({ isTauri: () => false }));
+vi.mock('@/utils/logger', () => ({ logger: { error: vi.fn() } }));
+
+// Fresh module per test so the in-memory token cache resets between cases.
+async function load() {
+  vi.resetModules();
+  return import('./storage');
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('safe localStorage helpers', () => {
+  it('round-trips a value and returns null for a missing key', async () => {
+    const { safeSetItem, safeGetItem } = await load();
+    safeSetItem('k', 'v');
+    expect(safeGetItem('k')).toBe('v');
+    expect(safeGetItem('absent')).toBeNull();
+  });
+
+  it('returns null instead of throwing when getItem blows up', async () => {
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    const { safeGetItem } = await load();
+    expect(safeGetItem('k')).toBeNull();
+    spy.mockRestore();
+  });
+});
+
+describe('authStorage (browser backend)', () => {
+  it('persists and reads back the access token', async () => {
+    const { authStorage } = await load();
+    authStorage.setToken('tok');
+    expect(authStorage.getToken()).toBe('tok');
+    expect(localStorage.getItem('auth_token')).toBe('tok');
+  });
+
+  it('hydrates the token cache from pre-existing localStorage', async () => {
+    localStorage.setItem('auth_token', 'existing');
+    const { authStorage } = await load();
+    expect(authStorage.getToken()).toBe('existing');
+  });
+
+  it('manages the refresh token independently and can remove it', async () => {
+    const { authStorage } = await load();
+    authStorage.setRefreshToken('refresh');
+    expect(authStorage.getRefreshToken()).toBe('refresh');
+
+    authStorage.removeRefreshToken();
+    expect(authStorage.getRefreshToken()).toBeNull();
+    expect(localStorage.getItem('refresh_token')).toBeNull();
+  });
+
+  it('clears both tokens on clearAuth', async () => {
+    const { authStorage } = await load();
+    authStorage.setToken('a');
+    authStorage.setRefreshToken('r');
+
+    authStorage.clearAuth();
+    expect(authStorage.getToken()).toBeNull();
+    expect(authStorage.getRefreshToken()).toBeNull();
+    expect(localStorage.getItem('auth_token')).toBeNull();
+    expect(localStorage.getItem('refresh_token')).toBeNull();
+  });
+});
+
+describe('cloudAuthStorage (browser backend)', () => {
+  it('keeps the access token in memory only', async () => {
+    const { cloudAuthStorage } = await load();
+    cloudAuthStorage.setAccessToken('cloud-access');
+    expect(cloudAuthStorage.getAccessToken()).toBe('cloud-access');
+    // Access token is never written to localStorage.
+    expect(localStorage.getItem('cloud_refresh_token')).toBeNull();
+  });
+
+  it('persists the refresh token and clears everything on clear', async () => {
+    const { cloudAuthStorage } = await load();
+    cloudAuthStorage.setRefreshToken('cloud-refresh');
+    expect(cloudAuthStorage.getRefreshToken()).toBe('cloud-refresh');
+    expect(localStorage.getItem('cloud_refresh_token')).toBe('cloud-refresh');
+
+    cloudAuthStorage.setAccessToken('x');
+    cloudAuthStorage.clear();
+    expect(cloudAuthStorage.getAccessToken()).toBeNull();
+    expect(cloudAuthStorage.getRefreshToken()).toBeNull();
+    expect(localStorage.getItem('cloud_refresh_token')).toBeNull();
+  });
+});
+
+describe('chatStorage event ids', () => {
+  it('scopes event ids per chat under the chat: key namespace', async () => {
+    const { chatStorage } = await load();
+    chatStorage.setEventId('chat-a', '42');
+    expect(chatStorage.getEventId('chat-a')).toBe('42');
+    expect(localStorage.getItem('chat:chat-a:lastEventId')).toBe('42');
+    expect(chatStorage.getEventId('chat-b')).toBeNull();
+
+    chatStorage.removeEventId('chat-a');
+    expect(chatStorage.getEventId('chat-a')).toBeNull();
+  });
+
+  it('prunes to the newest 500 entries, evicting the lowest seqs', async () => {
+    // 505 entries; keys carry the seq as their stored value.
+    for (let seq = 0; seq < 505; seq++) {
+      localStorage.setItem(`chat:c${seq}:lastEventId`, String(seq));
+    }
+    const { chatStorage } = await load();
+    chatStorage.pruneStaleEntries();
+
+    const remaining = Object.keys(localStorage).filter(
+      (k) => k.startsWith('chat:') && k.endsWith(':lastEventId'),
+    );
+    expect(remaining).toHaveLength(500);
+    // The 5 lowest seqs (0..4) are evicted; the newest survive.
+    expect(chatStorage.getEventId('c0')).toBeNull();
+    expect(chatStorage.getEventId('c4')).toBeNull();
+    expect(chatStorage.getEventId('c5')).toBe('5');
+    expect(chatStorage.getEventId('c504')).toBe('504');
+  });
+
+  it('leaves entries untouched when under the cap', async () => {
+    const { chatStorage } = await load();
+    chatStorage.setEventId('only', '1');
+    chatStorage.pruneStaleEntries();
+    expect(chatStorage.getEventId('only')).toBe('1');
+  });
+});

--- a/frontend/src/utils/theme.test.ts
+++ b/frontend/src/utils/theme.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import type { Theme } from '@/types/ui.types';
+import { THEMES, THEME_CYCLE, getThemeMeta, DARK_PALETTES } from './theme';
+
+describe('getThemeMeta', () => {
+  it('returns the matching meta for a known theme', () => {
+    const meta = getThemeMeta('light');
+    expect(meta.value).toBe('light');
+    expect(meta.label).toBe('Light');
+    expect(meta.icon).toBeDefined();
+  });
+
+  it('falls back to the dark theme for an unknown value', () => {
+    // A stale persisted theme must not crash callers reading `.icon`.
+    const meta = getThemeMeta('not-a-real-theme' as Theme);
+    expect(meta.value).toBe('dark');
+  });
+});
+
+describe('THEME_CYCLE', () => {
+  it('mirrors THEMES order exactly', () => {
+    expect(THEME_CYCLE).toEqual(THEMES.map((t) => t.value));
+  });
+
+  it('has no duplicate entries', () => {
+    expect(new Set(THEME_CYCLE).size).toBe(THEME_CYCLE.length);
+  });
+});
+
+describe('DARK_PALETTES', () => {
+  it('always includes the base dark palette and excludes light', () => {
+    expect(DARK_PALETTES.has('dark')).toBe(true);
+    expect(DARK_PALETTES.has('light')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for previously-uncovered hooks (`useAsyncEffect`, `useMountEffect`, `useToggleSet`, `usePermissionRequest`, `useInputSubmit`, `useMessageInitialization`, `useLocalStreamRestoration`, `useCloudStreamRestoration`, `createContextHook`)
- Add unit tests for stores (`chatSettingsStore`, `cloudSettingsStore`, `uiStore`, `updateStore`) and lib utilities (`api`, `editorChatActions`, `queryClient`) and misc utils (`authSession`, `logger`, `notifications`, `openExternal`, `storage`, `theme`)
- Add unit tests for chat components (`ChatInlinePermission`, `QueueMessageCard`, `MessageRenderer`, `Input`, `ToolPermissionInline`)
- Extend `sidebarGrouping.test.ts` with workspace/status/ungrouped cases and `streamStore.test.ts` with multi-stream edge cases

## Test plan
- [ ] `cd frontend && npm test` (or equivalent) to run the new suite