### PR TITLE
fix: install Grok CLI via direct binary download

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,11 +40,18 @@ RUN curl -fsSL https://opencode.ai/install | bash && \
     cp /root/.opencode/bin/opencode /usr/local/bin/opencode && \
     chmod +x /usr/local/bin/opencode
 
-# Grok Build CLI (installs `grok` to /root/.grok/bin as a symlink into
-# downloads/) — used for the Grok ACP server (`grok agent stdio`).
-# cp -L dereferences so appuser can run the binary without needing /root.
-RUN curl -fsSL https://x.ai/cli/install.sh | bash && \
-    cp -L /root/.grok/bin/grok /usr/local/bin/grok && \
+# Grok Build CLI — used for the Grok ACP server (`grok agent stdio`).
+# Download the static binary directly: install.sh symlinks into /usr/local/bin
+# then our old `cp -L` treats src/dest as the same file and exits 1.
+RUN set -eux; \
+    version="$(curl -fsSL https://x.ai/cli/stable)"; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+      x86_64|amd64) arch=x86_64 ;; \
+      aarch64|arm64) arch=aarch64 ;; \
+      *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://x.ai/cli/grok-${version}-linux-${arch}" -o /usr/local/bin/grok; \
     chmod +x /usr/local/bin/grok
 
 # Install uv package manager

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -68,11 +68,19 @@ RUN curl -fsSL https://opencode.ai/install | bash && \
     mkdir -p /home/user/.local/bin && \
     ln -sf /home/user/.opencode/bin/opencode /home/user/.local/bin/opencode
 
-# Grok Build CLI (installs `grok` to ~/.grok/bin; symlink into ~/.local/bin
-# so the ACP binary resolves without modifying PATH).
-RUN curl -fsSL https://x.ai/cli/install.sh | bash && \
-    mkdir -p /home/user/.local/bin && \
-    ln -sf /home/user/.grok/bin/grok /home/user/.local/bin/grok
+# Grok Build CLI — download static binary into ~/.local/bin (already on PATH).
+# Avoid install.sh: it targets ~/.grok/bin and is awkward under non-root USER.
+RUN set -eux; \
+    version="$(curl -fsSL https://x.ai/cli/stable)"; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+      x86_64|amd64) arch=x86_64 ;; \
+      aarch64|arm64) arch=aarch64 ;; \
+      *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /home/user/.local/bin; \
+    curl -fsSL "https://x.ai/cli/grok-${version}-linux-${arch}" -o /home/user/.local/bin/grok; \
+    chmod +x /home/user/.local/bin/grok
 
 RUN python3 -m pip install --user --upgrade pip && \
     python3 -m pip install --user \


### PR DESCRIPTION
## Summary
- Root cause of the remaining API image build failure: `install.sh` already creates `/usr/local/bin/grok` → `~/.grok/bin/grok`, then `cp -L` treats source and dest as the same file and exits 1 (`are identical (not copied)`).
- Bypass `install.sh` and download the static Linux binary from `https://x.ai/cli/grok-<version>-linux-<arch>` straight into PATH.
- Same approach in the sandbox image for consistency and a smaller install surface.

## Test plan
- [ ] `docker compose build api` succeeds past the Grok install step
- [ ] `docker compose run --rm api grok --version` works
- [ ] Sandbox image build succeeds and `grok` is on PATH for the sandbox user