### PR TITLE
chore: remove dangling AGENTS.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,0 @@
-CLAUDE.md


### PR DESCRIPTION
## Summary
- Removes `AGENTS.md`, a symlink to `CLAUDE.md`, which was deleted in dae1f8d2 and left the symlink dangling