### PR TITLE
fix: forward real proto to API behind Coolify/Traefik

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,8 @@ DOCKER_PERMISSION_API_URL=http://agentrove-api-web:8080
 FRONTEND_PORT=3000
 VITE_API_BASE_URL=/api/v1
 VITE_WS_URL=/api/v1/ws
+
+# Production / Coolify (docker-compose-production.yml)
+# APP_URL=https://yourdomain.com
+# ALLOWED_ORIGINS=https://yourdomain.com
+# TRUSTED_PROXY_HOSTS=*

--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ ALLOWED_ORIGINS=https://yourdomain.com \
 docker compose -f docker-compose-production.yml up -d --build
 ```
 
+### Coolify / reverse proxy
+
+Point Coolify at the `web` service (port 80). Set:
+
+| Variable | Example |
+| --- | --- |
+| `APP_URL` | `https://yourdomain.com` |
+| `ALLOWED_ORIGINS` | `https://yourdomain.com` |
+| `SECRET_KEY` | 32+ char secret |
+| `TRUSTED_PROXY_HOSTS` | `*` (default in production compose) |
+
+If `/admin` loads as plain unstyled HTML (blue links, no layout), the API is generating `http://` URLs for SQLAdmin CSS/JS while the page is `https://`. Rebuild with the production compose above so nginx forwards Coolify's `X-Forwarded-Proto` and the API trusts the proxy.
+
 ## Stack
 
 - Frontend: React 19, TypeScript, Vite, Tailwind CSS, Monaco, xterm.js

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -54,6 +54,10 @@ services:
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost,http://127.0.0.1}
       BASE_URL: ${APP_URL:-http://localhost}
       FRONTEND_URL: ${APP_URL:-http://localhost}
+      # Coolify/Traefik (and the web nginx container) sit in front of the API.
+      # Without this, ProxyHeadersMiddleware ignores X-Forwarded-Proto and
+      # SQLAdmin emits http:// asset URLs on an https:// page (unstyled admin).
+      TRUSTED_PROXY_HOSTS: ${TRUSTED_PROXY_HOSTS:-*}
     networks:
       - default
       - sandbox

--- a/frontend/nginx-production.conf
+++ b/frontend/nginx-production.conf
@@ -1,3 +1,12 @@
+# Coolify/Traefik terminates TLS and forwards HTTP here with
+# X-Forwarded-Proto: https. Prefer that over nginx's own $scheme (always
+# "http" on this listener) so the API builds correct absolute URLs for
+# SQLAdmin CSS/JS — otherwise browsers block them as mixed content.
+map $http_x_forwarded_proto $forwarded_proto {
+  default $http_x_forwarded_proto;
+  ""      $scheme;
+}
+
 server {
   listen 80;
   server_name _;
@@ -13,7 +22,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
     proxy_read_timeout 3600s;
@@ -26,7 +35,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
   }
 
   location /health {


### PR DESCRIPTION
## Summary
- nginx's own `$scheme` is always `http` on the plain `listen 80` server, so behind Coolify/Traefik (which terminate TLS and forward `X-Forwarded-Proto: https`) it overwrote that header with `http`.
- The API's `ProxyHeadersMiddleware` needs `TRUSTED_PROXY_HOSTS` set to trust forwarded headers at all; without it, SQLAdmin generated `http://` asset URLs on an `https://` page, which browsers block as mixed content, leaving `/admin` unstyled.
- Fix: nginx now prefers the upstream `X-Forwarded-Proto` when present (falling back to `$scheme`), the production compose trusts the proxy by default (`TRUSTED_PROXY_HOSTS=*`), and the README/`.env.example` document the required vars and the symptom.

## Test plan
- [ ] Deploy via `docker-compose-production.yml` behind Coolify/Traefik and confirm `/admin` loads styled over HTTPS
- [ ] Verify plain `http://` local runs still work (fallback to `$scheme` when no forwarded header is present)