### PR TITLE
revert: drop SSE no-transform workaround — proxy compression disabled at source

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -301,12 +301,7 @@ async def stream_user_chat_events(
     return EventSourceResponse(
         chat_service.create_chat_events_stream(current_user.id),
         headers={
-            # no-transform: compression middlewares (Traefik compress, Caddy
-            # encode) buffer the first ~1KB of a response to decide whether to
-            # compress, which stalls a sparse SSE feed — events sit in the
-            # encoder until keep-alive pings fill the buffer. Both skip
-            # responses marked no-transform. X-Accel-Buffering covers nginx.
-            "Cache-Control": "no-cache, no-transform",
+            "Cache-Control": "no-cache",
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",
         },
@@ -339,12 +334,7 @@ async def stream_user_streams(
     return EventSourceResponse(
         chat_service.create_user_streams_feed(current_user.id, replay_cursors),
         headers={
-            # no-transform: compression middlewares (Traefik compress, Caddy
-            # encode) buffer the first ~1KB of a response to decide whether to
-            # compress, which stalls a sparse SSE feed — events sit in the
-            # encoder until keep-alive pings fill the buffer. Both skip
-            # responses marked no-transform. X-Accel-Buffering covers nginx.
-            "Cache-Control": "no-cache, no-transform",
+            "Cache-Control": "no-cache",
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",
         },


### PR DESCRIPTION
## What happened
Chats created out-of-band (e.g. from the desktop app) took 15–20s to appear on the web app even though the SSE feed was connected. Root cause: **Coolify's per-app "Enable Gzip Compression" setting**. The proxy's compression middleware withholds the first ~1KB of a response — headers included — while deciding whether to compress. Browsers advertise `zstd`/`br`, so their `/chat/chats/events` connection received nothing until keep-alive pings (~40 bytes / 15s) slowly filled the buffer. curl without `Accept-Encoding` bypassed compression, which made the server look healthy.

## The actual fix
Turning off **Enable Gzip Compression** for the app in Coolify. The feeds are now real-time (compression of the API responses was providing little value anyway, and static assets can be compressed by the app's own nginx if desired).

## What this PR does
Reverts the `Cache-Control: no-transform` header added in #869 — verified against production that the proxy ignores it, so it was dead weight. This restores the SSE endpoint headers to their pre-#869 state. (This PR originally added a 2KB padding prologue as a workaround; that's no longer needed and was dropped.)

## Note for self-hosters
Any deployment that puts a compressing proxy (Traefik `compress`, Caddy `encode`) in front of the API will reintroduce the stall — worth a mention in deployment docs.

## Testing
- `pytest tests/test_streaming.py` — 20 passed