### PR TITLE
fix: keep landing page composer at optical center

### DIFF
--- a/frontend/src/pages/LandingPage/LandingPage.module.scss
+++ b/frontend/src/pages/LandingPage/LandingPage.module.scss
@@ -15,27 +15,38 @@
 
 .agent-view {
   display: flex;
+  flex-direction: column;
   height: 100%;
   width: 100%;
   overflow-y: auto;
   padding: var(--space-4) var(--space-4) var(--space-10);
 }
 
-// margin:auto (not justify-content:center) so the greeting/recents stay
-// reachable when the panel grows taller than the viewport.
+// The greeting and recents/prompts regions are 1:1.5 flexible spacers, so the
+// composer sits at ~40% height (optical center). The panel still grows past
+// the viewport when content is tall, keeping everything reachable.
 .agent-panel {
-  margin: auto;
+  margin: 0 auto;
   width: 100%;
   max-width: 50.4rem;
+  flex: 1 0 auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .greeting {
+  flex: 1 0 0;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: flex-end;
   gap: var(--space-1-5);
   margin-bottom: var(--space-6);
   text-align: center;
+}
+
+.panel-below {
+  flex: 1.5 0 0;
 }
 
 .greeting-logo {

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -442,27 +442,29 @@ export function LandingPage() {
                   placeholder="Message Agentrove... (@ to mention, / for commands)"
                 />
 
-                {showRecents ? (
-                  <RecentChats
-                    chats={recentChats}
-                    workspaceBadgeById={workspaceBadgeById}
-                    onChatSelect={handleChatSelect}
-                  />
-                ) : (
-                  <div className={styles['example-prompts']}>
-                    {EXAMPLE_PROMPTS.map((prompt) => (
-                      <Button
-                        key={prompt}
-                        type="button"
-                        variant="unstyled"
-                        onClick={() => setMessage(prompt)}
-                        className={styles['example-prompt']}
-                      >
-                        {prompt}
-                      </Button>
-                    ))}
-                  </div>
-                )}
+                <div className={styles['panel-below']}>
+                  {showRecents ? (
+                    <RecentChats
+                      chats={recentChats}
+                      workspaceBadgeById={workspaceBadgeById}
+                      onChatSelect={handleChatSelect}
+                    />
+                  ) : (
+                    <div className={styles['example-prompts']}>
+                      {EXAMPLE_PROMPTS.map((prompt) => (
+                        <Button
+                          key={prompt}
+                          type="button"
+                          variant="unstyled"
+                          onClick={() => setMessage(prompt)}
+                          className={styles['example-prompt']}
+                        >
+                          {prompt}
+                        </Button>
+                      ))}
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
           );


### PR DESCRIPTION
## Summary
- Replace `margin: auto` centering on the agent panel with a flex layout where the greeting and recents/prompts regions act as 1:1.5 flexible spacers, settling the composer at ~40% height (optical center) instead of drifting toward true center as content grows.
- Wrap the recent-chats/example-prompts block in a new `.panel-below` flex spacer so it participates in the same ratio.
- Panel still grows past the viewport and stays scrollable/reachable when content is tall.