### PR TITLE
Add MCP persona CRUD, expose thinking-mode tiers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.57.0 @agentclientprotocol/codex-acp@1.1.2 @openai/codex@0.144.1 @github/copilot@1.0.36
+RUN npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.59.0 @agentclientprotocol/codex-acp@1.1.4 @openai/codex@0.144.1 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to /root/.local/bin) — used for the Cursor
 # ACP server (`cursor-agent acp`). The install script downloads the binary for

--- a/backend/app/api/endpoints/ai_model.py
+++ b/backend/app/api/endpoints/ai_model.py
@@ -4,7 +4,11 @@ from app.core.security import get_current_user
 from app.models.db_models.user import User
 from app.models.schemas.ai_model import AIModelResponse
 from app.constants import MODELS
-from app.services.acp.adapters import AgentKind
+from app.services.acp.adapters import (
+    THINKING_MODE_ORDER,
+    AgentKind,
+    valid_thinking_modes,
+)
 
 router = APIRouter()
 
@@ -30,6 +34,10 @@ async def list_models(
             name=info.display_name,
             agent_kind=info.agent_kind,
             context_window=info.context_window,
+            thinking_modes=sorted(
+                valid_thinking_modes(info.agent_kind, mid),
+                key=THINKING_MODE_ORDER.index,
+            ),
         )
         for mid, info in MODELS.items()
         if kind is None or info.agent_kind == kind

--- a/backend/app/models/schemas/ai_model.py
+++ b/backend/app/models/schemas/ai_model.py
@@ -8,3 +8,6 @@ class AIModelResponse(BaseModel):
     name: str
     agent_kind: AgentKind
     context_window: int | None = None
+    # Supported reasoning-effort tiers, ordered lowest to highest; empty when
+    # the model has no reasoning dial (thinking_mode is ignored for it).
+    thinking_modes: list[str] = []

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -106,6 +106,35 @@ PERSONAS_SUPPORTED_AGENTS: frozenset[AgentKind] = frozenset(
 )
 
 
+THINKING_MODE_ORDER = ("low", "medium", "high", "xhigh", "max", "ultra")
+
+
+def valid_thinking_modes(agent_kind: AgentKind, model_id: str) -> frozenset[str]:
+    # The thinking tiers a model actually accepts; empty means the model has no
+    # reasoning-effort dial (thinking_mode is ignored for it).
+    if agent_kind is AgentKind.CLAUDE:
+        return (
+            CLAUDE_XHIGH_VALID_THINKING_MODES
+            if model_id in CLAUDE_XHIGH_MODEL_IDS
+            else CLAUDE_VALID_THINKING_MODES
+        )
+    if agent_kind is AgentKind.CODEX:
+        if model_id in CODEX_ULTRA_MODEL_IDS:
+            return CODEX_ULTRA_VALID_THINKING_MODES
+        if model_id in CODEX_MAX_MODEL_IDS:
+            return CODEX_MAX_VALID_THINKING_MODES
+        return CODEX_VALID_THINKING_MODES
+    if agent_kind is AgentKind.COPILOT:
+        return COPILOT_VALID_THINKING_MODES
+    if agent_kind is AgentKind.GROK:
+        return (
+            GROK_VALID_THINKING_MODES
+            if model_id in GROK_REASONING_MODEL_IDS
+            else frozenset()
+        )
+    return frozenset()
+
+
 def coerce_thinking_mode(mode: str | None, valid_modes: frozenset[str]) -> str:
     # Normalises the UI's named thinking tier to one the agent actually accepts,
     # falling back to "medium" for None or unrecognised values.
@@ -229,14 +258,10 @@ class ClaudeAgentAdapter(AgentAdapter):
 
         # Claude exposes thinking budget as the "effort" session config option,
         # applied post-handshake via set_config_option; the UI's named tiers
