### PR TITLE
refactor: move new-chat button from tabs bar to title bar

### DIFF
--- a/frontend/src/components/layout/ChatTabs/ChatTabs.module.scss
+++ b/frontend/src/components/layout/ChatTabs/ChatTabs.module.scss
@@ -131,26 +131,3 @@
   border-radius: var(--radius-full);
   background-color: var(--theme-text-primary);
 }
-
-.new-tab {
-  @include anim.transition-colors;
-  display: flex;
-  height: var(--space-5);
-  width: var(--space-5);
-  flex-shrink: 0;
-  align-self: center;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-md);
-  color: var(--theme-text-tertiary);
-
-  @include responsive.hover {
-    background-color: var(--theme-surface-hover);
-    color: var(--theme-text-primary);
-  }
-}
-
-.new-tab-icon {
-  height: var(--space-3-5);
-  width: var(--space-3-5);
-}

--- a/frontend/src/components/layout/ChatTabs/ChatTabs.tsx
+++ b/frontend/src/components/layout/ChatTabs/ChatTabs.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useMatch, useNavigate } from 'react-router-dom';
-import { Plus, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import { AsciiSpinner } from '@/components/ui/AsciiSpinner/AsciiSpinner';
 import { ChatStatusDot, type ChatStatusTone } from '@/components/ui/ChatStatusDot/ChatStatusDot';
 import { Button } from '@/components/ui/primitives/Button/Button';
@@ -202,16 +202,6 @@ export function ChatTabs() {
           />
         );
       })}
-      {/* Browser-style new-tab button — the landing page is the "new tab page",
-          so + just routes there instead of creating a chat eagerly. */}
-      <Button
-        variant="unstyled"
-        onClick={() => navigate('/')}
-        aria-label="New chat"
-        className={styles['new-tab']}
-      >
-        <Plus className={styles['new-tab-icon']} />
-      </Button>
     </div>
   );
 }

--- a/frontend/src/components/layout/TitleBar/TitleBar.module.scss
+++ b/frontend/src/components/layout/TitleBar/TitleBar.module.scss
@@ -97,12 +97,12 @@
   gap: var(--space-1);
 }
 
-.search-button {
+.icon-button {
   height: var(--space-8);
   width: var(--space-8);
 }
 
-.search-icon {
+.icon-button-glyph {
   height: var(--space-4);
   width: var(--space-4);
   color: var(--theme-text-secondary);

--- a/frontend/src/components/layout/TitleBar/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar/TitleBar.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
-import { Search } from 'lucide-react';
-import { useMatch } from 'react-router-dom';
+import { Plus, Search } from 'lucide-react';
+import { useMatch, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/store/authStore';
 import { useUIStore } from '@/store/uiStore';
 import { Button } from '@/components/ui/primitives/Button/Button';
@@ -110,6 +110,7 @@ export function DesktopDragRegion() {
 }
 
 export function TitleBar() {
+  const navigate = useNavigate();
   const isChatPage = useMatch('/chat/:chatId');
   const isLandingPage = useMatch('/');
   const showSidebar = isChatPage || isLandingPage;
@@ -161,19 +162,35 @@ export function TitleBar() {
               position="left"
               ariaLabel="Toggle sidebar"
             />
+            {/* Search + new chat only when the sidebar is closed — open, the sidebar
+                already exposes both actions. Landing is the "new tab page". */}
             {!sidebarOpen && (
-              <FloatingTooltip content="Search">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className={styles['search-button']}
-                  onClick={() => useUIStore.getState().setCommandMenuOpen(true)}
-                  aria-label="Search"
-                >
-                  <Search className={styles['search-icon']} />
-                </Button>
-              </FloatingTooltip>
+              <>
+                <FloatingTooltip content="Search">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className={styles['icon-button']}
+                    onClick={() => useUIStore.getState().setCommandMenuOpen(true)}
+                    aria-label="Search"
+                  >
+                    <Search className={styles['icon-button-glyph']} />
+                  </Button>
+                </FloatingTooltip>
+                <FloatingTooltip content="New chat">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className={styles['icon-button']}
+                    onClick={() => navigate('/')}
+                    aria-label="New chat"
+                  >
+                    <Plus className={styles['icon-button-glyph']} />
+                  </Button>
+                </FloatingTooltip>
+              </>
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Removed the browser-style `+` new-tab button from `ChatTabs`, which duplicated the sidebar's new-chat action and cluttered the tabs row.
- Added a "New chat" icon button next to search in `TitleBar`, shown only when the sidebar is collapsed (when open, the sidebar already exposes both actions).
- Renamed `TitleBar` icon-button styles (`search-button`/`search-icon` → `icon-button`/`icon-button-glyph`) since they're now shared between the search and new-chat buttons.