### PR TITLE
fix: refresh token reuse grace window, revoke on password reset

### DIFF
--- a/backend/app/core/user_manager.py
+++ b/backend/app/core/user_manager.py
@@ -69,6 +69,24 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     "Failed to send verification email to %s: %s", user.email, e
                 )
 
+    async def on_after_reset_password(
+        self, user: User, request: Request | None = None
+    ) -> None:
+        # A password reset is the recovery path for a compromised account —
+        # refresh tokens issued under the old password must die with it.
+        # Inline import: core.security imports this module and the service
+        # imports core.security, so a top-level import would be circular.
+        from app.services.refresh_token import RefreshTokenService
+
+        revoked = await RefreshTokenService().revoke_all_tokens(
+            user.id, self.user_db.session
+        )
+        logger.info(
+            "Revoked %s refresh tokens for user %s after password reset",
+            revoked,
+            user.id,
+        )
+
     async def on_after_forgot_password(
         self, user: User, token: str, request: Request | None = None
     ) -> None:

--- a/backend/app/models/db_models/refresh_token.py
+++ b/backend/app/models/db_models/refresh_token.py
@@ -35,7 +35,3 @@ class RefreshToken(Base):
         if expires_at.tzinfo is None:
             expires_at = expires_at.replace(tzinfo=timezone.utc)
         return bool(datetime.now(timezone.utc) > expires_at)
-
-    @property
-    def is_revoked(self) -> bool:
-        return self.revoked_at is not None

--- a/backend/app/services/refresh_token.py
+++ b/backend/app/services/refresh_token.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, delete, or_, select, update
+from sqlalchemy import and_, delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import (
@@ -18,6 +18,11 @@ from app.services.db import SessionFactoryType
 from app.services.exceptions import AuthException
 
 logger = logging.getLogger(__name__)
+
+# How long a just-rotated token may still be replayed. Clients can lose the
+# rotation response (network drop, app killed mid-refresh) and retry with the
+# old token — rejecting that would log the device out for a benign retry.
+REUSE_GRACE_SECONDS = 60
 
 
 class RefreshTokenService:
@@ -62,18 +67,14 @@ class RefreshTokenService:
         )
         refresh_token = result.scalar_one_or_none()
 
-        if not refresh_token:
+        if not refresh_token or refresh_token.is_expired:
             raise AuthException("Invalid or expired refresh token")
 
