### PR TITLE
fix: close stale-closure and race-condition gaps in frontend effects

### DIFF
--- a/frontend/src/components/chat/chat-window/useChatScroll.ts
+++ b/frontend/src/components/chat/chat-window/useChatScroll.ts
@@ -123,10 +123,13 @@ export function useChatScroll({
     if (!container) return;
 
     // Use requestAnimationFrame to ensure DOM has rendered
-    requestAnimationFrame(() => {
+    const raf = requestAnimationFrame(() => {
       container.scrollTop = container.scrollHeight;
       hasInitializedToBottomRef.current = true;
     });
+    // Cancel so a chat switch or unmount can't let the stale frame scroll the
+    // old container and mark the new chat as already initialized.
+    return () => cancelAnimationFrame(raf);
   }, [messages]);
 
   // Prepend anchoring: restore scroll position after older messages are prepended

--- a/frontend/src/components/sandbox/git/DiffView/useDiffScroll.ts
+++ b/frontend/src/components/sandbox/git/DiffView/useDiffScroll.ts
@@ -81,7 +81,7 @@ export function useDiffScroll({
         step();
       });
     },
-    [cancelJump, setCollapsedFiles],
+    [cancelJump, paneRef, reviewCollapsedRef, rootRef, setActiveFile, setCollapsedFiles],
   );
 
   // Scope changes must cancel before a stale frame can run against the new diff.
@@ -102,7 +102,7 @@ export function useDiffScroll({
       root.removeEventListener('wheel', cancelJump, { capture: true });
       root.removeEventListener('keydown', cancelKeyboardScroll, { capture: true });
     };
-  }, [cancelJump, showFiles]);
+  }, [cancelJump, rootRef, showFiles]);
 
   // Scrollspy — capture-phase because scroll doesn't bubble and the Virtualizer
   // owns the scroll container. The last header within 32px of the pane top wins,
@@ -139,7 +139,7 @@ export function useDiffScroll({
       root.removeEventListener('scroll', onScroll, { capture: true });
       if (raf) cancelAnimationFrame(raf);
     };
-  }, [showFiles]);
+  }, [paneRef, rootRef, setActiveFile, showFiles]);
 
   return { jumpToFile };
 }

--- a/frontend/src/components/sandbox/terminal/Container/Container.tsx
+++ b/frontend/src/components/sandbox/terminal/Container/Container.tsx
@@ -19,53 +19,62 @@ interface TerminalInstance {
   label: string;
 }
 
