### PR TITLE
Collapse composer footer labels to icons on real overflow

### DIFF
--- a/frontend/src/components/chat/message-input/Input.test.tsx
+++ b/frontend/src/components/chat/message-input/Input.test.tsx
@@ -52,6 +52,8 @@ vi.mock('react-hot-toast', () => ({
 
 // Heavy composer sub-trees that don't participate in submit/queue logic.
 vi.mock('./InputControls', () => ({ InputControls: () => null }));
+// Layout measurement (ResizeObserver/document.fonts) — meaningless in jsdom.
+vi.mock('@/hooks/useOverflowCompact', () => ({ useOverflowCompact: () => false }));
 vi.mock('@/components/ui/FileUploadDialog/FileUploadDialog', () => ({
   FileUploadDialog: () => null,
 }));

--- a/frontend/src/components/chat/message-input/Input.tsx
+++ b/frontend/src/components/chat/message-input/Input.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactNode } from 'react';
+import { memo, useRef, type ReactNode } from 'react';
 import clsx from 'clsx';
 import { stateClasses } from '@/config/stateClasses';
 import { FileUploadDialog } from '@/components/ui/FileUploadDialog/FileUploadDialog';
@@ -16,6 +16,7 @@ import { InputSuggestionsPanel } from './InputSuggestionsPanel';
 import { ContextUsageIndicator } from './ContextUsageIndicator';
 import { InputProvider } from './InputProvider';
 import { useInputContext } from '@/hooks/useInputContext';
+import { useOverflowCompact } from '@/hooks/useOverflowCompact';
 import type { ContextUsageInfo } from './ContextUsageIndicator';
 import styles from './Input.module.scss';
 
@@ -54,6 +55,9 @@ export const Input = memo(function Input(props: InputProps) {
 
 function InputLayout({ footerLeading }: { footerLeading?: ReactNode }) {
   const { state, actions, meta } = useInputContext();
+  // Collapses the footer's labels to icons when the labeled row would wrap.
+  const footerRowRef = useRef<HTMLDivElement>(null);
+  const isFooterCompact = useOverflowCompact(footerRowRef);
 
   const shouldShowAttachedPreview =
     state.hasAttachments &&
@@ -132,7 +136,10 @@ function InputLayout({ footerLeading }: { footerLeading?: ReactNode }) {
         </div>
       </div>
 
-      <div className={styles['footer-row']}>
+      <div
+        ref={footerRowRef}
+        className={clsx(styles['footer-row'], isFooterCompact && stateClasses.COMPACT)}
+      >
         <div className={styles['footer-leading']}>
           {footerLeading}
           <div className={styles['context-slot']}>

--- a/frontend/src/components/chat/message-input/InputControls.module.scss
+++ b/frontend/src/components/chat/message-input/InputControls.module.scss
@@ -3,4 +3,8 @@
   min-width: 0;
   align-items: center;
   gap: var(--space-1);
+  // No-op while the footer fits on one line (space-between already pins the
+  // controls right); when the row wraps, this keeps them right-aligned on their
+  // own line instead of stranding them at the left edge.
+  margin-left: auto;
 }

--- a/frontend/src/components/chat/workspace-selector/WorkspacePicker.module.scss
+++ b/frontend/src/components/chat/workspace-selector/WorkspacePicker.module.scss
@@ -2,6 +2,7 @@
 @use '@/styles/globals/typography' as type;
 @use '@/styles/globals/animations' as anim;
 @use '@/styles/globals/responsive' as responsive;
+@use '@/styles/globals/state-classes' as state;
 
 .trigger {
   @include anim.transition-colors;
@@ -40,6 +41,13 @@
 
   @include responsive.media('sm-up') {
     max-width: var(--space-64);
+  }
+
+  // Composer footer overflowed: back to the phone cap — unlike the other
+  // triggers this one keeps its label, since which project the message runs
+  // in is the state worth seeing.
+  :global(.#{state.$state-compact}) & {
+    max-width: var(--space-24);
   }
 }
 

--- a/frontend/src/components/ui/primitives/Dropdown/Dropdown.module.scss
+++ b/frontend/src/components/ui/primitives/Dropdown/Dropdown.module.scss
@@ -66,10 +66,16 @@
     color: currentColor;
   }
 
-  // compactOnMobile: the icon stands in for the label only below the sm breakpoint
+  // compactOnMobile: the icon stands in for the label only below the sm breakpoint,
+  // or whenever an ancestor (the composer footer row) is in the compact state
+  // because the labeled row overflowed.
   &--responsive {
     @include responsive.media('sm-up') {
       display: none;
+    }
+
+    :global(.#{state.$state-compact}) & {
+      display: block;
     }
   }
 }
@@ -82,6 +88,10 @@
 
     @include responsive.media('sm-up') {
       display: block;
+    }
+
+    :global(.#{state.$state-compact}) & {
+      display: none;
     }
   }
 
@@ -117,6 +127,10 @@
 
     @include responsive.media('sm-up') {
       display: block;
+    }
+
+    :global(.#{state.$state-compact}) & {
+      display: none;
     }
   }
 }

