### PR TITLE
Scale up type and spacing system by 1.2x

### DIFF
--- a/frontend/src/components/chat/chat-search/ChatSearchResultLine.module.scss
+++ b/frontend/src/components/chat/chat-search/ChatSearchResultLine.module.scss
@@ -12,7 +12,7 @@
   padding: var(--space-0-5) var(--space-1-5);
   text-align: left;
   // TODO(refactor): leading-5 (1.25rem) overrides type-meta's default line-height; no token for a standalone leading value
-  line-height: 1.25rem;
+  line-height: 1.5rem;
   color: var(--theme-text-secondary);
 
   @include responsive.hover {

--- a/frontend/src/components/chat/chat-window/Chat.module.scss
+++ b/frontend/src/components/chat/chat-window/Chat.module.scss
@@ -35,7 +35,7 @@
     margin-left: auto;
     margin-right: auto;
     // TODO(refactor): Tailwind's max-w-4xl (56rem) has no spacing-scale token
-    max-width: 56rem;
+    max-width: 67.2rem;
   }
 }
 
@@ -80,7 +80,7 @@
     margin-left: auto;
     margin-right: auto;
     // TODO(refactor): Tailwind's max-w-4xl (56rem) has no spacing-scale token
-    max-width: 56rem;
+    max-width: 67.2rem;
   }
 }
 

--- a/frontend/src/components/chat/chat-window/ChatSkeleton.module.scss
+++ b/frontend/src/components/chat/chat-window/ChatSkeleton.module.scss
@@ -5,7 +5,7 @@
   margin-left: auto;
   margin-right: auto;
   // TODO(refactor): Tailwind's max-w-4xl (56rem) has no spacing-scale token — kept as a raw rem value
-  max-width: 56rem;
+  max-width: 67.2rem;
   padding-left: var(--space-6);
   padding-right: var(--space-6);
 }

--- a/frontend/src/components/chat/message-input/DropIndicator.module.scss
+++ b/frontend/src/components/chat/message-input/DropIndicator.module.scss
@@ -58,7 +58,7 @@
 
 .hint {
   @include type.type-default(500);
-  max-width: 20rem;
+  max-width: 24rem;
   text-align: center;
   color: var(--theme-text-tertiary);
 }

