### PR TITLE
feat: share one agent home per user across workspaces

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -192,6 +192,15 @@ class Settings(BaseSettings):
             return self.HOST_SANDBOX_BASE_DIR
         return f"{self.STORAGE_PATH.rstrip('/')}/host-sandboxes"
 
+    def get_agent_home_dir(self, user_id: str) -> str:
+        # Per-user HOME for host-provider agents and terminal PTYs in web mode.
+        # One dir per user — not per sandbox — so CLI logins (claude/codex),
+        # MCP registrations, and skills are configured once and shared across
+        # every workspace, matching desktop mode where the real $HOME plays
+        # this role. Kept under the persistent storage volume so logins
+        # survive restarts. Desktop mode never resolves this.
+        return f"{self.STORAGE_PATH.rstrip('/')}/agent-homes/{user_id}"
+
     # Security Headers Configuration
     ENABLE_SECURITY_HEADERS: bool = True
     HSTS_MAX_AGE: int = 31536000

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -183,11 +183,13 @@ async def get_skill_service(
     current_user: User = Depends(get_current_user),
     workspace_service: WorkspaceService = Depends(get_workspace_service),
 ) -> SkillService:
-    # Skills live under each workspace's .{agent}/skills dir, so scope discovery
-    # to the selected workspace rather than a single global root that, in cloud
-    # mode, holds no skills.
+    # Two tiers: the selected workspace's .{agent}/skills dirs, layered over
+    # the owner's agent home — the same HOME host-mode agents run with.
     workspace = await workspace_service.get_workspace(workspace_id, current_user)
-    return SkillService(workspace_path=Path(workspace.workspace_path))
+    return SkillService(
+        workspace_path=Path(workspace.workspace_path),
+        user_id=str(workspace.user_id),
+    )
 
 
 def get_attachment_service() -> AttachmentService:

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -81,6 +81,9 @@ class AcpSessionConfig:
     sandbox_id: str
     sandbox_provider: SandboxProviderType
     cwd: str
+    # Owner of the chat's workspace — keys the per-user agent home that
+    # host-mode processes get as HOME in web mode.
+    user_id: str
     agent_kind: AgentKind = AgentKind.CLAUDE
     env: dict[str, str] = field(default_factory=dict)
     mcp_servers: list[dict[str, Any]] = field(default_factory=list)
@@ -604,20 +607,20 @@ class AcpSession:
         # Start from the host environment so auth tokens, proxy vars,
         # TLS settings, and tool paths are available to the agent process.
         env = dict(os.environ)
-        if config.sandbox_id:
-            host_base = settings.get_host_sandbox_base_dir()
-            host_home = f"{host_base}/{config.sandbox_id}"
+        if config.sandbox_id and not settings.DESKTOP_MODE:
+            # Web mode: HOME is the per-user agent home, shared by every
+            # workspace of the user, so CLI logins/MCP/skills are configured
+            # once — not once per workspace.
+            home = settings.get_agent_home_dir(config.user_id)
+            Path(home).mkdir(parents=True, exist_ok=True)
             # Rewrite virtual sandbox paths (/home/user/...) in env values to
-            # the real host sandbox directory. GIT_ASKPASS is exempt by design:
-            # in host mode it already points at a real API-filesystem path.
+            # the real home. GIT_ASKPASS is exempt by design: in host mode it
+            # already points at a real API-filesystem path.
             for key, val in config.env.items():
-                env[key] = val.replace(SANDBOX_HOME_DIR, host_home)
-            # Web mode: override HOME so the agent uses the sandbox dir.
-            # Desktop mode keeps the real host location so existing auth resolves.
-            if not settings.DESKTOP_MODE:
-                Path(host_home).mkdir(parents=True, exist_ok=True)
-                env["HOME"] = host_home
+                env[key] = val.replace(SANDBOX_HOME_DIR, home)
+            env["HOME"] = home
         else:
