### PR TITLE
feat: add create_persona MCP tool

### DIFF
--- a/mcp-server/client.py
+++ b/mcp-server/client.py
@@ -94,6 +94,17 @@ class AgentroveClient:
         resp = await self.request("GET", "/settings/")
         return resp.json().get("personas") or []
 
+    async def create_persona(self, name: str, content: str) -> dict[str, Any]:
+        # No per-persona endpoint: personas live as a list on user settings, so we
+        # read the current list, append, and PATCH the whole array back.
+        resp = await self.request("GET", "/settings/")
+        personas = resp.json().get("personas") or []
+        if any(p["name"] == name for p in personas):
+            raise AgentroveError(f"A persona named {name!r} already exists.")
+        persona = {"name": name, "content": content}
+        await self.request("PATCH", "/settings/", json={"personas": [*personas, persona]})
+        return persona
+
     async def list_models(self, agent_kind: str | None) -> list[dict[str, Any]]:
         params = {"agent_kind": agent_kind} if agent_kind else None
         resp = await self.request("GET", "/models/", params=params)

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -139,6 +139,18 @@ async def list_personas() -> dict[str, Any]:
 
 
 @mcp.tool()
+async def create_persona(name: str, content: str) -> dict[str, Any]:
+    """Create a custom persona usable as send_message's `persona` argument.
+
+    `name` is the unique label you'll pass as `persona` (it must not match an existing
+    persona); `content` is the system prompt that shapes the agent's behavior for turns
+    using this persona. Returns the created persona's name.
+    """
+    persona = await client.create_persona(name, content)
+    return {"persona": {"name": persona["name"]}}
+
+
+@mcp.tool()
 async def send_message(
     prompt: str,
     chat_id: str | None = None,


### PR DESCRIPTION
## Summary
- Add `AgentroveClient.create_persona` — reads the current persona list from user settings, appends the new one, and PATCHes it back (there's no dedicated per-persona endpoint).
- Expose it as the `create_persona` MCP tool so agents can define custom personas for use with `send_message`'s `persona` argument, without being limited to pre-existing ones.