### PR TITLE
fix: hop through plan mode for Grok auto/always-approve switches

### DIFF
--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -262,9 +262,8 @@ class AcpSession:
 
     async def set_mode(self, mode_id: str) -> None:
         try:
-            await self._conn.set_session_mode(
-                mode_id=mode_id,
-                session_id=self.acp_session_id,
+            await self._set_mode_on_conn(
+                self._conn, self._agent_kind, self.acp_session_id, mode_id
             )
         except Exception:
             logger.warning("Failed to set ACP mode: %s", mode_id, exc_info=True)
@@ -397,9 +396,11 @@ class AcpSession:
 
             if config.permission_mode and config.permission_mode != "default":
                 try:
-                    await conn.set_session_mode(
-                        mode_id=config.permission_mode,
-                        session_id=acp_session_id,
+                    await cls._set_mode_on_conn(
+                        conn,
+                        config.agent_kind,
+                        acp_session_id,
+                        config.permission_mode,
                     )
                 except Exception:
                     logger.warning(
@@ -472,6 +473,21 @@ class AcpSession:
             agent_kind=config.agent_kind,
             stderr_task=stderr_task,
         )
+
+    @staticmethod
+    async def _set_mode_on_conn(
+        conn: ClientSideConnection,
+        agent_kind: AgentKind,
+        session_id: str,
+        mode_id: str,
+    ) -> None:
+        # Grok silently ignores direct auto <-> always-approve switches (the
+        # TUI gates those behind a confirmation ACP can't answer) but accepts
+        # any transition out of plan, so hop through plan to make the target
+        # mode actually take effect. No turn runs between the two calls.
+        if agent_kind == AgentKind.GROK and mode_id != "plan":
+            await conn.set_session_mode(mode_id="plan", session_id=session_id)
+        await conn.set_session_mode(mode_id=mode_id, session_id=session_id)
 
     @staticmethod
     async def _set_model_on_conn(

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -628,18 +628,20 @@ async def test_chat_enter_plan_mode_tool_triggers_mid_stream_mode_switch(
 
 
 @pytest.mark.parametrize(
-    "model_id,agent_permission_mode,expect_raises,expect_mapped_mode",
+    "model_id,agent_permission_mode,expect_raises,expect_mapped_modes",
     [
         ("gpt-5.4", "bypassPermissions", True, None),
         (
             "copilot:gpt-5.4",
             "bypassPermissions",
             False,
-            "https://agentclientprotocol.com/protocol/session-modes#agent",
+            ["https://agentclientprotocol.com/protocol/session-modes#agent"],
         ),
-        ("cursor:auto", "bypassPermissions", False, "agent"),
-        ("grok:grok-4.5", "bypassPermissions", False, "always-approve"),
-        ("opencode:opencode/gpt-5-nano", "bypassPermissions", False, "plan"),
+        ("cursor:auto", "bypassPermissions", False, ["agent"]),
+        # Grok mode-sets hop through plan first — direct auto <->
+        # always-approve switches are silently ignored by the CLI.
+        ("grok:grok-4.5", "bypassPermissions", False, ["plan", "always-approve"]),
+        ("opencode:opencode/gpt-5-nano", "bypassPermissions", False, ["plan"]),
     ],
 )
 async def test_chat_permission_mode_unsupported_by_adapter(
@@ -650,7 +652,7 @@ async def test_chat_permission_mode_unsupported_by_adapter(
     model_id: str,
     agent_permission_mode: str,
     expect_raises: bool,
-    expect_mapped_mode: str | None,
+    expect_mapped_modes: list[str] | None,
 ) -> None:
     # "bypassPermissions" is a globally valid PermissionMode literal but isn't
     # in every adapter's own session-mode set: Codex raises (a caller bug must
@@ -679,9 +681,12 @@ async def test_chat_permission_mode_unsupported_by_adapter(
     assert message["stream_status"] == "completed"
     set_modes = fake_agent.events_of("set_session_mode")
     assert set_modes
-    # First mode-set belongs to the chat session — background title generation
-    # opens a second session afterwards (opencode's uses a persona mode).
-    assert set_modes[0]["mode_id"] == expect_mapped_mode
+    assert expect_mapped_modes is not None
+    # Leading mode-sets belong to the chat session — background title
+    # generation opens a second session afterwards (opencode's uses a persona
+    # mode).
+    leading = [m["mode_id"] for m in set_modes[: len(expect_mapped_modes)]]
+    assert leading == expect_mapped_modes
 
 
 async def test_chat_attachments_with_only_native_files_skip_the_note(


### PR DESCRIPTION
## Summary
- Grok's CLI silently ignores direct `auto` <-> `always-approve` session-mode switches (the TUI gates those behind a confirmation ACP can't answer), but accepts any transition out of `plan` mode.
- `AcpSession._set_mode_on_conn` now hops through `plan` first when targeting a non-plan mode on a Grok session, so the intended mode actually takes effect.
- Updated `test_chat_permission_mode_unsupported_by_adapter` to assert the full ordered sequence of mode-set calls (`plan` then `always-approve`) for Grok instead of just the first call.