### PR TITLE
fix: update Grok CLI Docker install path

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,10 +40,11 @@ RUN curl -fsSL https://opencode.ai/install | bash && \
     cp /root/.opencode/bin/opencode /usr/local/bin/opencode && \
     chmod +x /usr/local/bin/opencode
 
-# Grok Build CLI (installs `grok` to /root/.local/bin) — used for the Grok ACP
-# server (`grok agent stdio`).
+# Grok Build CLI (installs `grok` to /root/.grok/bin as a symlink into
+# downloads/) — used for the Grok ACP server (`grok agent stdio`).
+# cp -L dereferences so appuser can run the binary without needing /root.
 RUN curl -fsSL https://x.ai/cli/install.sh | bash && \
-    cp /root/.local/bin/grok /usr/local/bin/grok && \
+    cp -L /root/.grok/bin/grok /usr/local/bin/grok && \
     chmod +x /usr/local/bin/grok
 
 # Install uv package manager

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -68,8 +68,11 @@ RUN curl -fsSL https://opencode.ai/install | bash && \
     mkdir -p /home/user/.local/bin && \
     ln -sf /home/user/.opencode/bin/opencode /home/user/.local/bin/opencode
 
-# Grok Build CLI (installs `grok` to ~/.local/bin, which is already on PATH).
-RUN curl -fsSL https://x.ai/cli/install.sh | bash
+# Grok Build CLI (installs `grok` to ~/.grok/bin; symlink into ~/.local/bin
+# so the ACP binary resolves without modifying PATH).
+RUN curl -fsSL https://x.ai/cli/install.sh | bash && \
+    mkdir -p /home/user/.local/bin && \
+    ln -sf /home/user/.grok/bin/grok /home/user/.local/bin/grok
 
 RUN python3 -m pip install --user --upgrade pip && \
     python3 -m pip install --user \


### PR DESCRIPTION
## Summary
- The xAI Grok CLI installer now installs to `~/.grok/bin` (symlink into downloads), not `~/.local/bin`.
- Backend Dockerfile copies the real binary with `cp -L` into `/usr/local/bin` so `appuser` can run it without `/root` access.
- Sandbox Dockerfile symlinks `grok` into `~/.local/bin` (already on PATH), matching the OpenCode install pattern.

## Test plan
- [ ] `docker compose build api` succeeds past the Grok CLI install step
- [ ] `grok --version` works inside the built API container
- [ ] Sandbox image build succeeds and resolves `grok` on PATH for the sandbox user