-        if refresh_token.is_revoked:
-            # Revoked token reuse = potential theft; revoke all tokens for this user
-            await self._revoke_all_tokens(refresh_token.user_id, db)
-            await db.commit()
-            raise AuthException("Invalid or expired refresh token")
-
-        if refresh_token.is_expired:
-            refresh_token.revoked_at = datetime.now(timezone.utc)
-            await db.commit()
+        # Reject stale replays per-token only — revoking every session here would
+        # log the user out of all devices over one device's stale token.
+        if refresh_token.revoked_at is not None and not self._replay_within_grace(
+            refresh_token.revoked_at
+        ):
             raise AuthException("Invalid or expired refresh token")
 
         user_result = await db.execute(
@@ -84,7 +85,10 @@ class RefreshTokenService:
         if not user or not user.is_active:
             raise AuthException("Invalid or expired refresh token")
 
-        refresh_token.revoked_at = datetime.now(timezone.utc)
+        # A grace-window replay keeps its original revoked_at — refreshing it
+        # would let repeated replays extend the window indefinitely.
+        if refresh_token.revoked_at is None:
+            refresh_token.revoked_at = datetime.now(timezone.utc)
 
         new_token = generate_refresh_token()
         new_token_hash = hash_refresh_token(new_token)
@@ -103,39 +107,51 @@ class RefreshTokenService:
 
         return user, new_token
 
+    def _replay_within_grace(self, revoked_at: datetime) -> bool:
+        # ORM objects written in this session keep the Python-side value, which
+        # can be naive — UTCDateTime only normalizes on DB read.
+        if revoked_at.tzinfo is None:
+            revoked_at = revoked_at.replace(tzinfo=timezone.utc)
+        return datetime.now(timezone.utc) - revoked_at <= timedelta(
+            seconds=REUSE_GRACE_SECONDS
+        )
+
     async def revoke_token(self, token: str, db: AsyncSession) -> bool:
         token_hash = hash_refresh_token(token)
 
         result = await db.execute(
-            select(RefreshToken).where(
-                and_(
+            select(RefreshToken.user_id).where(RefreshToken.token_hash == token_hash)
+        )
+        user_id = result.scalar_one_or_none()
+        if user_id is None:
+            return False
+
+        # Hard-delete rather than mark revoked, and take the user's rotated
+        # predecessors (revoked_at set) with it — a grace-eligible predecessor
+        # left behind could re-mint credentials for up to REUSE_GRACE_SECONDS
+        # after logout.
+        await db.execute(
+            delete(RefreshToken).where(
+                or_(
                     RefreshToken.token_hash == token_hash,
-                    RefreshToken.revoked_at.is_(None),
+                    and_(
+                        RefreshToken.user_id == user_id,
+                        RefreshToken.revoked_at.is_not(None),
+                    ),
                 )
             )
         )
-        refresh_token = result.scalar_one_or_none()
-
-        if not refresh_token:
-            return False
-
-        refresh_token.revoked_at = datetime.now(timezone.utc)
         await db.commit()
 
         return True
 
-    async def _revoke_all_tokens(self, user_id: UUID, db: AsyncSession) -> int:
-        now = datetime.now(timezone.utc)
+    async def revoke_all_tokens(self, user_id: UUID, db: AsyncSession) -> int:
+        # Hard-delete for the same reason as revoke_token — revocation here
+        # (password reset) must take effect immediately, not after the grace.
         result = await db.execute(
-            update(RefreshToken)
-            .where(
-                and_(
-                    RefreshToken.user_id == user_id,
-                    RefreshToken.revoked_at.is_(None),
-                )
-            )
-            .values(revoked_at=now)
+            delete(RefreshToken).where(RefreshToken.user_id == user_id)
         )
+        await db.commit()
         return int(getattr(result, "rowcount", 0))
 
     async def cleanup_expired_and_revoked_tokens(

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from email.mime.multipart import MIMEMultipart
 
 import aiosmtplib
 import httpx
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import hash_refresh_token
@@ -325,10 +326,41 @@ async def test_refresh_rotates_refresh_token(
     assert body["token_type"] == "bearer"
 
 
-async def test_refresh_rejects_rotated_token(
+async def test_refresh_allows_replay_within_grace(
     client: AsyncClient,
     create_user: UserFactory,
     login: LoginClient,
+) -> None:
+    # A client that lost the rotation response retries with the old token —
+    # within the grace window that must mint a working pair, not a 401.
+    await create_user(email="refresh@example.com", username="refreshuser")
+    tokens = await login(email="refresh@example.com")
+    first = await client.post(
+        "/api/v1/auth/jwt/refresh",
+        json={"refresh_token": tokens["refresh_token"]},
+    )
+    assert first.status_code == 200
+
+    replay = await client.post(
+        "/api/v1/auth/jwt/refresh",
+        json={"refresh_token": tokens["refresh_token"]},
+    )
+
+    assert replay.status_code == 200
+    replayed_token = replay.json()["refresh_token"]
+    assert replayed_token != tokens["refresh_token"]
+    followup = await client.post(
+        "/api/v1/auth/jwt/refresh",
+        json={"refresh_token": replayed_token},
+    )
+    assert followup.status_code == 200
+
+
+async def test_refresh_rejects_rotated_token_after_grace(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    db_session: AsyncSession,
 ) -> None:
     await create_user(email="refresh@example.com", username="refreshuser")
     tokens = await login(email="refresh@example.com")
@@ -336,6 +368,13 @@ async def test_refresh_rejects_rotated_token(
         "/api/v1/auth/jwt/refresh",
         json={"refresh_token": tokens["refresh_token"]},
     )
+    # Backdate the rotation past the reuse grace window.
+    await db_session.execute(
+        update(RefreshToken)
+        .where(RefreshToken.token_hash == hash_refresh_token(tokens["refresh_token"]))
+        .values(revoked_at=datetime.now(timezone.utc) - timedelta(minutes=5))
+    )
+    await db_session.commit()
 
     response = await client.post(
         "/api/v1/auth/jwt/refresh",
@@ -344,6 +383,41 @@ async def test_refresh_rejects_rotated_token(
 
     assert response.status_code == 401
     assert response.json()["detail"] == "Invalid or expired refresh token"
+
+
+async def test_refresh_reuse_does_not_revoke_other_sessions(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    db_session: AsyncSession,
+) -> None:
+    # One device replaying a stale token must not log out the user's other
+    # devices — reuse is rejected per-token, never via revoke-all.
+    await create_user(email="multi@example.com", username="multiuser")
+    device_a = await login(email="multi@example.com")
+    device_b = await login(email="multi@example.com")
+    await client.post(
+        "/api/v1/auth/jwt/refresh",
+        json={"refresh_token": device_a["refresh_token"]},
+    )
+    await db_session.execute(
+        update(RefreshToken)
+        .where(RefreshToken.token_hash == hash_refresh_token(device_a["refresh_token"]))
+        .values(revoked_at=datetime.now(timezone.utc) - timedelta(minutes=5))
+    )
+    await db_session.commit()
+    stale_replay = await client.post(
+        "/api/v1/auth/jwt/refresh",
+        json={"refresh_token": device_a["refresh_token"]},
+    )
+    assert stale_replay.status_code == 401
+
+    response = await client.post(
+        "/api/v1/auth/jwt/refresh",
+        json={"refresh_token": device_b["refresh_token"]},
+    )
+
+    assert response.status_code == 200
 
 
 async def test_refresh_rejects_invalid_token(client: AsyncClient) -> None:
@@ -375,6 +449,34 @@ async def test_logout_revokes_refresh_token(
         json={"refresh_token": tokens["refresh_token"]},
     )
     assert refresh_response.status_code == 401
+
+
+async def test_logout_invalidates_grace_eligible_predecessor(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    # Rotate then log out with the successor within the reuse grace window —
+    # the rotated-away predecessor must not be able to re-mint credentials.
+    await create_user(email="logout@example.com", username="logoutuser")
+    tokens = await login(email="logout@example.com")
+    rotated = await client.post(
+        "/api/v1/auth/jwt/refresh",
+        json={"refresh_token": tokens["refresh_token"]},
+    )
+    assert rotated.status_code == 200
+
+    response = await client.post(
+        "/api/v1/auth/jwt/logout",
+        json={"refresh_token": rotated.json()["refresh_token"]},
+    )
+
+    assert response.status_code == 204
+    replay = await client.post(
+        "/api/v1/auth/jwt/refresh",
+        json={"refresh_token": tokens["refresh_token"]},
+    )
+    assert replay.status_code == 401
 
 
 async def test_forgot_password_sends_reset_email(
@@ -418,6 +520,34 @@ async def test_reset_password_accepts_valid_token(
         data={"username": "reset@example.com", "password": "newpassword123"},
     )
     assert login_response.status_code == 200
+
+
+async def test_reset_password_revokes_refresh_tokens(
+    client: AsyncClient,
+    create_user: UserFactory,
+    login: LoginClient,
+    email_capture: EmailCapture,
+) -> None:
+    # Sessions issued under the old password must not survive a reset.
+    await create_user(email="reset@example.com", username="resetuser")
+    tokens = await login(email="reset@example.com")
+    await client.post(
+        "/api/v1/auth/forgot-password",
+        json={"email": "reset@example.com"},
+    )
+    reset_token = email_capture.password_reset[0]["token"]
+
+    response = await client.post(
+        "/api/v1/auth/reset-password",
+        json={"token": reset_token, "password": "newpassword123"},
+    )
+
+    assert response.status_code == 200
+    refresh_response = await client.post(
+        "/api/v1/auth/jwt/refresh",
+        json={"refresh_token": tokens["refresh_token"]},
+    )
+    assert refresh_response.status_code == 401
 
 
 async def test_reset_password_rejects_invalid_token(client: AsyncClient) -> None:

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -4,8 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const h = vi.hoisted(() => ({
   getToken: vi.fn<() => string | null>(() => 'access'),
   getRefreshToken: vi.fn<() => string | null>(() => null),
-  setToken: vi.fn(),
-  setRefreshToken: vi.fn(),
+  setTokens: vi.fn(async () => {}),
   onSessionExpired: vi.fn(),
   isCloudChat: vi.fn<(id: string) => boolean>(() => false),
   isCloudSandbox: vi.fn<(id: string) => boolean>(() => false),
@@ -16,14 +15,12 @@ vi.mock('@/utils/storage', () => ({
   authStorage: {
     getToken: h.getToken,
     getRefreshToken: h.getRefreshToken,
-    setToken: h.setToken,
-    setRefreshToken: h.setRefreshToken,
+    setTokens: h.setTokens,
   },
   cloudAuthStorage: {
     getAccessToken: () => null,
     getRefreshToken: () => null,
-    setAccessToken: vi.fn(),
-    setRefreshToken: vi.fn(),
+    setTokens: vi.fn(async () => {}),
     clear: vi.fn(),
   },
 }));
@@ -112,7 +109,7 @@ describe('APIClient 401 handling', () => {
       .mockResolvedValueOnce(json({ ok: true })); // retried request
 
     await expect(apiClient.get('/thing')).resolves.toEqual({ ok: true });
-    expect(h.setToken).toHaveBeenCalledWith('a2');
+    expect(h.setTokens).toHaveBeenCalledWith('a2', 'r2');
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
@@ -131,6 +128,58 @@ describe('APIClient 401 handling', () => {
       .mockResolvedValueOnce(json({ message: 'dead' }, 401)); // refresh -> terminal
 
     await expect(apiClient.get('/thing')).rejects.toThrow('Session expired');
+    expect(h.onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getValidToken', () => {
+  // Minimal JWT shape — only the base64url payload's exp claim is read.
+  const jwtWithExp = (expSecs: number) => `h.${btoa(JSON.stringify({ exp: expSecs }))}.s`;
+
+  it('reuses a cached access token that is not near expiry, without refreshing', async () => {
+    const token = jwtWithExp(Math.floor(Date.now() / 1000) + 3600);
+    h.getToken.mockReturnValue(token);
+    h.getRefreshToken.mockReturnValue('refresh-tok');
+
+    await expect(apiClient.getValidToken()).resolves.toBe(token);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('refreshes when the cached access token is expired', async () => {
+    h.getToken.mockReturnValue(jwtWithExp(Math.floor(Date.now() / 1000) - 10));
+    h.getRefreshToken.mockReturnValue('refresh-tok');
+    fetchMock.mockResolvedValueOnce(
+      json({ access_token: 'fresh', refresh_token: 'r2', token_type: 'bearer' }),
+    );
+
+    await expect(apiClient.getValidToken()).resolves.toBe('fresh');
+    expect(h.setTokens).toHaveBeenCalledWith('fresh', 'r2');
+  });
+
+  it('refreshes when the cached token is not a decodable JWT', async () => {
+    h.getToken.mockReturnValue('opaque-garbage');
+    h.getRefreshToken.mockReturnValue('refresh-tok');
+    fetchMock.mockResolvedValueOnce(
+      json({ access_token: 'fresh', refresh_token: 'r2', token_type: 'bearer' }),
+    );
+
+    await expect(apiClient.getValidToken()).resolves.toBe('fresh');
+  });
+
+  it('returns the cached token as-is when there is no refresh token', async () => {
+    h.getToken.mockReturnValue('whatever');
+    h.getRefreshToken.mockReturnValue(null);
+
+    await expect(apiClient.getValidToken()).resolves.toBe('whatever');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('tears down the session and returns null when the refresh 401s', async () => {
+    h.getToken.mockReturnValue(null);
+    h.getRefreshToken.mockReturnValue('refresh-tok');
+    fetchMock.mockResolvedValueOnce(json({ message: 'dead' }, 401));
+
+    await expect(apiClient.getValidToken()).resolves.toBeNull();
     expect(h.onSessionExpired).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -46,27 +46,21 @@ const resolveWsBaseUrl = (rawUrl: string): string => {
 interface ClientAuth {
   getToken: () => string | null;
   getRefreshToken: () => string | null;
-  setTokens: (accessToken: string, refreshToken: string) => void;
+  setTokens: (accessToken: string, refreshToken: string) => Promise<void>;
   onSessionExpired: () => void;
 }
 
 const localAuth: ClientAuth = {
   getToken: () => authStorage.getToken(),
   getRefreshToken: () => authStorage.getRefreshToken(),
-  setTokens: (accessToken, refreshToken) => {
-    authStorage.setToken(accessToken);
-    authStorage.setRefreshToken(refreshToken);
-  },
+  setTokens: (accessToken, refreshToken) => authStorage.setTokens(accessToken, refreshToken),
   onSessionExpired: invalidateSessionAndRedirect,
 };
 
 const cloudAuth: ClientAuth = {
   getToken: () => cloudAuthStorage.getAccessToken(),
   getRefreshToken: () => cloudAuthStorage.getRefreshToken(),
-  setTokens: (accessToken, refreshToken) => {
-    cloudAuthStorage.setAccessToken(accessToken);
-    cloudAuthStorage.setRefreshToken(refreshToken);
-  },
+  setTokens: (accessToken, refreshToken) => cloudAuthStorage.setTokens(accessToken, refreshToken),
   // A revoked/expired VPS refresh token can't be recovered silently — drop the
   // cloud credentials so the settings UI reflects a disconnected state.
   onSessionExpired: () => {
@@ -83,6 +77,21 @@ const cloudAuth: ClientAuth = {
 // identity/session store resets. Treat refresh 401 as terminal to break retry loops.
 function shouldInvalidateSession(error: unknown): boolean {
   return error instanceof RefreshTokenError && error.status === 401;
+}
+
+const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 30_000;
+
+// True when the access token can't be trusted for a new long-lived connection —
+// missing/undecodable claims or an exp within the buffer.
+function accessTokenExpiresSoon(token: string): boolean {
+  try {
+    const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+    const claims = JSON.parse(atob(base64 + '='.repeat((4 - (base64.length % 4)) % 4)));
+    if (typeof claims.exp !== 'number') return true;
+    return claims.exp * 1000 - Date.now() < ACCESS_TOKEN_EXPIRY_BUFFER_MS;
+  } catch {
+    return true;
+  }
 }
 
 const extractErrorMessage = async (response: Response): Promise<string> => {
@@ -119,10 +128,14 @@ class APIClient {
   }
 
   // For SSE openers that bypass request(): the token rides the URL and the cached
-  // one may be missing (after a restart) or expired (reopening a dead feed), so
-  // mint a fresh one from the refresh token on every open.
+  // one may be missing (after a restart) or expired (reopening a dead feed).
   async getValidToken(): Promise<string | null> {
-    if (!this.auth.getRefreshToken()) return this.auth.getToken();
+    const cached = this.auth.getToken();
+    if (!this.auth.getRefreshToken()) return cached;
+    // Only refresh when the cached token is actually stale — rotating on every
+    // open churns refresh tokens and multiplies the lost-response windows where
+    // a client is left holding a rotated-away token.
+    if (cached && !accessTokenExpiresSoon(cached)) return cached;
     try {
       return (await this.refreshTokenIfNeeded()).access_token;
     } catch (error) {
@@ -167,7 +180,9 @@ class APIClient {
     }
 
     const data: TokenResponse = await response.json();
-    this.auth.setTokens(data.access_token, data.refresh_token);
+    // Awaited: on desktop the persist is a disk write, and returning before it
+    // lands lets an app quit strand the old (rotated-away) token on disk.
+    await this.auth.setTokens(data.access_token, data.refresh_token);
     return data;
   }
 

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -72,8 +72,7 @@ async function signup(data: SignupRequest): Promise<User> {
 
     const loginResponse = await apiClient.postForm<AuthResponse>('/auth/jwt/login', formData);
     const auth = ensureResponse(loginResponse, 'Invalid response from server');
-    authStorage.setToken(auth.access_token);
-    authStorage.setRefreshToken(auth.refresh_token);
+    await authStorage.setTokens(auth.access_token, auth.refresh_token);
 
     return user;
   });
@@ -91,8 +90,7 @@ async function login(data: LoginRequest): Promise<AuthResponse> {
     const response = await apiClient.postForm<AuthResponse>('/auth/jwt/login', formData);
     const payload = ensureResponse(response, 'Invalid response from server');
 
-    authStorage.setToken(payload.access_token);
-    authStorage.setRefreshToken(payload.refresh_token);
+    await authStorage.setTokens(payload.access_token, payload.refresh_token);
     return payload;
   });
 }

--- a/frontend/src/services/cloudChatService.ts
+++ b/frontend/src/services/cloudChatService.ts
@@ -37,8 +37,7 @@ async function connect(url: string, email: string, password: string): Promise<vo
     throw error;
   }
 
-  cloudAuthStorage.setRefreshToken(auth.refresh_token);
-  cloudAuthStorage.setAccessToken(auth.access_token);
+  await cloudAuthStorage.setTokens(auth.access_token, auth.refresh_token);
   useCloudSettingsStore.getState().setCloud(trimmedUrl, email);
 }
 

--- a/frontend/src/utils/storage.test.ts
+++ b/frontend/src/utils/storage.test.ts
@@ -35,11 +35,13 @@ describe('safe localStorage helpers', () => {
 });
 
 describe('authStorage (browser backend)', () => {
-  it('persists and reads back the access token', async () => {
+  it('persists and reads back both tokens', async () => {
     const { authStorage } = await load();
-    authStorage.setToken('tok');
+    await authStorage.setTokens('tok', 'refresh');
     expect(authStorage.getToken()).toBe('tok');
+    expect(authStorage.getRefreshToken()).toBe('refresh');
     expect(localStorage.getItem('auth_token')).toBe('tok');
+    expect(localStorage.getItem('refresh_token')).toBe('refresh');
   });
 
   it('hydrates the token cache from pre-existing localStorage', async () => {
@@ -48,20 +50,9 @@ describe('authStorage (browser backend)', () => {
     expect(authStorage.getToken()).toBe('existing');
   });
 
-  it('manages the refresh token independently and can remove it', async () => {
-    const { authStorage } = await load();
-    authStorage.setRefreshToken('refresh');
-    expect(authStorage.getRefreshToken()).toBe('refresh');
-
-    authStorage.removeRefreshToken();
-    expect(authStorage.getRefreshToken()).toBeNull();
-    expect(localStorage.getItem('refresh_token')).toBeNull();
-  });
-
   it('clears both tokens on clearAuth', async () => {
     const { authStorage } = await load();
-    authStorage.setToken('a');
-    authStorage.setRefreshToken('r');
+    await authStorage.setTokens('a', 'r');
 
     authStorage.clearAuth();
     expect(authStorage.getToken()).toBeNull();
@@ -69,28 +60,76 @@ describe('authStorage (browser backend)', () => {
     expect(localStorage.getItem('auth_token')).toBeNull();
     expect(localStorage.getItem('refresh_token')).toBeNull();
   });
+
+  it('applies token changes from other tabs via the storage event', async () => {
+    const { authStorage } = await load();
+    await authStorage.setTokens('tok', 'refresh');
+
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: 'refresh_token', newValue: 'rotated' }),
+    );
+    window.dispatchEvent(new StorageEvent('storage', { key: 'auth_token', newValue: 'fresh' }));
+
+    expect(authStorage.getRefreshToken()).toBe('rotated');
+    expect(authStorage.getToken()).toBe('fresh');
+  });
+
+  it('drops cached tokens when another tab logs out', async () => {
+    const { authStorage } = await load();
+    await authStorage.setTokens('tok', 'refresh');
+
+    window.dispatchEvent(new StorageEvent('storage', { key: 'auth_token', newValue: null }));
+    window.dispatchEvent(new StorageEvent('storage', { key: 'refresh_token', newValue: null }));
+
+    expect(authStorage.getToken()).toBeNull();
+    expect(authStorage.getRefreshToken()).toBeNull();
+  });
 });
 
 describe('cloudAuthStorage (browser backend)', () => {
-  it('keeps the access token in memory only', async () => {
+  it('keeps the access token in memory and persists only the refresh token', async () => {
     const { cloudAuthStorage } = await load();
-    cloudAuthStorage.setAccessToken('cloud-access');
+    await cloudAuthStorage.setTokens('cloud-access', 'cloud-refresh');
     expect(cloudAuthStorage.getAccessToken()).toBe('cloud-access');
+    expect(cloudAuthStorage.getRefreshToken()).toBe('cloud-refresh');
     // Access token is never written to localStorage.
-    expect(localStorage.getItem('cloud_refresh_token')).toBeNull();
+    expect(localStorage.getItem('cloud_refresh_token')).toBe('cloud-refresh');
+    expect(localStorage.getItem('cloud_access_token')).toBeNull();
   });
 
-  it('persists the refresh token and clears everything on clear', async () => {
+  it('clears everything on clear', async () => {
     const { cloudAuthStorage } = await load();
-    cloudAuthStorage.setRefreshToken('cloud-refresh');
-    expect(cloudAuthStorage.getRefreshToken()).toBe('cloud-refresh');
-    expect(localStorage.getItem('cloud_refresh_token')).toBe('cloud-refresh');
+    await cloudAuthStorage.setTokens('x', 'cloud-refresh');
 
-    cloudAuthStorage.setAccessToken('x');
     cloudAuthStorage.clear();
     expect(cloudAuthStorage.getAccessToken()).toBeNull();
     expect(cloudAuthStorage.getRefreshToken()).toBeNull();
     expect(localStorage.getItem('cloud_refresh_token')).toBeNull();
+  });
+
+  it('applies cloud refresh token changes from other tabs via the storage event', async () => {
+    const { cloudAuthStorage } = await load();
+    await cloudAuthStorage.setTokens('a', 'cloud-refresh');
+
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: 'cloud_refresh_token', newValue: 'rotated' }),
+    );
+
+    expect(cloudAuthStorage.getRefreshToken()).toBe('rotated');
+    // A rotation elsewhere doesn't invalidate this tab's access token.
+    expect(cloudAuthStorage.getAccessToken()).toBe('a');
+  });
+
+  it('drops the memory-only access token when another tab disconnects', async () => {
+    const { cloudAuthStorage } = await load();
+    await cloudAuthStorage.setTokens('a', 'cloud-refresh');
+
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: 'cloud_refresh_token', newValue: null }),
+    );
+
+    expect(cloudAuthStorage.getRefreshToken()).toBeNull();
+    expect(cloudAuthStorage.getAccessToken()).toBeNull();
   });
 });
 

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -173,47 +173,28 @@ export const authStorage = {
     }
     return cachedToken;
   },
-  setToken: (token: string): void => {
-    cachedToken = token;
-    tokenCacheInitialized = true;
-
-    if (isTauri()) {
-      void persistDesktopAuthState();
-      safeRemoveItem(AUTH_TOKEN_KEY);
-      return;
-    }
-
-    safeSetItem(AUTH_TOKEN_KEY, token);
-  },
   getRefreshToken: (): string | null => {
     if (!tokenCacheInitialized && !isTauri()) {
       initTokenCacheFromLocalStorage();
     }
     return cachedRefreshToken;
   },
-  setRefreshToken: (token: string): void => {
-    cachedRefreshToken = token;
+  setTokens: async (token: string, refreshToken: string): Promise<void> => {
+    cachedToken = token;
+    cachedRefreshToken = refreshToken;
     tokenCacheInitialized = true;
 
     if (isTauri()) {
-      void persistDesktopAuthState();
+      // Awaited so refresh rotation can't complete before the new token hits
+      // disk — a quit mid-persist would strand the old (rotated-away) one.
+      await persistDesktopAuthState();
+      safeRemoveItem(AUTH_TOKEN_KEY);
       safeRemoveItem(REFRESH_TOKEN_KEY);
       return;
     }
 
-    safeSetItem(REFRESH_TOKEN_KEY, token);
-  },
-  removeRefreshToken: (): void => {
-    cachedRefreshToken = null;
-    tokenCacheInitialized = true;
-
-    if (isTauri()) {
-      void persistDesktopAuthState();
-      safeRemoveItem(REFRESH_TOKEN_KEY);
-      return;
-    }
-
-    safeRemoveItem(REFRESH_TOKEN_KEY);
+    safeSetItem(AUTH_TOKEN_KEY, token);
+    safeSetItem(REFRESH_TOKEN_KEY, refreshToken);
   },
   clearAuth: (): void => {
     cachedToken = null;
@@ -282,9 +263,6 @@ export const cloudAuthStorage = {
     cloudCacheInitialized = true;
   },
   getAccessToken: (): string | null => cloudAccessToken,
-  setAccessToken: (token: string): void => {
-    cloudAccessToken = token;
-  },
   getRefreshToken: (): string | null => {
     if (!cloudCacheInitialized && !isTauri()) {
       cloudRefreshToken = safeGetItem(CLOUD_REFRESH_TOKEN_KEY);
@@ -292,18 +270,20 @@ export const cloudAuthStorage = {
     }
     return cloudRefreshToken;
   },
-  setRefreshToken: (token: string): void => {
-    cloudRefreshToken = token;
+  setTokens: async (accessToken: string, refreshToken: string): Promise<void> => {
+    cloudAccessToken = accessToken;
+    cloudRefreshToken = refreshToken;
     cloudCacheInitialized = true;
 
     // Unlike authStorage there's no stale-localStorage cleanup on the Tauri
     // path — this key is new and only ever written to localStorage in browsers.
     if (isTauri()) {
-      void persistCloudRefreshToken();
+      // Awaited for the same reason as authStorage.setTokens.
+      await persistCloudRefreshToken();
       return;
     }
 
-    safeSetItem(CLOUD_REFRESH_TOKEN_KEY, token);
+    safeSetItem(CLOUD_REFRESH_TOKEN_KEY, refreshToken);
   },
   clear: (): void => {
     cloudAccessToken = null;
@@ -318,6 +298,27 @@ export const cloudAuthStorage = {
     safeRemoveItem(CLOUD_REFRESH_TOKEN_KEY);
   },
 };
+
+// Cross-tab sync (browser only — the `storage` event fires in every tab except
+// the writer): another tab rotating or clearing tokens must update this tab's
+// in-memory cache, or its next refresh replays a rotated-away token and gets a
+// 401 once the backend's reuse grace window closes.
+if (typeof window !== 'undefined' && !isTauri()) {
+  window.addEventListener('storage', (event) => {
+    if (event.key === AUTH_TOKEN_KEY) {
+      cachedToken = event.newValue;
+    } else if (event.key === REFRESH_TOKEN_KEY) {
+      cachedRefreshToken = event.newValue;
+    } else if (event.key === CLOUD_REFRESH_TOKEN_KEY) {
+      cloudRefreshToken = event.newValue;
+      // Disconnect in another tab must also drop this tab's memory-only access
+      // token — it has no localStorage key of its own to sync through.
+      if (event.newValue === null) {
+        cloudAccessToken = null;
+      }
+    }
+  });
+}
 
 // Per-chat SSE cursor persistence: stores the last-seen seq number in
 // localStorage so stream reconnection can resume from the right point after


### PR DESCRIPTION
## Summary
- Add a short reuse grace window for rotated refresh tokens so a client that loses the rotation response (network drop, app killed mid-refresh) can retry with the old token instead of being logged out; reuse outside the window now revokes only the replayed token, not the user's other sessions.
- Revoke all of a user's refresh tokens on password reset, since a reset is the recovery path for a compromised account.
- Switch token revocation (logout, reuse-past-grace, password reset) to hard-delete rather than marking rows revoked.
- Frontend: consolidate access/refresh token persistence into a single awaited `setTokens` (avoids stranding a rotated-away token on disk if the app quits mid-persist on desktop), sync the in-memory auth cache across browser tabs via the `storage` event, and avoid refreshing SSE tokens that aren't actually near expiry.

## Test plan
- [ ] `cd backend && pytest tests/test_auth.py`
- [ ] `cd frontend && npm test -- api.test.ts storage.test.ts`