### PR TITLE
Add ⌘⇧<key> chords for command menu filter tabs

### DIFF
--- a/frontend/src/components/ui/command-menu/CommandMenu.tsx
+++ b/frontend/src/components/ui/command-menu/CommandMenu.tsx
@@ -7,7 +7,7 @@ import { CommandMenuInput } from './CommandMenuInput';
 import { CommandMenuList } from './CommandMenuList';
 import { useCommandMenu } from './useCommandMenu';
 import { FILTER_LABELS, isMainMode, isPanelMode } from './commandMenuModes';
-import { MAIN_FILTERS } from './commandRegistry';
+import { FILTER_SHORTCUTS, MAIN_FILTERS, formatShortcut } from './commandRegistry';
 import styles from './CommandMenu.module.scss';
 
 export function CommandMenu() {
@@ -91,6 +91,7 @@ export function CommandMenu() {
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => switchFilter(filter)}
                 className={clsx(styles.filter, filter === mode && styles['filter--active'])}
+                title={filter === 'all' ? undefined : formatShortcut(FILTER_SHORTCUTS[filter])}
               >
                 {FILTER_LABELS[filter]}
               </Button>

--- a/frontend/src/components/ui/command-menu/commandRegistry.ts
+++ b/frontend/src/components/ui/command-menu/commandRegistry.ts
@@ -170,10 +170,29 @@ export const ALL_COMMANDS: CommandItem[] = [
   ...VIEW_COMMANDS,
 ];
 
+const PUNCTUATION_CODES: Record<string, string> = { '.': 'Period', ',': 'Comma' };
+
+const shortcutToCode = (key: string) => PUNCTUATION_CODES[key] ?? `Key${key.toUpperCase()}`;
+
 export const SHORTCUT_MAP = new Map<string, CommandItem>(
-  ALL_COMMANDS.map((cmd) => [
-    cmd.shortcut === '.' ? 'Period' : `Key${cmd.shortcut.toUpperCase()}`,
-    cmd,
+  ALL_COMMANDS.map((cmd) => [shortcutToCode(cmd.shortcut), cmd]),
+);
+
+// ⌘⇧<key> chords that jump straight to a filter tab — opening the menu on it when
+// closed, switching tabs when open. 'all' is covered by the ⌘⇧P toggle. Keys must
+// not collide with command shortcuts above.
+export const FILTER_SHORTCUTS: Record<Exclude<MainFilter, 'all'>, string> = {
+  chats: 'k',
+  messages: 's',
+  files: 'o',
+  grep: 'f',
+  actions: 'x',
+};
+
+export const FILTER_SHORTCUT_MAP = new Map<string, MainFilter>(
+  (Object.entries(FILTER_SHORTCUTS) as [MainFilter, string][]).map(([filter, key]) => [
+    shortcutToCode(key),
+    filter,
   ]),
 );
 

--- a/frontend/src/components/ui/command-menu/useCommandMenu.ts
+++ b/frontend/src/components/ui/command-menu/useCommandMenu.ts
@@ -10,6 +10,7 @@ import { useCommandMenuData } from './useCommandMenuData';
 import { isMainMode, isPanelMode } from './commandMenuModes';
 import {
   COMMAND_TO_MODE,
+  FILTER_SHORTCUT_MAP,
   MAIN_FILTERS,
   executeCommand,
   type CommandItem,
@@ -234,6 +235,17 @@ export function useCommandMenu() {
         const current = MAIN_FILTERS.indexOf(m);
         switchFilter(MAIN_FILTERS[(current + step + MAIN_FILTERS.length) % MAIN_FILTERS.length]);
         return;
+      }
+
+      // ⌘⇧<key> jumps straight to a filter tab, mirroring the global open-on-tab chords.
+      if (isMainMode(m) && (e.metaKey || e.ctrlKey) && e.shiftKey) {
+        const filter = FILTER_SHORTCUT_MAP.get(e.code);
+        if (filter) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          switchFilter(filter);
+          return;
+        }
       }
 
       if (isPanelMode(m)) {

--- a/frontend/src/hooks/useCommandMenu.ts
+++ b/frontend/src/hooks/useCommandMenu.ts
@@ -4,6 +4,7 @@ import { useUIStore } from '@/store/uiStore';
 import { useChatStore } from '@/store/chatStore';
 import { useQueryClient } from '@tanstack/react-query';
 import {
+  FILTER_SHORTCUT_MAP,
   SHORTCUT_MAP,
   executeCommand,
   resolveActiveGitTarget,
@@ -33,7 +34,17 @@ export function useCommandMenu() {
       }
 
       if (isEmbeddedEditor(e.target)) return;
+      // While open, the menu's own handler owns filter chords (they switch tabs there).
       if (useUIStore.getState().commandMenuOpen) return;
+
+      const filter = FILTER_SHORTCUT_MAP.get(e.code);
+      if (filter) {
+        e.preventDefault();
+        const ui = useUIStore.getState();
+        ui.setPendingMenuMode(filter);
+        ui.setCommandMenuOpen(true);
+        return;
+      }
 
       const cmd = SHORTCUT_MAP.get(e.code);
       if (!cmd) return;


### PR DESCRIPTION
## Summary
- Add `⌘⇧<key>` chords (chats/messages/files/grep/actions) that open the command menu directly on a given filter tab, or switch to that tab if the menu is already open
- Show the chord as a `title` tooltip on each filter tab button
- Guard against collisions with existing single-key command shortcuts via a shared `shortcutToCode` helper