### PR TITLE
feat: support Grok's auto/always-approve modes and ask_user_question

### DIFF
--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -9,7 +9,7 @@ PermissionMode: TypeAlias = Literal[
     "agent",
     "autopilot",
     "auto",
-    "code",
+    "always-approve",
     "read-only",
     "full-access",
     "ask",

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -66,11 +66,12 @@ COPILOT_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
 # Cursor CLI exposes three ACP session modes (see https://cursor.com/docs/cli/acp).
 CURSOR_SESSION_MODES = frozenset({"agent", "plan", "ask"})
 
-# Grok Build's ACP session modes: `code` is normal full execution, `plan`
-# blocks writes except the session plan file. Grok auto-approves every tool
-# call over ACP stdio (it never sends session/request_permission), so there
-# is no separate ask/approve mode to expose.
-GROK_SESSION_MODES = frozenset({"code", "plan"})
+# Grok Build's ACP session modes (CLI >= 0.2.9x): `auto` is the default —
+# a classifier auto-approves routine tool calls and prompts via
+# session/request_permission for risky ones; `always-approve` skips all
+# prompts; `plan` blocks writes except the session plan file. The old `code`
+# mode was removed upstream (set_mode silently ignores unknown ids).
+GROK_SESSION_MODES = frozenset({"auto", "always-approve", "plan"})
 # Only Grok 4.5 exposes the low/medium/high reasoning-effort dial; Composer
 # ignores it, so the effort launch flag is skipped for other models.
 GROK_VALID_THINKING_MODES = frozenset({"low", "medium", "high"})
@@ -89,7 +90,7 @@ NORMAL_SESSION_MODE: dict[AgentKind, PermissionMode] = {
     AgentKind.CODEX: "auto",
     AgentKind.COPILOT: "agent",
     AgentKind.CURSOR: "agent",
-    AgentKind.GROK: "code",
+    AgentKind.GROK: "always-approve",
     AgentKind.OPENCODE: "build",
 }
 
@@ -427,10 +428,9 @@ class GrokAgentAdapter(AgentAdapter):
     # Grok Build (xAI) runs as an ACP server via `grok agent stdio`. Reasoning
     # effort is a launch-only flag (`grok agent --reasoning-effort <tier> stdio`)
     # — there is no ACP method to change it mid-session, so effort changes take
-    # effect through the session fingerprint respawning the process. Grok
-    # auto-approves every tool call over ACP stdio (it never sends
-    # session/request_permission), so its modes (code/plan) are workflow
-    # choices rather than approval policies.
+    # effect through the session fingerprint respawning the process. In `auto`
+    # mode Grok prompts for risky tool calls via session/request_permission
+    # (handled by the shared permission flow); `always-approve` never prompts.
 
     def __init__(self) -> None:
         super().__init__(kind=AgentKind.GROK)
@@ -483,11 +483,11 @@ class GrokAgentAdapter(AgentAdapter):
         )
 
     def map_session_mode(self, permission_mode: str) -> str:
-        # Persisted settings may still carry mode strings from a different
-        # previous agent. Default to Grok's normal code mode — both Grok modes
-        # auto-approve what they allow, so no mapping widens permissions.
+        # Persisted settings may carry mode strings from a different agent or
+        # the legacy Grok `code` mode. Map those to always-approve — it matches
+        # code mode's old behavior of never prompting.
         if permission_mode not in GROK_SESSION_MODES:
-            return "code"
+            return "always-approve"
         return permission_mode
 
     def map_model_id(self, model_id: str) -> str:

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -69,6 +69,12 @@ PERMISSION_MODE_BY_OPTION_NAME: dict[str, PermissionMode] = {
     "full access": "full-access",
 }
 
+# Grok delivers its ask_user_question tool as an ACP extension request
+# (`_x.ai/ask_user_question`; the SDK strips the leading underscore). It must
+# be answered with an AskUserQuestionExtResponse — an empty result fails the
+# tool with "missing field `outcome`".
+GROK_ASK_USER_QUESTION_METHOD = "x.ai/ask_user_question"
+
 
 class AcpClientHandler:
     # Implements the ACP client-side handler interface. The ACP SDK calls