--- a/frontend/src/components/ui/shared/ToggleDropdown/ToggleDropdown.module.scss
+++ b/frontend/src/components/ui/shared/ToggleDropdown/ToggleDropdown.module.scss
@@ -2,6 +2,7 @@
 @use '@/styles/globals/typography' as type;
 @use '@/styles/globals/animations' as anim;
 @use '@/styles/globals/responsive' as responsive;
+@use '@/styles/globals/state-classes' as state;
 @use '@/styles/globals/zlayer' as z;
 
 .toggle-dropdown {
@@ -37,14 +38,19 @@
   color: var(--theme-text-quaternary);
 }
 
-// Same compact-on-mobile behavior as the Dropdown primitive's triggers: below
-// the sm breakpoint the icon stands in for the label.
+// Same compact behavior as the Dropdown primitive's triggers: the icon stands
+// in for the label below the sm breakpoint, or when the composer footer row is
+// in the compact state because the labeled row overflowed.
 .trigger-label {
   display: none;
   min-width: 0;
 
   @include responsive.media('sm-up') {
     display: block;
+  }
+
+  :global(.#{state.$state-compact}) & {
+    display: none;
   }
 }
 

--- a/frontend/src/config/stateClasses.ts
+++ b/frontend/src/config/stateClasses.ts
@@ -19,6 +19,7 @@ export const stateClasses = {
   EXPANDED: 'is-expanded',
   PENDING: 'is-pending',
   CURRENT: 'is-current',
+  COMPACT: 'is-compact',
 } as const;
 
 export type StateClass = (typeof stateClasses)[keyof typeof stateClasses];

--- a/frontend/src/hooks/useOverflowCompact.ts
+++ b/frontend/src/hooks/useOverflowCompact.ts
@@ -1,0 +1,55 @@
+import { useLayoutEffect, useRef, useState, type RefObject } from 'react';
+
+// A wrapping flex row has pushed a child below the first one. Children sharing
+// a line can still have different offsetTops (align-items: center with
+// different heights), so "below" means the last child's midpoint sits past the
+// first child's bottom — true on a wrapped line, never within one.
+function isWrapped(row: HTMLElement): boolean {
+  const first = row.firstElementChild as HTMLElement | null;
+  const last = row.lastElementChild as HTMLElement | null;
+  if (!first || !last || first === last) return false;
+  return last.offsetTop + last.offsetHeight / 2 > first.offsetTop + first.offsetHeight;
+}
+
+// Overflow-driven compacting for the composer footer: true once the fully
+// labeled row wraps, so labels can collapse to icons — the same collapse the
+// sm breakpoint gives phones, but keyed to the row's real width (sidebar open,
+// split view, long model/branch names) instead of the viewport.
+export function useOverflowCompact(rowRef: RefObject<HTMLElement | null>): boolean {
+  const [compact, setCompact] = useState(false);
+  // Row width at which labels last overflowed. Labels are only retried once
+  // the row grows past it, so a constant-width row can't flip-flop; if the
+  // retry wraps again, the wrap re-triggers a measure and we re-compact.
+  const overflowWidthRef = useRef(0);
+
+  useLayoutEffect(() => {
+    const row = rowRef.current;
+    if (!row) return;
+    const measure = () => {
+      if (isWrapped(row)) {
+        overflowWidthRef.current = Math.max(overflowWidthRef.current, row.clientWidth);
+        setCompact(true);
+      } else if (row.clientWidth > overflowWidthRef.current) {
+        setCompact(false);
+      }
+    };
+    measure();
+    // Fires on width changes and on the height change a wrap causes.
+    const observer = new ResizeObserver(measure);
+    observer.observe(row);
+    // A wrap measured with fallback-font metrics could latch compact for a row
+    // that fits once the real fonts load — retry labels from scratch then.
+    let cancelled = false;
+    void document.fonts.ready.then(() => {
+      if (cancelled) return;
+      overflowWidthRef.current = 0;
+      setCompact(false);
+    });
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
+  }, [rowRef]);
+
+  return compact;
+}

--- a/frontend/src/styles/globals/_state-classes.scss
+++ b/frontend/src/styles/globals/_state-classes.scss
@@ -21,3 +21,4 @@ $state-collapsed: 'is-collapsed';
 $state-expanded: 'is-expanded';
 $state-pending: 'is-pending';
 $state-current: 'is-current';
+$state-compact: 'is-compact';


### PR DESCRIPTION
## Summary
- Add `useOverflowCompact`, a ResizeObserver-backed hook that detects when the composer footer row's labeled controls actually wrap onto a second line, independent of viewport width.
- Apply a new `is-compact` state class to the footer row when it overflows, and wire the `Dropdown`, `ToggleDropdown`, and `WorkspacePicker` label styles to collapse to icon-only under that class — the same collapse they already do below the `sm` breakpoint.
- This fixes cases where the composer is narrow for reasons other than viewport size (sidebar open, split-pane view, long model/branch names) but the row still wrapped with labels intact.

## Test plan
- [ ] Resize the composer (toggle sidebar, open split view) and confirm footer labels collapse to icons once the row would otherwise wrap, and restore once it fits again.
- [ ] Confirm the workspace picker keeps its label (capped width) while other controls go icon-only in compact mode.
- [ ] Verify no flicker/flip-flop when resizing near the wrap threshold.