-        # are passed through directly as effort level IDs. `xhigh` is only
-        # valid for selected Claude models, so others keep the narrower tier set.
-        valid_modes = (
-            CLAUDE_XHIGH_VALID_THINKING_MODES
-            if model_id in CLAUDE_XHIGH_MODEL_IDS
-            else CLAUDE_VALID_THINKING_MODES
+        # are passed through directly as effort level IDs.
+        reasoning_effort = coerce_thinking_mode(
+            thinking_mode, valid_thinking_modes(AgentKind.CLAUDE, model_id)
         )
-        reasoning_effort = coerce_thinking_mode(thinking_mode, valid_modes)
 
         return SessionConfig(
             meta=meta,
@@ -290,15 +315,9 @@ class CodexAgentAdapter(AgentAdapter):
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:
-        # GPT-5.6 adds `max` (and `ultra` on Sol/Terra); older Codex models
-        # keep the narrower tier set.
-        if model_id in CODEX_ULTRA_MODEL_IDS:
-            valid_modes = CODEX_ULTRA_VALID_THINKING_MODES
-        elif model_id in CODEX_MAX_MODEL_IDS:
-            valid_modes = CODEX_MAX_VALID_THINKING_MODES
-        else:
-            valid_modes = CODEX_VALID_THINKING_MODES
-        reasoning_effort = coerce_thinking_mode(thinking_mode, valid_modes)
+        reasoning_effort = coerce_thinking_mode(
+            thinking_mode, valid_thinking_modes(AgentKind.CODEX, model_id)
+        )
 
         # Codex config rides on the CODEX_CONFIG launch env var and the model
         # ID, not session meta.
@@ -348,7 +367,7 @@ class CopilotCliAdapter(AgentAdapter):
 
         # Copilot ACP exposes reasoning effort as a CLI/ACP value directly.
         reasoning_effort = coerce_thinking_mode(
-            thinking_mode, COPILOT_VALID_THINKING_MODES
+            thinking_mode, valid_thinking_modes(AgentKind.COPILOT, model_id)
         )
 
         return SessionConfig(
@@ -468,10 +487,9 @@ class GrokAgentAdapter(AgentAdapter):
             else:
                 meta["rules"] = system_prompt
 
+        grok_modes = valid_thinking_modes(AgentKind.GROK, model_id)
         reasoning_effort = (
-            coerce_thinking_mode(thinking_mode, GROK_VALID_THINKING_MODES)
-            if model_id in GROK_REASONING_MODEL_IDS
-            else None
+            coerce_thinking_mode(thinking_mode, grok_modes) if grok_modes else None
         )
 
         return SessionConfig(

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -36,7 +36,18 @@ async def test_list_models_returns_registered_models(
         "name": MODELS["haiku"].display_name,
         "agent_kind": MODELS["haiku"].agent_kind.value,
         "context_window": MODELS["haiku"].context_window,
+        "thinking_modes": ["low", "medium", "high", "max"],
     } in body
+    by_id = {item["model_id"]: item for item in body}
+    assert by_id["claude-fable-5"]["thinking_modes"] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
+    assert by_id["grok:grok-4.5"]["thinking_modes"] == ["low", "medium", "high"]
+    assert by_id["cursor:auto"]["thinking_modes"] == []
 
 
 async def test_list_models_filters_by_agent_kind(

--- a/desktop/run_build.mjs
+++ b/desktop/run_build.mjs
@@ -22,8 +22,8 @@ const PYTHON_VERSION = '3.12.12';
 const NODE_VERSION = '22.12.0';
 const RELEASE_TAG = '20260211';
 const RIPGREP_VERSION = '14.1.1';
-const CLAUDE_AGENT_ACP_VERSION = '0.57.0';
-const CODEX_ACP_VERSION = '1.1.2';
+const CLAUDE_AGENT_ACP_VERSION = '0.59.0';
+const CODEX_ACP_VERSION = '1.1.4';
 const GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py';
 
 const platform = process.platform;

--- a/frontend/src/components/chat/model-selector/AgentFilterChips.module.scss
+++ b/frontend/src/components/chat/model-selector/AgentFilterChips.module.scss
@@ -14,6 +14,9 @@
 .chip {
   @include type.type-meta(500);
   @include anim.transition-colors(var(--duration-fast));
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid var(--theme-border);
   border-radius: var(--radius-full);
   padding: var(--space-0-5) var(--space-2);
@@ -21,9 +24,6 @@
 
   // Icon chips: square padding so the pill hugs the icon
   &--icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
     padding: var(--space-1);
   }
 

--- a/mcp-server/client.py
+++ b/mcp-server/client.py
@@ -105,6 +105,24 @@ class AgentroveClient:
         await self.request("PATCH", "/settings/", json={"personas": [*personas, persona]})
         return persona
 
+    async def update_persona(self, name: str, content: str) -> dict[str, Any]:
+        resp = await self.request("GET", "/settings/")
+        personas = resp.json().get("personas") or []
+        persona = next((p for p in personas if p["name"] == name), None)
+        if persona is None:
+            raise AgentroveError(f"No persona named {name!r} exists.")
+        persona["content"] = content
+        await self.request("PATCH", "/settings/", json={"personas": personas})
+        return persona
+
+    async def delete_persona(self, name: str) -> None:
+        resp = await self.request("GET", "/settings/")
+        personas = resp.json().get("personas") or []
+        remaining = [p for p in personas if p["name"] != name]
+        if len(remaining) == len(personas):
+            raise AgentroveError(f"No persona named {name!r} exists.")
+        await self.request("PATCH", "/settings/", json={"personas": remaining})
+
     async def list_models(self, agent_kind: str | None) -> list[dict[str, Any]]:
         params = {"agent_kind": agent_kind} if agent_kind else None
         resp = await self.request("GET", "/models/", params=params)

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -17,6 +17,7 @@ PERMISSION_MODE_BY_AGENT = {
     "codex": "full-access",
     "copilot": "autopilot",
     "cursor": "agent",
+    "grok": "always-approve",
     "opencode": "build",
 }
 
@@ -65,18 +66,25 @@ async def list_workspaces() -> dict[str, Any]:
 
 @mcp.tool()
 async def list_models(
-    agent_kind: Literal["claude", "codex", "copilot", "cursor", "opencode"] | None = None,
+    agent_kind: Literal["claude", "codex", "copilot", "cursor", "grok", "opencode"] | None = None,
 ) -> dict[str, Any]:
     """List available AI models, optionally filtered by agent_kind.
 
-    Each entry has model_id, name and agent_kind. Pass a model_id as `model_id` to
-    send_message to use it; otherwise a Claude model is used. An instance can expose
-    many models, so filter by agent_kind to narrow the list.
+    Each entry has model_id, name, agent_kind and thinking_modes — the reasoning-effort
+    tiers the model accepts for send_message's thinking_mode, ordered lowest to highest
+    (empty when the model has no reasoning dial; unsupported values fall back to medium).
+    Pass a model_id as `model_id` to send_message to use it; otherwise a Claude model is
+    used. An instance can expose many models, so filter by agent_kind to narrow the list.
     """
     models = await client.list_models(agent_kind)
     return {
         "models": [
-            {"model_id": m["model_id"], "name": m["name"], "agent_kind": m["agent_kind"]}
+            {
+                "model_id": m["model_id"],
+                "name": m["name"],
+                "agent_kind": m["agent_kind"],
+                "thinking_modes": m.get("thinking_modes", []),
+            }
             for m in models
         ]
     }
@@ -147,6 +155,29 @@ async def create_persona(name: str, content: str) -> dict[str, Any]:
     """
     persona = await client.create_persona(name, content)
     return {"persona": {"name": persona["name"]}}
+
+
+@mcp.tool()
+async def update_persona(name: str, content: str) -> dict[str, Any]:
+    """Replace an existing persona's system prompt.
+
+    `name` must match an existing persona (see list_personas); `content` fully replaces
+    its current system prompt. Chats already streaming keep the prompt they started with;
+    new turns pick up the updated one. Returns the updated persona's name.
+    """
+    persona = await client.update_persona(name, content)
+    return {"persona": {"name": persona["name"]}}
+
+
+@mcp.tool()
+async def delete_persona(name: str) -> dict[str, Any]:
+    """Delete a custom persona permanently.
+
+    `name` must match an existing persona (see list_personas). Chats that used it keep
+    their history, but new turns can no longer select it. Returns {"deleted": true}.
+    """
+    await client.delete_persona(name)
+    return {"deleted": True}
 
 
 @mcp.tool()

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -57,7 +57,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.57.0 @agentclientprotocol/codex-acp@1.1.2 @openai/codex@0.144.1 @github/copilot@1.0.36
+    npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.59.0 @agentclientprotocol/codex-acp@1.1.4 @openai/codex@0.144.1 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to ~/.local/bin, which is already on PATH).
 RUN curl -fsS https://cursor.com/install | bash


### PR DESCRIPTION
## Summary
- Adds `update_persona` and `delete_persona` MCP tools (backed by new `AgentroveClient` methods) so personas can be edited/removed without going through the UI.
- `GET /models/` and the MCP `list_models` tool now return `thinking_modes`, the reasoning-effort tiers each model actually accepts, computed via a new `valid_thinking_modes()` helper shared by all ACP adapters instead of duplicated per-adapter logic.
- Adds `grok` to the MCP server's agent-kind literal and permission-mode map.
- Bumps `@agentclientprotocol/claude-agent-acp` to 0.59.0 and `@agentclientprotocol/codex-acp` to 1.1.4 across backend/sandbox Dockerfiles and the desktop build script.
- Fixes `AgentFilterChips` so icon centering applies to all chips, not just icon chips.

## Test plan
- [x] `ruff` / `ruff format` pre-commit hooks passed
- [ ] Run `backend/tests/test_models.py` to confirm `thinking_modes` values for claude/grok/cursor models
- [ ] Manually verify MCP `update_persona`/`delete_persona` against a running instance