### PR TITLE
Add landing page greeting and recent chats

### DIFF
--- a/frontend/src/components/chat/message-input/Input.module.scss
+++ b/frontend/src/components/chat/message-input/Input.module.scss
@@ -42,7 +42,17 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-2);
   padding: var(--space-1-5) var(--space-2) var(--safe-area-bottom);
+}
+
+.footer-leading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
 .context-slot {

--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, type ReactNode } from 'react';
 import clsx from 'clsx';
 import { stateClasses } from '@/config/stateClasses';
 import { FileUploadDialog } from '@/components/ui/FileUploadDialog/FileUploadDialog';
@@ -39,17 +39,20 @@ export interface InputProps {
   chatId?: string;
   showLoadingSpinner?: boolean;
   disabled?: boolean;
+  // Extra selectors rendered on the left of the footer row (landing page's
+  // workspace/worktree/run-location pickers); chats leave this empty.
+  footerLeading?: ReactNode;
 }
 
 export const Input = memo(function Input(props: InputProps) {
   return (
     <InputProvider {...props}>
-      <InputLayout />
+      <InputLayout footerLeading={props.footerLeading} />
     </InputProvider>
   );
 });
 
-function InputLayout() {
+function InputLayout({ footerLeading }: { footerLeading?: ReactNode }) {
   const { state, actions, meta } = useInputContext();
 
   const shouldShowAttachedPreview =
@@ -130,8 +133,11 @@ function InputLayout() {
       </div>
 
       <div className={styles['footer-row']}>
-        <div className={styles['context-slot']}>
-          {state.contextUsage && <ContextUsageIndicator usage={state.contextUsage} />}
+        <div className={styles['footer-leading']}>
+          {footerLeading}
+          <div className={styles['context-slot']}>
+            {state.contextUsage && <ContextUsageIndicator usage={state.contextUsage} />}
+          </div>
         </div>
         <InputControls />
       </div>

--- a/frontend/src/components/chat/workspace-selector/WorkspacePicker.module.scss
+++ b/frontend/src/components/chat/workspace-selector/WorkspacePicker.module.scss
@@ -34,7 +34,13 @@
 
 .trigger-label {
   @include type.type-overflow;
-  max-width: var(--space-64);
+  // Tighter cap on phones: the label keeps the selected workspace visible while
+  // leaving the rest of the footer row room to fit on one line.
+  max-width: var(--space-24);
+
+  @include responsive.media('sm-up') {
+    max-width: var(--space-64);
+  }
 }
 
 .body {

--- a/frontend/src/components/layout/Sidebar/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarChatItem.tsx
@@ -4,6 +4,7 @@ import { AsciiSpinner } from '@/components/ui/AsciiSpinner/AsciiSpinner';
 import {
   ChatStatusDot,
   chatStatusTone,
+  CHAT_STATUS_LABEL,
   type ChatStatusTone,
 } from '@/components/ui/ChatStatusDot/ChatStatusDot';
 import { Button } from '@/components/ui/primitives/Button/Button';
@@ -17,15 +18,6 @@ import { stateClasses } from '@/config/stateClasses';
 import type { Chat } from '@/types/chat.types';
 import type { WorkspaceBadge } from '@/hooks/queries/useSidebarChatLists';
 import styles from './SidebarChatItem.module.scss';
-
-// The `status` discriminant (derived per-row below) drives the leading glyph, its
-// dot tone, and its tooltip word — precedence: needs-you > running > done > unread.
-const STATUS_LABEL: Record<ChatStatusTone, string> = {
-  blocked: 'Needs you',
-  running: 'Running',
-  completed: 'Done',
-  unread: 'Unread',
-};
 
 interface SidebarChatItemProps {
   chat: Chat;
@@ -90,7 +82,7 @@ export const SidebarChatItem = memo(function SidebarChatItem({
   // The main slot shows the spinner for 'running', so it takes no dot there; every
   // other status renders its tone directly.
   const statusTone: ChatStatusTone | null = showSpinner ? null : status;
-  const statusLabel = status ? STATUS_LABEL[status] : null;
+  const statusLabel = status ? CHAT_STATUS_LABEL[status] : null;
   // Mirrors the leading-slot render below — the workspace line indents to stay flush with the title
   const hasLeadingSlot = hasSubThreads || agentKind != null || status != null;
   const statusSlot = hasLeadingSlot ? (

--- a/frontend/src/components/ui/ChatStatusDot/ChatStatusDot.tsx
+++ b/frontend/src/components/ui/ChatStatusDot/ChatStatusDot.tsx
@@ -18,6 +18,14 @@ export function chatStatusTone(flags: {
   return null;
 }
 
+// Human word for each tone, shown in tooltips next to the dot/spinner.
+export const CHAT_STATUS_LABEL: Record<ChatStatusTone, string> = {
+  blocked: 'Needs you',
+  running: 'Running',
+  completed: 'Done',
+  unread: 'Unread',
+};
+
 // Shared status dot for the sidebar rows and the title-bar tabs so both read the
 // same: red (pulsing) = needs you, amber = running, green = done, blue = unread.
 // (Running normally shows the braille spinner; the amber dot is its compact form.)

--- a/frontend/src/components/ui/shared/ToggleDropdown/ToggleDropdown.module.scss
+++ b/frontend/src/components/ui/shared/ToggleDropdown/ToggleDropdown.module.scss
@@ -37,6 +37,17 @@
   color: var(--theme-text-quaternary);
 }
 
+// Same compact-on-mobile behavior as the Dropdown primitive's triggers: below
+// the sm breakpoint the icon stands in for the label.
+.trigger-label {
+  display: none;
+  min-width: 0;
+
+  @include responsive.media('sm-up') {
+    display: block;
+  }
+}
+
 .chevron {
   height: var(--space-3);
   width: var(--space-3);

--- a/frontend/src/components/ui/shared/ToggleDropdown/ToggleDropdown.tsx
+++ b/frontend/src/components/ui/shared/ToggleDropdown/ToggleDropdown.tsx
@@ -46,7 +46,7 @@ export const ToggleDropdown = memo(function ToggleDropdown({
         className={styles.trigger}
       >
         {TriggerIcon && <TriggerIcon className={styles['trigger-icon']} />}
-        <span>{selected.label}</span>
+        <span className={styles['trigger-label']}>{selected.label}</span>
         <ChevronDown className={styles.chevron} />
       </Button>
 

--- a/frontend/src/pages/LandingPage/LandingPage.module.scss
+++ b/frontend/src/pages/LandingPage/LandingPage.module.scss
@@ -17,32 +17,70 @@
   display: flex;
   height: 100%;
   width: 100%;
-  align-items: center;
-  justify-content: center;
-  padding-left: var(--space-4);
-  padding-right: var(--space-4);
-  padding-bottom: var(--space-10);
+  overflow-y: auto;
+  padding: var(--space-4) var(--space-4) var(--space-10);
 }
 
+// margin:auto (not justify-content:center) so the greeting/recents stay
+// reachable when the panel grows taller than the viewport.
 .agent-panel {
+  margin: auto;
   width: 100%;
   max-width: 42rem;
 }
 
-.selector-row {
+.greeting {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1-5);
+  margin-bottom: var(--space-6);
+  text-align: center;
+}
+
+.greeting-logo {
+  height: var(--space-7);
+  width: var(--space-7);
+  margin-bottom: var(--space-1);
+
+  // Two variants swap by theme — the dark glyph shows on light surfaces and
+  // vice versa, same convention as the message avatars.
+  &--on-light {
+    display: block;
+
+    :global([data-theme='dark']) & {
+      display: none;
+    }
+  }
+
+  &--on-dark {
+    display: none;
+
+    :global([data-theme='dark']) & {
+      display: block;
+    }
+  }
+}
+
+.greeting-title {
+  @include type.type-page-title;
+  margin: 0;
+  color: var(--theme-text-primary);
+}
+
+.greeting-subtitle {
+  @include type.type-body;
+  margin: 0;
+  color: var(--theme-text-tertiary);
+}
+
+.composer-selectors {
   @include z.z('raised');
   position: relative;
-  margin-bottom: var(--space-2);
   display: flex;
   align-items: center;
   gap: var(--space-1);
-  padding-left: var(--space-4);
-  padding-right: var(--space-4);
-
-  @include responsive.media('sm-up') {
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-  }
+  flex-wrap: wrap;
 }
 
 .example-prompts {

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useMemo, useCallback, useEffect, ReactNode, Suspense } from 'react';
+import clsx from 'clsx';
 import { lazyNamed } from '@/utils/lazyNamed';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useNavigate, useLocation } from 'react-router-dom';
@@ -49,6 +50,11 @@ import { useEditorState } from '@/hooks/useEditorState';
 import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback/ViewLoadingFallback';
 import { PENDING_NEW_CHAT_KEY, type TileId } from '@/types/ui.types';
 import { tileIdToViewType } from '@/utils/tileHelpers';
+import { useCurrentUserQuery } from '@/hooks/queries/useAuthQueries';
+import { useSidebarChatLists } from '@/hooks/queries/useSidebarChatLists';
+import { RecentChats } from './RecentChats';
+import iconDark from '/assets/images/icon-dark.svg';
+import iconLight from '/assets/images/icon-white.svg';
 import styles from './LandingPage.module.scss';
 
 const Editor = lazyNamed(() => import('@/components/editor/editor-core/Editor'), 'Editor');
@@ -64,6 +70,13 @@ const EXAMPLE_PROMPTS = [
   'Refactor this project to use TypeScript',
 ];
 
+function getTimeGreeting(): string {
+  const hour = new Date().getHours();
+  if (hour < 12) return 'Good morning';
+  if (hour < 18) return 'Good afternoon';
+  return 'Good evening';
+}
+
 export function LandingPage() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -78,6 +91,20 @@ export function LandingPage() {
 
   const workspaces = useWorkspacesList({ enabled: isAuthenticated });
   const modelMap = useModelMap(isAuthenticated);
+
+  const { data: currentUser } = useCurrentUserQuery({ enabled: isAuthenticated });
+  // Recents for the "jump back in" section — the merged local + cloud list the
+  // sidebar uses, so both stay consistent. Falls back to example prompts when
+  // there are no chats yet.
+  const { recentChats, workspaceBadgeById, isLoadingChats } = useSidebarChatLists(
+    workspaces,
+    isAuthenticated,
+  );
+  const showRecents = !isLoadingChats && recentChats.length > 0;
+  const greeting = getTimeGreeting();
+  // Usernames are lowercase handles ("michael") — capitalize for the greeting.
+  const username = currentUser?.username ?? '';
+  const greetingName = username && username.charAt(0).toUpperCase() + username.slice(1);
 
   const createChat = useCreateChatMutation();
   const queryClient = useQueryClient();
@@ -341,6 +368,31 @@ export function LandingPage() {
     [navigate],
   );
 
+  // The workspace pickers live in the composer's footer row; preventDefault on
+  // mousedown keeps focus in the textarea, matching InputControls.
+  const composerSelectors = useMemo(
+    () => (
+      <div className={styles['composer-selectors']} onMouseDown={(e) => e.preventDefault()}>
+        {isCloud ? (
+          <CloudWorkspaceSelector
+            selectedWorkspaceId={selectedCloudWorkspaceId}
+            onWorkspaceChange={setSelectedCloudWorkspaceId}
+            disabled={isLoading}
+          />
+        ) : (
+          <WorkspaceSelector
+            selectedWorkspaceId={selectedWorkspaceId}
+            onWorkspaceChange={setSelectedWorkspaceId}
+            enabled={isAuthenticated}
+          />
+        )}
+        <WorktreeToggle disabled={isLoading} />
+        <RunLocationSelector disabled={isLoading} />
+      </div>
+    ),
+    [isCloud, selectedCloudWorkspaceId, selectedWorkspaceId, isLoading, isAuthenticated],
+  );
+
   const sidebarContent = useMemo(() => {
     if (!isAuthenticated) return null;
 
@@ -358,22 +410,22 @@ export function LandingPage() {
           return (
             <div className={styles['agent-view']}>
               <div className={styles['agent-panel']}>
-                <div className={styles['selector-row']}>
-                  {isCloud ? (
-                    <CloudWorkspaceSelector
-                      selectedWorkspaceId={selectedCloudWorkspaceId}
-                      onWorkspaceChange={setSelectedCloudWorkspaceId}
-                      disabled={isLoading}
-                    />
-                  ) : (
-                    <WorkspaceSelector
-                      selectedWorkspaceId={selectedWorkspaceId}
-                      onWorkspaceChange={setSelectedWorkspaceId}
-                      enabled={isAuthenticated}
-                    />
-                  )}
-                  <WorktreeToggle disabled={isLoading} />
-                  <RunLocationSelector disabled={isLoading} />
+                <div className={styles.greeting}>
+                  <img
+                    src={iconDark}
+                    alt="Agentrove"
+                    className={clsx(styles['greeting-logo'], styles['greeting-logo--on-light'])}
+                  />
+                  <img
+                    src={iconLight}
+                    alt="Agentrove"
+                    className={clsx(styles['greeting-logo'], styles['greeting-logo--on-dark'])}
+                  />
+                  <h1 className={styles['greeting-title']}>
+                    {greeting}
+                    {greetingName && `, ${greetingName}`}
+                  </h1>
+                  <p className={styles['greeting-subtitle']}>What are we building today?</p>
                 </div>
 
                 <ChatInput
@@ -388,21 +440,30 @@ export function LandingPage() {
                   onModelChange={selectModel}
                   showTip={false}
                   placeholder="Message Agentrove... (@ to mention, / for commands)"
+                  footerLeading={composerSelectors}
                 />
 
-                <div className={styles['example-prompts']}>
-                  {EXAMPLE_PROMPTS.map((prompt) => (
-                    <Button
-                      key={prompt}
-                      type="button"
-                      variant="unstyled"
-                      onClick={() => setMessage(prompt)}
-                      className={styles['example-prompt']}
-                    >
-                      {prompt}
-                    </Button>
-                  ))}
-                </div>
+                {showRecents ? (
+                  <RecentChats
+                    chats={recentChats}
+                    workspaceBadgeById={workspaceBadgeById}
+                    onChatSelect={handleChatSelect}
+                  />
+                ) : (
+                  <div className={styles['example-prompts']}>
+                    {EXAMPLE_PROMPTS.map((prompt) => (
+                      <Button
+                        key={prompt}
+                        type="button"
+                        variant="unstyled"
+                        onClick={() => setMessage(prompt)}
+                        className={styles['example-prompt']}
+                      >
+                        {prompt}
+                      </Button>
+                    ))}
+                  </div>
+                )}
               </div>
             </div>
           );
@@ -451,20 +512,24 @@ export function LandingPage() {
       attachedFiles,
       handleFileAttach,
       handleNewChat,
-      isAuthenticated,
+      handleChatSelect,
       isLoading,
       message,
       selectModel,
       selectedModelId,
-      selectedWorkspaceId,
-      isCloud,
-      selectedCloudWorkspaceId,
+      composerSelectors,
+      showRecents,
+      recentChats,
+      workspaceBadgeById,
+      greeting,
+      greetingName,
       fileStructure,
       selectedFile,
       setSelectedFile,
       openFiles,
       closeFile,
       selectedSandboxId,
+      isFilesMetadataLoading,
       handleRefresh,
       isRefreshing,
     ],

--- a/frontend/src/pages/LandingPage/RecentChats.module.scss
+++ b/frontend/src/pages/LandingPage/RecentChats.module.scss
@@ -1,0 +1,89 @@
+@use '@/styles/globals/colors' as colors;
+@use '@/styles/globals/typography' as type;
+@use '@/styles/globals/responsive' as responsive;
+@use '@/styles/globals/animations' as anim;
+
+.recents {
+  margin-top: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding-left: var(--space-4);
+  padding-right: var(--space-4);
+
+  @include responsive.media('sm-up') {
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
+  }
+}
+
+.header {
+  @include type.type-section-header;
+  padding-left: var(--space-2);
+  padding-right: var(--space-2);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+}
+
+.row {
+  @include anim.transition-colors;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-5);
+  width: 100%;
+  padding: var(--space-2) var(--space-2-5);
+  border-radius: var(--radius-lg);
+  border: 1px solid transparent;
+  text-align: left;
+
+  @include responsive.hover {
+    background-color: var(--theme-surface-hover);
+    border-color: colors.theme-color('border', 0.5);
+  }
+}
+
+// Same fixed box as the sidebar's status slot: the dot/spinner centers in it,
+// and no-status rows keep it empty so titles stay aligned.
+.status-slot {
+  position: relative;
+  display: flex;
+  height: var(--space-3-5);
+  width: var(--space-3-5);
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.spinner {
+  @include type.type-title;
+  line-height: 1;
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-0-5);
+  min-width: 0;
+  flex: 1;
+}
+
+.title {
+  @include type.type-default(500);
+  @include type.type-overflow;
+  color: var(--theme-text-primary);
+}
+
+.meta {
+  @include type.type-meta;
+  @include type.type-overflow;
+  color: var(--theme-text-tertiary);
+}
+
+.time {
+  @include type.type-meta;
+  color: var(--theme-text-quaternary);
+  flex-shrink: 0;
+}

--- a/frontend/src/pages/LandingPage/RecentChats.tsx
+++ b/frontend/src/pages/LandingPage/RecentChats.tsx
@@ -1,0 +1,93 @@
+import { useMemo } from 'react';
+import type { Chat } from '@/types/chat.types';
+import { useStreamStore } from '@/store/streamStore';
+import { usePermissionStore } from '@/store/permissionStore';
+import { useModelMap } from '@/hooks/queries/useModelQueries';
+import { formatRelativeTime } from '@/utils/date';
+import { stripMarkdownTitle } from '@/utils/format';
+import type { WorkspaceBadge } from '@/hooks/queries/useSidebarChatLists';
+import {
+  ChatStatusDot,
+  chatStatusTone,
+  CHAT_STATUS_LABEL,
+} from '@/components/ui/ChatStatusDot/ChatStatusDot';
+import { AsciiSpinner } from '@/components/ui/AsciiSpinner/AsciiSpinner';
+import { FloatingTooltip } from '@/components/ui/FloatingTooltip/FloatingTooltip';
+import { Button } from '@/components/ui/primitives/Button/Button';
+import styles from './RecentChats.module.scss';
+
+const MAX_RECENT_CHATS = 4;
+
+export interface RecentChatsProps {
+  chats: Chat[];
+  workspaceBadgeById: Map<string, WorkspaceBadge>;
+  onChatSelect: (chatId: string) => void;
+}
+
+export function RecentChats({ chats, workspaceBadgeById, onChatSelect }: RecentChatsProps) {
+  const activeStreamMetadata = useStreamStore((state) => state.activeStreamMetadata);
+  const completedChatIds = useStreamStore((state) => state.completedChatIds);
+  // Empty queues are deleted from the store, so every remaining key is a chat
+  // blocked on a plan/question/permission answer.
+  const pendingRequests = usePermissionStore((state) => state.pendingRequests);
+  // Recents only render when authenticated, so the models query is safe to enable.
+  const modelMap = useModelMap();
+
+  const streamingChatIds = useMemo(
+    () => new Set(activeStreamMetadata.map((meta) => meta.chatId)),
+    [activeStreamMetadata],
+  );
+
+  const modelLabel = (chat: Chat) =>
+    (chat.last_model_id && modelMap.get(chat.last_model_id)?.name) || chat.session_agent_kind;
+
+  return (
+    <div className={styles.recents}>
+      <div className={styles.header}>Jump back in</div>
+      <div className={styles.list}>
+        {chats.slice(0, MAX_RECENT_CHATS).map((chat) => {
+          // Same tone precedence as the sidebar rows and chat tabs; no chat is
+          // open on the landing page, so unread is never suppressed here.
+          const status = chatStatusTone({
+            blocked: pendingRequests.has(chat.id),
+            streaming: streamingChatIds.has(chat.id),
+            completed: completedChatIds.has(chat.id),
+            unread: chat.unread,
+          });
+          const statusSlot = (
+            <span className={styles['status-slot']}>
+              {status === 'running' ? (
+                <AsciiSpinner className={styles.spinner} />
+              ) : status ? (
+                <ChatStatusDot tone={status} />
+              ) : null}
+            </span>
+          );
+          const meta = [workspaceBadgeById.get(chat.workspace_id)?.name, modelLabel(chat)]
+            .filter(Boolean)
+            .join(' · ');
+          return (
+            <Button
+              key={chat.id}
+              type="button"
+              variant="unstyled"
+              onClick={() => onChatSelect(chat.id)}
+              className={styles.row}
+            >
+              {status ? (
+                <FloatingTooltip content={CHAT_STATUS_LABEL[status]}>{statusSlot}</FloatingTooltip>
+              ) : (
+                statusSlot
+              )}
+              <span className={styles.text}>
+                <span className={styles.title}>{stripMarkdownTitle(chat.title)}</span>
+                <span className={styles.meta}>{meta}</span>
+              </span>
+              <span className={styles.time}>{formatRelativeTime(chat.updated_at)}</span>
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace the landing page's bare selector row with a time-of-day greeting ("Good morning, Michael") and move the workspace/worktree/run-location pickers into the composer's footer row, alongside the context-usage indicator.
- When the user has recent chats, show a "Jump back in" list (status dot, workspace/model, relative time) in place of the static example prompts, reusing the same merged local+cloud chat data and status logic as the sidebar (`CHAT_STATUS_LABEL` hoisted out of `SidebarChatItem` for reuse).
- Adjust `ToggleDropdown` and `WorkspacePicker` trigger labels to collapse on small screens so the composer footer stays on one line on mobile.

## Test plan
- [ ] `npm run build` / typecheck in `frontend`
- [ ] Manually load the landing page signed in with no chats — confirm greeting + example prompts render
- [ ] Manually load the landing page signed in with existing chats — confirm "Jump back in" list renders and clicking a row opens that chat
- [ ] Check composer footer layout at mobile width (workspace/worktree/run-location selectors + context indicator)