### PR TITLE
fix: remove autofocus from workspace picker search input

### DIFF
--- a/frontend/src/components/chat/workspace-selector/WorkspacePicker.tsx
+++ b/frontend/src/components/chat/workspace-selector/WorkspacePicker.tsx
@@ -92,7 +92,6 @@ export function WorkspacePicker({
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Search workspaces…"
-                  autoFocus
                   className={styles['search-input']}
                 />
                 {searchQuery && (


### PR DESCRIPTION
## Summary
- Removes `autoFocus` from the workspace picker's search input so opening the picker no longer steals focus into the search field.