@@ -80,7 +86,7 @@ class AcpClientHandler:
         self.agent_kind = agent_kind
         self.event_queue: asyncio.Queue[StreamEvent | object] = asyncio.Queue()
         self._active_tools: dict[str, ToolPayload] = {}
-        self._pending_permissions: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._pending_permissions: dict[str, asyncio.Future[str]] = {}
         # Tracks which permission mode the user selected for each tool call,
         # so we can include it in the tool_completed/tool_failed event.
         self._resolved_permissions: dict[str, PermissionMode | None] = {}
@@ -204,17 +210,22 @@ class AcpClientHandler:
         )
         self.event_queue.put_nowait(event)
 
-        future: asyncio.Future[dict[str, Any]] = (
-            asyncio.get_running_loop().create_future()
-        )
-        self._pending_permissions[request_id] = future
+        option_id = await self._wait_for_user_choice(request_id)
+        if option_id:
+            return RequestPermissionResponse(
+                outcome=AllowedOutcome(outcome="selected", option_id=option_id)
+            )
+        return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
 
+    async def _wait_for_user_choice(self, request_id: str) -> str:
+        # Blocks until resolve_permission() delivers the user's selection for
+        # this request; empty string means the user cancelled/dismissed.
+        future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        self._pending_permissions[request_id] = future
         try:
-            result = await future
+            return await future
         finally:
             self._pending_permissions.pop(request_id, None)
-
-        return result.get("response")
 
     def resolve_permission(
         self,
@@ -223,8 +234,8 @@ class AcpClientHandler:
         option_id: str = "",
     ) -> bool:
         # Called from the SSE endpoint when the user responds to a permission
-        # request. Unblocks the matching request_permission() awaiter with
-        # either an AllowedOutcome (option selected) or DeniedOutcome (cancelled).
+        # request or user question. Unblocks the matching _wait_for_user_choice()
+        # awaiter; an empty option_id means the request was cancelled.
         future = self._pending_permissions.get(request_id)
         if future is None or future.done():
             return False
@@ -232,13 +243,10 @@ class AcpClientHandler:
         if option_id:
             option_modes = self._permission_option_modes.pop(request_id, {})
             self._resolved_permissions[request_id] = option_modes.get(option_id)
-            outcome = AllowedOutcome(outcome="selected", option_id=option_id)
         else:
             self._permission_option_modes.pop(request_id, None)
-            outcome = DeniedOutcome(outcome="cancelled")
 
