### PR TITLE
Add agent filter chips and provider icons to model selector

### DIFF
--- a/frontend/src/components/chat/model-selector/AgentFilterChips.module.scss
+++ b/frontend/src/components/chat/model-selector/AgentFilterChips.module.scss
@@ -1,0 +1,51 @@
+@use '@/styles/globals/colors' as colors;
+@use '@/styles/globals/typography' as type;
+@use '@/styles/globals/animations' as anim;
+@use '@/styles/globals/responsive' as responsive;
+
+.agent-filter-chips {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  border-bottom: 1px solid colors.theme-color('border', 0.5);
+  padding: var(--space-1-5) var(--space-2);
+}
+
+.chip {
+  @include type.type-meta(500);
+  @include anim.transition-colors(var(--duration-fast));
+  border: 1px solid var(--theme-border);
+  border-radius: var(--radius-full);
+  padding: var(--space-0-5) var(--space-2);
+  color: var(--theme-text-secondary);
+
+  // Icon chips: square padding so the pill hugs the icon
+  &--icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-1);
+  }
+
+  @include responsive.hover {
+    border-color: var(--theme-border-hover);
+    color: var(--theme-text-primary);
+  }
+
+  &--active {
+    border-color: var(--theme-text-primary);
+    background-color: var(--theme-text-primary);
+    color: var(--theme-surface);
+
+    // Re-assert over .chip:hover — same specificity, later in source
+    @include responsive.hover {
+      border-color: var(--theme-text-primary);
+      color: var(--theme-surface);
+    }
+  }
+}
+
+.chip-icon {
+  height: var(--space-3);
+  width: var(--space-3);
+}

--- a/frontend/src/components/chat/model-selector/AgentFilterChips.tsx
+++ b/frontend/src/components/chat/model-selector/AgentFilterChips.tsx
@@ -1,0 +1,57 @@
+import { memo } from 'react';
+import clsx from 'clsx';
+import { Button } from '@/components/ui/primitives/Button/Button';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip/FloatingTooltip';
+import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
+import type { AgentKind } from '@/types/chat.types';
+import styles from './AgentFilterChips.module.scss';
+
+const AGENT_LABELS: Record<AgentKind, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  copilot: 'Copilot',
+  cursor: 'Cursor',
+  grok: 'Grok',
+  opencode: 'OpenCode',
+};
+
+export interface AgentFilterChipsProps {
+  agentKinds: AgentKind[];
+  value: AgentKind | null;
+  onChange: (kind: AgentKind | null) => void;
+}
+
+export const AgentFilterChips = memo(function AgentFilterChips({
+  agentKinds,
+  value,
+  onChange,
+}: AgentFilterChipsProps) {
+  const chips: { kind: AgentKind | null; label: string }[] = [
+    { kind: null, label: 'All' },
+    ...agentKinds.map((kind) => ({ kind, label: AGENT_LABELS[kind] })),
+  ];
+
+  return (
+    <div className={styles['agent-filter-chips']}>
+      {chips.map(({ kind, label }) => (
+        // Empty content renders no bubble — the "All" chip's label is already visible
+        <FloatingTooltip key={kind ?? 'all'} content={kind ? label : ''}>
+          <Button
+            type="button"
+            variant="unstyled"
+            aria-label={kind ? label : undefined}
+            aria-pressed={value === kind}
+            onClick={() => onChange(kind)}
+            className={clsx(
+              styles.chip,
+              kind && styles['chip--icon'],
+              value === kind && styles['chip--active'],
+            )}
+          >
+            {kind ? <ProviderIcon agentKind={kind} className={styles['chip-icon']} /> : label}
+          </Button>
+        </FloatingTooltip>
+      ))}
+    </div>
+  );
+});

--- a/frontend/src/components/chat/model-selector/ModelSelector.module.scss
+++ b/frontend/src/components/chat/model-selector/ModelSelector.module.scss
@@ -31,6 +31,13 @@
   gap: var(--space-2);
 }
 
