### PR TITLE
fix: always refetch chat list on mount

### DIFF
--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -78,6 +78,11 @@ export const useInfiniteChatsQuery = (options?: {
     initialPageParam: 1,
     enabled: options?.enabled ?? true,
     gcTime: 1000 * 60 * 1,
+    // The list hydrates from the persisted localStorage snapshot for a fast
+    // first paint; always refetch behind it so chats created out-of-band
+    // (another device, MCP) surface on load even when the snapshot is fresher
+    // than the default staleTime.
+    refetchOnMount: 'always',
   });
 };
 


### PR DESCRIPTION
## Summary
- The chat list hydrates instantly from a persisted localStorage snapshot for fast first paint, but relied on the query's default `staleTime` to trigger a refetch.
- Chats created out-of-band (another device, MCP automation) could stay hidden until the snapshot went stale.
- Sets `refetchOnMount: 'always'` so the list always revalidates behind the cached snapshot on mount, regardless of staleness.