-        response = RequestPermissionResponse(outcome=outcome)
-        future.set_result({"response": response})
+        future.set_result(option_id)
         return True
 
     async def read_text_file(
@@ -310,7 +318,47 @@ class AcpClientHandler:
         return KillTerminalResponse()
 
     async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if method == GROK_ASK_USER_QUESTION_METHOD:
+            return await self._answer_user_question(params)
         return {}
+
+    async def _answer_user_question(self, params: dict[str, Any]) -> dict[str, Any]:
+        # Reuses the permission round trip: each question is forwarded as a
+        # permission_request whose options are the question's choices, so the
+        # existing approval UI collects the answer. Questions go one at a time
+        # since the UI shows a single pending request.
+        tool_call_id = params.get("toolCallId", "")
+        answers: dict[str, str] = {}
+        for index, question in enumerate(params.get("questions") or []):
+            question_text = question.get("question", "")
+            option_dicts = [
+                {
+                    "kind": "allow_once",
+                    "name": opt.get("label", ""),
+                    "option_id": opt.get("label", ""),
+                    "permission_mode": None,
+                }
+                for opt in question.get("options") or []
+            ]
+            request_id = f"{tool_call_id}:q{index}"
+            self.event_queue.put_nowait(
+                StreamEvent(
+                    type="permission_request",
+                    request_id=request_id,
+                    tool_name="AskUserQuestion",
+                    tool_input={"question": question_text},
+                    data={"options": option_dicts},
+                )
+            )
+            selected = await self._wait_for_user_choice(request_id)
+            if not selected:
+                # User dismissed the question — tell Grok to stop interviewing
+                # and proceed with whatever answers it already has.
+                return {"outcome": "skip_interview"}
+            answers[question_text] = selected
+        # The wire format accepts string-or-list answer values; we always send
+        # a single label (multiSelect degrades to picking one option).
+        return {"outcome": "accepted", "answers": answers}
 
     async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
         pass

--- a/backend/tests/fake_acp_agent.py
+++ b/backend/tests/fake_acp_agent.py
@@ -62,6 +62,7 @@ MARKER_TOOL_PROGRESS_NEW = "MARKER_TOOL_PROGRESS_NEW"
 MARKER_RAW_INPUT_STRING = "MARKER_RAW_INPUT_STRING"
 MARKER_RAW_INPUT_INVALID = "MARKER_RAW_INPUT_INVALID"
 MARKER_PERMISSION = "MARKER_PERMISSION"
+MARKER_ASK_USER_QUESTION = "MARKER_ASK_USER_QUESTION"
 MARKER_CANCEL = "MARKER_CANCEL"
 MARKER_CRASH_MID_PROMPT = "MARKER_CRASH_MID_PROMPT"
 MARKER_TOOL_LEFT_OPEN = "MARKER_TOOL_LEFT_OPEN"
@@ -251,6 +252,8 @@ class FakeAgent:
             return await self._run_cancel_turn(session_id)
         if MARKER_PERMISSION in text:
             return await self._run_permission_turn(session_id)
+        if MARKER_ASK_USER_QUESTION in text:
+            return await self._run_ask_user_question_turn(session_id)
         if MARKER_FS_TERMINAL_STUBS in text:
             await self._call_fs_terminal_stubs(session_id)
         if MARKER_ENTER_PLAN_MODE in text:
@@ -466,6 +469,45 @@ class FakeAgent:
                     raw_output="Permission denied by user",
                 ),
             )
+        await asyncio.sleep(0.05)
+        return PromptResponse(stop_reason="end_turn")
+
+    async def _run_ask_user_question_turn(self, session_id: str) -> PromptResponse:
+        # Mirrors Grok's ask_user_question flow: the question arrives as an
+        # `_x.ai/ask_user_question` extension request (the SDK's ext_method
+        # adds the underscore prefix) while the tool call is still active, and
+        # the client must answer with an AskUserQuestionExtResponse.
+        assert self._client is not None
+        tool_call_id = "tool-ask-user"
+        await self._emit_tool_started(session_id, tool_call_id, "Ask: Pick a color")
+        response = await self._client.ext_method(
+            "x.ai/ask_user_question",
+            {
+                "sessionId": session_id,
+                "toolCallId": tool_call_id,
+                "questions": [
+                    {
+                        "question": "Pick a color",
+                        "options": [
+                            {"label": "Red", "description": "Warm"},
+                            {"label": "Blue", "description": "Cool"},
+                        ],
+                        "multiSelect": False,
+                    }
+                ],
+                "mode": "default",
+            },
+        )
+        log_event({"event": "ask_user_question", "response": response})
+        await self._client.session_update(
+            session_id=session_id,
+            update=ToolCallProgress(
+                session_update="tool_call_update",
+                tool_call_id=tool_call_id,
+                status="completed",
+                raw_output=response,
+            ),
+        )
         await asyncio.sleep(0.05)
         return PromptResponse(stop_reason="end_turn")
 

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -17,6 +17,7 @@ from app.models.db_models.workspace import Workspace
 from app.services.session_registry import session_registry
 from tests.conftest import LoginClient, UserFactory
 from tests.fake_acp_agent import (
+    MARKER_ASK_USER_QUESTION,
     MARKER_CANCEL,
     MARKER_CRASH_MID_PROMPT,
     MARKER_ENTER_PLAN_MODE,
@@ -43,7 +44,14 @@ from tests.helpers import EndpointCache, create_authenticated_workspace
 pytestmark = pytest.mark.anyio
 
 FAKE_AGENT_SCRIPT = Path(__file__).resolve().parent / "fake_acp_agent.py"
-BINARY_NAMES = ["claude-agent-acp", "codex-acp", "copilot", "cursor-agent", "opencode"]
+BINARY_NAMES = [
+    "claude-agent-acp",
+    "codex-acp",
+    "copilot",
+    "cursor-agent",
+    "grok",
+    "opencode",
+]
 
 DEFAULT_TURN_TEXT = "Hello from the fake agent."
 
@@ -630,6 +638,7 @@ async def test_chat_enter_plan_mode_tool_triggers_mid_stream_mode_switch(
             "https://agentclientprotocol.com/protocol/session-modes#agent",
         ),
         ("cursor:auto", "bypassPermissions", False, "agent"),
+        ("grok:grok-4.5", "bypassPermissions", False, "always-approve"),
         ("opencode:opencode/gpt-5-nano", "bypassPermissions", False, "plan"),
     ],
 )
