### PR TITLE
fix: allow admin user edits without setting a password

### DIFF
--- a/backend/app/admin/views.py
+++ b/backend/app/admin/views.py
@@ -58,7 +58,13 @@ class UserAdmin(ModelView, model=User):
         "updated_at": _format_datetime,
     }
 
-    form_excluded_columns = ["chats", "settings", "hashed_password"]
+    form_excluded_columns = [
+        "chats",
+        "settings",
+        "workspaces",
+        "refresh_tokens",
+        "hashed_password",
+    ]
 
     async def scaffold_form(self, rules: list[str] | None = None) -> type[Form]:
         # This sqladmin version has no form_extra_fields support, so graft the
@@ -78,9 +84,13 @@ class UserAdmin(ModelView, model=User):
     async def on_model_change(
         self, data: dict[str, Any], model: User, is_created: bool, request: Request
     ) -> None:
-        if "password" in data and data["password"]:
-            data["hashed_password"] = get_password_hash(data["password"])
-            del data["password"]
+        # Always strip password from form data — it is not a model column.
+        # Leaving an empty password in data makes SQLAdmin crash with
+        # "'NoneType' object has no attribute 'nullable'" when it looks up
+        # the column on the mapper.
+        password = data.pop("password", None)
+        if password:
+            data["hashed_password"] = get_password_hash(password)
         await super().on_model_change(data, model, is_created, request)
 
     name = "User"

--- a/backend/tests/test_infra.py
+++ b/backend/tests/test_infra.py
@@ -297,6 +297,64 @@ async def test_admin_create_user_hashes_grafted_password_field(
     assert verify_password("freshpass123", created.hashed_password)
 
 
+async def test_admin_edit_user_username_without_password(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session: AsyncSession,
+) -> None:
+    # Empty password field is not a model column; leaving it in form data
+    # previously crashed SQLAdmin with "'NoneType' object has no attribute
+    # 'nullable'" on update.
+    monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
+    admin_user = User(
+        email="edit-admin@example.com",
+        username="editadmin",
+        hashed_password=get_password_hash("adminpass123"),
+        is_active=True,
+        is_verified=True,
+        is_superuser=True,
+    )
+    target_user = User(
+        email="edit-target@example.com",
+        username="edittarget",
+        hashed_password=get_password_hash("targetpass123"),
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    db_session.add_all([admin_user, target_user])
+    await db_session.commit()
+    target_id = str(target_user.id)
+    original_hash = target_user.hashed_password
+
+    application = create_application()
+    transport = httpx.ASGITransport(app=application, client=("testclient", 50000))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as test_client:
+        await test_client.post(
+            "/admin/login",
+            data={"username": "edit-admin@example.com", "password": "adminpass123"},
+            follow_redirects=False,
+        )
+        edit_response = await test_client.post(
+            f"/admin/user/edit/{target_id}",
+            data={
+                "email": "edit-target@example.com",
+                "username": "renamedtarget",
+                "password": "",
+                "is_active": "on",
+                "is_verified": "on",
+            },
+            follow_redirects=False,
+        )
+
+    assert edit_response.status_code == 302, edit_response.text
+
+    await db_session.refresh(target_user)
+    assert target_user.username == "renamedtarget"
+    assert target_user.hashed_password == original_hash
+
+
 class AsyncCallRecorder:
     # Awaitable stand-in for lifespan collaborators; counts invocations so a
     # test can assert shutdown wiring without running the real teardown.


### PR DESCRIPTION
## Summary
- Always strip the grafted password field from admin user form data so empty password no longer crashes SQLAdmin with `'NoneType' object has no attribute 'nullable'`
- Exclude workspaces/refresh_tokens from the user edit form (same as chats/settings)
- Add regression test for username-only admin user updates

## Test plan
- [x] `pytest tests/test_infra.py -k admin`
- [ ] Edit a user in `/admin` and change username without setting password
- [ ] Confirm password is still hashed when provided on create/edit