### PR TITLE
feat: record chat's last-turn settings

### DIFF
--- a/backend/app/models/db_models/chat.py
+++ b/backend/app/models/db_models/chat.py
@@ -54,6 +54,11 @@ class Chat(Base):
     parent_chat_id: Mapped[UUID | None] = mapped_column(
         GUID(), ForeignKey("chats.id", ondelete="SET NULL"), nullable=True
     )
+    # The last turn's settings — server-side source of truth so out-of-band
+    # follow-ups (MCP) and the UI inherit them instead of their own defaults.
+    last_model_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    last_thinking_mode: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    last_persona_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     user = relationship("User", back_populates="chats")
     workspace = relationship("Workspace", back_populates="chats")

--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -91,6 +91,9 @@ class Chat(ChatBase):
     sub_thread_count: int = 0
     session_agent_kind: str | None = None
     unread: bool = False
+    last_model_id: str | None = None
+    last_thinking_mode: str | None = None
+    last_persona_name: str | None = None
 
 
 class ContextUsage(BaseModel):

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -1074,9 +1074,6 @@ class ChatService(BaseDbService[Chat]):
         # persist — open sessions refetch the sidebar on the stream_started
         # broadcast and must already see the new order. Sub-threads bump their
         # parent too, since top-level ordering follows the parent.
-        bump_ids = [chat.id]
-        if chat.parent_chat_id:
-            bump_ids.append(chat.parent_chat_id)
         now = datetime.now(timezone.utc)
         async with self.session_factory() as db:
             if chat.parent_chat_id:
@@ -1093,8 +1090,22 @@ class ChatService(BaseDbService[Chat]):
                     )
                     .values(last_viewed_at=now)
                 )
+                await db.execute(
+                    update(Chat)
+                    .where(Chat.id == chat.parent_chat_id)
+                    .values(updated_at=now)
+                )
+            # Record the turn's settings alongside the bump — the server-side
+            # source of truth that MCP follow-ups and the UI inherit.
             await db.execute(
-                update(Chat).where(Chat.id.in_(bump_ids)).values(updated_at=now)
+                update(Chat)
+                .where(Chat.id == chat.id)
+                .values(
+                    updated_at=now,
+                    last_model_id=request.model_id,
+                    last_thinking_mode=request.thinking_mode,
+                    last_persona_name=request.selected_persona_name,
+                )
             )
             await db.commit()
 