--- a/frontend/src/components/chat/message-input/MentionSuggestionsPanel.module.scss
+++ b/frontend/src/components/chat/message-input/MentionSuggestionsPanel.module.scss
@@ -14,7 +14,7 @@
 }
 
 .file-name {
-  @include type.type-mono(0.75rem, 1.25);
+  @include type.type-mono(0.9rem, 1.25);
   color: var(--theme-text-secondary);
 
   &--active {

--- a/frontend/src/components/chat/message-input/SlashCommandsPanel.module.scss
+++ b/frontend/src/components/chat/message-input/SlashCommandsPanel.module.scss
@@ -6,7 +6,7 @@
 }
 
 .command-value {
-  @include type.type-mono(0.75rem, 1.25);
+  @include type.type-mono(0.9rem, 1.25);
   flex-shrink: 0;
   color: var(--theme-text-secondary);
 

--- a/frontend/src/components/chat/tools/ToolPermissionInline.module.scss
+++ b/frontend/src/components/chat/tools/ToolPermissionInline.module.scss
@@ -63,7 +63,7 @@
 }
 
 .headline {
-  @include type.type(0.75rem, 1.625);
+  @include type.type(0.9rem, 1.625);
   margin-bottom: var(--space-3);
   color: var(--theme-text-primary);
 }

--- a/frontend/src/components/chat/tools/claude/AgentOutputTool.module.scss
+++ b/frontend/src/components/chat/tools/claude/AgentOutputTool.module.scss
@@ -6,7 +6,7 @@
   // TODO(refactor): old `rounded` (0.25rem) has no radius token (sm 0.125 / md 0.375)
   border-radius: var(--radius-sm);
   padding: var(--space-1-5) var(--space-2);
-  @include type.type-mono(0.75rem, 1rem);
+  @include type.type-mono(0.9rem, 1.2rem);
   color: var(--theme-text-secondary);
   // subtle inset surface — black overlay on light, white overlay on dark
   background-color: rgb(0 0 0 / 0.05);

--- a/frontend/src/components/chat/tools/claude/BashTool.module.scss
+++ b/frontend/src/components/chat/tools/claude/BashTool.module.scss
@@ -9,7 +9,7 @@
 .command {
   white-space: pre-wrap;
   word-break: break-all;
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   color: var(--theme-text-secondary);
 
   :global([data-theme='dark']) & {

--- a/frontend/src/components/chat/tools/claude/FileOperationTool.module.scss
+++ b/frontend/src/components/chat/tools/claude/FileOperationTool.module.scss
@@ -9,7 +9,7 @@
 .diff {
   max-height: var(--space-48);
   overflow: auto;
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
 }
 
 .line {

--- a/frontend/src/components/chat/tools/claude/GlobTool.module.scss
+++ b/frontend/src/components/chat/tools/claude/GlobTool.module.scss
@@ -3,7 +3,7 @@
 .files {
   max-height: var(--space-48);
   overflow: auto;
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   color: var(--theme-text-tertiary);
 
   :global([data-theme='dark']) & {

--- a/frontend/src/components/chat/tools/codex/EditTool.module.scss
+++ b/frontend/src/components/chat/tools/codex/EditTool.module.scss
@@ -12,7 +12,7 @@
 }
 
 .body {
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   max-height: var(--space-48);
   overflow: auto;
 }

--- a/frontend/src/components/chat/tools/codex/codexShellPayload.module.scss
+++ b/frontend/src/components/chat/tools/codex/codexShellPayload.module.scss
@@ -3,7 +3,7 @@
 // Command line preview (`$ <command>`) — reads one shade lighter than the shared
 // output-pre body, so it needs its own asymmetric light/dark pair.
 .command-pre {
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   white-space: pre-wrap;
   word-break: break-all;
   color: var(--theme-text-secondary);

--- a/frontend/src/components/chat/tools/common/DiffView/DiffView.module.scss
+++ b/frontend/src/components/chat/tools/common/DiffView/DiffView.module.scss
@@ -2,7 +2,7 @@
 @use '@/styles/globals/colors' as colors;
 
 .diff {
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   max-height: var(--space-48);
   overflow: auto;
 }

--- a/frontend/src/components/chat/tools/common/NumberedContent/NumberedContent.module.scss
+++ b/frontend/src/components/chat/tools/common/NumberedContent/NumberedContent.module.scss
@@ -1,7 +1,7 @@
 @use '@/styles/globals/typography' as type;
 
 .numbered {
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   max-height: var(--space-48);
   overflow: auto;
 }

--- a/frontend/src/components/chat/tools/common/ToolCard/ToolCard.module.scss
+++ b/frontend/src/components/chat/tools/common/ToolCard/ToolCard.module.scss
@@ -50,7 +50,7 @@
 .title {
   display: block;
   // TODO(refactor): no spacing token for 28rem (old max-w-md); scale skips 24rem→32rem
-  max-width: 28rem;
+  max-width: 33.6rem;
   @include type.type-meta;
   @include type.type-overflow;
   color: var(--theme-text-tertiary);

--- a/frontend/src/components/chat/tools/common/toolText.module.scss
+++ b/frontend/src/components/chat/tools/common/toolText.module.scss
@@ -4,7 +4,7 @@
 // Shared <pre> bodies for tool output/error snippets (was utils/toolStyles.ts).
 // leading-relaxed (1.625) on mono 10px — keep the original dense-code line-height.
 .output-pre {
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   max-height: var(--space-48);
   overflow: auto;
   white-space: pre-wrap;
@@ -46,7 +46,7 @@
 }
 
 .error-pre {
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   max-height: var(--space-48);
   overflow: auto;
   white-space: pre-wrap;

--- a/frontend/src/components/chat/tools/copilot/ExecuteTool.module.scss
+++ b/frontend/src/components/chat/tools/copilot/ExecuteTool.module.scss
@@ -9,7 +9,7 @@
 .command {
   white-space: pre-wrap;
   word-break: break-all;
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   color: var(--theme-text-secondary);
 
   :global([data-theme='dark']) & {

--- a/frontend/src/components/chat/tools/grok/BashTool.module.scss
+++ b/frontend/src/components/chat/tools/grok/BashTool.module.scss
@@ -9,7 +9,7 @@
 // Command line preview (`$ <command>`) — reads one shade lighter than the shared
 // output-pre body, so it needs its own asymmetric light/dark pair.
 .command-pre {
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   white-space: pre-wrap;
   word-break: break-all;
   color: var(--theme-text-secondary);

--- a/frontend/src/components/chat/tools/opencode/BashTool.module.scss
+++ b/frontend/src/components/chat/tools/opencode/BashTool.module.scss
@@ -9,7 +9,7 @@
 // Command line preview (`$ <command>`) — reads one shade lighter than the shared
 // output-pre body, so it needs its own asymmetric light/dark pair.
 .command-pre {
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   white-space: pre-wrap;
   word-break: break-all;
   color: var(--theme-text-secondary);

--- a/frontend/src/components/editor/editor-view/Content.tsx
+++ b/frontend/src/components/editor/editor-view/Content.tsx
@@ -19,7 +19,7 @@ const EDITOR_OPTIONS = {
   },
   snippetSuggestions: 'inline',
   fontFamily: MONACO_FONT_FAMILY,
-  fontSize: 12,
+  fontSize: 14,
   lineHeight: 1.5,
   renderLineHighlight: 'none',
   scrollbar: {

--- a/frontend/src/components/editor/editor-view/DiffContent.tsx
+++ b/frontend/src/components/editor/editor-view/DiffContent.tsx
@@ -23,7 +23,7 @@ const DIFF_OPTIONS = {
   padding: { top: 8, bottom: 8 },
   automaticLayout: true,
   fontFamily: MONACO_FONT_FAMILY,
-  fontSize: 12,
+  fontSize: 14,
   lineHeight: 1.5,
   renderLineHighlight: 'none',
   scrollbar: {

--- a/frontend/src/components/editor/file-preview/PowerPointPreview.module.scss
+++ b/frontend/src/components/editor/file-preview/PowerPointPreview.module.scss
@@ -18,7 +18,7 @@
 .slide-card {
   margin-inline: auto;
   // TODO(refactor): Tailwind's max-w-4xl (56rem) has no spacing-scale token — kept as a raw rem value
-  max-width: 56rem;
+  max-width: 67.2rem;
   min-height: var(--space-96);
   border-radius: var(--radius-lg);
   background-color: var(--theme-surface);

--- a/frontend/src/components/editor/file-search/SearchResultLine.module.scss
+++ b/frontend/src/components/editor/file-search/SearchResultLine.module.scss
@@ -12,7 +12,7 @@
   padding: var(--space-0-5) var(--space-1-5);
   text-align: left;
   // TODO(refactor): leading-5 (1.25rem) overrides type-mono-meta's default line-height; no token for a standalone leading value
-  line-height: 1.25rem;
+  line-height: 1.5rem;
   color: var(--theme-text-secondary);
 
   @include responsive.hover {

--- a/frontend/src/components/layout/Sidebar/SidebarActions.module.scss
+++ b/frontend/src/components/layout/Sidebar/SidebarActions.module.scss
@@ -19,7 +19,7 @@
   border-radius: var(--radius-lg);
   padding: var(--space-2) var(--space-3);
   // TODO(refactor): no 13px type token exists — sidebar controls use a one-off text-[13px]
-  font-size: 13px;
+  font-size: 16px;
   font-weight: 500;
   color: var(--theme-text-primary);
   background-color: var(--theme-surface-tertiary);
@@ -43,7 +43,7 @@
   border-radius: var(--radius-lg);
   padding: var(--space-2) var(--space-3);
   // TODO(refactor): no 13px type token exists — sidebar controls use a one-off text-[13px]
-  font-size: 13px;
+  font-size: 16px;
   color: var(--theme-text-secondary);
 
   @include responsive.hover {

--- a/frontend/src/components/layout/Sidebar/SidebarChatItem.module.scss
+++ b/frontend/src/components/layout/Sidebar/SidebarChatItem.module.scss
@@ -143,7 +143,7 @@
   gap: var(--space-1-5);
   text-align: left;
   // TODO(refactor): no 13px type token exists — sidebar rows use a one-off text-[13px]
-  font-size: 13px;
+  font-size: 16px;
 }
 
 .title-text {

--- a/frontend/src/components/sandbox/git/DiffFileRow/DiffFileRow.module.scss
+++ b/frontend/src/components/sandbox/git/DiffFileRow/DiffFileRow.module.scss
@@ -34,7 +34,7 @@
   padding: var(--space-0-5) var(--space-1);
   // No 9px type token exists — micro-badge sizing kept literal.
   // TODO(refactor): add a type-micro mixin if 9px badges proliferate.
-  font-size: 9px;
+  font-size: 11px;
   font-weight: 500;
   line-height: 1;
 

--- a/frontend/src/components/sandbox/git/DiffFileSidebar/DiffFileSidebar.module.scss
+++ b/frontend/src/components/sandbox/git/DiffFileSidebar/DiffFileSidebar.module.scss
@@ -131,7 +131,7 @@
   padding: var(--space-0-5) var(--space-1);
   // No 9px type token exists — micro-badge sizing kept literal.
   // TODO(refactor): add a type-micro mixin if 9px badges proliferate.
-  font-size: 9px;
+  font-size: 11px;
   font-weight: 500;
   line-height: 1;
 

--- a/frontend/src/components/settings/dialogs/SkillEditDialog/SkillEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/SkillEditDialog/SkillEditDialog.tsx
@@ -21,7 +21,7 @@ const EDITOR_OPTIONS = {
   padding: { top: 8, bottom: 8 },
   automaticLayout: true,
   fontFamily: MONACO_FONT_FAMILY,
-  fontSize: 12,
+  fontSize: 14,
   scrollbar: {
     useShadows: false,
     vertical: 'auto',

--- a/frontend/src/components/settings/tabs/CloudSettingsTab/CloudSettingsTab.module.scss
+++ b/frontend/src/components/settings/tabs/CloudSettingsTab/CloudSettingsTab.module.scss
@@ -30,7 +30,7 @@
 }
 
 .url {
-  @include type.type-mono(0.75rem, 1rem, 500);
+  @include type.type-mono(0.9rem, 1.2rem, 500);
   @include type.type-overflow;
   min-width: 0;
   color: var(--theme-text-primary);

--- a/frontend/src/components/settings/tabs/EnvVarsSettingsTab/EnvVarsSettingsTab.module.scss
+++ b/frontend/src/components/settings/tabs/EnvVarsSettingsTab/EnvVarsSettingsTab.module.scss
@@ -8,7 +8,7 @@
 }
 
 .item-key {
-  @include type.type-mono(0.75rem, 1rem, 500);
+  @include type.type-mono(0.9rem, 1.2rem, 500);
   @include type.type-overflow;
   min-width: 0;
   max-width: 100%;

--- a/frontend/src/components/settings/tabs/PersonasSettingsTab/PersonasSettingsTab.module.scss
+++ b/frontend/src/components/settings/tabs/PersonasSettingsTab/PersonasSettingsTab.module.scss
@@ -9,7 +9,7 @@
 
 .item-content {
   // Relaxed line-height preserved from the old leading-relaxed on a mono preview
-  @include type.type-mono(0.625rem, 1.625);
+  @include type.type-mono(0.75rem, 1.625);
   @include type.type-lineclamp(3);
   color: var(--theme-text-quaternary);
 }

--- a/frontend/src/components/ui/Mermaid/Mermaid.module.scss
+++ b/frontend/src/components/ui/Mermaid/Mermaid.module.scss
@@ -46,7 +46,7 @@
 }
 
 .code {
-  @include type.type-mono(0.75rem, 1rem);
+  @include type.type-mono(0.9rem, 1.2rem);
   color: var(--theme-text-primary);
 }
 

--- a/frontend/src/components/ui/attachment-viewer/AttachmentThumbnails.module.scss
+++ b/frontend/src/components/ui/attachment-viewer/AttachmentThumbnails.module.scss
@@ -107,7 +107,7 @@
 
 .icon-label {
   // TODO(refactor): no 8px type token — file-type badge kept at a fixed size.
-  font-size: 8px;
+  font-size: 10px;
   line-height: 1.25;
   color: var(--theme-text-tertiary);
 }
@@ -133,7 +133,7 @@
 
 .error-label {
   // TODO(refactor): no 8px type token — error badge kept at a fixed size.
-  font-size: 8px;
+  font-size: 10px;
   color: var(--theme-text-tertiary);
 }
 

--- a/frontend/src/components/ui/command-menu/CommandMenu.module.scss
+++ b/frontend/src/components/ui/command-menu/CommandMenu.module.scss
@@ -16,7 +16,7 @@
   margin-top: var(--space-20);
   height: fit-content;
   width: 100%;
-  max-width: 42rem;
+  max-width: 50.4rem;
   border: 1px solid colors.theme-color('border', 0.5);
   border-radius: var(--radius-xl);
   background-color: colors.theme-color('surface', 0.95);
@@ -26,7 +26,7 @@
 }
 
 .panel {
-  height: 28rem;
+  height: 33.6rem;
 }
 
 .filters {

--- a/frontend/src/components/ui/command-menu/CommandMenuList.module.scss
+++ b/frontend/src/components/ui/command-menu/CommandMenuList.module.scss
@@ -3,7 +3,7 @@
 @use '@/styles/globals/responsive' as responsive;
 
 .list-body {
-  max-height: 24rem;
+  max-height: 28.8rem;
   overflow-y: auto;
   padding: var(--space-1) 0;
 }

--- a/frontend/src/components/ui/markdown/markdownComponents.module.scss
+++ b/frontend/src/components/ui/markdown/markdownComponents.module.scss
@@ -73,7 +73,7 @@
 .p {
   margin-bottom: var(--space-3);
   white-space: pre-wrap;
-  line-height: 1.25rem;
+  line-height: 1.5rem;
   color: var(--theme-text-secondary);
   overflow-wrap: anywhere;
 

--- a/frontend/src/components/ui/shared/BaseModal/BaseModal.module.scss
+++ b/frontend/src/components/ui/shared/BaseModal/BaseModal.module.scss
@@ -27,22 +27,22 @@
 
   // Content max-widths mirror the old Tailwind max-w-* scale (rem, not spacing steps)
   &--sm {
-    max-width: 24rem;
+    max-width: 28.8rem;
   }
   &--md {
-    max-width: 28rem;
+    max-width: 33.6rem;
   }
   &--lg {
-    max-width: 32rem;
+    max-width: 38.4rem;
   }
   &--xl {
-    max-width: 36rem;
+    max-width: 43.2rem;
   }
   &--2xl {
-    max-width: 42rem;
+    max-width: 50.4rem;
   }
   &--4xl {
-    max-width: 56rem;
+    max-width: 67.2rem;
   }
   &--full {
     max-width: 100%;

--- a/frontend/src/config/toaster.ts
+++ b/frontend/src/config/toaster.ts
@@ -16,7 +16,7 @@ export const toasterConfig: ToasterProps = {
     className: '',
     style: {
       padding: '12px 16px',
-      fontSize: '14px',
+      fontSize: '17px',
       fontFamily: 'inherit',
       maxWidth: '420px',
     },

--- a/frontend/src/hooks/useXterm.ts
+++ b/frontend/src/hooks/useXterm.ts
@@ -136,7 +136,7 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
         // tmux attaches without the alternate screen (smcup@ override), so this
         // buffer is the scroll/search history — sized to tmux's history-limit.
         scrollback: 10000,
-        fontSize: 12,
+        fontSize: 14,
         // Nerd Font primary so PUA icon glyphs (eza/ls icons, Starship prompt
         // symbols) render; generic monospace is only a last-resort fallback.
         fontFamily: '"JetBrainsMono Nerd Font", monospace',

--- a/frontend/src/pages/LandingPage/LandingPage.module.scss
+++ b/frontend/src/pages/LandingPage/LandingPage.module.scss
@@ -26,7 +26,7 @@
 .agent-panel {
   margin: auto;
   width: 100%;
-  max-width: 42rem;
+  max-width: 50.4rem;
 }
 
 .greeting {

--- a/frontend/src/pages/SettingsPage/SettingsPage.module.scss
+++ b/frontend/src/pages/SettingsPage/SettingsPage.module.scss
@@ -44,7 +44,7 @@
   margin-left: auto;
   margin-right: auto;
   width: 100%;
-  max-width: 48rem;
+  max-width: 57.6rem;
   padding: var(--space-6) var(--space-4);
 
   @include responsive.media('sm-up') {

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -60,15 +60,15 @@
 }
 
 // Monaco peek widget (go-to-definition / references): monaco's CSS sets no
-// font-size on the results tree, so it inherits the page's 16px root font while
-// the editor renders at 12px. Pin the widget chrome to the editor scale and pad
+// font-size on the results tree, so it inherits the page's root font while
+// the editor renders at 14px. Pin the widget chrome to the editor scale and pad
 // labels away from the fixed-width twistie chevron.
 .monaco-editor .peekview-widget .head .peekview-title {
-  font-size: 12px;
+  font-size: 14px;
 }
 
 .monaco-editor .reference-zone-widget .ref-tree {
-  font-size: 12px;
+  font-size: 14px;
 
   .monaco-tl-contents {
     padding-left: 3px;

--- a/frontend/src/styles/globals/_spacing.scss
+++ b/frontend/src/styles/globals/_spacing.scss
@@ -1,12 +1,13 @@
-// Spacing scale. Unit matches the old Tailwind scale (1 step = 0.25rem) so migration is
-// mechanical: p-3 → padding: space(3); gap-1.5 → gap: space(1.5).
+// Spacing scale. Steps match the old Tailwind scale so migration is mechanical:
+// p-3 → padding: space(3); gap-1.5 → gap: space(1.5). The base is Tailwind's
+// 0.25rem ×1.2, matching the ×1.2 type scale so text-to-space ratios are unchanged.
 // Always use space() for margin/padding/gap/inset — never raw rem/px (px allowed only for
 // things that must never rescale, e.g. 1px borders).
 
 @use 'sass:math';
 @use 'sass:list';
 
-$space-base: 0.25rem;
+$space-base: 0.3rem;
 $space-steps: (
   0,
   0.5,

--- a/frontend/src/styles/globals/_typography.scss
+++ b/frontend/src/styles/globals/_typography.scss
@@ -1,10 +1,12 @@
 // Typography system. Components never set font-size/weight/line-height directly —
-// always via a type-* mixin. Semantic names map to the app's dense-UI scale:
-//   type-meta      10px — metadata, badges, section headers (old text-2xs)
-//   type-default   12px — the app-wide default (old text-xs)
-//   type-body      14px — primary inputs, prose (old text-sm)
-//   type-title     18px — dialog titles only (old text-lg)
-//   type-page-title 20px — page headings (old text-xl font-semibold)
+// always via a type-* mixin. Semantic names map to the app's dense-UI scale.
+// The scale (and $space-base) is the original 10/12/14/18/20px design ×1.2 —
+// the ratios were right but the whole system rendered too small at 1×:
+//   type-meta      12px — metadata, badges, section headers (old text-2xs)
+//   type-default   14.4px — the app-wide default (old text-xs)
+//   type-body      16.8px — primary inputs, prose (old text-sm)
+//   type-title     21.6px — dialog titles only (old text-lg)
+//   type-page-title 24px — page headings (old text-xl font-semibold)
 
 @mixin typography-tokens {
   :root {
@@ -28,43 +30,43 @@
 }
 
 @mixin type-meta($weight: 400) {
-  @include type(0.625rem, 0.875rem, $weight);
+  @include type(0.75rem, 1.05rem, $weight);
 }
 
 @mixin type-default($weight: 400) {
-  @include type(0.75rem, 1rem, $weight);
+  @include type(0.9rem, 1.2rem, $weight);
 }
 
 @mixin type-body($weight: 400) {
-  @include type(0.875rem, 1.25rem, $weight);
+  @include type(1.05rem, 1.5rem, $weight);
 }
 
 @mixin type-large($weight: 400) {
-  @include type(1rem, 1.5rem, $weight);
+  @include type(1.2rem, 1.8rem, $weight);
 }
 
 @mixin type-title($weight: 500) {
-  @include type(1.125rem, 1.75rem, $weight);
+  @include type(1.35rem, 2.1rem, $weight);
 }
 
 @mixin type-page-title($weight: 600) {
-  @include type(1.25rem, 1.75rem, $weight);
+  @include type(1.5rem, 2.1rem, $weight);
 }
 
-// Panel/sidebar section headers: 10px uppercase wide-tracked quaternary
+// Panel/sidebar section headers: 12px uppercase wide-tracked quaternary
 @mixin type-section-header {
-  @include type(0.625rem, 0.875rem, 500, $letter-spacing: 0.05em);
+  @include type(0.75rem, 1.05rem, 500, $letter-spacing: 0.05em);
   text-transform: uppercase;
   color: var(--theme-text-quaternary);
 }
 
 // Code, file paths, env vars, technical IDs
-@mixin type-mono($size: 0.75rem, $line-height: 1rem, $weight: 400) {
+@mixin type-mono($size: 0.9rem, $line-height: 1.2rem, $weight: 400) {
   @include type($size, $line-height, $weight, var(--font-mono));
 }
 
 @mixin type-mono-meta {
-  @include type-mono(0.625rem, 0.875rem);
+  @include type-mono(0.75rem, 1.05rem);
 }
 
 // ---- utilities ----

--- a/frontend/src/styles/pierre-tree-theme.css
+++ b/frontend/src/styles/pierre-tree-theme.css
@@ -54,5 +54,5 @@ file-tree-container {
   --trees-git-ignored-color-override: rgb(var(--theme-text-quaternary-rgb) / 0.6);
   --trees-git-deleted-color-override: var(--theme-text-quaternary);
 
-  --trees-font-size-override: 12px;
+  --trees-font-size-override: 14px;
 }


### PR DESCRIPTION
## Summary
- The dense-UI type scale (10/12/14/18/20px) and matching spacing base rendered too small at 1x; rescale both by ×1.2 so text-to-space ratios stay unchanged.
- Update dependent fixed px values (Monaco editor font size, xterm font size, toaster font size, Monaco peek-widget font size) to match the new baseline.