### PR TITLE
fix: close command menu on Escape from any tab

### DIFF
--- a/frontend/src/components/ui/command-menu/CommandMenu.tsx
+++ b/frontend/src/components/ui/command-menu/CommandMenu.tsx
@@ -143,12 +143,12 @@ export function CommandMenu() {
           <div className={styles.footer}>
             <span className={styles['footer-hint']}>
               {mode === 'branches'
-                ? '↵ Switch branch · Esc to go back'
+                ? '↵ Switch branch · Esc to close'
                 : mode === 'themes'
-                  ? '↵ Set theme · Esc to go back'
+                  ? '↵ Set theme · Esc to close'
                   : isPanelMode(mode)
-                    ? `${modKey}[ or ${modKey}] change filter · Esc to go back`
-                    : `↑↓ Select · ↵ Open · ${modKey}[ or ${modKey}] change filter · Esc to ${mode === 'all' ? 'close' : 'go back'}`}
+                    ? `${modKey}[ or ${modKey}] change filter · Esc to close`
+                    : `↑↓ Select · ↵ Open · ${modKey}[ or ${modKey}] change filter · Esc to close`}
             </span>
           </div>
         )}

--- a/frontend/src/components/ui/command-menu/useCommandMenu.ts
+++ b/frontend/src/components/ui/command-menu/useCommandMenu.ts
@@ -238,11 +238,11 @@ export function useCommandMenu() {
 
       if (isPanelMode(m)) {
         // The embedded panel handles its own typing + click-to-open; don't
-        // hijack Enter/arrows here. Only wire Escape to step back to the All tab.
+        // hijack Enter/arrows here. Only wire Escape to close the menu.
         if (e.key === 'Escape') {
           e.preventDefault();
           e.stopImmediatePropagation();
-          switchFilter('all');
+          close();
         }
         return;
       }
@@ -251,13 +251,7 @@ export function useCommandMenu() {
         case 'Escape':
           e.preventDefault();
           e.stopImmediatePropagation();
-          if (m === 'branches' || m === 'themes') {
-            switchMode('all');
-          } else if (m !== 'all') {
-            switchFilter('all');
-          } else {
-            close();
-          }
+          close();
           break;
         case 'ArrowDown':
           e.preventDefault();
@@ -303,7 +297,6 @@ export function useCommandMenu() {
     handleOpenChatResult,
     handleSelectBranch,
     handleSelectTheme,
-    switchMode,
     switchFilter,
     close,
   ]);


### PR DESCRIPTION
## Summary
- Escape in the command menu always closes the palette, instead of stepping back to the All tab from filters, panel modes, or branches/themes
- Footer hints updated to say "Esc to close" consistently

## Test plan
- [ ] Open command menu (Cmd/Ctrl+Shift+P)
- [ ] Switch to a non-All filter (e.g. Files, Chats) and press Escape — menu should close
- [ ] Open branches or themes sub-mode and press Escape — menu should close
- [ ] Open messages/grep panel mode and press Escape — menu should close
- [ ] From All tab, Escape still closes as before