+function readStoredTerminals(
+  storageKey: string | null,
+  defaultTerminalId: string,
+): { terminals: TerminalInstance[]; activeTerminalId: string } {
+  const defaults = {
+    terminals: [{ id: defaultTerminalId, label: 'Terminal 1' }],
+    activeTerminalId: defaultTerminalId,
+  };
+  if (!storageKey) return defaults;
+  const stored = localStorage.getItem(storageKey);
+  if (!stored) return defaults;
+  try {
+    const parsed = JSON.parse(stored) as {
+      terminals?: TerminalInstance[];
+      activeTerminalId?: string;
+    };
+    const valid = parsed.terminals?.filter((terminal) => terminal.id && terminal.label) ?? [];
+    if (valid.length === 0) return defaults;
+    return {
+      terminals: valid,
+      activeTerminalId:
+        parsed.activeTerminalId && valid.some((terminal) => terminal.id === parsed.activeTerminalId)
+          ? parsed.activeTerminalId
+          : (valid[0]?.id ?? defaultTerminalId),
+    };
+  } catch {
+    // corrupt storage, use defaults
+    return defaults;
+  }
+}
+
 export function Container({ sandboxId, chatId, worktreeCwd, isVisible, panelKey }: ContainerProps) {
   const defaultTerminalId = `terminal-${panelKey}-1`;
   const storageKey = chatId ? terminalStorageKey(chatId, panelKey) : null;
-  const [terminals, setTerminals] = useState<TerminalInstance[]>([
-    { id: defaultTerminalId, label: 'Terminal 1' },
-  ]);
-  const [activeTerminalId, setActiveTerminalId] = useState<string>(defaultTerminalId);
+  const [terminals, setTerminals] = useState<TerminalInstance[]>(
+    () => readStoredTerminals(storageKey, defaultTerminalId).terminals,
+  );
+  const [activeTerminalId, setActiveTerminalId] = useState<string>(
+    () => readStoredTerminals(storageKey, defaultTerminalId).activeTerminalId,
+  );
   const [closingTerminalIds, setClosingTerminalIds] = useState<Set<string>>(() => new Set());
-  const isRestoringRef = useRef(true);
+
+  // Re-restore during render when the storage identity changes (chat/panel
+  // switch): React re-renders before running effects, so the persist effect
+  // below can never observe the new key paired with the old chat's state.
+  const restoreKey = `${storageKey}|${defaultTerminalId}`;
+  const prevRestoreKeyRef = useRef(restoreKey);
+  if (prevRestoreKeyRef.current !== restoreKey) {
+    prevRestoreKeyRef.current = restoreKey;
+    const restored = readStoredTerminals(storageKey, defaultTerminalId);
+    setTerminals(restored.terminals);
+    setActiveTerminalId(restored.activeTerminalId);
+  }
 
   useEffect(() => {
-    isRestoringRef.current = true;
-    const defaultTerminals = [{ id: defaultTerminalId, label: 'Terminal 1' }];
-
-    let nextTerminals = defaultTerminals;
-    let nextActiveId = defaultTerminalId;
-
-    if (storageKey) {
-      const stored = localStorage.getItem(storageKey);
-      if (stored) {
-        try {
-          const parsed = JSON.parse(stored) as {
-            terminals?: TerminalInstance[];
-            activeTerminalId?: string;
-          };
-          const valid = parsed.terminals?.filter((terminal) => terminal.id && terminal.label) ?? [];
-          if (valid.length > 0) {
-            nextTerminals = valid;
-            nextActiveId =
-              parsed.activeTerminalId &&
-              valid.some((terminal) => terminal.id === parsed.activeTerminalId)
-                ? parsed.activeTerminalId
-                : (valid[0]?.id ?? defaultTerminalId);
-          }
-        } catch {
-          // corrupt storage, use defaults
-        }
-      }
-    }
-
-    setTerminals(nextTerminals);
-    setActiveTerminalId(nextActiveId);
-    isRestoringRef.current = false;
-  }, [storageKey, defaultTerminalId]);
-
-  useEffect(() => {
-    if (!storageKey || isRestoringRef.current) {
+    if (!storageKey) {
       return;
     }
     localStorage.setItem(storageKey, JSON.stringify({ terminals, activeTerminalId }));

--- a/frontend/src/components/ui/Mermaid/Mermaid.tsx
+++ b/frontend/src/components/ui/Mermaid/Mermaid.tsx
@@ -73,6 +73,12 @@ export function Mermaid({ content }: MermaidProps) {
         document.getElementById(`d${id}`)?.remove();
       }
     })();
+
+    // Invalidate the in-flight render on cleanup so it can't set state after
+    // unmount (or after showPreview flipped the effect onto its early-return path).
+    return () => {
+      renderIdRef.current += 1;
+    };
   }, [showPreview, content, theme]);
 
   return (

--- a/frontend/src/components/ui/attachment-viewer/AttachmentViewer.tsx
+++ b/frontend/src/components/ui/attachment-viewer/AttachmentViewer.tsx
@@ -142,7 +142,6 @@ export const AttachmentViewer = memo(function AttachmentViewer({
       });
       ownedObjectUrls.clear();
       loadedIds.clear();
-      setImageStates({});
     };
   }, []);
 

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -88,6 +88,7 @@ export function useChatStreaming({
   const pendingStopRef = useRef<Set<string>>(new Set());
   const prevChatIdRef = useRef<string | undefined>(chatId);
   const currentMessageIdRef = useRef<string | null>(null);
+  currentMessageIdRef.current = currentMessageId;
 
   const isLoading = streamState === 'loading';
   const isStreaming = streamState === 'streaming';
@@ -291,10 +292,6 @@ export function useChatStreaming({
     },
     [chatId, markStreamIdleAfterAbort, reconcileStreamState, stopStream],
   );
-
-  useEffect(() => {
-    currentMessageIdRef.current = currentMessageId;
-  }, [currentMessageId]);
 
   const handleStop = useCallback(() => {
     if (streamState === 'loading') {

--- a/frontend/src/hooks/useCloudStreamRestoration.ts
+++ b/frontend/src/hooks/useCloudStreamRestoration.ts
@@ -15,8 +15,12 @@ export function useCloudStreamRestoration({ enabled }: { enabled: boolean }) {
   useEffect(() => {
     if (!enabled || !cloudUrl) return;
 
+    // A cloudUrl switch mid-flight must not land the old instance's streams;
+    // the re-run restores from the new instance instead.
+    let cancelled = false;
     const restore = async () => {
       const active = await cloudChatService.getActiveStreams();
+      if (cancelled) return;
       for (const stream of active) {
         useStreamStore.getState().addStreamMetadataIfAbsent({
           chatId: stream.chat_id,
@@ -29,5 +33,8 @@ export function useCloudStreamRestoration({ enabled }: { enabled: boolean }) {
     restore().catch((error) => {
       logger.error('Cloud stream restoration failed', 'useCloudStreamRestoration', error);
     });
+    return () => {
+      cancelled = true;
+    };
   }, [enabled, cloudUrl]);
 }

--- a/frontend/src/hooks/useFileHandling.ts
+++ b/frontend/src/hooks/useFileHandling.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { logger } from '@/utils/logger';
 import { isUploadedImageFile } from '@/utils/fileTypes';
 import { filterChatAttachmentFiles } from '@/utils/file';
@@ -10,7 +10,6 @@ interface UseFileHandlingOptions {
 
 export function useFileHandling({ initialFiles = null, onChange }: UseFileHandlingOptions = {}) {
   const [files, setFiles] = useState<File[]>(initialFiles ?? []);
-  const urlsToCleanupRef = useRef<string[]>([]);
 
   useEffect(() => {
     setFiles(initialFiles ?? []);
@@ -39,7 +38,6 @@ export function useFileHandling({ initialFiles = null, onChange }: UseFileHandli
 
   useEffect(() => {
     const currentUrls = previewUrls.filter((url) => url !== '');
-    urlsToCleanupRef.current = currentUrls;
 
     return () => {
       currentUrls.forEach((url) => {

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -110,6 +110,7 @@ export function useStreamCallbacks({
 
   const pendingUserMessageIdRef = useRef<string | null>(null);
   const messagesRef = useRef<Message[]>(messages);
+  messagesRef.current = messages;
   const timerIdsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const buffersRef = useRef<Map<string, StreamContentBuffer>>(new Map());
   const flushTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
@@ -250,10 +251,6 @@ export function useStreamCallbacks({
     },
     [queryClient],
   );
-
-  useEffect(() => {
-    messagesRef.current = messages;
-  }, [messages]);
 
   useEffect(() => {
     const flushTimers = flushTimersRef.current;
@@ -728,11 +725,7 @@ export function useStreamCallbacks({
   // intentionally stable (only the stable queryClient in deps) so re-renders
   // don't re-fire the effects that consume them — always dispatch through the
   // freshest closures.
-  useEffect(() => {
-    optionsRef.current = chatId
-      ? { chatId, onEnvelope, onComplete, onError, onQueueProcess }
-      : null;
-  }, [chatId, onEnvelope, onComplete, onError, onQueueProcess]);
+  optionsRef.current = chatId ? { chatId, onEnvelope, onComplete, onError, onQueueProcess } : null;
 
   const startStream = useCallback(
     async (

--- a/frontend/src/pages/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.tsx
@@ -73,12 +73,9 @@ export function SettingsPage() {
 
   const [localSettings, setLocalSettings] = useState<UserSettings | null>(settings ?? null);
   const localSettingsRef = useRef<UserSettings | null>(localSettings);
+  localSettingsRef.current = localSettings;
 
   const instantUpdateMutation = useUpdateSettingsMutation();
-
-  useEffect(() => {
-    localSettingsRef.current = localSettings;
-  }, [localSettings]);
 
   const buildChangedPayload = useCallback(
     (current: UserSettings, previous: UserSettings): UserSettingsUpdate => {


### PR DESCRIPTION
## Summary
- Convert several `useEffect`-based ref syncs (currentMessageIdRef, messagesRef, optionsRef, localSettingsRef) to render-time assignments so consumers never read a stale value from the render before the effect ran.
- Guard async/animation-frame work in `useChatScroll`, `useDiffScroll`, `useCloudStreamRestoration`, and `Mermaid` with cancellation on cleanup so results from a stale chat/scope/instance can't land on the new one.
- Rework terminal state restoration in `Container.tsx` to restore synchronously during render on storage-key change, instead of via a post-render effect gated by an `isRestoringRef` flag.
- Remove a dead `setImageStates({})` call and an unused ref in `AttachmentViewer`/`useFileHandling`.

## Test plan
- [ ] Manually verify chat scroll behavior when switching chats quickly
- [ ] Manually verify terminal state persists correctly when switching sandbox panels/chats
- [ ] Manually verify streaming/stop behavior in chat