### PR TITLE
fix: correct cache headers for hashed vs unhashed assets

### DIFF
--- a/frontend/nginx-production.conf
+++ b/frontend/nginx-production.conf
@@ -33,7 +33,16 @@ server {
     proxy_pass http://api:8080/health;
   }
 
+  # Vite content-hashes everything under /assets/, so cache those forever and
+  # force revalidation on everything else (index.html above all) — otherwise
+  # browsers heuristically cache index.html and keep loading the previous
+  # deploy's bundles in new tabs.
+  location /assets/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+
   location / {
+    add_header Cache-Control "no-cache";
     try_files $uri $uri/ /index.html;
   }
 }


### PR DESCRIPTION
## Summary
- Cache `/assets/` (Vite content-hashed bundles) forever with `immutable`
- Force revalidation on `index.html` and everything else via `no-cache`, so new tabs always pick up the latest deploy's bundle references instead of getting stuck on a stale `index.html`