### PR TITLE
Add user-configurable title model, generate titles concurrently

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -185,15 +185,14 @@ async def generate_chat_title(
 ) -> dict[str, str]:
     # Title from the first user message — same source the automatic
     # background titling uses when a chat starts.
-    source = await chat_service.get_title_source(chat.id)
-    if source is None:
+    prompt = await chat_service.get_title_source(chat.id)
+    if prompt is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Chat has no messages to generate a title from",
         )
-    prompt, model_id = source
 
-    title = await ai_service.generate_title(prompt, model_id, current_user, chat=chat)
+    title = await ai_service.generate_title(prompt, current_user, chat=chat)
     if not title:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -21,6 +21,9 @@ REDIS_KEY_CHAT_QUEUE_SEND_NOW: Final[str] = "chat:{chat_id}:queue:send_now"
 
 QUEUE_MESSAGE_TTL_SECONDS: Final[int] = 3600
 
+# Default model for chat title generation — cheap and fast; user-overridable in settings.
+DEFAULT_TITLE_MODEL_ID: Final[str] = "haiku"
+
 SANDBOX_DEFAULT_COMMAND_TIMEOUT: Final[int] = 120
 PTY_OUTPUT_QUEUE_SIZE: Final[int] = 512
 PTY_INPUT_QUEUE_SIZE: Final[int] = 1024

--- a/backend/app/models/db_models/user.py
+++ b/backend/app/models/db_models/user.py
@@ -6,6 +6,7 @@ from fastapi_users.db import SQLAlchemyBaseUserTableUUID
 from sqlalchemy import Boolean, ForeignKey, JSON, String, Text
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
+from app.constants import DEFAULT_TITLE_MODEL_ID
 from app.models.types import (
     CustomEnvVarDict,
     PersonaDict,
@@ -88,5 +89,11 @@ class UserSettings(Base):
     )
     notifications_enabled: Mapped[bool] = mapped_column(
         Boolean, default=True, server_default="true", nullable=False
+    )
+    title_model_id: Mapped[str] = mapped_column(
+        String(128),
+        default=DEFAULT_TITLE_MODEL_ID,
+        server_default=DEFAULT_TITLE_MODEL_ID,
+        nullable=False,
     )
     user = relationship("User", back_populates="settings")

--- a/backend/app/models/schemas/settings.py
+++ b/backend/app/models/schemas/settings.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from app.constants import DEFAULT_TITLE_MODEL_ID, MODELS
 from app.prompts.system_prompt import DEFAULT_PERSONA_NAME
 
 
@@ -34,6 +35,16 @@ class UserSettingsBase(BaseModel):
     personas: list[Persona] | None = None
     stream_actions: list[StreamAction] | None = None
     notifications_enabled: bool = True
+    title_model_id: str = Field(
+        default=DEFAULT_TITLE_MODEL_ID, min_length=1, max_length=128
+    )
+
+    @field_validator("title_model_id")
+    @classmethod
+    def _validate_title_model(cls, value: str) -> str:
+        if value not in MODELS:
+            raise ValueError(f"Unknown model: {value}")
+        return value
 
     @field_validator(
         "custom_env_vars",

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -269,15 +269,18 @@ class AgentService:
         )
 
     async def generate_title(
-        self, prompt: str, model_id: str, user: User, chat: Chat | None = None
+        self, prompt: str, user: User, chat: Chat | None = None
     ) -> str | None:
+        # Titles always run on the user's configured title model (settings),
+        # never the chat's model — no fallback chain.
         try:
+            user_settings = await self._get_user_settings(user.id)
             title = await self._generate_text(
                 GENERATE_TITLE_SYSTEM_PROMPT,
                 "Generate a title for this message:\n<message>\n"
                 + prompt
                 + "\n</message>",
-                model_id,
+                user_settings.title_model_id,
                 user,
                 chat=chat,
             )

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -351,7 +351,7 @@ class ChatService(BaseDbService[Chat]):
 
         # Announce so open browser sessions can show chats created out-of-band
         # (e.g. via the MCP server) without a refresh.