+            # Desktop mode keeps the real host env/HOME so existing auth resolves.
             env.update(config.env)
         # Launch env carries runtime-resolved values (e.g. Codex's CODEX_CONFIG
         # with an absolute instructions path), so it skips the sandbox-path rewrite.

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -141,6 +141,7 @@ class AgentService:
 
         return await self._build_acp_config(
             user_settings=user_settings,
+            user_id=str(user.id),
             agent_kind=agent_kind,
             permission_mode=permission_mode,
             model_id=model_id,
@@ -386,6 +387,7 @@ class AgentService:
         # AcpSessionConfig skips the adapter and sends neither.
         config = await self._build_acp_config(
             user_settings=user_settings,
+            user_id=str(user.id),
             agent_kind=agent_kind,
             permission_mode=NORMAL_SESSION_MODE[agent_kind],
             model_id=model_id,
@@ -476,6 +478,7 @@ class AgentService:
         self,
         *,
         user_settings: UserSettings,
+        user_id: str,
         agent_kind: AgentKind,
         permission_mode: PermissionMode,
         model_id: str,
@@ -524,6 +527,7 @@ class AgentService:
             sandbox_id=sandbox_id,
             sandbox_provider=sandbox_provider,
             cwd=cwd,
+            user_id=user_id,
             agent_kind=agent_kind,
             env=env,
             mcp_servers=self._build_mcp_server_configs(chat_id),

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -90,6 +90,7 @@ class SandboxService:
         cwd: str,
         on_data: PtyDataCallbackType,
         on_exit: PtyExitCallbackType,
+        user_id: str = "",
     ) -> str:
         return await self.provider.create_pty(
             sandbox_id,
@@ -99,6 +100,7 @@ class SandboxService:
             cwd,
             on_data=on_data,
             on_exit=on_exit,
+            user_id=user_id,
         )
 
     async def send_pty_input(

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -146,17 +146,29 @@ class SandboxProvider:
         cwd: str,
         on_data: PtyDataCallbackType,
         on_exit: PtyExitCallbackType,
+        user_id: str = "",
     ) -> str:
         # Returns the new PTY session id. `cwd` is workspace-relative; ""
         # means the provider's default start dir. `on_exit` fires when the
         # PTY stream ends on its own (shell exit, container gone) — never on
-        # kill_pty's own cancellation.
+        # kill_pty's own cancellation. `user_id` keys the per-user agent home
+        # used as HOME in web host mode (unused by Docker — container HOME is
+        # fixed).
         raise NotImplementedError
 
     @staticmethod
-    def build_pty_shell_command(tmux_session: str, fallback_shell: str) -> str:
+    def build_pty_shell_command(
+        tmux_session: str,
+        fallback_shell: str,
+        session_env: dict[str, str] | None = None,
+    ) -> str:
         # Shared tmux launch for every provider's PTY, falling back to a bare
-        # shell when tmux isn't installed. history-limit and the smcup@/rmcup@
+        # shell when tmux isn't installed. session_env entries are passed with
+        # new-session -e: the tmux server is shared per OS user and hands its
+        # own (first-start) environment to new shells, so vars like the
+        # per-user agent HOME must be pinned at the session level — the
+        # spawning client's env never reaches shells on an existing server.
+        # history-limit and the smcup@/rmcup@
         # override precede new -A: they only apply to panes/clients created
         # after they're set (tmux applies them fine with no server running).
         # smcup@/rmcup@ keep tmux off the alternate screen so output lands in
@@ -169,11 +181,15 @@ class SandboxProvider:
         # forwards mouse-mode requests from inner TUIs. set-clipboard plus the
         # Ms override forward inner-app/copy-mode copies as OSC 52 to the
         # frontend clipboard addon.
+        env_flags = "".join(
+            f" -e {shlex.quote(key + '=' + value)}"
+            for key, value in (session_env or {}).items()
+        )
         return (
             "command -v tmux >/dev/null && "
             "tmux set -g history-limit 10000"
             " \\; set -as terminal-overrides ',xterm-256color:smcup@:rmcup@:indn@'"
-            f" \\; new -A -s {shlex.quote(tmux_session)}"
+            f" \\; new -A{env_flags} -s {shlex.quote(tmux_session)}"
             " \\; set -g status off"
             " \\; set -g mouse off"
             " \\; set -s set-clipboard on"

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -388,10 +388,12 @@ class LocalDockerProvider(SandboxProvider):
         cwd: str,
         on_data: PtyDataCallbackType,
         on_exit: PtyExitCallbackType,
+        user_id: str = "",
     ) -> str:
         # Spawn a PTY-attached shell inside the container via docker exec.
         # Tries tmux for session persistence across WebSocket reconnections,
-        # falls back to bare bash if tmux is not installed.
+        # falls back to bare bash if tmux is not installed. `user_id` is
+        # unused: the container's HOME is fixed at image build time.
         container = await self._get_container(sandbox_id)
         session_id = str(uuid.uuid4())
 

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -232,6 +232,7 @@ class LocalHostProvider(SandboxProvider):
         cwd: str,
         on_data: PtyDataCallbackType,
         on_exit: PtyExitCallbackType,
+        user_id: str = "",
     ) -> str:
         # Spawn a PTY-attached shell in the workspace directory (or a
         # workspace-relative cwd, e.g. a chat's worktree). Tries tmux
