### PR TITLE
Simplify git diff to all/branch modes, fix unborn-HEAD duplicate diffs

### DIFF
--- a/backend/app/api/endpoints/sandbox.py
+++ b/backend/app/api/endpoints/sandbox.py
@@ -133,7 +133,7 @@ async def download_sandbox_files(
 async def get_git_diff(
     sandbox_id: str = Depends(validate_sandbox_ownership),
     git_service: GitService = Depends(get_git_service),
-    mode: Literal["all", "staged", "unstaged", "branch"] = Query("all"),
+    mode: Literal["all", "branch"] = Query("all"),
     full_context: bool = Query(False),
     cwd: str | None = Query(None),
 ) -> GitDiffResponse:

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -243,6 +243,9 @@ MODELS: dict[str, ModelInfo] = {
     "opencode:opencode-go/glm-5.2": ModelInfo(
         "GLM-5.2 (Opencode Go)", AgentKind.OPENCODE, 1_000_000
     ),
+    "opencode:opencode-go/grok-4.5": ModelInfo(
+        "Grok 4.5 (Opencode Go)", AgentKind.OPENCODE, 500_000
+    ),
     "opencode:opencode-go/hy3-preview": ModelInfo(
         "Hy3 Preview (Opencode Go)", AgentKind.OPENCODE, 256_000
     ),
@@ -254,6 +257,9 @@ MODELS: dict[str, ModelInfo] = {
     ),
     "opencode:opencode-go/kimi-k2.7-code": ModelInfo(
         "Kimi K2.7 Code (Opencode Go)", AgentKind.OPENCODE, 262_144
+    ),
+    "opencode:opencode-go/kimi-k3": ModelInfo(
+        "Kimi K3 (Opencode Go)", AgentKind.OPENCODE, 1_048_576
     ),
     "opencode:opencode-go/mimo-v2-omni": ModelInfo(
         "MiMo V2 Omni (Opencode Go)", AgentKind.OPENCODE, 262_144

--- a/backend/app/services/git.py
+++ b/backend/app/services/git.py
@@ -98,25 +98,25 @@ GIT_WORKTREE_REMOVE_TEMPLATE = Template(
     "git worktree remove '$worktree_dir' 2>&1 && git branch -d '$branch_name' 2>&1"
 )
 
-GIT_DIFF_STAGED_TEMPLATE = Template("git diff$ctx --cached 2>/dev/null")
-GIT_DIFF_UNSTAGED_TEMPLATE = Template("git diff$ctx 2>/dev/null;$untracked")
 # "all" mode: try `git diff HEAD` first (combined staged+unstaged in one pass);
-# falls back to separate staged + unstaged when HEAD doesn't exist (initial
-# commit).
+# falls back to diffing against the empty tree when HEAD doesn't exist (unborn
+# branch) — same combined view, whereas running `--cached` and the plain diff
+# back-to-back emits a staged-then-modified file twice and downstream parsing
+# keys files by path. `hash-object -t tree /dev/null` yields the empty-tree id
+# for the repo's object format (the stock pre-commit-hook idiom).
 GIT_DIFF_ALL_TEMPLATE = Template(
-    "{ git diff$ctx HEAD 2>/dev/null"
-    " || { git diff$ctx --cached 2>/dev/null; git diff$ctx 2>/dev/null; }; };"
+    "git diff$ctx HEAD 2>/dev/null"
+    " || git diff$ctx $$(git hash-object -t tree /dev/null) 2>/dev/null;"
     "$untracked"
 )
 # Default context (no -U flag): restore resets --hard to base_head before
 # applying, and changed-files builds its temp index from exactly base_head, so
 # the patch base is always byte-identical — full-file context would only bloat
 # every checkpoint row stored in the DB.
+# No unborn-HEAD fallback (unlike GIT_DIFF_ALL_TEMPLATE): the checkpoint probe
+# already required a resolvable HEAD before this diff runs.
 GIT_CHECKPOINT_DIFF_ALL_TEMPLATE = Template(
-    "{ git diff --binary HEAD 2>/dev/null"
-    " || { git diff --binary --cached 2>/dev/null; "
-    "git diff --binary 2>/dev/null; }; };"
-    "$untracked"
+    "git diff --binary HEAD 2>/dev/null;$untracked"
 )
 GIT_UNTRACKED_DIFF_TEMPLATE = Template(
     " git ls-files --others --exclude-standard -z"
@@ -226,7 +226,7 @@ class GitService:
     async def get_diff(
         self,
         sandbox_id: str,
-        mode: Literal["all", "staged", "unstaged", "branch"] = "all",
+        mode: Literal["all", "branch"] = "all",
         full_context: bool = False,
         cwd: str | None = None,
     ) -> GitDiffResponse:
@@ -245,12 +245,6 @@ class GitService:
 
         if mode == "branch":
             cmd = GIT_DIFF_BRANCH_TEMPLATE.substitute(ctx=ctx)
-        elif mode == "staged":
-            cmd = GIT_DIFF_STAGED_TEMPLATE.substitute(ctx=ctx)
-        elif mode == "unstaged":
-            cmd = GIT_DIFF_UNSTAGED_TEMPLATE.substitute(
-                ctx=ctx, untracked=untracked_diff
-            )
         else:
             cmd = GIT_DIFF_ALL_TEMPLATE.substitute(ctx=ctx, untracked=untracked_diff)
 

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -284,8 +284,7 @@ async def test_git_endpoints_propagate_cwd_and_request_fields(
     sandbox_id = workspace.sandbox_id
 
     diff_response = await client.get(
-        f"/api/v1/sandbox/{sandbox_id}/git/diff"
-        "?mode=staged&full_context=true&cwd=packages/api",
+        f"/api/v1/sandbox/{sandbox_id}/git/diff?full_context=true&cwd=packages/api",
         headers=headers,
     )
     branches_response = await client.get(
@@ -341,7 +340,7 @@ async def test_git_endpoints_propagate_cwd_and_request_fields(
         )
         for command in commands
     )
-    assert any("git diff -U99999 --cached" in command for command in commands)
+    assert any("git diff -U99999 HEAD" in command for command in commands)
     assert any("git for-each-ref" in command for command in commands)
     assert any("git checkout 'feature'" in command for command in commands)
     assert any("git commit -m 'Update API'" in command for command in commands)
@@ -550,7 +549,7 @@ async def test_git_diff_not_a_repo(
     }
 
 
-async def test_git_diff_unstaged_and_branch_success_modes(
+async def test_git_diff_default_and_branch_success_modes(
     client: AsyncClient,
     db_session: AsyncSession,
     create_user: UserFactory,
@@ -564,10 +563,6 @@ async def test_git_diff_unstaged_and_branch_success_modes(
     default_mode_response = await client.get(
         f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff", headers=headers
     )
-    unstaged_response = await client.get(
-        f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff?mode=unstaged",
-        headers=headers,
-    )
     branch_response = await client.get(
         f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff?mode=branch",
         headers=headers,
@@ -575,8 +570,6 @@ async def test_git_diff_unstaged_and_branch_success_modes(
 
     assert default_mode_response.status_code == 200
     assert default_mode_response.json()["is_git_repo"] is True
-    assert unstaged_response.status_code == 200
-    assert unstaged_response.json()["is_git_repo"] is True
     assert branch_response.status_code == 200
     assert branch_response.json()["is_git_repo"] is True
 
@@ -1410,8 +1403,7 @@ async def test_host_provider_runs_real_git_commands(
         f"/api/v1/sandbox/{workspace.sandbox_id}/git/branches", headers=headers
     )
     diff_response = await client.get(
-        f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff?mode=unstaged",
-        headers=headers,
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff", headers=headers
     )
     remote_response = await client.get(
         f"/api/v1/sandbox/{workspace.sandbox_id}/git/remote-url", headers=headers
@@ -1447,6 +1439,55 @@ async def test_host_provider_runs_real_git_commands(
         "type": "file",
         "is_binary": False,
     } in metadata_files
+
+
+async def test_git_diff_unborn_head_emits_each_file_once(
+    tmp_path: Path,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    # Real git against a repo with no commits: `git diff HEAD` fails, so "all"
+    # mode falls back to diffing the worktree against the empty tree. The old
+    # `--cached` + plain-diff fallback emitted a staged-then-modified file
+    # twice, which downstream parsing (keyed by path) can't represent.
+    workspace_dir = tmp_path / "unborn-workspace"
+    workspace_dir.mkdir()
+    subprocess.run(
+        ["git", "-c", "init.defaultBranch=main", "init", "-q"],
+        cwd=workspace_dir,
+        check=True,
+    )
+    (workspace_dir / "app.py").write_text("print('v1')\n")
+    subprocess.run(["git", "add", "."], cwd=workspace_dir, check=True)
+    (workspace_dir / "app.py").write_text("print('v1')\nprint('v2')\n")
+    (workspace_dir / "notes.txt").write_text("untracked\n")
+
+    headers, workspace = await create_host_workspace(
+        db_session,
+        create_user,
+        login,
+        workspace_dir,
+        email="unborn@example.com",
+        username="unborn",
+    )
+
+    response = await client.get(
+        f"/api/v1/sandbox/{workspace.sandbox_id}/git/diff", headers=headers
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["is_git_repo"] is True
+    assert body["has_changes"] is True
+    diff = body["diff"]
+    # One section per file: the staged-then-modified file exactly once, with
+    # combined worktree content, plus the untracked file.
+    assert diff.count("diff --git a/app.py b/app.py") == 1
+    assert "print('v2')" in diff
+    assert "diff --git a/notes.txt b/notes.txt" in diff
+    assert diff.count("diff --git") == 2
 
 
 async def test_git_endpoint_injects_github_token_env(

--- a/frontend/src/components/sandbox/git/DiffFileSidebar/DiffFileSidebar.tsx
+++ b/frontend/src/components/sandbox/git/DiffFileSidebar/DiffFileSidebar.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useMemo, useRef } from 'react';
 import { CheckCircle2, Circle } from 'lucide-react';
-import type { FileDiffMetadata } from '@pierre/diffs';
+import type { ChangeTypes, FileDiffMetadata } from '@pierre/diffs';
 import { Button } from '@/components/ui/primitives/Button/Button';
 import { FloatingTooltip } from '@/components/ui/FloatingTooltip/FloatingTooltip';
 import clsx from 'clsx';
@@ -12,7 +12,8 @@ export interface FileChangeStats {
 }
 
 // Single-letter badges — the sidebar is too narrow for the full status words.
-const SIDEBAR_BADGES: Record<string, { label: string; modifier: string }> = {
+// Plain `change` rows intentionally have none.
+const SIDEBAR_BADGES: Partial<Record<ChangeTypes, { label: string; modifier: string }>> = {
   new: { label: 'N', modifier: styles['badge--new'] },
   deleted: { label: 'D', modifier: styles['badge--deleted'] },
   'rename-pure': { label: 'R', modifier: styles['badge--renamed'] },
@@ -59,18 +60,20 @@ function DirLabel({ dir }: { dir: string }) {
 export const DiffFileSidebar = memo(function DiffFileSidebar({
   files,
   statsByFile,
+  totals,
   activeFile,
   onSelectFile,
   reviewedFiles,
 }: {
   files: FileDiffMetadata[];
   statsByFile: Map<string, FileChangeStats>;
+  totals: FileChangeStats;
   activeFile: string | null;
   onSelectFile: (name: string) => void;
   reviewedFiles: Set<string>;
 }) {
-  // Git emits paths sorted, so same-directory files are contiguous — consecutive
-  // grouping is enough, no tree build needed.
+  // Files arrive dir-major sorted (DiffView's parsedFiles), so a directory's
+  // files are contiguous — consecutive grouping is enough, no tree build needed.
   const groups = useMemo(() => {
     const out: { dir: string; files: FileDiffMetadata[] }[] = [];
     for (const file of files) {
@@ -83,24 +86,16 @@ export const DiffFileSidebar = memo(function DiffFileSidebar({
     return out;
   }, [files]);
 
-  const totals = useMemo(() => {
-    let additions = 0;
-    let deletions = 0;
-    statsByFile.forEach((stats) => {
-      additions += stats.additions;
-      deletions += stats.deletions;
-    });
-    return { additions, deletions };
-  }, [statsByFile]);
-
-  // Keep the scrollspy-highlighted row visible as the diff pane scrolls.
+  // Keep the scrollspy-highlighted row visible as the diff pane scrolls. `files`
+  // is a dep too: a refetch can rebuild the list (moving the row) while the
+  // active file stays the same.
   const listRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!activeFile) return;
     listRef.current
       ?.querySelector(`[data-sidebar-file="${CSS.escape(activeFile)}"]`)
       ?.scrollIntoView({ block: 'nearest' });
-  }, [activeFile]);
+  }, [activeFile, files]);
 
   return (
     <div className={styles.sidebar}>
@@ -120,7 +115,7 @@ export const DiffFileSidebar = memo(function DiffFileSidebar({
             {group.files.map((file) => {
               const isActive = file.name === activeFile;
               const isReviewed = reviewedFiles.has(file.name);
-              const badge = file.type ? SIDEBAR_BADGES[file.type] : undefined;
+              const badge = SIDEBAR_BADGES[file.type];
               const stats = statsByFile.get(file.name);
               return (
                 <FloatingTooltip

--- a/frontend/src/components/sandbox/git/DiffView/DiffToolbar.tsx
+++ b/frontend/src/components/sandbox/git/DiffView/DiffToolbar.tsx
@@ -151,11 +151,10 @@ export function DiffToolbar({
       {!isNarrow && showFiles && (
         <div className={styles.progress}>
           <div className={styles['progress-track']}>
+            {/* showFiles guarantees parsedFiles is non-empty. */}
             <div
               className={styles['progress-fill']}
-              style={{
-                width: `${parsedFiles.length > 0 ? (reviewedCount / parsedFiles.length) * 100 : 0}%`,
-              }}
+              style={{ width: `${(reviewedCount / parsedFiles.length) * 100}%` }}
             />
           </div>
           <span className={styles['progress-label']}>

--- a/frontend/src/components/sandbox/git/DiffView/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView/DiffView.tsx
@@ -27,6 +27,7 @@ import {
   DIFF_THEMES,
   DIFF_UNSAFE_CSS,
   NARROW_BREAKPOINT,
+  compareFilePaths,
   computeMenuPos,
   computeOverflowMenuPos,
   hashDiffContent,
@@ -183,6 +184,7 @@ const DiffViewContent = memo(function DiffViewContent({
             ? f
             : rebuildWithCollapsedContext(f, parseDiffFromFile),
         )
+        .sort((a, b) => compareFilePaths(a.name, b.name))
     );
   }, [diffContent, diffCacheKey]);
 
@@ -220,6 +222,7 @@ const DiffViewContent = memo(function DiffViewContent({
   } = useDiffReview({
     parsedFiles,
     scopeKey,
+    isPlaceholder: isPlaceholderData,
     collapsedFiles,
     setCollapsedFiles,
     toggleCollapsed,
@@ -295,6 +298,7 @@ const DiffViewContent = memo(function DiffViewContent({
     <DiffFileSidebar
       files={parsedFiles}
       statsByFile={statsByFile}
+      totals={totals}
       activeFile={currentFile}
       onSelectFile={selectFile}
       reviewedFiles={reviewedNames}

--- a/frontend/src/components/sandbox/git/DiffView/diffView.utils.ts
+++ b/frontend/src/components/sandbox/git/DiffView/diffView.utils.ts
@@ -8,10 +8,10 @@ export const DIFF_THEMES = { dark: 'pierre-dark', light: 'pierre-light' } as con
 // on scroll + rAF) and flashes unstyled text or striped buffer regions.
 export const VIRTUALIZER_CONFIG = { overscrollSize: 2500, intersectionObserverMargin: 10000 };
 
+// Label-only rename: `all` stays the wire value — query keys, the scopeKey,
+// and persisted review-✓ state are keyed by it.
 export const DIFF_MODE_OPTIONS = [
-  { value: 'all', label: 'All' },
-  { value: 'staged', label: 'Staged' },
-  { value: 'unstaged', label: 'Unstaged' },
+  { value: 'all', label: 'Uncommitted' },
   { value: 'branch', label: 'Branch' },
 ] satisfies { value: DiffMode; label: string }[];
 
@@ -31,9 +31,7 @@ export const SCROLL_KEYS = new Set([
 ]);
 
 export const DIFF_EMPTY_LABELS: Record<DiffMode, string> = {
-  all: 'No changes',
-  staged: 'No staged changes',
-  unstaged: 'No unstaged changes',
+  all: 'No uncommitted changes',
   branch: 'No changes from base branch',
 };
 
@@ -67,11 +65,31 @@ export const computeOverflowMenuPos = (rect: DOMRect) => ({
   ),
 });
 
+// Dir-major path order: a directory's files sort together, before any of its
+// subdirectories' files. The raw patch isn't display-ordered (untracked diffs
+// are appended after the tracked diff), and even git's own path sort splits a
+// directory (`a/sub/x.ts` lands between `a/b.ts` and `a/z.ts`). The sidebar's
+// consecutive dir grouping and its sidebar-order == scroll-order assumption
+// both rely on this ordering.
+export function compareFilePaths(a: string, b: string): number {
+  const dirA = a.slice(0, a.lastIndexOf('/') + 1);
+  const dirB = b.slice(0, b.lastIndexOf('/') + 1);
+  if (dirA !== dirB) return dirA < dirB ? -1 : 1;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
 // Nearest scrollable ancestor, bounded to the diff pane — the Virtualizer owns
-// the scroll container and doesn't expose a ref to it.
+// the scroll container and doesn't expose a ref to it. The overflow style is
+// checked, not just the heights: scrollHeight/clientHeight round to integers,
+// so with fractional layout heights (retina/zoom) a plain flow div can read
+// scrollHeight == clientHeight + 1. Height comparison alone then picks the
+// Virtualizer's content wrapper, where scrollTop writes are silently clamped
+// to 0 and jump-to-file dies without a trace.
 export function findScroller(el: HTMLElement, boundary: HTMLElement | null): HTMLElement | null {
   for (let p = el.parentElement; p && p !== boundary; p = p.parentElement) {
-    if (p.scrollHeight > p.clientHeight) return p;
+    const { overflowY } = getComputedStyle(p);
+    const scrollable = overflowY === 'auto' || overflowY === 'scroll';
+    if (scrollable && p.scrollHeight > p.clientHeight) return p;
   }
   return null;
 }

--- a/frontend/src/components/sandbox/git/DiffView/useDiffReview.ts
+++ b/frontend/src/components/sandbox/git/DiffView/useDiffReview.ts
@@ -13,6 +13,9 @@ import { hashDiffContent } from './diffView.utils';
 interface UseDiffReviewParams {
   parsedFiles: FileDiffMetadata[];
   scopeKey: string;
+  // True while a scope switch is still serving the previous scope's rows
+  // (keepPreviousData) — parsedFiles and scopeKey disagree until the fetch lands.
+  isPlaceholder: boolean;
   collapsedFiles: Set<string>;
   setCollapsedFiles: Dispatch<SetStateAction<Set<string>>>;
   toggleCollapsed: (name: string) => void;
@@ -28,6 +31,7 @@ interface UseDiffReviewParams {
 export function useDiffReview({
   parsedFiles,
   scopeKey,
+  isPlaceholder,
   collapsedFiles,
   setCollapsedFiles,
   toggleCollapsed,
@@ -109,6 +113,9 @@ export function useDiffReview({
 
   const toggleReviewed = useCallback(
     (name: string) => {
+      // Placeholder rows belong to the previous scope — a ✓ would persist a key
+      // hashed from them under the new scope, which its real diff never matches.
+      if (isPlaceholder) return;
       const key = reviewKeyByFile.get(name);
       if (!key) return;
       const store = useDiffReviewStore.getState();
@@ -137,7 +144,7 @@ export function useDiffReview({
         });
       }
     },
-    [reviewKeyByFile, scopeKey, setCollapsedFiles],
+    [isPlaceholder, reviewKeyByFile, scopeKey, setCollapsedFiles],
   );
 
   return {

--- a/frontend/src/types/sandbox.types.ts
+++ b/frontend/src/types/sandbox.types.ts
@@ -21,7 +21,8 @@ export interface UpdateFileResult {
   message: string;
 }
 
-export type DiffMode = 'all' | 'staged' | 'unstaged' | 'branch';
+// `all` = uncommitted changes (worktree + index vs HEAD); shown as "Uncommitted".
+export type DiffMode = 'all' | 'branch';
 
 export interface GitDiffData {
   diff: string;


### PR DESCRIPTION
## Summary
- Drop the `staged`/`unstaged` diff modes; only `all` (uncommitted, renamed to "Uncommitted" in the UI) and `branch` remain.
- Fix `GIT_DIFF_ALL_TEMPLATE`'s unborn-HEAD fallback: it used to run `--cached` then a plain `diff` back-to-back, which could emit a staged-then-modified file twice (downstream parsing keys files by path and can't represent that). Now falls back to diffing against the empty tree in one pass.
- `DiffFileSidebar`/`DiffView`: sort parsed files into dir-major order so the sidebar's directory grouping and scroll-order assumptions hold; pass `totals` down instead of recomputing.
- `findScroller`: also check `overflow-y` is `auto`/`scroll`, not just height deltas — fractional layout heights could otherwise match the Virtualizer's non-scrollable content wrapper and silently break jump-to-file.
- `useDiffReview`: ignore `toggleReviewed` while a scope switch is still serving placeholder rows from the previous scope, so a checkmark can't get persisted under a key that the new scope's real diff will never match.
- Add two new Opencode Go models (Grok 4.5, Kimi K3) to `constants.py`.

## Test plan
- [x] `backend/tests/test_sandbox.py` updated: renamed/removed staged/unstaged assertions, added `test_git_diff_unborn_head_emits_each_file_once` covering the duplicate-diff bug against a real unborn-HEAD repo.
- [ ] Manually verify the DiffView sidebar/jump-to-file/review-checkbox behavior in the browser.