### PR TITLE
fix: mark SSE feeds no-transform so proxy compression can't stall them

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -301,7 +301,12 @@ async def stream_user_chat_events(
     return EventSourceResponse(
         chat_service.create_chat_events_stream(current_user.id),
         headers={
-            "Cache-Control": "no-cache",
+            # no-transform: compression middlewares (Traefik compress, Caddy
+            # encode) buffer the first ~1KB of a response to decide whether to
+            # compress, which stalls a sparse SSE feed — events sit in the
+            # encoder until keep-alive pings fill the buffer. Both skip
+            # responses marked no-transform. X-Accel-Buffering covers nginx.
+            "Cache-Control": "no-cache, no-transform",
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",
         },
@@ -334,7 +339,12 @@ async def stream_user_streams(
     return EventSourceResponse(
         chat_service.create_user_streams_feed(current_user.id, replay_cursors),
         headers={
-            "Cache-Control": "no-cache",
+            # no-transform: compression middlewares (Traefik compress, Caddy
+            # encode) buffer the first ~1KB of a response to decide whether to
+            # compress, which stalls a sparse SSE feed — events sit in the
+            # encoder until keep-alive pings fill the buffer. Both skip
+            # responses marked no-transform. X-Accel-Buffering covers nginx.
+            "Cache-Control": "no-cache, no-transform",
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",
         },


### PR DESCRIPTION
## Problem
Chats created from the desktop app (cloud run location) only appeared on the web app after 15–20 seconds, even with the live SSE feed connected and healthy.

## Root cause
Reverse-proxy compression middlewares (Traefik `compress`, Caddy `encode`) buffer the first ~1KB of a response body before deciding whether to compress. The `/chat/chats/events` feed is extremely sparse (~40 bytes of keep-alive ping per 15s), so browser clients — which advertise `zstd`/`br` — received **nothing, not even response headers**, until events slowly filled the encoder buffer.

Verified against the production deployment:
- `Accept-Encoding: zstd` / `br` → feed hangs, `EventSource` stuck in CONNECTING
- `Accept-Encoding: gzip` or none → streams instantly
- Creating ~1.3KB of events at once forced an immediate flush (buffer-threshold behavior confirmed)

## Fix
`Cache-Control: no-cache, no-transform` on both SSE endpoints (`/chats/events`, `/chats/streams`). Traefik and Caddy both skip responses marked `no-transform`; `X-Accel-Buffering: no` already covers nginx.

## Testing
- `pytest tests/test_streaming.py` — 20 passed