### PR TITLE
fix: switch SQLite engine to NullPool with WAL mode

### DIFF
--- a/backend/app/api/endpoints/attachments.py
+++ b/backend/app/api/endpoints/attachments.py
@@ -27,7 +27,7 @@ async def preview_temp_attachment(
         raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
     # The file body streams after the handler returns while yield deps stay
     # open — release the auth chain's session so a slow download doesn't pin
-    # a pooled DB connection.
+    # a DB connection (and its aiosqlite thread).
     await db.close()
     return response
 

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -296,7 +296,8 @@ async def stream_user_chat_events(
     # isn't parsed as a UUID.
     # `db` is the same cached session the auth chain used; FastAPI keeps yield
     # deps open until the response finishes, so a long-lived SSE connection would
-    # pin its pooled DB connection until disconnect. Auth is done — release it.
+    # pin its DB connection and aiosqlite thread until disconnect. Auth is
+    # done — release it.
     await db.close()
     return EventSourceResponse(
         chat_service.create_chat_events_stream(current_user.id),
@@ -328,8 +329,8 @@ async def stream_user_streams(
     owned = await chat_service.filter_owned_chat_ids(current_user.id, list(requested))
     replay_cursors = {cid: seq for cid, seq in requested.items() if cid in owned}
 
-    # Same rationale as /chats/events: auth is done — release the pooled DB
-    # session so the long-lived SSE connection doesn't pin it until disconnect.
+    # Same rationale as /chats/events: auth is done — release the DB session
+    # so the long-lived SSE connection doesn't pin it until disconnect.
     await db.close()
     return EventSourceResponse(
         chat_service.create_user_streams_feed(current_user.id, replay_cursors),

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -5,18 +5,23 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
+from sqlalchemy.pool import NullPool
 
 from app.core.config import get_settings
-from app.db.sqlite import enable_foreign_keys
+from app.db.sqlite import configure_sqlite
 
 settings = get_settings()
 
+# NullPool: SQLite connections are cheap local file opens, and a bounded pool
+# gets exhausted when slow requests (Docker setup, LLM calls) pin connections
+# for their full duration — WAL mode handles the resulting write concurrency.
 engine = create_async_engine(
     settings.DATABASE_URL,
     connect_args={"check_same_thread": False},
     echo=False,
+    poolclass=NullPool,
 )
-enable_foreign_keys(engine.sync_engine)
+configure_sqlite(engine.sync_engine)
 
 SessionLocal = async_sessionmaker(
     engine,

--- a/backend/app/db/sqlite.py
+++ b/backend/app/db/sqlite.py
@@ -4,13 +4,20 @@ from sqlalchemy import event
 from sqlalchemy.engine import Engine
 
 
-def _set_foreign_keys_pragma(dbapi_connection: Any, _: Any) -> None:
+def _set_pragmas(dbapi_connection: Any, _: Any) -> None:
     cursor = dbapi_connection.cursor()
+    # SQLite ignores FK constraints unless PRAGMA foreign_keys=ON is set per
+    # connection — required for ondelete CASCADE / SET NULL to be enforced.
     cursor.execute("PRAGMA foreign_keys=ON")
+    # WAL lets readers and the writer proceed concurrently — the engine uses
+    # NullPool (one connection per session), so without WAL concurrent sessions
+    # would serialize behind the rollback journal's exclusive lock.
+    cursor.execute("PRAGMA journal_mode=WAL")
+    # Wait for a busy writer instead of failing fast with "database is locked"
+    # (the driver default is 5s, too short for bursts of stream-snapshot writes).
+    cursor.execute("PRAGMA busy_timeout=30000")
     cursor.close()
 
 
-def enable_foreign_keys(engine: Engine) -> None:
-    # SQLite ignores FK constraints unless PRAGMA foreign_keys=ON is set per
-    # connection — required for ondelete CASCADE / SET NULL to be enforced.
-    event.listen(engine, "connect", _set_foreign_keys_pragma)
+def configure_sqlite(engine: Engine) -> None:
+    event.listen(engine, "connect", _set_pragmas)

--- a/backend/migrate.py
+++ b/backend/migrate.py
@@ -6,7 +6,7 @@ from alembic.config import Config
 from sqlalchemy import create_engine, inspect
 
 from app.core.config import get_settings
-from app.db.sqlite import enable_foreign_keys
+from app.db.sqlite import configure_sqlite
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ def check_and_run_migrations():
     is_production = settings.ENVIRONMENT.lower() == "production"
 
     engine = create_engine(db_url)
-    enable_foreign_keys(engine)
+    configure_sqlite(engine)
 
     try:
         with engine.connect():

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -6,7 +6,7 @@ from sqlalchemy.engine import Connection
 
 from alembic import context
 from app.db.base_class import Base
-from app.db.sqlite import enable_foreign_keys
+from app.db.sqlite import configure_sqlite
 from app.models.db_models import (  # noqa: F401
     automation,
     chat,
@@ -98,7 +98,7 @@ def do_run_migrations(connection: Connection) -> None:
 def run_migrations_online() -> None:
     sync_url = database_url.replace("sqlite+aiosqlite://", "sqlite://", 1)
     engine = create_engine(sync_url, poolclass=pool.NullPool)
-    enable_foreign_keys(engine)
+    configure_sqlite(engine)
     with engine.connect() as connection:
         do_run_migrations(connection)
     engine.dispose()

--- a/backend/seed_data.py
+++ b/backend/seed_data.py
@@ -3,10 +3,10 @@ import asyncio
 import os
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import get_settings
 from app.core.security import get_password_hash
+from app.db.session import SessionLocal, engine
 from app.models.db_models.user import User, UserSettings
 
 
@@ -46,13 +46,9 @@ async def seed_admin(session: AsyncSession) -> None:
 
 
 async def seed_data() -> None:
-    settings = get_settings()
-    engine = create_async_engine(settings.DATABASE_URL, echo=False)
-    async_session = async_sessionmaker(
-        engine, class_=AsyncSession, expire_on_commit=False
-    )
-
-    async with async_session() as session:
+    # Reuse the app engine so seeding runs with the same SQLite pragmas
+    # (foreign keys, WAL) instead of a bare unconfigured connection.
+    async with SessionLocal() as session:
         await seed_admin(session)
         await session.commit()
         print("Seed completed successfully")

--- a/backend/tests/test_streaming.py
+++ b/backend/tests/test_streaming.py
@@ -13,6 +13,7 @@ import uvicorn
 from acp.schema import PermissionOption, ToolCallUpdate
 from fastapi import FastAPI
 from httpx import AsyncClient
+from sqlalchemy import event as sa_event
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.endpoints import chat as chat_endpoint
@@ -48,6 +49,19 @@ pytestmark = pytest.mark.anyio
 # Sentinel script step: makes the fake ACP session block forever on this
 # prompt (until the runtime cancels it), simulating a long-running turn.
 BLOCK_FOREVER = object()
+
+
+class ConnectionCounter:
+    # NullPool has no checkedout() — count live DBAPI connections via pool
+    # checkout/checkin events instead, which fire for every pool implementation.
+    def __init__(self) -> None:
+        self.active = 0
+
+    def on_checkout(self, *_: Any) -> None:
+        self.active += 1
+
+    def on_checkin(self, *_: Any) -> None:
+        self.active -= 1
 
 
 @dataclass
@@ -1192,26 +1206,34 @@ async def test_sse_endpoints_release_db_connection_while_streaming(
     )
     chat = await create_chat_row(db_session, user, workspace)
 
-    baseline = engine.pool.checkedout()
-    async with asyncio.timeout(15):
-        sse_client = httpx.AsyncClient(base_url=live_server_url, timeout=10.0)
-        async with (
-            sse_client,
-            sse_client.stream(
-                "GET", "/api/v1/chat/chats/events", headers=headers
-            ) as events_response,
-            sse_client.stream(
-                "GET",
-                "/api/v1/chat/chats/streams",
-                params={"cursors": json.dumps({str(chat.id): 0})},
-                headers=headers,
-            ) as chat_stream_response,
-        ):
-            assert events_response.status_code == 200
-            assert chat_stream_response.status_code == 200
-            # The chat stream's backlog replay briefly opens its own session,
-            # so poll rather than assert instantly. Without the release fix
-            # each open stream pins a connection forever, the count never
-            # returns to baseline, and asyncio.timeout fails the test.
-            while engine.pool.checkedout() > baseline:
-                await asyncio.sleep(0.01)
+    counter = ConnectionCounter()
+    sa_event.listen(engine.sync_engine, "checkout", counter.on_checkout)
+    sa_event.listen(engine.sync_engine, "checkin", counter.on_checkin)
+    try:
+        async with asyncio.timeout(15):
+            sse_client = httpx.AsyncClient(base_url=live_server_url, timeout=10.0)
+            async with (
+                sse_client,
+                sse_client.stream(
+                    "GET", "/api/v1/chat/chats/events", headers=headers
+                ) as events_response,
+                sse_client.stream(
+                    "GET",
+                    "/api/v1/chat/chats/streams",
+                    params={"cursors": json.dumps({str(chat.id): 0})},
+                    headers=headers,
+                ) as chat_stream_response,
+            ):
+                assert events_response.status_code == 200
+                assert chat_stream_response.status_code == 200
+                # The chat stream's backlog replay briefly opens its own session,
+                # so poll rather than assert instantly. Without the release fix
+                # each open stream pins a connection forever, the count never
+                # returns to zero, and asyncio.timeout fails the test.
+                while counter.active > 0:
+                    await asyncio.sleep(0.01)
+    finally:
+        # The engine is module-global — unhook so the counter doesn't leak
+        # into other tests.
+        sa_event.remove(engine.sync_engine, "checkout", counter.on_checkout)
+        sa_event.remove(engine.sync_engine, "checkin", counter.on_checkin)


### PR DESCRIPTION
## Summary
- Switch the SQLite async engine from a bounded connection pool to `NullPool`, since slow requests (Docker setup, LLM calls) can pin connections for their full duration and exhaust a bounded pool
- Enable `journal_mode=WAL` so readers and the writer can proceed concurrently under `NullPool`, and raise `busy_timeout` to 30s so bursts of stream-snapshot writes wait instead of failing with "database is locked"
- Rename `enable_foreign_keys` to `configure_sqlite` since it now sets multiple pragmas, and update all call sites (`session.py`, `migrate.py`, `migrations/env.py`)
- Reuse the app's configured engine/session in `seed_data.py` instead of creating a bare unconfigured connection
- Update `test_streaming.py`'s DB-connection-release test to count live connections via pool `checkout`/`checkin` events instead of `pool.checkedout()`, which `NullPool` doesn't support

## Test plan
- [ ] Run backend test suite, in particular `tests/test_streaming.py::test_sse_endpoints_release_db_connection_while_streaming`