-        await self._publish_user_chat_event(
+        await self.publish_user_chat_event(
             user.id,
             {
                 "kind": "chat_created",
@@ -361,9 +361,8 @@ class ChatService(BaseDbService[Chat]):
 
         return loaded_chat
 
-    async def _publish_user_chat_event(
-        self, user_id: UUID, payload: dict[str, Any]
-    ) -> None:
+    @staticmethod
+    async def publish_user_chat_event(user_id: UUID, payload: dict[str, Any]) -> None:
         # Best-effort broadcast on the user's live channel — a missed event only
         # delays the sidebar/tab update until the next normal refetch.
         try:
@@ -536,11 +535,9 @@ class ChatService(BaseDbService[Chat]):
             )
             return result.scalar() or 0
 
-    async def get_title_source(self, chat_id: UUID) -> tuple[str, str] | None:
-        # Title prompt is the first non-empty user message; model is the most
-        # recent one stored on a message (only assistant messages carry it).
-        # Returns None when either is missing. Queried directly so callers don't
-        # need the full message history loaded.
+    async def get_title_source(self, chat_id: UUID) -> str | None:
+        # Title prompt is the first non-empty user message. Queried directly so
+        # callers don't need the full message history loaded.
         async with self.session_factory() as db:
             prompt = (
                 await db.execute(
@@ -556,22 +553,7 @@ class ChatService(BaseDbService[Chat]):
                 )
             ).scalar_one_or_none()
 
-            model_id = (
-                await db.execute(
-                    select(Message.model_id)
-                    .filter(
-                        Message.chat_id == chat_id,
-                        Message.deleted_at.is_(None),
-                        Message.model_id.is_not(None),
-                    )
-                    .order_by(Message.created_at.desc())
-                    .limit(1)
-                )
-            ).scalar_one_or_none()
-
-        if not prompt or not model_id:
-            return None
-        return prompt, model_id
+        return prompt or None
 
     async def get_model_context_window(self, chat_id: UUID) -> int | None:
         last_msg = await self.message_service.get_latest_assistant_message(chat_id)
@@ -1190,7 +1172,7 @@ class ChatService(BaseDbService[Chat]):
 
         # Lets open sessions mark this chat "running" even when the turn was
         # started out-of-band (e.g. via the MCP server) with no client stream.
-        await self._publish_user_chat_event(
+        await self.publish_user_chat_event(
             current_user.id,
             {
                 "kind": "stream_started",

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -116,6 +116,12 @@ class ChatStreamRuntime:
         stream: AsyncIterator[StreamEvent],
     ) -> str:
         self._stream = stream
+        # Titling only needs the user's prompt, so it starts alongside the turn
+        # instead of after it — the sidebar shows a real title while streaming.
+        title_task = asyncio.create_task(self._generate_title())
+        self._bg_tasks.add(title_task)
+        title_task.add_done_callback(self._bg_tasks.discard)
+        title_task.add_done_callback(ChatStreamRuntime._on_title_task_done)
         try:
             start_seq = await self.emit_event(
                 "stream_started",
@@ -409,8 +415,6 @@ class ChatStreamRuntime:
         final_content = self.snapshot.content_text
 
         if status == MessageStreamStatus.COMPLETED:
-            title_task = asyncio.create_task(self._generate_title())
-            title_task.add_done_callback(ChatStreamRuntime._on_title_task_done)
             # If there's a queued follow-up message, start it immediately in this
             # same background task chain — the "complete" event is deferred until
             # the entire queue is drained so the client stays in streaming mode.
@@ -652,9 +656,7 @@ class ChatStreamRuntime:
 
         ai_service = AgentService(session_factory=self.session_factory)
         user = User(id=self.chat.user_id)
-        title = await ai_service.generate_title(
-            self.prompt, self.model_id, user, chat=self.chat
-        )
+        title = await ai_service.generate_title(self.prompt, user, chat=self.chat)
         if not title:
             return
         title = title[:255]
@@ -669,6 +671,16 @@ class ChatStreamRuntime:
                 .values(title=title, updated_at=Chat.updated_at)
             )
             await db.commit()
+
+        # Inline import to avoid circular dependency with chat.py.
+        from app.services.chat import ChatService
+
+        # Push the title to open sessions so the sidebar/tab update mid-stream
+        # instead of waiting for the completion refetch.
+        await ChatService.publish_user_chat_event(
+            self.chat.user_id,
+            {"kind": "title_updated", "chat_id": self.chat_id, "title": title},
+        )
 
     @staticmethod
     def _on_title_task_done(task: asyncio.Task[None]) -> None:

--- a/backend/migrations/versions/a1b2c3d4e5f6_add_title_model_id_to_user_settings.py
+++ b/backend/migrations/versions/a1b2c3d4e5f6_add_title_model_id_to_user_settings.py
@@ -1,0 +1,30 @@
+# Revision ID: a1b2c3d4e5f6
+# Revises: 752b41aaca3a
+# Create Date: 2026-07-13 00:00:00.000000
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "752b41aaca3a"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_settings",
+        sa.Column(
+            "title_model_id",
+            sa.String(length=128),
+            nullable=False,
+            server_default="haiku",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_settings", "title_model_id")

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -120,7 +120,7 @@ class AgentServiceOverride:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, User]] = []
         self.ask_code_calls: list[tuple[str, str, str | None, str, User, Chat]] = []
-        self.title_calls: list[tuple[str, str, User, Chat | None]] = []
+        self.title_calls: list[tuple[str, User, Chat | None]] = []
         self.fail = False
         self.next_title: str | None = "Generated Title"
 
@@ -151,9 +151,9 @@ class AgentServiceOverride:
         return "Answer: " + question
 
     async def generate_title(
-        self, prompt: str, model_id: str, user: User, chat: Chat | None = None
+        self, prompt: str, user: User, chat: Chat | None = None
     ) -> str | None:
-        self.title_calls.append((prompt, model_id, user, chat))
+        self.title_calls.append((prompt, user, chat))
         return self.next_title
 
 
@@ -1408,9 +1408,8 @@ async def test_generate_chat_title_endpoint_covers_success_and_failure_paths(
     assert success_response.json() == {"title": "Generated Title"}
     assert failure_response.status_code == 503
     assert failure_response.json()["detail"] == "Title generation failed"
-    [prompt, model_id, stored_user, stored_chat] = agent_service.title_calls[0]
+    [prompt, stored_user, stored_chat] = agent_service.title_calls[0]
     assert prompt == "Ship the release notes"
-    assert model_id == TEST_MODEL_ID
     assert stored_user.id == user.id
     assert stored_chat is not None
     assert stored_chat.id == chat.id

--- a/frontend/src/components/settings/tabs/GeneralSettingsTab/GeneralSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/GeneralSettingsTab/GeneralSettingsTab.tsx
@@ -8,6 +8,7 @@ import type { UserSettings } from '@/types/user.types';
 import type { Theme } from '@/types/ui.types';
 import { useUIStore } from '@/store/uiStore';
 import { SecretInput } from '@/components/settings/inputs/SecretInput/SecretInput';
+import { ModelSelector } from '@/components/chat/model-selector/ModelSelector';
 import { THEMES } from '@/utils/theme';
 import styles from './GeneralSettingsTab.module.scss';
 
@@ -19,6 +20,7 @@ interface GeneralSettingsTabProps {
   onToggleVisibility: (field: ApiFieldKey) => void;
   onDeleteAllChats: () => void;
   onNotificationsEnabledChange: (enabled: boolean) => void;
+  onTitleModelChange: (modelId: string) => void;
 }
 
 function SectionCard({
@@ -104,6 +106,7 @@ export function GeneralSettingsTab({
   onToggleVisibility,
   onDeleteAllChats,
   onNotificationsEnabledChange,
+  onTitleModelChange,
 }: GeneralSettingsTabProps) {
   return (
     <div className={styles.general}>
@@ -139,6 +142,18 @@ export function GeneralSettingsTab({
               checked={settings.notifications_enabled}
               onCheckedChange={onNotificationsEnabledChange}
               aria-label="Notifications"
+            />
+          </div>
+          <div className={styles['pref-row-notif']}>
+            <div className={styles['pref-text']}>
+              <h3 className={styles['setting-title']}>Title Generation Model</h3>
+              <p className={styles['field-desc']}>Model used to generate chat titles.</p>
+            </div>
+            <ModelSelector
+              selectedModelId={settings.title_model_id}
+              onModelChange={onTitleModelChange}
+              compact={false}
+              dropdownAlign="right"
             />
           </div>
         </div>

--- a/frontend/src/hooks/useChatEvents.ts
+++ b/frontend/src/hooks/useChatEvents.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { chatService } from '@/services/chatService';
-import { applyCreatedChat } from '@/hooks/queries/useChatQueries';
+import { applyCreatedChat, patchChatInCache } from '@/hooks/queries/useChatQueries';
 import { useUIStore } from '@/store/uiStore';
 import { useStreamStore } from '@/store/streamStore';
 import { queryKeys } from '@/hooks/queries/queryKeys';
@@ -41,6 +41,16 @@ export function useChatEvents(options?: { enabled?: boolean }) {
           logger.error('Chat cache update failed', 'useChatEvents', error),
         );
         useUIStore.getState().openChatTab(parsed.chat.id);
+        return;
+      }
+
+      if (parsed.kind === 'title_updated') {
+        // Backfilled mid-stream by the background titling task — patch caches
+        // directly so the sidebar/tab rename without waiting for a refetch.
+        patchChatInCache(queryClient, parsed.chat_id, (chat) => ({
+          ...chat,
+          title: parsed.title,
+        }));
         return;
       }
 

--- a/frontend/src/hooks/useCloudChatEvents.ts
+++ b/frontend/src/hooks/useCloudChatEvents.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { cloudChatService } from '@/services/cloudChatService';
+import { patchChatInCache } from '@/hooks/queries/useChatQueries';
 import { markCloudChats, markCloudSandboxes } from '@/utils/chatOrigin';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import { useUIStore } from '@/store/uiStore';
@@ -54,6 +55,17 @@ export function useCloudChatEvents(options?: { enabled?: boolean }) {
         }
         invalidateCloudLists(queryClient);
         useUIStore.getState().openChatTab(chat.id);
+        return;
+      }
+
+      if (parsed.kind === 'title_updated') {
+        // Patch reaches the single-chat cache (tabs/header); cloud sidebar rows
+        // live in their own list query, so refetch those.
+        patchChatInCache(queryClient, parsed.chat_id, (chat) => ({
+          ...chat,
+          title: parsed.title,
+        }));
+        void queryClient.invalidateQueries({ queryKey: queryKeys.cloudChatsAll });
         return;
       }
 

--- a/frontend/src/pages/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.tsx
@@ -90,6 +90,7 @@ export function SettingsPage() {
         'personas',
         'stream_actions',
         'notifications_enabled',
+        'title_model_id',
       ];
 
       for (const field of fields) {
@@ -165,6 +166,10 @@ export function SettingsPage() {
     void persistSettings((prev) => ({ ...prev, notifications_enabled: enabled })).catch(
       () => undefined,
     );
+  };
+
+  const handleTitleModelChange = (modelId: string) => {
+    void persistSettings((prev) => ({ ...prev, title_model_id: modelId })).catch(() => undefined);
   };
 
   const confirmDeleteAllChats = async () => {
@@ -258,6 +263,7 @@ export function SettingsPage() {
                         onToggleVisibility={toggleFieldVisibility}
                         onDeleteAllChats={handleDeleteAllChats}
                         onNotificationsEnabledChange={handleNotificationsEnabledChange}
+                        onTitleModelChange={handleTitleModelChange}
                       />
                     </div>
                   )}

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -82,7 +82,8 @@ export interface Chat {
 // consumed by useChatEvents (local) and useCloudChatEvents (VPS).
 export type ChatEvent =
   | { kind: 'chat_created'; chat: Chat }
-  | { kind: 'stream_started'; chat_id: string; message_id: string };
+  | { kind: 'stream_started'; chat_id: string; message_id: string }
+  | { kind: 'title_updated'; chat_id: string; title: string };
 
 export interface ChatRequest {
   prompt: string;

--- a/frontend/src/types/user.types.ts
+++ b/frontend/src/types/user.types.ts
@@ -56,6 +56,7 @@ export interface UserSettings {
   personas: Persona[] | null;
   stream_actions: StreamAction[] | null;
   notifications_enabled: boolean;
+  title_model_id: string;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- Titles now generate on a dedicated, user-configurable model (`title_model_id`, default `haiku`) instead of reusing the chat's own model
- Title generation starts alongside the turn instead of after it completes, and pushes a `title_updated` event so the sidebar/tab renames mid-stream
- Adds a "Title Generation Model" picker to General Settings backed by the new `title_model_id` user setting

## Test plan
- [ ] Start a new chat and confirm the sidebar title updates mid-stream (not just after completion)
- [ ] Change the title model in Settings > General and confirm new chats use it
- [ ] Run backend test suite (`backend/tests/test_chat.py`)