@@ -248,13 +249,19 @@ class LocalHostProvider(SandboxProvider):
         )
 
         env = os.environ.copy()
+        session_env: dict[str, str] = {}
         if sandbox_id and not settings.DESKTOP_MODE:
-            host_home = Path(settings.get_host_sandbox_base_dir()) / sandbox_id
-            host_home.mkdir(parents=True, exist_ok=True)
-            env["HOME"] = str(host_home)
+            # Same per-user HOME as spawned agents, so `claude login` etc. run
+            # from the terminal lands where every workspace's agent reads it.
+            # Pinned via tmux session env too — the process env alone is lost
+            # when the session lands on an already-running tmux server.
+            host_home = settings.get_agent_home_dir(user_id)
+            Path(host_home).mkdir(parents=True, exist_ok=True)
+            env["HOME"] = host_home
+            session_env["HOME"] = host_home
         env["TERM"] = TERMINAL_TYPE
         shell = env.get("SHELL", "/bin/bash")
-        cmd = self.build_pty_shell_command(tmux_session, shell)
+        cmd = self.build_pty_shell_command(tmux_session, shell, session_env)
         process = await asyncio.to_thread(
             subprocess.Popen,
             ["bash", "-lc", cmd],

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -19,9 +19,9 @@ SKILL_MD_FILENAME = "SKILL.md"
 
 
 class SkillService:
-    def __init__(self, workspace_path: Path | None = None) -> None:
+    def __init__(self, workspace_path: Path | None = None, *, user_id: str) -> None:
         self.paths_by_source, self.readonly_paths = self._build_paths_by_source(
-            workspace_path
+            workspace_path, user_id
         )
 
     @staticmethod
@@ -38,9 +38,16 @@ class SkillService:
     @staticmethod
     def _build_paths_by_source(
         workspace_path: Path | None,
+        user_id: str,
     ) -> tuple[dict[str, list[Path]], set[Path]]:
-        # Desktop mode reads from the user's home dir, server mode from STORAGE_PATH.
-        base = Path.home() if settings.DESKTOP_MODE else Path(settings.STORAGE_PATH)
+        # The global tier roots at the HOME the user's agents actually run
+        # with — real home on desktop, per-user agent home on web — so the UI
+        # lists exactly the skills agents can load.
+        base = (
+            Path.home()
+            if settings.DESKTOP_MODE
+            else Path(settings.get_agent_home_dir(user_id))
+        )
         ns = SkillService._namespace_paths
 
         # .{name}/skills namespaces each agent searches. Codex/Copilot/Cursor share

--- a/backend/app/services/terminal.py
+++ b/backend/app/services/terminal.py
@@ -58,6 +58,7 @@ class TerminalSessionRecord:
                     self.cwd,
                     on_data=self._enqueue_output,
                     on_exit=self._schedule_pty_exit,
+                    user_id=self.user_id,
                 )
                 self.input_queue = asyncio.Queue(maxsize=PTY_INPUT_QUEUE_SIZE)
                 self.input_task = asyncio.create_task(self._input_worker(self.pty_id))

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -268,8 +268,10 @@ class WorkspaceService(BaseDbService[Workspace]):
     ) -> WorkspaceResources:
         # Thread-offloaded: SkillService walks the filesystem synchronously.
         workspace = await self.get_workspace(workspace_id, user)