+.item-icon {
+  height: var(--space-3);
+  width: var(--space-3);
+  flex-shrink: 0;
+  color: var(--theme-text-tertiary);
+}
+
 .item-tooltip {
   min-width: 0;
   flex: 1;
@@ -39,6 +46,8 @@
 .item-label {
   @include type.type-meta(500);
   @include type.type-overflow;
+  // Spans are inline by default and inline elements ignore overflow/ellipsis
+  display: block;
   color: var(--theme-text-secondary);
 
   &--selected {

--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import clsx from 'clsx';
 import { Star } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button/Button';
@@ -9,21 +9,11 @@ import { useAuthStore } from '@/store/authStore';
 import { useModelStore } from '@/store/modelStore';
 import { useModelsQuery } from '@/hooks/queries/useModelQueries';
 import { useIsSplitMode } from '@/hooks/useIsSplitMode';
-import { AGENT_ICONS } from '@/components/ui/icons/ProviderIcon';
+import { AGENT_ICONS, ProviderIcon } from '@/components/ui/icons/ProviderIcon';
+import { AgentFilterChips } from '@/components/chat/model-selector/AgentFilterChips';
 import { formatNumberCompact } from '@/utils/format';
 import type { AgentKind, Model } from '@/types/chat.types';
 import styles from './ModelSelector.module.scss';
-
-const FAVORITES_LABEL = 'Favorites';
-
-const AGENT_LABELS: Record<AgentKind, string> = {
-  claude: 'Claude',
-  codex: 'Codex',
-  copilot: 'Copilot',
-  cursor: 'Cursor',
-  grok: 'Grok',
-  opencode: 'OpenCode',
-};
 
 export interface ModelSelectorProps {
   selectedModelId: string;
@@ -52,6 +42,8 @@ export const ModelSelector = memo(function ModelSelector({
   // effect and persist models[0] before the owner derives the model from history.
   const { data: models = [], isLoading } = useModelsQuery({ enabled: isAuthenticated });
   const favoriteModelIds = useModelStore((state) => state.favoriteModelIds);
+  // Panel-local agent filter driven by the chip row; null = all agents.
+  const [agentFilter, setAgentFilter] = useState<AgentKind | null>(null);
 
   const filteredModels = useMemo(
     () => (lockedAgentKind ? models.filter((m) => m.agent_kind === lockedAgentKind) : models),
@@ -60,34 +52,38 @@ export const ModelSelector = memo(function ModelSelector({
 
   const favoriteIdSet = useMemo(() => new Set(favoriteModelIds), [favoriteModelIds]);
 
+  const agentKinds = useMemo(() => {
+    const kinds: AgentKind[] = [];
+    filteredModels.forEach((m) => {
+      if (!kinds.includes(m.agent_kind)) kinds.push(m.agent_kind);
+    });
+    return kinds;
+  }, [filteredModels]);
+
   const groupedItems = useMemo(() => {
-    const items: DropdownItemType<Model>[] = [];
+    const visibleModels = agentFilter
+      ? filteredModels.filter((m) => m.agent_kind === agentFilter)
+      : filteredModels;
     // Favorites ordered by when each model was starred, not alphabetically.
-    const modelById = new Map(filteredModels.map((m) => [m.model_id, m]));
+    const modelById = new Map(visibleModels.map((m) => [m.model_id, m]));
     const favoriteModels = favoriteModelIds
       .map((id) => modelById.get(id))
       .filter((m): m is Model => m !== undefined);
-    if (favoriteModels.length > 0) {
-      items.push({ type: 'header', label: FAVORITES_LABEL });
-      favoriteModels.forEach((model) => items.push({ type: 'item', data: model }));
-    }
+    const restModels = visibleModels.filter((m) => !favoriteIdSet.has(m.model_id));
 
-    const groups = new Map<AgentKind, Model[]>();
-    filteredModels.forEach((model) => {
-      if (favoriteIdSet.has(model.model_id)) return;
-      const list = groups.get(model.agent_kind) ?? [];
-      list.push(model);
-      groups.set(model.agent_kind, list);
-    });
-
-    groups.forEach((agentModels, kind) => {
-      items.push({ type: 'header', label: AGENT_LABELS[kind] ?? kind });
-      agentModels.forEach((model) => {
-        items.push({ type: 'item', data: model });
-      });
-    });
+    const items: DropdownItemType<Model>[] = favoriteModels.map((model) => ({
+      type: 'item',
+      data: model,
+    }));
+    if (favoriteModels.length > 0 && restModels.length > 0) items.push({ type: 'divider' });
+    restModels.forEach((model) => items.push({ type: 'item', data: model }));
     return items;
-  }, [filteredModels, favoriteModelIds, favoriteIdSet]);
+  }, [filteredModels, agentFilter, favoriteModelIds, favoriteIdSet]);
+
+  // Reopen with the full list — a lingering agent filter would hide the selected model's row.
+  const handleOpenChange = useCallback((isOpen: boolean) => {
+    if (!isOpen) setAgentFilter(null);
+  }, []);
 
   const selectedModel = filteredModels.find((m) => m.model_id === selectedModelId);
 
@@ -129,10 +125,23 @@ export const ModelSelector = memo(function ModelSelector({
       selectionStyle="accent"
       triggerVariant={variant}
       dropdownAlign={dropdownAlign}
+      onOpenChange={handleOpenChange}
+      renderHeader={
+        agentKinds.length > 1
+          ? () => (
+              <AgentFilterChips
+                agentKinds={agentKinds}
+                value={agentFilter}
+                onChange={setAgentFilter}
+              />
+            )
+          : undefined
+      }
       renderItem={(model, isSelected) => {
         const isFavorite = favoriteIdSet.has(model.model_id);
         return (
           <div className={styles.item}>
+            <ProviderIcon agentKind={model.agent_kind} className={styles['item-icon']} />
             <FloatingTooltip content={model.name} className={styles['item-tooltip']}>
               <span
                 className={clsx(styles['item-label'], isSelected && styles['item-label--selected'])}

--- a/frontend/src/components/ui/primitives/Dropdown/Dropdown.module.scss
+++ b/frontend/src/components/ui/primitives/Dropdown/Dropdown.module.scss
@@ -265,6 +265,11 @@
   }
 }
 
+.divider {
+  margin: var(--space-1) var(--space-2);
+  border-top: 1px solid var(--theme-border);
+}
+
 .group-header {
   @include type.type-section-header;
   padding: var(--space-1-5) var(--space-2) var(--space-0-5);

--- a/frontend/src/components/ui/primitives/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/ui/primitives/Dropdown/Dropdown.tsx
@@ -2,6 +2,7 @@ import {
   memo,
   ReactElement,
   ReactNode,
+  useEffect,
   useState,
   useRef,
   KeyboardEvent,
@@ -19,7 +20,10 @@ import { fuzzySearch } from '@/utils/fuzzySearch';
 import { stateClasses } from '@/config/stateClasses';
 import styles from './Dropdown.module.scss';
 
-export type DropdownItemType<T> = { type: 'item'; data: T } | { type: 'header'; label: string };
+export type DropdownItemType<T> =
+  | { type: 'item'; data: T }
+  | { type: 'header'; label: string }
+  | { type: 'divider' };
 
 export interface DropdownProps<T> {
   value: T;
@@ -41,7 +45,10 @@ export interface DropdownProps<T> {
   searchPlaceholder?: string;
   searchVariant?: 'boxed' | 'underline';
   selectionStyle?: 'check' | 'accent';
+  // Rendered pinned at the top of the panel, above the search field
+  renderHeader?: () => ReactNode;
   renderFooter?: () => ReactNode;
+  onOpenChange?: (isOpen: boolean) => void;
   triggerVariant?: 'default' | 'text';
   dropdownAlign?: 'left' | 'right';
 }
@@ -69,33 +76,31 @@ function getFilteredGroupedItems<T>(
 ): DropdownItemType<T>[] {
   if (!searchQuery.trim()) return [...items];
 
+  // Search results render flat: a header survives only when its group has matches,
+  // headerless groups keep their matches, and dividers drop.
   const result: DropdownItemType<T>[] = [];
   let currentHeader: string | null = null;
   const pendingItems: T[] = [];
 
-  for (const item of items) {
-    if (item.type === 'header') {
-      if (pendingItems.length > 0 && currentHeader) {
-        const filtered = filterItems(pendingItems, searchQuery);
-        if (filtered.length > 0) {
-          result.push({ type: 'header', label: currentHeader });
-          filtered.forEach((data) => result.push({ type: 'item', data }));
-        }
-      }
-      currentHeader = item.label;
-      pendingItems.length = 0;
-    } else {
-      pendingItems.push(item.data);
-    }
-  }
-
-  if (pendingItems.length > 0 && currentHeader) {
+  const flushGroup = () => {
+    if (pendingItems.length === 0) return;
     const filtered = filterItems(pendingItems, searchQuery);
     if (filtered.length > 0) {
-      result.push({ type: 'header', label: currentHeader });
+      if (currentHeader) result.push({ type: 'header', label: currentHeader });
       filtered.forEach((data) => result.push({ type: 'item', data }));
     }
+    pendingItems.length = 0;
+  };
+
+  for (const item of items) {
+    if (item.type === 'item') {
+      pendingItems.push(item.data);
+    } else {
+      flushGroup();
+      currentHeader = item.type === 'header' ? item.label : null;
+    }
   }
+  flushGroup();
 
   return result;
 }
@@ -131,7 +136,9 @@ const Dropdown = memo(function Dropdown<T>({
   searchPlaceholder = 'Search...',
   searchVariant = 'boxed',
   selectionStyle = 'check',
+  renderHeader,
   renderFooter,
+  onOpenChange,
   triggerVariant = 'default',
   dropdownAlign = 'left',
 }: DropdownProps<T>) {
@@ -146,6 +153,11 @@ const Dropdown = memo(function Dropdown<T>({
       setSearchQuery('');
     }
   }
+
+  // Parent-owned state can't be written from the render check above — notify via effect
+  useEffect(() => {
+    onOpenChange?.(isOpen);
+  }, [isOpen, onOpenChange]);
 
   const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Escape') {
@@ -216,6 +228,7 @@ const Dropdown = memo(function Dropdown<T>({
             styles[`panel--${dropdownAlign}`],
           )}
         >
+          {renderHeader?.()}
           {searchable && searchVariant === 'boxed' && (
             <div className={styles['search-box']}>
               <div className={styles['search-box-field']}>
@@ -268,6 +281,9 @@ const Dropdown = memo(function Dropdown<T>({
           )}
           <div className={styles.items}>
             {displayItems.map((entry, index) => {
+              if (entry.type === 'divider') {
+                return <div key={`divider-${index}`} role="separator" className={styles.divider} />;
+              }
               if (entry.type === 'header') {
                 return (
                   <div


### PR DESCRIPTION
## Summary
- Adds an `AgentFilterChips` row to the model selector dropdown so users can narrow the list to a single agent (Claude, Codex, Copilot, etc.) instead of scanning one long combined list
- Adds a per-row `ProviderIcon` next to each model name for quicker visual scanning
- Extends the `Dropdown` primitive with a generic `renderHeader` slot (pinned above search) and a `divider` item type, replacing the old per-agent group headers with a favorites/rest split plus the new chip filter
- Resets the agent filter on close so reopening always shows the full list, including the currently selected model