--- a/backend/migrations/versions/b8c9d0e1f2a3_add_chat_last_turn_settings.py
+++ b/backend/migrations/versions/b8c9d0e1f2a3_add_chat_last_turn_settings.py
@@ -1,0 +1,30 @@
+# Revision ID: b8c9d0e1f2a3
+# Revises: a1b2c3d4e5f6
+# Create Date: 2026-07-18 00:00:00.000000
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b8c9d0e1f2a3"
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("chats", sa.Column("last_model_id", sa.String(128), nullable=True))
+    op.add_column(
+        "chats", sa.Column("last_thinking_mode", sa.String(16), nullable=True)
+    )
+    op.add_column(
+        "chats", sa.Column("last_persona_name", sa.String(255), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chats", "last_persona_name")
+    op.drop_column("chats", "last_thinking_mode")
+    op.drop_column("chats", "last_model_id")

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -508,6 +508,41 @@ async def test_chat_tool_progress_orphan_update_is_a_no_op(
     assert not any(e["tool"]["id"] == "tool-orphan" for e in tool_events(message))
 
 
+async def test_chat_records_last_turn_settings(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+) -> None:
+    # The chat must record each turn's model/thinking/persona so out-of-band
+    # follow-ups (MCP) and the UI can inherit them instead of their defaults.
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+    response = await client.post(
+        "/api/v1/chat/chat",
+        data={
+            "prompt": "hello",
+            "chat_id": chat["id"],
+            "model_id": "sonnet",
+            "permission_mode": "default",
+            "thinking_mode": "low",
+            "selected_persona_name": "Bugbot",
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    message_id = response.json()["message_id"]
+    await wait_for_message(client, headers, chat_id=chat["id"], message_id=message_id)
+
+    detail = await client.get(f"/api/v1/chat/chats/{chat['id']}", headers=headers)
+    assert detail.status_code == 200, detail.text
+    body = detail.json()
+    assert body["last_model_id"] == "sonnet"
+    assert body["last_thinking_mode"] == "low"
+    assert body["last_persona_name"] == "Bugbot"
+
+
 async def test_chat_tool_left_active_is_auto_completed_on_finish(
     client: httpx.AsyncClient,
     auth_workspace: tuple[dict[str, str], Workspace],

--- a/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
+++ b/frontend/src/components/chat/chat-window/ChatSessionOrchestrator.tsx
@@ -64,6 +64,19 @@ export function ChatSessionOrchestrator({
   const fastMode = useChatSettingsStore(
     (state) => state.fastModeByChat[chatId] ?? DEFAULT_FAST_MODE,
   );
+  // Adopt the server-recorded last-turn settings when this client has no local
+  // choice for the chat — turns started out-of-band (MCP, automations) would
+  // otherwise display and re-send the client defaults instead of what ran.
+  useEffect(() => {
+    if (!currentChat) return;
+    const settings = useChatSettingsStore.getState();
+    if (settings.thinkingModeByChat[chatId] === undefined && currentChat.last_thinking_mode) {
+      settings.setThinkingMode(chatId, currentChat.last_thinking_mode);
+    }
+    if (settings.personaByChat[chatId] === undefined && currentChat.last_persona_name) {
+      settings.setPersona(chatId, currentChat.last_persona_name);
+    }
+  }, [chatId, currentChat]);
   const lastAssistantModelId = useMemo((): string | null | undefined => {
     if (messagesQuery.isLoading) return null;
     for (let i = fetchedMessages.length - 1; i >= 0; i--) {

--- a/frontend/src/components/layout/Sidebar/sidebarGrouping.test.ts
+++ b/frontend/src/components/layout/Sidebar/sidebarGrouping.test.ts
@@ -19,6 +19,9 @@ function chat(id: string, updatedAt: Date, over: Partial<Chat> = {}): Chat {
     sub_thread_count: 0,
     session_agent_kind: null,
     unread: false,
+    last_model_id: null,
+    last_thinking_mode: null,
+    last_persona_name: null,
     ...over,
   };
 }

--- a/frontend/src/hooks/useChatEvents.ts
+++ b/frontend/src/hooks/useChatEvents.ts
@@ -60,6 +60,10 @@ export function useChatEvents(options?: { enabled?: boolean }) {
         // lists so the chat surfaces even from outside the loaded pages.
         queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
         queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
+        // The turn also records its model/thinking/persona on the chat — drop
+        // the cached detail so the toolbar seeds from what actually ran
+        // instead of a copy cached before the turn (5-minute staleTime).
+        queryClient.invalidateQueries({ queryKey: queryKeys.chat(parsed.chat_id) });
         // Self-started turns are already tracked via addStream; settled turns
         // are cleaned up by useGlobalStream's orphan pruning.
         useStreamStore.getState().addStreamMetadataIfAbsent({

--- a/frontend/src/hooks/useCloudChatEvents.ts
+++ b/frontend/src/hooks/useCloudChatEvents.ts
@@ -82,6 +82,10 @@ export function useCloudChatEvents(options?: { enabled?: boolean }) {
         markCloudChats([parsed.chat_id]);
         useUIStore.getState().openChatTab(parsed.chat_id);
         invalidateCloudLists(queryClient);
+        // The turn also records its model/thinking/persona on the chat — drop
+        // the cached detail so the toolbar seeds from what actually ran
+        // instead of a copy cached before the turn (5-minute staleTime).
+        void queryClient.invalidateQueries({ queryKey: queryKeys.chat(parsed.chat_id) });
         // Self-started turns are already tracked via addStream; settled turns
         // are cleaned up by useGlobalStream's orphan pruning.
         useStreamStore.getState().addStreamMetadataIfAbsent({

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -76,6 +76,9 @@ export interface Chat {
   sub_thread_count: number;
   session_agent_kind: AgentKind | null;
   unread: boolean;
+  last_model_id: string | null;
+  last_thinking_mode: string | null;
+  last_persona_name: string | null;
 }
 
 // Wire contract of the per-user chat lifecycle SSE feed (/chat/chats/events),

--- a/mcp-server/client.py
+++ b/mcp-server/client.py
@@ -90,6 +90,10 @@ class AgentroveClient:
         resp = await self.request("GET", "/chat/chats", params=params)
         return resp.json()
 
+    async def get_chat(self, chat_id: str) -> dict[str, Any]:
+        resp = await self.request("GET", f"/chat/chats/{chat_id}")
+        return resp.json()
+
     async def list_personas(self) -> list[dict[str, Any]]:
         resp = await self.request("GET", "/settings/")
         return resp.json().get("personas") or []

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -207,11 +207,22 @@ async def send_message(
     non-Codex agents); persona selects a custom persona by name (defaults to the
     standard persona).
 
+    Follow-up turns (chat_id given) inherit the chat's previous model_id, thinking_mode
+    and persona when you omit them — pass a value only to change it for this turn.
+
     Returns immediately with chat_id and the streaming message_id. To get the reply, poll
     get_messages and watch that message's stream_status flip from "in_progress" to
     "completed". The turn runs unattended — it uses the model's full-execution permission
     mode (e.g. bypassPermissions for Claude, full-access for Codex).
     """
+    if chat_id is not None:
+        # Follow-up: default omitted settings to the chat's previous turn so a
+        # bare send_message(chat_id=...) continues with the same model/persona/
+        # effort instead of silently switching to the global defaults.
+        chat = await client.get_chat(chat_id)
+        model_id = model_id or chat.get("last_model_id")
+        thinking_mode = thinking_mode or chat.get("last_thinking_mode")
+        persona = persona or chat.get("last_persona_name")
     resolved_model, agent_kind = await client.resolve_model(model_id)
     permission_mode = PERMISSION_MODE_BY_AGENT[agent_kind]
     if chat_id is None:


### PR DESCRIPTION
## Summary
- Add `last_model_id`, `last_thinking_mode`, `last_persona_name` columns to `chats`, populated on every turn.
- MCP `send_message` follow-ups (`chat_id` given) now default omitted `model_id`/`thinking_mode`/`persona` to the chat's last turn instead of silently switching to global defaults.
- Frontend toolbar adopts the server-recorded last-turn settings when the client has no local choice for the chat (e.g. turns started via MCP/automations), and invalidates the cached chat detail on stream-started events so it reflects what actually ran.

## Test plan
- [x] `backend/tests/test_acp.py::test_chat_records_last_turn_settings` covers persistence and API exposure.
- [ ] Manual: start a turn via the MCP `send_message` tool, then confirm a browser follow-up in the same chat shows the same model/thinking-mode/persona.