### PR TITLE
fix: readable ANSI colors for light terminal themes

### DIFF
--- a/frontend/src/utils/terminal.test.ts
+++ b/frontend/src/utils/terminal.test.ts
@@ -20,6 +20,9 @@ describe('buildTerminalTheme', () => {
       selectionBackground: 'rgba(0, 0, 0, 0.15)',
       selectionInactiveBackground: 'rgba(0, 0, 0, 0.08)',
     });
+    // Light palettes override the ANSI 16 — the built-ins are dark-background colors.
+    expect(theme?.white).toBe('#555555');
+    expect(theme?.brightYellow).toBe('#b5ba00');
   });
 
   it('uses the dark base surface and dark-mode accents for dark', () => {
@@ -30,6 +33,8 @@ describe('buildTerminalTheme', () => {
       cursorAccent: '#0a0a0a',
       selectionBackground: 'rgba(255, 255, 255, 0.2)',
     });
+    // Dark palettes keep xterm's built-in ANSI defaults.
+    expect(theme?.white).toBeUndefined();
   });
 
   it('derives a dark custom palette from its shared tokens', () => {

--- a/frontend/src/utils/terminal.ts
+++ b/frontend/src/utils/terminal.ts
@@ -17,6 +17,28 @@ function paletteSurface(palette: Palette): { background: string; foreground: str
   return { background: t.surfaceSecondary, foreground: t.textPrimary };
 }
 
+// xterm's built-in ANSI 16 defaults assume a dark background — on a light canvas,
+// white/bright-white and yellow output (git, ls, prompts) is near-invisible. Light
+// palettes get VS Code Light+'s re-tuned set; dark palettes keep the built-ins.
+const LIGHT_ANSI = {
+  black: '#000000',
+  red: '#cd3131',
+  green: '#00bc00',
+  yellow: '#949800',
+  blue: '#0451a5',
+  magenta: '#bc05bc',
+  cyan: '#0598bc',
+  white: '#555555',
+  brightBlack: '#666666',
+  brightRed: '#cd3131',
+  brightGreen: '#14ce14',
+  brightYellow: '#b5ba00',
+  brightBlue: '#0451a5',
+  brightMagenta: '#bc05bc',
+  brightCyan: '#0598bc',
+  brightWhite: '#a5a5a5',
+} as const;
+
 export const buildTerminalTheme = (palette: Palette): ITerminalOptions['theme'] => {
   const isDark = DARK_PALETTES.has(palette);
   const { background, foreground } = paletteSurface(palette);
@@ -27,6 +49,7 @@ export const buildTerminalTheme = (palette: Palette): ITerminalOptions['theme'] 
     cursorAccent: isDark ? '#0a0a0a' : '#ffffff',
     selectionBackground: isDark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.15)',
     selectionInactiveBackground: isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.08)',
+    ...(isDark ? null : LIGHT_ANSI),
   };
 };
 


### PR DESCRIPTION
## Summary
- xterm's built-in ANSI 16 defaults assume a dark background, so white and bright-yellow terminal output (git, ls, prompts) is near-invisible on light palettes.
- Light palettes now use VS Code Light+'s re-tuned ANSI 16 set; dark palettes keep xterm's built-in defaults.

## Test plan
- [x] Updated unit tests cover both light-palette overrides and dark-palette passthrough (`frontend/src/utils/terminal.test.ts`)