### PR TITLE
Route chat-scoped calls to the backend that owns the chat

### DIFF
--- a/frontend/src/components/chat/chat-search/ChatSearchPanel.tsx
+++ b/frontend/src/components/chat/chat-search/ChatSearchPanel.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/primitives/Input/Input';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useSearchChatsQuery } from '@/hooks/queries/useChatQueries';
+import { useSearchCloudChatsQuery } from '@/hooks/queries/useCloudQueries';
 import type { ChatSearchResult } from '@/types/chat.types';
 import { ChatSearchResultGroup } from './ChatSearchResultGroup';
 import styles from './ChatSearchPanel.module.scss';
@@ -51,7 +52,15 @@ export const ChatSearchPanel = memo(function ChatSearchPanel({
     activeInputRef.current?.focus();
   });
 
-  const { data, isFetching, error } = useSearchChatsQuery(debouncedQuery);
+  // Local and cloud chats live on separate backends — search both and merge,
+  // like the sidebar's merged lists. Each source errors independently so a
+  // down VPS doesn't take local search with it.
+  const local = useSearchChatsQuery(debouncedQuery);
+  const cloud = useSearchCloudChatsQuery(debouncedQuery);
+  const isFetching = local.isFetching || cloud.isFetching;
+  const hasLoaded = !!local.data || !!cloud.data;
+  const error = local.error ?? cloud.error;
+  const truncated = !!local.data?.truncated || !!cloud.data?.truncated;
 
   const handleClear = useCallback(() => {
     setQuery('');
@@ -68,16 +77,17 @@ export const ChatSearchPanel = memo(function ChatSearchPanel({
     [query, handleClear],
   );
 
-  const { grouped, totalMatches } = useMemo(() => {
-    const results = data?.results ?? [];
+  const { grouped, totalMatches, resultCount } = useMemo(() => {
+    const results = [...(local.data?.results ?? []), ...(cloud.data?.results ?? [])];
     return {
       grouped: groupByWorkspace(results),
       totalMatches: results.reduce((acc, r) => acc + r.match_count, 0),
+      resultCount: results.length,
     };
-  }, [data]);
+  }, [local.data, cloud.data]);
 
   const hasQuery = debouncedQuery.trim().length >= 2;
-  const hasResults = !!data && data.results.length > 0;
+  const hasResults = resultCount > 0;
 
   return (
     <div className={styles['chat-search-panel']}>
@@ -116,20 +126,33 @@ export const ChatSearchPanel = memo(function ChatSearchPanel({
           <p className={styles['empty-message']}>Type at least 2 characters to search.</p>
         )}
 
-        {hasQuery && isFetching && !data && (
+        {/* Keep the spinner until something is showable — one source settling
+            empty while the other is still in flight must not blank the panel. */}
+        {hasQuery && isFetching && !hasResults && (
           <div className={styles['loading-message']}>
             <Loader2 className={styles['spin-icon']} />
             Searching...
           </div>
         )}
 
-        {hasQuery && error && (
+        {/* Blocking failure means neither source returned and nothing is still
+            in flight — a source that's still fetching gets its chance first.
+            Once anything loaded, a failed source degrades to a non-blocking
+            incompleteness notice, coherent alongside results or "No results". */}
+        {hasQuery && error && !hasLoaded && !isFetching && (
           <p className={styles['error-message']}>
             {error instanceof Error ? error.message : 'Search failed'}
           </p>
         )}
 
-        {hasQuery && data && !hasResults && !isFetching && (
+        {hasQuery && error && hasLoaded && (
+          <p className={styles['error-message']}>
+            {[local.error && 'local', cloud.error && 'cloud'].filter(Boolean).join(' and ')} search
+            failed — results may be incomplete.
+          </p>
+        )}
+
+        {hasQuery && hasLoaded && !hasResults && !isFetching && (
           <p className={styles['empty-message']}>No results for &ldquo;{debouncedQuery}&rdquo;</p>
         )}
 
@@ -138,10 +161,10 @@ export const ChatSearchPanel = memo(function ChatSearchPanel({
             <p className={styles.summary}>
               {isFetching && <Loader2 className={styles['spin-icon']} />}
               <span>
-                {totalMatches} {totalMatches === 1 ? 'result' : 'results'} in {data.results.length}{' '}
-                {data.results.length === 1 ? 'chat' : 'chats'} · {grouped.length}{' '}
+                {totalMatches} {totalMatches === 1 ? 'result' : 'results'} in {resultCount}{' '}
+                {resultCount === 1 ? 'chat' : 'chats'} · {grouped.length}{' '}
                 {grouped.length === 1 ? 'workspace' : 'workspaces'}
-                {data.truncated && ' (truncated)'}
+                {truncated && ' (truncated)'}
               </span>
             </p>
             <div aria-busy={isFetching} className={styles['result-list']}>

--- a/frontend/src/components/chat/chat-window/AgentPane.tsx
+++ b/frontend/src/components/chat/chat-window/AgentPane.tsx
@@ -5,7 +5,7 @@ import { ChatProvider } from '@/contexts/ChatContext';
 import { useChatData } from '@/hooks/useChatData';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
 import { useWorkspaceResourcesQuery } from '@/hooks/queries/useWorkspaceQueries';
-import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
+import { useSettingsForChatQuery } from '@/hooks/queries/useSettingsQueries';
 
 interface AgentPaneProps {
   chatId: string;
@@ -21,7 +21,8 @@ export const AgentPane = memo(function AgentPane({ chatId }: AgentPaneProps) {
     currentChat?.workspace_id,
     chatId,
   );
-  const { data: settings } = useSettingsQuery();
+  // Personas come from the instance that owns the chat (local or cloud VPS).
+  const { data: settings } = useSettingsForChatQuery(chatId);
 
   return (
     <ChatProvider

--- a/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
+++ b/frontend/src/components/chat/chat-window/QueueMessageCard.tsx
@@ -4,7 +4,8 @@ import { X, Pencil, CornerDownRight, FileText, FileSpreadsheet, Send } from 'luc
 import { Button } from '@/components/ui/primitives/Button/Button';
 import { Input } from '@/components/ui/primitives/Input/Input';
 import { Spinner } from '@/components/ui/primitives/Spinner/Spinner';
-import { apiClient } from '@/lib/api';
+import { resolveChatClient } from '@/lib/api';
+import { useChatContext } from '@/hooks/useChatContext';
 import { detectFileType } from '@/utils/fileTypes';
 import { HighlightedText } from '@/components/ui/shared/HighlightedText/HighlightedText';
 import { fetchAttachmentBlob } from '@/utils/file';
@@ -98,6 +99,8 @@ function LocalFilePreview({ file, uploading }: { file: File; uploading: boolean 
 }
 
 function AuthenticatedPreview({ attachment }: { attachment: QueueAttachment }) {
+  // A cloud chat's attachment URLs only exist on the VPS — route like AttachmentViewer.
+  const { chatId } = useChatContext();
   const [imageSrc, setImageSrc] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -114,7 +117,7 @@ function AuthenticatedPreview({ attachment }: { attachment: QueueAttachment }) {
           return;
         }
 
-        const blob = await fetchAttachmentBlob(attachment.file_url, apiClient);
+        const blob = await fetchAttachmentBlob(attachment.file_url, resolveChatClient(chatId));
         if (cancelled) return;
         objectUrl = URL.createObjectURL(blob);
         setImageSrc(objectUrl);
@@ -137,7 +140,7 @@ function AuthenticatedPreview({ attachment }: { attachment: QueueAttachment }) {
       cancelled = true;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [attachment.file_url, attachment.file_type]);
+  }, [attachment.file_url, attachment.file_type, chatId]);
 
   if (attachment.file_type === 'pdf') {
     return (

--- a/frontend/src/components/chat/chat-window/StreamActionsBar.tsx
+++ b/frontend/src/components/chat/chat-window/StreamActionsBar.tsx
@@ -1,7 +1,7 @@
 import { GitBranch } from 'lucide-react';
 import { Button } from '@/components/ui/primitives/Button/Button';
 import { useChatQuery } from '@/hooks/queries/useChatQueries';
-import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
+import { useSettingsForChatQuery } from '@/hooks/queries/useSettingsQueries';
 import { useRunStreamAction } from '@/hooks/useRunStreamAction';
 import styles from './StreamActionsBar.module.scss';
 
@@ -11,7 +11,8 @@ interface StreamActionsBarProps {
 
 export function StreamActionsBar({ chatId }: StreamActionsBarProps) {
   const { data: chat } = useChatQuery(chatId);
-  const { data: settings } = useSettingsQuery();
+  // Stream actions come from the instance that owns the chat (local or cloud VPS).
+  const { data: settings } = useSettingsForChatQuery(chatId);
   const runAction = useRunStreamAction(chat);
 
   const enabledActions = (settings?.stream_actions ?? []).filter((action) => action.enabled);

--- a/frontend/src/components/chat/github/CreateCommitDialog.tsx
+++ b/frontend/src/components/chat/github/CreateCommitDialog.tsx
@@ -22,7 +22,8 @@ export function CreateCommitDialog({ onClose }: CreateCommitDialogProps) {
   const sandboxId = currentChat?.sandbox_id ?? '';
   const worktreeCwd = currentChat?.worktree_cwd ?? undefined;
   const commitMutation = useGitCommitMutation();
-  const generateMessage = useGenerateCommitMessageMutation();
+  // Generation runs on the backend that owns the chat (local or cloud VPS).
+  const generateMessage = useGenerateCommitMessageMutation(currentChat?.id);
 
   const { data: diffData, isPlaceholderData } = useGitDiffQuery(
     sandboxId,

--- a/frontend/src/components/chat/github/CreatePRDialog.tsx
+++ b/frontend/src/components/chat/github/CreatePRDialog.tsx
@@ -68,8 +68,15 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
 
   const { data: branchesData } = useGitBranchesQuery(sandboxId, !!sandboxId, worktreeCwd);
   const { data: diffData } = useGitDiffQuery(sandboxId, 'branch', false, worktreeCwd);
-  const { data: collaborators } = useGitHubCollaboratorsQuery(owner, repo, !!owner && !!repo);
-  const { data: pullsData } = useGitHubPullsQuery(owner, repo, !!owner && !!repo);
+  // GitHub calls run with the credentials of the backend that owns the chat.
+  const chatId = currentChat?.id;
+  const { data: collaborators } = useGitHubCollaboratorsQuery(
+    owner,
+    repo,
+    !!owner && !!repo,
+    chatId,
+  );
+  const { data: pullsData } = useGitHubPullsQuery(owner, repo, !!owner && !!repo, chatId);
 
   const changedFiles = useMemo(
     () => (diffData?.diff ? parseChangedFiles(diffData.diff) : []),
@@ -134,8 +141,8 @@ export function CreatePRDialog({ onClose }: CreatePRDialogProps) {
   const selectedModelId = useModelStore((s) =>
     currentChat ? (s.modelByChat[currentChat.id] ?? '') : '',
   );
-  const createPR = useCreatePullRequestMutation();
-  const generateDescription = useGeneratePRDescriptionMutation();
+  const createPR = useCreatePullRequestMutation(chatId);
+  const generateDescription = useGeneratePRDescriptionMutation(chatId);
   const hasDiff = !!diffData?.diff;
   const diffError = diffData?.error;
   const hasModel = !!selectedModelId.trim();

--- a/frontend/src/components/chat/github/CreatePRReviewers.tsx
+++ b/frontend/src/components/chat/github/CreatePRReviewers.tsx
@@ -1,8 +1,9 @@
 import { Button } from '@/components/ui/primitives/Button/Button';
+import type { GitHubCollaborator } from '@/types/github.types';
 import styles from './CreatePRReviewers.module.scss';
 
 interface CreatePRReviewersProps {
-  collaborators: Array<{ login: string; avatar_url: string }> | undefined;
+  collaborators: GitHubCollaborator[] | undefined;
   selected: string[];
   onToggle: (login: string) => void;
 }

--- a/frontend/src/components/chat/sub-threads/CreateSubThreadDialog.tsx
+++ b/frontend/src/components/chat/sub-threads/CreateSubThreadDialog.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/components/chat/permission-mode-selector/permissionModes';
 import type { PermissionMode } from '@/store/chatSettingsStore';
 import { useModelsQuery } from '@/hooks/queries/useModelQueries';
-import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
+import { useSettingsForChatQuery } from '@/hooks/queries/useSettingsQueries';
 import { useCreateSubThreadMutation } from '@/hooks/queries/useChatQueries';
 import { useSlashCommandSuggestions } from '@/hooks/useSlashCommandSuggestions';
 import { useChatContext } from '@/hooks/useChatContext';
@@ -47,7 +47,8 @@ export function CreateSubThreadDialog({ parentChat, onClose }: CreateSubThreadDi
   const navigate = useNavigate();
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { data: models = [] } = useModelsQuery({ enabled: isAuthenticated });
-  const { data: settings } = useSettingsQuery({ enabled: isAuthenticated });
+  // A sub-thread runs on the parent's instance — offer that instance's personas.
+  const { data: settings } = useSettingsForChatQuery(parentChat.id, isAuthenticated);
   const personas = settings?.personas ?? [];
 
   const [selectedModelId, setSelectedModelId] = useState('');

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -88,7 +88,11 @@ export const queryKeys = {
   models: 'models',
   github: {
     repos: (query: string) => ['github-repos', query] as const,
-    pulls: (owner: string, repo: string) => ['github-pulls', owner, repo] as const,
-    collaborators: (owner: string, repo: string) => ['github-collaborators', owner, repo] as const,
+    // Keyed by chatId because the response depends on which backend's GitHub
+    // credentials served it (local vs the chat-owning cloud VPS).
+    pulls: (owner: string, repo: string, chatId?: string) =>
+      ['github-pulls', owner, repo, chatId ?? null] as const,
+    collaborators: (owner: string, repo: string, chatId?: string) =>
+      ['github-collaborators', owner, repo, chatId ?? null] as const,
   },
 } as const;

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -13,6 +13,8 @@ import type {
   QueryClient,
 } from '@tanstack/react-query';
 import { chatService } from '@/services/chatService';
+import { cloudChatService } from '@/services/cloudChatService';
+import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import { isCloudChat } from '@/utils/chatOrigin';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
 import { useUIStore, type ComposerSelection } from '@/store/uiStore';
@@ -337,15 +339,49 @@ export const useDeleteChatMutation = createMutation<void, Error, string>(
   },
 );
 
-export const useDeleteAllChatsMutation = createMutation<void, Error, void>(
-  () => chatService.deleteAllChats(),
-  (queryClient) => {
-    // removeQueries on the prefix ['chats'] also clears chatsSearch entries.
-    queryClient.removeQueries({ queryKey: [queryKeys.chats] });
-    queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
-    useUIStore.getState().cleanupAllChats();
-  },
-);
+// The sidebar presents one merged list, so "delete all" must reach both
+// backends. Each backend's wipe reconciles its own caches as it succeeds: a
+// partial failure is real (e.g. VPS offline) and the successful side's chats
+// are already gone server-side, so the UI must drop them even while the
+// aggregate error still surfaces to the caller.
+export const useDeleteAllChatsMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: async () => {
+      const wipes = [
+        chatService.deleteAllChats().then(() => {
+          // removeQueries on the prefix ['chats'] also clears chatsSearch entries.
+          queryClient.removeQueries({ queryKey: [queryKeys.chats] });
+          queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
+        }),
+      ];
+      const { cloudUrl, connectedEmail } = useCloudSettingsStore.getState();
+      if (connectedEmail) {
+        wipes.push(
+          cloudChatService.deleteAllChats().then(() => {
+            queryClient.invalidateQueries({ queryKey: queryKeys.cloudChatsAll });
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.cloudWorkspaces(cloudUrl, connectedEmail),
+            });
+          }),
+        );
+      }
+      const results = await Promise.allSettled(wipes);
+      // Tabs/layouts are ephemeral — reset them whenever anything was wiped.
+      if (results.some((result) => result.status === 'fulfilled')) {
+        useUIStore.getState().cleanupAllChats();
+      }
+      const failed = results.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected',
+      );
+      if (failed) {
+        throw failed.reason instanceof Error
+          ? failed.reason
+          : new Error('Failed to delete all chats');
+      }
+    },
+  });
+};
 
 interface EnhancePromptParams {
   prompt: string;

--- a/frontend/src/hooks/queries/useCloudQueries.ts
+++ b/frontend/src/hooks/queries/useCloudQueries.ts
@@ -1,4 +1,4 @@
-import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
+import { useQuery, useInfiniteQuery, keepPreviousData } from '@tanstack/react-query';
 import { cloudChatService } from '@/services/cloudChatService';
 import { queryKeys } from '@/hooks/queries/queryKeys';
 import { createMutation } from '@/hooks/queries/createMutation';
@@ -10,6 +10,7 @@ import type {
 } from '@/types/workspace.types';
 import type { UserSettings } from '@/types/user.types';
 import type { ActiveStreamSnapshot } from '@/types/stream.types';
+import type { ChatSearchResponse } from '@/types/chat.types';
 
 const CLOUD_CHATS_PER_PAGE = 25;
 
@@ -114,6 +115,24 @@ export const useCloudChatsTotalQuery = (enabled: boolean) => {
     select: (data) => data.total,
     enabled: enabled && !!cloudUrl,
     staleTime: 30_000,
+  });
+};
+
+// Cloud twin of useSearchChatsQuery — ChatSearchPanel merges the two result sets
+// like the sidebar merges its lists. Key extends queryKeys.cloudChats so
+// cloudChatsAll invalidations (deletes, renames) prefix-match it.
+export const useSearchCloudChatsQuery = (query: string) => {
+  const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
+  const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
+  const trimmed = query.trim();
+  return useQuery<ChatSearchResponse>({
+    queryKey: [...queryKeys.cloudChats(cloudUrl, connectedEmail), 'search', trimmed] as const,
+    queryFn: () => cloudChatService.searchChats(trimmed),
+    enabled: !!cloudUrl && trimmed.length >= 2,
+    // Placeholder retention only while connected: after disconnect the origin
+    // tracking is cleared, so held-over VPS results would misroute when opened.
+    placeholderData: cloudUrl ? keepPreviousData : undefined,
+    staleTime: 15_000,
   });
 };
 

--- a/frontend/src/hooks/queries/useGitHubQueries.ts
+++ b/frontend/src/hooks/queries/useGitHubQueries.ts
@@ -20,38 +20,50 @@ export function useGitHubReposQuery(query: string, enabled: boolean) {
   });
 }
 
-export function useGitHubPullsQuery(owner: string, repo: string, enabled: boolean) {
+// chatId routes each call to the backend that owns the chat (local or cloud VPS)
+// so its GitHub credentials are used — see githubService.
+export function useGitHubPullsQuery(
+  owner: string,
+  repo: string,
+  enabled: boolean,
+  chatId?: string,
+) {
   return useQuery({
-    queryKey: queryKeys.github.pulls(owner, repo),
-    queryFn: () => githubService.listPullRequests(owner, repo),
+    queryKey: queryKeys.github.pulls(owner, repo, chatId),
+    queryFn: () => githubService.listPullRequests(owner, repo, chatId),
     enabled: enabled && !!owner && !!repo,
     staleTime: 30_000,
   });
 }
 
-export function useGitHubCollaboratorsQuery(owner: string, repo: string, enabled: boolean) {
+export function useGitHubCollaboratorsQuery(
+  owner: string,
+  repo: string,
+  enabled: boolean,
+  chatId?: string,
+) {
   return useQuery({
-    queryKey: queryKeys.github.collaborators(owner, repo),
-    queryFn: () => githubService.getCollaborators(owner, repo),
+    queryKey: queryKeys.github.collaborators(owner, repo, chatId),
+    queryFn: () => githubService.getCollaborators(owner, repo, chatId),
     enabled: enabled && !!owner && !!repo,
     staleTime: 300_000,
   });
 }
 
-export function useCreatePullRequestMutation() {
+export function useCreatePullRequestMutation(chatId?: string) {
   return useMutation<CreatePRResponse, Error, CreatePRRequest>({
-    mutationFn: (request) => githubService.createPullRequest(request),
+    mutationFn: (request) => githubService.createPullRequest(request, chatId),
   });
 }
 
-export function useGeneratePRDescriptionMutation() {
+export function useGeneratePRDescriptionMutation(chatId?: string) {
   return useMutation<GeneratePRDescriptionResponse, Error, GeneratePRDescriptionRequest>({
-    mutationFn: (request) => githubService.generatePRDescription(request),
+    mutationFn: (request) => githubService.generatePRDescription(request, chatId),
   });
 }
 
-export function useGenerateCommitMessageMutation() {
+export function useGenerateCommitMessageMutation(chatId?: string) {
   return useMutation<GenerateCommitMessageResponse, Error, GenerateCommitMessageRequest>({
-    mutationFn: (request) => githubService.generateCommitMessage(request),
+    mutationFn: (request) => githubService.generateCommitMessage(request, chatId),
   });
 }

--- a/frontend/src/hooks/queries/useSettingsQueries.ts
+++ b/frontend/src/hooks/queries/useSettingsQueries.ts
@@ -4,6 +4,8 @@ import { settingsService } from '@/services/settingsService';
 import type { UserSettings, UserSettingsUpdate } from '@/types/user.types';
 import { createMutation } from './createMutation';
 import { queryKeys } from './queryKeys';
+import { useCloudSettingsQuery } from './useCloudQueries';
+import { isCloudChat } from '@/utils/chatOrigin';
 
 export const useSettingsQuery = (options?: Partial<UseQueryOptions<UserSettings>>) => {
   return useQuery({
@@ -11,6 +13,17 @@ export const useSettingsQuery = (options?: Partial<UseQueryOptions<UserSettings>
     queryFn: () => settingsService.getSettings(),
     ...options,
   });
+};
+
+// Settings are per-instance: a cloud chat's personas and stream actions live on
+// the VPS that owns it, not the local backend. Routes to the owning instance the
+// same way resolveChatClient routes per-chat API calls. isCloudChat hydrates
+// synchronously from localStorage, so deep links resolve before the query fires.
+export const useSettingsForChatQuery = (chatId: string | undefined, enabled = true) => {
+  const chatIsCloud = !!chatId && isCloudChat(chatId);
+  const localQuery = useSettingsQuery({ enabled: enabled && !chatIsCloud });
+  const cloudQuery = useCloudSettingsQuery(enabled && chatIsCloud);
+  return chatIsCloud ? cloudQuery : localQuery;
 };
 
 export const useUpdateSettingsMutation = createMutation<UserSettings, Error, UserSettingsUpdate>(

--- a/frontend/src/hooks/useChatEvents.ts
+++ b/frontend/src/hooks/useChatEvents.ts
@@ -5,6 +5,8 @@ import { applyCreatedChat, patchChatInCache } from '@/hooks/queries/useChatQueri
 import { useUIStore } from '@/store/uiStore';
 import { useStreamStore } from '@/store/streamStore';
 import { queryKeys } from '@/hooks/queries/queryKeys';
+import { subscribeChatEventsFeed } from '@/utils/chatEventsFeed';
+import { resyncActiveStreams } from '@/utils/activeStreams';
 import { logger } from '@/utils/logger';
 import type { ChatEvent } from '@/types/chat.types';
 
@@ -18,13 +20,9 @@ export function useChatEvents(options?: { enabled?: boolean }) {
   useEffect(() => {
     if (!enabled) return;
 
-    let source: EventSource;
-    try {
-      source = chatService.createChatEventsSource();
-    } catch (error) {
-      logger.error('Chat events stream failed to open', 'useChatEvents', error);
-      return;
-    }
+    // Guards in-flight resync snapshots across teardown (logout flips enabled) —
+    // a late response must not register ghost stream indicators.
+    let cancelled = false;
 
     const onChatEvent = (event: MessageEvent) => {
       if (!event.data) return;
@@ -72,9 +70,30 @@ export function useChatEvents(options?: { enabled?: boolean }) {
       }
     };
 
-    // EventSource handles transient-error reconnects itself; no error handler needed.
-    // Custom event names hit the generic EventTarget overload, which takes Event.
-    source.addEventListener('chat_event', (event: Event) => onChatEvent(event as MessageEvent));
-    return () => source.close();
+    const unsubscribe = subscribeChatEventsFeed({
+      createSource: () => chatService.createChatEventsSource(),
+      onChatEvent,
+      // Events published while the feed was down are lost — refetch the sidebar
+      // lists, refetch active per-chat caches (titles, sub-threads, context
+      // usage — the live path patches those directly), and re-register active
+      // streams so a missed stream_started still gets its running indicator
+      // (startup restoration only runs once).
+      onResync: () => {
+        void queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
+        void queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
+        void queryClient.invalidateQueries({ queryKey: ['chat'] });
+        resyncActiveStreams(
+          () => chatService.getActiveStreams(),
+          () => cancelled,
+          'useChatEvents',
+        );
+      },
+      logContext: 'useChatEvents',
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
   }, [enabled, queryClient]);
 }

--- a/frontend/src/hooks/useCloudChatEvents.ts
+++ b/frontend/src/hooks/useCloudChatEvents.ts
@@ -7,6 +7,8 @@ import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import { useUIStore } from '@/store/uiStore';
 import { useStreamStore } from '@/store/streamStore';
 import { queryKeys } from '@/hooks/queries/queryKeys';
+import { subscribeChatEventsFeed } from '@/utils/chatEventsFeed';
+import { resyncActiveStreams } from '@/utils/activeStreams';
 import { logger } from '@/utils/logger';
 import type { ChatEvent } from '@/types/chat.types';
 
@@ -30,6 +32,11 @@ export function useCloudChatEvents(options?: { enabled?: boolean }) {
 
   useEffect(() => {
     if (!enabled || !cloudUrl) return;
+
+    // Guards in-flight resync snapshots across disconnect/VPS switch — a late
+    // response from the old instance must not register ghost stream indicators
+    // (same generation guard useCloudStreamRestoration uses).
+    let cancelled = false;
 
     const onChatEvent = (event: MessageEvent) => {
       if (!event.data) return;
@@ -85,50 +92,30 @@ export function useCloudChatEvents(options?: { enabled?: boolean }) {
       }
     };
 
-    // Opening is async (mints an access token first), so guard against the
-    // effect being cleaned up before the source resolves.
-    let source: EventSource | undefined;
-    let cancelled = false;
-    let retryTimer: number | undefined;
-
-    const scheduleReopen = () => {
-      if (cancelled) return;
-      retryTimer = window.setTimeout(openFeed, 15_000);
-    };
-
-    const openFeed = () => {
-      cloudChatService
-        .createChatEventsSource()
-        .then((eventSource) => {
-          if (cancelled) {
-            eventSource.close();
-            return;
-          }
-          source = eventSource;
-          source.addEventListener('chat_event', (event: Event) =>
-            onChatEvent(event as MessageEvent),
-          );
-          // EventSource retries transient drops itself (readyState CONNECTING) but
-          // treats HTTP errors as fatal — e.g. 401 once the query-param token
-          // expires. Reopen with a freshly minted token so the feed can't die
-          // silently while the UI looks connected.
-          source.onerror = () => {
-            if (source?.readyState !== EventSource.CLOSED) return;
-            scheduleReopen();
-          };
-        })
-        .catch((error) => {
-          logger.error('Cloud chat events stream failed to open', 'useCloudChatEvents', error);
-          scheduleReopen();
-        });
-    };
-
-    openFeed();
+    const unsubscribe = subscribeChatEventsFeed({
+      createSource: () => cloudChatService.createChatEventsSource(),
+      onChatEvent,
+      // Events published while the feed was down are lost — refetch the cloud
+      // lists so chats created/renamed on the VPS during the gap surface,
+      // refetch active per-chat caches (titles, sub-threads), and re-register
+      // active streams so a missed stream_started still gets its running
+      // indicator (connection-time restoration doesn't re-run).
+      // getActiveStreams also marks the chat IDs cloud-owned before reconnect.
+      onResync: () => {
+        invalidateCloudLists(queryClient);
+        void queryClient.invalidateQueries({ queryKey: ['chat'] });
+        resyncActiveStreams(
+          () => cloudChatService.getActiveStreams(),
+          () => cancelled,
+          'useCloudChatEvents',
+        );
+      },
+      logContext: 'useCloudChatEvents',
+    });
 
     return () => {
       cancelled = true;
-      window.clearTimeout(retryTimer);
-      source?.close();
+      unsubscribe();
     };
   }, [enabled, cloudUrl, queryClient]);
 }

--- a/frontend/src/hooks/useCloudStreamRestoration.ts
+++ b/frontend/src/hooks/useCloudStreamRestoration.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { logger } from '@/utils/logger';
-import { useStreamStore } from '@/store/streamStore';
+import { registerActiveStreams } from '@/utils/activeStreams';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import { cloudChatService } from '@/services/cloudChatService';
 
@@ -21,13 +21,7 @@ export function useCloudStreamRestoration({ enabled }: { enabled: boolean }) {
     const restore = async () => {
       const active = await cloudChatService.getActiveStreams();
       if (cancelled) return;
-      for (const stream of active) {
-        useStreamStore.getState().addStreamMetadataIfAbsent({
-          chatId: stream.chat_id,
-          messageId: stream.message_id,
-          startTime: Date.now(),
-        });
-      }
+      registerActiveStreams(active);
     };
 
     restore().catch((error) => {

--- a/frontend/src/hooks/useLocalStreamRestoration.ts
+++ b/frontend/src/hooks/useLocalStreamRestoration.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { logger } from '@/utils/logger';
-import { useStreamStore } from '@/store/streamStore';
+import { registerActiveStreams } from '@/utils/activeStreams';
 import { chatService } from '@/services/chatService';
 
 // Restores local streams in one bulk request — the backend enumerates its
@@ -14,14 +14,7 @@ export function useLocalStreamRestoration({ enabled }: { enabled: boolean }) {
     hasRestoredRef.current = true;
 
     const restore = async () => {
-      const active = await chatService.getActiveStreams();
-      for (const stream of active) {
-        useStreamStore.getState().addStreamMetadataIfAbsent({
-          chatId: stream.chat_id,
-          messageId: stream.message_id,
-          startTime: Date.now(),
-        });
-      }
+      registerActiveStreams(await chatService.getActiveStreams());
     };
 
     restore().catch((error) => {

--- a/frontend/src/pages/ChatPage/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage/ChatPage.tsx
@@ -22,7 +22,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useChatQuery, markChatViewed } from '@/hooks/queries/useChatQueries';
 import { useSandboxFiles } from '@/hooks/useSandboxFiles';
 import { useWorkspacesList, useWorkspaceResourcesQuery } from '@/hooks/queries/useWorkspaceQueries';
-import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
+import { useSettingsForChatQuery } from '@/hooks/queries/useSettingsQueries';
 import { ChatProvider } from '@/contexts/ChatContext';
 import { SubThreadDialog } from './SubThreadDialog';
 import styles from './ChatPage.module.scss';
@@ -140,7 +140,9 @@ export function ChatPage() {
   }, [activeViews, currentChat?.sandbox_id, refetchFilesMetadata]);
 
   const workspaces = useWorkspacesList();
-  const { data: settings } = useSettingsQuery();
+  // Routes to the instance that owns the chat so a cloud chat's persona selector
+  // shows the VPS's personas (and sends resolve the selected name against them).
+  const { data: settings } = useSettingsForChatQuery(chatId);
 
   const { data: workspaceResources } = useWorkspaceResourcesQuery(
     currentChat?.workspace_id,

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -243,16 +243,17 @@ function normalizePositiveInt(value: unknown): number {
   return Math.floor(parsed);
 }
 
-function createChatEventsSource(): EventSource {
+async function createChatEventsSource(): Promise<EventSource> {
   // Local backend only — the VPS feed is opened separately via
   // cloudChatService.createChatEventsSource, against the remote client's auth.
-  const token = apiClient.getToken();
+  // EventSource bypasses APIClient's 401→refresh path and access tokens are
+  // short-lived, so mint a valid token up front instead of using the cached one.
+  const token = await apiClient.getValidToken();
   if (!token) {
     throw new Error('Authentication token required');
   }
 
-  const params = new URLSearchParams();
-  params.append('token', token);
+  const params = new URLSearchParams({ token });
   return new EventSource(`${apiClient.getBaseUrl()}/chat/chats/events?${params.toString()}`);
 }
 

--- a/frontend/src/services/cloudChatService.ts
+++ b/frontend/src/services/cloudChatService.ts
@@ -10,7 +10,7 @@ import type {
   WorkspaceResources,
   UpdateWorkspaceRequest,
 } from '@/types/workspace.types';
-import type { Chat, ChatRequest, CreateChatRequest } from '@/types/chat.types';
+import type { Chat, ChatRequest, ChatSearchResponse, CreateChatRequest } from '@/types/chat.types';
 import type { ActiveStreamSnapshot } from '@/types/stream.types';
 import type { PaginatedChats, PaginatedResponse } from '@/types/api.types';
 
@@ -72,6 +72,20 @@ async function listWorkspaces(): Promise<Workspace[]> {
   });
 }
 
+// Search the VPS's chats — the search panel merges these with local results.
+// Marks returned chat IDs cloud-owned so opening a result routes to the VPS.
+async function searchChats(query: string): Promise<ChatSearchResponse> {
+  return serviceCall(async () => {
+    const queryString = buildQueryString({ q: query });
+    const response = await remoteApiClient.get<ChatSearchResponse>(
+      `/chat/chats/search${queryString}`,
+    );
+    const data = ensureResponse(response, 'Failed to search cloud chats');
+    markCloudChats(data.results.map((result) => result.chat_id));
+    return data;
+  });
+}
+
 async function createChat(data: CreateChatRequest): Promise<Chat> {
   return serviceCall(async () => {
     const response = await remoteApiClient.post<Chat>('/chat/chats', data);
@@ -92,6 +106,14 @@ async function updateWorkspace(
 async function deleteWorkspace(workspaceId: string): Promise<void> {
   await serviceCall(async () => {
     await remoteApiClient.delete(`/workspaces/${workspaceId}`);
+  });
+}
+
+// Cloud half of Settings → "Delete All Chats": the sidebar presents one merged
+// list, so the wipe must reach the VPS's chats too.
+async function deleteAllChats(): Promise<void> {
+  await serviceCall(async () => {
+    await remoteApiClient.delete('/chat/chats/all');
   });
 }
 
@@ -158,7 +180,9 @@ export const cloudChatService = {
   updateWorkspace,
   deleteWorkspace,
   listChats,
+  searchChats,
   createChat,
+  deleteAllChats,
   getWorkspaceResources,
   getSettings,
   startCompletion,

--- a/frontend/src/services/githubService.ts
+++ b/frontend/src/services/githubService.ts
@@ -1,8 +1,14 @@
-import { apiClient } from '@/lib/api';
-import { ensureResponse, withAuth, buildQueryString } from '@/services/base/BaseService';
+import { apiClient, resolveChatClient } from '@/lib/api';
+import {
+  ensureResponse,
+  serviceCall,
+  withAuth,
+  buildQueryString,
+} from '@/services/base/BaseService';
 import type {
   GitHubReposResponse,
   GitHubPRListResponse,
+  GitHubCollaborator,
   CreatePRRequest,
   CreatePRResponse,
   GenerateCommitMessageRequest,
@@ -11,6 +17,13 @@ import type {
   GeneratePRDescriptionResponse,
 } from '@/types/github.types';
 
+// Repo search backs local workspace creation (no chat exists yet), so it always
+// targets the local instance and uses withAuth (auth failure = local session
+// dead). Everything else is invoked from a chat's git dialogs and must use the
+// GitHub credentials of the backend that owns the chat — a cloud chat's
+// PRs/commits go through the VPS's GitHub connection. Routed calls use
+// serviceCall like chatService's: withAuth would tear down the LOCAL session on
+// a VPS auth failure, while APIClient already handles per-client expiry.
 async function searchRepositories(
   query: string,
   page: number,
@@ -23,26 +36,39 @@ async function searchRepositories(
   });
 }
 
-async function listPullRequests(owner: string, repo: string): Promise<GitHubPRListResponse> {
-  return withAuth(async () => {
+async function listPullRequests(
+  owner: string,
+  repo: string,
+  chatId?: string,
+): Promise<GitHubPRListResponse> {
+  return serviceCall(async () => {
     const qs = buildQueryString({ owner, repo });
-    const response = await apiClient.get<GitHubPRListResponse>(`/github/pulls${qs}`);
+    const response = await resolveChatClient(chatId).get<GitHubPRListResponse>(
+      `/github/pulls${qs}`,
+    );
     return ensureResponse(response, 'Failed to fetch pull requests');
   });
 }
 
-async function createPullRequest(request: CreatePRRequest): Promise<CreatePRResponse> {
-  return withAuth(async () => {
-    const response = await apiClient.post<CreatePRResponse>('/github/pulls', request);
+async function createPullRequest(
+  request: CreatePRRequest,
+  chatId?: string,
+): Promise<CreatePRResponse> {
+  return serviceCall(async () => {
+    const response = await resolveChatClient(chatId).post<CreatePRResponse>(
+      '/github/pulls',
+      request,
+    );
     return ensureResponse(response, 'Failed to create pull request');
   });
 }
 
 async function generatePRDescription(
   request: GeneratePRDescriptionRequest,
+  chatId?: string,
 ): Promise<GeneratePRDescriptionResponse> {
-  return withAuth(async () => {
-    const response = await apiClient.post<GeneratePRDescriptionResponse>(
+  return serviceCall(async () => {
+    const response = await resolveChatClient(chatId).post<GeneratePRDescriptionResponse>(
       '/github/generate-pr-description',
       request,
     );
@@ -52,9 +78,10 @@ async function generatePRDescription(
 
 async function generateCommitMessage(
   request: GenerateCommitMessageRequest,
+  chatId?: string,
 ): Promise<GenerateCommitMessageResponse> {
-  return withAuth(async () => {
-    const response = await apiClient.post<GenerateCommitMessageResponse>(
+  return serviceCall(async () => {
+    const response = await resolveChatClient(chatId).post<GenerateCommitMessageResponse>(
       '/github/generate-commit-message',
       request,
     );
@@ -65,10 +92,11 @@ async function generateCommitMessage(
 async function getCollaborators(
   owner: string,
   repo: string,
-): Promise<Array<{ login: string; avatar_url: string }>> {
-  return withAuth(async () => {
+  chatId?: string,
+): Promise<GitHubCollaborator[]> {
+  return serviceCall(async () => {
     const qs = buildQueryString({ owner, repo });
-    const response = await apiClient.get<Array<{ login: string; avatar_url: string }>>(
+    const response = await resolveChatClient(chatId).get<GitHubCollaborator[]>(
       `/github/collaborators${qs}`,
     );
     return ensureResponse(response, 'Failed to fetch collaborators');

--- a/frontend/src/types/github.types.ts
+++ b/frontend/src/types/github.types.ts
@@ -32,6 +32,11 @@ export interface GitHubPRListResponse {
   items: GitHubPullRequest[];
 }
 
+export interface GitHubCollaborator {
+  login: string;
+  avatar_url: string;
+}
+
 export interface CreatePRRequest {
   owner: string;
   repo: string;

--- a/frontend/src/utils/activeStreams.ts
+++ b/frontend/src/utils/activeStreams.ts
@@ -1,0 +1,34 @@
+import { useStreamStore } from '@/store/streamStore';
+import { logger } from '@/utils/logger';
+import type { ActiveStreamSnapshot } from '@/types/stream.types';
+
+// Registers a backend's active-streams snapshot so sidebar/tab streaming
+// indicators cover turns started while this client wasn't listening — startup
+// restoration and post-gap SSE resyncs. Already-tracked streams are untouched.
+export function registerActiveStreams(streams: ActiveStreamSnapshot[]): void {
+  for (const stream of streams) {
+    useStreamStore.getState().addStreamMetadataIfAbsent({
+      chatId: stream.chat_id,
+      messageId: stream.message_id,
+      startTime: Date.now(),
+    });
+  }
+}
+
+// Post-gap resync for the SSE feeds: fetch the backend's snapshot and register
+// it, skipping registration when the subscribing effect already tore down —
+// a late response from a logged-out session or switched VPS must not write
+// ghost metadata into the global store.
+export function resyncActiveStreams(
+  getStreams: () => Promise<ActiveStreamSnapshot[]>,
+  isCancelled: () => boolean,
+  logContext: string,
+): void {
+  getStreams()
+    .then((streams) => {
+      if (!isCancelled()) registerActiveStreams(streams);
+    })
+    .catch((error: unknown) => {
+      logger.error('Active stream resync failed', logContext, error);
+    });
+}

--- a/frontend/src/utils/chatEventsFeed.ts
+++ b/frontend/src/utils/chatEventsFeed.ts
@@ -1,0 +1,68 @@
+import { logger } from '@/utils/logger';
+
+const REOPEN_DELAY_MS = 15_000;
+
+// Keeps a per-user chat lifecycle SSE feed alive. EventSource retries transient
+// drops itself but treats HTTP errors as fatal (readyState CLOSED) — e.g. a 401
+// once the query-param token expires — so fatal closes reopen with a freshly
+// minted token via `createSource`. The backend feed is a pub/sub relay with no
+// replay, so events published during a gap are gone: any successful open that
+// follows a failure (native retry, fatal-close reopen, or a failed first
+// attempt) calls `onResync` so the subscriber can refetch what it missed.
+// Returns a cleanup that cancels retries and closes the feed.
+export function subscribeChatEventsFeed(options: {
+  createSource: () => Promise<EventSource>;
+  onChatEvent: (event: MessageEvent) => void;
+  onResync: () => void;
+  logContext: string;
+}): () => void {
+  const { createSource, onChatEvent, onResync, logContext } = options;
+  let source: EventSource | undefined;
+  let cancelled = false;
+  let retryTimer: number | undefined;
+  let needsResync = false;
+
+  const scheduleReopen = () => {
+    if (cancelled) return;
+    retryTimer = window.setTimeout(openFeed, REOPEN_DELAY_MS);
+  };
+
+  const openFeed = () => {
+    createSource()
+      .then((eventSource) => {
+        if (cancelled) {
+          eventSource.close();
+          return;
+        }
+        source = eventSource;
+        // Custom event names hit the generic EventTarget overload, which takes Event.
+        source.addEventListener('chat_event', (event: Event) => onChatEvent(event as MessageEvent));
+        source.onopen = () => {
+          if (needsResync) {
+            needsResync = false;
+            onResync();
+          }
+        };
+        source.onerror = () => {
+          // Any error marks a potential gap — including transient drops the
+          // EventSource retries natively without reaching the CLOSED branch.
+          needsResync = true;
+          if (source?.readyState !== EventSource.CLOSED) return;
+          scheduleReopen();
+        };
+      })
+      .catch((error: unknown) => {
+        logger.error('Chat events stream failed to open', logContext, error);
+        needsResync = true;
+        scheduleReopen();
+      });
+  };
+
+  openFeed();
+
+  return () => {
+    cancelled = true;
+    window.clearTimeout(retryTimer);
+    source?.close();
+  };
+}


### PR DESCRIPTION
## Summary
- Settings, GitHub PR/commit generation, and attachment fetches always hit the local backend, even for chats owned by a cloud VPS — cloud chats showed the wrong personas/stream actions and used the wrong GitHub credentials. These now route through `resolveChatClient`/`useSettingsForChatQuery` based on chat origin.
- Unified the local and cloud SSE reconnect/resync logic into shared utilities (`chatEventsFeed.ts`, `activeStreams.ts`) so both feeds get fatal-close reopen with a fresh token and post-gap resync (missed events, active-stream re-registration).
- Chat search (`ChatSearchPanel`) and "Delete All Chats" now span both local and cloud backends, consistent with how the sidebar already merges both lists.
- Local chat-events SSE now mints a fresh token instead of reusing a possibly-expired cached one.