@@ -806,6 +815,70 @@ async def test_chat_permission_response_flow(
     tool = last_tool(message, "tool-permission")
     assert tool["status"] == expect_status.removeprefix("tool_")
     assert tool.get("permission_mode") == expect_permission_mode
+
+
+@pytest.mark.parametrize(
+    "option_id,expect_response",
+    [
+        ("Red", {"outcome": "accepted", "answers": {"Pick a color": "Red"}}),
+        ("", {"outcome": "skip_interview"}),
+    ],
+)
+async def test_chat_ask_user_question_flow(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+    option_id: str,
+    expect_response: dict[str, Any],
+) -> None:
+    # Grok's ask_user_question arrives as an ACP extension request and must be
+    # answered with an AskUserQuestionExtResponse: the question is surfaced as
+    # a permission_request whose options are the question's choices, and the
+    # user's selection (or dismissal → skip_interview) becomes the response.
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="grok:grok-4.5")
+
+    send_response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="grok:grok-4.5",
+        prompt=f"{MARKER_ASK_USER_QUESTION} choose",
+    )
+    message_id = send_response.json()["message_id"]
+
+    question_event = await wait_for_message_event(
+        client, headers, message_id=message_id, event_type="permission_request"
+    )
+    payload = question_event["render_payload"]
+    assert payload["tool_name"] == "AskUserQuestion"
+    assert payload["tool_input"] == {"question": "Pick a color"}
+    # Request ids are suffixed per question so they can't collide with the
+    # tool_call_id-keyed permission requests.
+    assert payload["request_id"] == "tool-ask-user:q0"
+    assert [opt["option_id"] for opt in payload["data"]["options"]] == ["Red", "Blue"]
+
+    respond = await client.post(
+        f"/api/v1/chat/chats/{chat['id']}/permissions/{payload['request_id']}/respond",
+        data={"option_id": option_id},
+        headers=headers,
+    )
+    assert respond.status_code == 200, respond.text
+
+    message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=message_id
+    )
+    assert message["stream_status"] == "completed"
+
+    # The fake agent completes the tool with raw_output=<the client's ext
+    # response>, so this message's own tool result is the response the client
+    # returned. Don't assert on the fake-agent log: background title generation
+    # re-runs the marker turn (its prompt embeds the user message) and its
+    # auto-denied question appends a stray skip_interview entry.
+    tool = last_tool(message, "tool-ask-user")
+    assert tool["status"] == "completed"
+    assert tool["result"] == expect_response
 
 
 async def test_chat_cancel_marks_message_interrupted(

--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -1,7 +1,7 @@
 import { PermissionModeSelector } from '@/components/chat/permission-mode-selector/PermissionModeSelector';
 import { ModelSelector } from '@/components/chat/model-selector/ModelSelector';
 import { ThinkingModeSelector } from '@/components/chat/thinking-mode-selector/ThinkingModeSelector';
-import { THINKING_MODES_BY_AGENT } from '@/components/chat/thinking-mode-selector/thinkingModes';
+import { getThinkingModesForAgent } from '@/components/chat/thinking-mode-selector/thinkingModes';
 import { FastModeSelector } from '@/components/chat/fast-mode-selector/FastModeSelector';
 import { PersonaSelector } from '@/components/chat/persona-selector/PersonaSelector';
 import { PERSONAS_SUPPORTED_AGENTS } from '@/components/chat/persona-selector/personaSupport';
@@ -31,7 +31,11 @@ export function InputControls() {
   const showPersona =
     personas.length > 0 && (!agentKind || PERSONAS_SUPPORTED_AGENTS.has(agentKind));
   const showBranch = !!sandboxId && !!branchesData?.is_git_repo && branchesData.branches.length > 0;
-  const showThinking = agentKind ? THINKING_MODES_BY_AGENT[agentKind].length > 0 : true;
+  // Model-aware: some agents only expose a reasoning dial on specific models
+  // (e.g. Grok 4.5 but not Composer), so the base per-agent list isn't enough.
+  const showThinking = agentKind
+    ? getThinkingModesForAgent(agentKind, state.selectedModelId).length > 0
+    : true;
   const showFastMode = agentKind === 'codex';
 
   return (

--- a/frontend/src/components/chat/permission-mode-selector/permissionModes.ts
+++ b/frontend/src/components/chat/permission-mode-selector/permissionModes.ts
@@ -70,9 +70,14 @@ export const CURSOR_PERMISSION_MODES: PermissionModeOption[] = [
 
 export const GROK_PERMISSION_MODES: PermissionModeOption[] = [
   {
-    value: 'code',
-    label: 'Code',
-    description: 'Full tool access, tool calls run without approval prompts',
+    value: 'auto',
+    label: 'Auto',
+    description: 'Approves routine tool calls, asks for risky ones',
+  },
+  {
+    value: 'always-approve',
+    label: 'Always Approve',
+    description: 'Skip all permission prompts',
   },
   {
     value: 'plan',
@@ -108,7 +113,7 @@ const DEFAULT_BY_AGENT: Record<AgentKind, PermissionMode> = {
   codex: 'full-access',
   copilot: 'agent',
   cursor: 'agent',
-  grok: 'code',
+  grok: 'always-approve',
   opencode: 'build',
 };
 

--- a/frontend/src/store/chatSettingsStore.ts
+++ b/frontend/src/store/chatSettingsStore.ts
@@ -9,7 +9,7 @@ type PermissionMode =
   | 'agent'
   | 'autopilot'
   | 'auto'
-  | 'code'
+  | 'always-approve'
   | 'read-only'
   | 'full-access'
   | 'ask'


### PR DESCRIPTION
## Summary
- Grok Build CLI >= 0.2.9x replaced the `code` session mode with `auto` (classifier auto-approves routine tool calls, prompts for risky ones) and `always-approve` (skips all prompts); updates `GROK_SESSION_MODES`, `NORMAL_SESSION_MODE`, and mode mapping/defaults accordingly across backend and frontend
- Adds handling for Grok's `x.ai/ask_user_question` ACP extension request, routing each question through the existing permission-request UI flow instead of returning an empty (and failing) result
- Refactors `AcpClientHandler` permission waiting into a shared `_wait_for_user_choice` helper reused by both the permission-request and ask-user-question flows
- Fixes `InputControls.tsx` to use the existing model-aware `getThinkingModesForAgent` helper instead of the flat `THINKING_MODES_BY_AGENT` map, so the thinking-mode selector correctly reflects per-model support (e.g. Grok 4.5 vs Composer)

## Test plan
- [ ] Start a Grok session and verify `auto` mode prompts for risky tool calls while routine ones proceed without prompting
- [ ] Switch to `always-approve` mode and verify no prompts appear
- [ ] Trigger a Grok flow that invokes `ask_user_question` and confirm the question renders via the permission UI and the selected answer is sent back correctly
- [ ] Verify the thinking-mode selector shows/hides correctly when switching between Grok 4.5 and Composer models