-        workspace_path = Path(workspace.workspace_path)
-        skill_service = SkillService(workspace_path=workspace_path)
+        skill_service = SkillService(
+            workspace_path=Path(workspace.workspace_path),
+            user_id=str(workspace.user_id),
+        )
 
         return await asyncio.to_thread(self._build_workspace_resources, skill_service)
 

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -156,6 +156,7 @@ class FakeSandboxProvider(SandboxProvider):
         cwd: str,
         on_data: PtyDataCallbackType,
         on_exit: PtyExitCallbackType,
+        user_id: str = "",
     ) -> str:
         return "pty-1"
 

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -132,6 +132,12 @@ async def create_real_workspace(
     return headers, body["id"], body["workspace_path"]
 
 
+def agent_home_for(workspace_path: str) -> Path:
+    # Workspaces live under STORAGE_PATH/workspaces/<user_id>/..., so the
+    # owner's id — which keys the per-user agent home — is the parent dir name.
+    return Path(get_settings().get_agent_home_dir(Path(workspace_path).parent.name))
+
+
 def write_skill_md(skill_dir: Path, description: str, body: str = "Body text") -> None:
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(
@@ -415,16 +421,17 @@ async def test_real_skill_service_rejects_readonly_cursor_builtin_update(
     real_sandbox: None,
     real_skill_service: None,
 ) -> None:
-    headers, workspace_id, _path = await create_real_workspace(
+    headers, workspace_id, workspace_path = await create_real_workspace(
         client,
         create_user,
         login,
         email="real-skill-readonly@example.com",
         username="realskillro",
     )
-    settings = get_settings()
     skill_name = f"builtin-{uuid4().hex[:8]}"
-    builtin_dir = Path(settings.STORAGE_PATH) / ".cursor" / "skills-cursor" / skill_name
+    builtin_dir = (
+        agent_home_for(workspace_path) / ".cursor" / "skills-cursor" / skill_name
+    )
     write_skill_md(builtin_dir, "Cursor built-in skill")
 
     response = await client.put(
@@ -604,10 +611,18 @@ async def test_real_skill_service_discovers_enabled_claude_plugin_skills(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    # Server mode resolves the plugin config under STORAGE_PATH, not the
-    # process home dir — point it at the per-test tmp dir.
+    # Server mode resolves the plugin config under the owner's agent home —
+    # isolate under the per-test tmp dir, and create the workspace first since
+    # the agent home is keyed by the owner's user id.
     monkeypatch.setattr(get_settings(), "STORAGE_PATH", str(tmp_path))
-    claude_dir = tmp_path / ".claude"
+    headers, workspace_id, workspace_path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-plugin@example.com",
+        username="realskillplugin",
+    )
+    claude_dir = agent_home_for(workspace_path) / ".claude"
     claude_dir.mkdir(parents=True)
     enabled_install = tmp_path / "enabled-install"
     write_skill_md(enabled_install / "skills" / "pluginskill", "Plugin skill")
@@ -636,14 +651,6 @@ async def test_real_skill_service_discovers_enabled_claude_plugin_skills(
         encoding="utf-8",
     )
 
-    headers, workspace_id, _path = await create_real_workspace(
-        client,
-        create_user,
-        login,
-        email="real-skill-plugin@example.com",
-        username="realskillplugin",
-    )
-
     response = await client.get(
         "/api/v1/skills", params={"workspace_id": workspace_id}, headers=headers
     )
@@ -663,8 +670,8 @@ async def test_real_skill_service_returns_no_plugin_skills_without_settings_file
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    # Server mode resolves the plugin config under STORAGE_PATH, not the
-    # process home dir — point it at the per-test tmp dir.
+    # Server mode resolves the plugin config under the owner's agent home
+    # (below STORAGE_PATH) — point it at the per-test tmp dir.
     monkeypatch.setattr(get_settings(), "STORAGE_PATH", str(tmp_path))
 
     headers, workspace_id, _path = await create_real_workspace(
@@ -694,23 +701,22 @@ async def test_real_skill_service_skips_malformed_plugin_settings_json(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    # Server mode resolves the plugin config under STORAGE_PATH, not the
-    # process home dir — point it at the per-test tmp dir.
+    # Server mode resolves the plugin config under the owner's agent home —
+    # workspace first, since the agent home is keyed by the owner's user id.
     monkeypatch.setattr(get_settings(), "STORAGE_PATH", str(tmp_path))
-    claude_dir = tmp_path / ".claude"
-    claude_dir.mkdir(parents=True)
-    (claude_dir / "settings.json").write_text("{not valid json", encoding="utf-8")
-    plugins_dir = claude_dir / "plugins"
-    plugins_dir.mkdir()
-    (plugins_dir / "installed_plugins.json").write_text("{}", encoding="utf-8")
-
-    headers, workspace_id, _path = await create_real_workspace(
+    headers, workspace_id, workspace_path = await create_real_workspace(
         client,
         create_user,
         login,
         email="real-skill-badjson@example.com",
         username="realskillbadjson",
     )
+    claude_dir = agent_home_for(workspace_path) / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "settings.json").write_text("{not valid json", encoding="utf-8")
+    plugins_dir = claude_dir / "plugins"
+    plugins_dir.mkdir()
+    (plugins_dir / "installed_plugins.json").write_text("{}", encoding="utf-8")
 
     response = await client.get(
         "/api/v1/skills", params={"workspace_id": workspace_id}, headers=headers
@@ -728,10 +734,17 @@ async def test_real_skill_service_skips_plugin_discovery_without_enabled_plugins
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    # Server mode resolves the plugin config under STORAGE_PATH, not the
-    # process home dir — point it at the per-test tmp dir.
+    # Server mode resolves the plugin config under the owner's agent home —
+    # workspace first, since the agent home is keyed by the owner's user id.
     monkeypatch.setattr(get_settings(), "STORAGE_PATH", str(tmp_path))
-    claude_dir = tmp_path / ".claude"
+    headers, workspace_id, workspace_path = await create_real_workspace(
+        client,
+        create_user,
+        login,
+        email="real-skill-noenabled@example.com",
+        username="realskillnoenabled",
+    )
+    claude_dir = agent_home_for(workspace_path) / ".claude"
     claude_dir.mkdir(parents=True)
     (claude_dir / "settings.json").write_text(
         json.dumps({"enabledPlugins": {}}), encoding="utf-8"
@@ -740,14 +753,6 @@ async def test_real_skill_service_skips_plugin_discovery_without_enabled_plugins
     plugins_dir.mkdir()
     (plugins_dir / "installed_plugins.json").write_text(
         json.dumps({"plugins": {}}), encoding="utf-8"
-    )
-
-    headers, workspace_id, _path = await create_real_workspace(
-        client,
-        create_user,
-        login,
-        email="real-skill-noenabled@example.com",
-        username="realskillnoenabled",
     )
 
     response = await client.get(

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -147,6 +147,7 @@ class FakePtySandboxProvider(SandboxProvider):
         cwd: str,
         on_data: PtyDataCallbackType,
         on_exit: PtyExitCallbackType,
+        user_id: str = "",
     ) -> str:
         if self.create_delay:
             await asyncio.sleep(self.create_delay)


### PR DESCRIPTION
## Summary
- In web mode, host-provider agents and terminal PTYs previously got a fresh HOME under `<storage>/host-sandboxes/<sandbox_id>`, so CLI logins (`claude login`, `codex login`), MCP registrations, and skill configuration had to be redone for every new workspace/sandbox.
- Adds `Settings.get_agent_home_dir(user_id)`, keying the agent HOME by user id instead of sandbox id, so it's shared across every workspace the user opens — matching desktop mode where the real `$HOME` fills this role.
- `AcpSession`, `LocalHostProvider.create_pty`, and `SkillService` all resolve this same per-user home. Since tmux reuses an already-running server (which ignores the spawning process's env for new panes), the HOME override is also pinned via `tmux new -e HOME=...` at session creation.
- Docker provider is unaffected — container HOME is fixed at image build time.

## Test plan
- [x] `ruff` / `ruff format` pre-commit hooks pass
- [x] `pytest backend/tests/test_skills.py backend/tests/test_websocket.py` (35 passed)