### PR TITLE
fix: persist pre-chat terminal tabs on the landing page

### DIFF
--- a/frontend/src/components/sandbox/terminal/Container/Container.tsx
+++ b/frontend/src/components/sandbox/terminal/Container/Container.tsx
@@ -8,7 +8,9 @@ import styles from './Container.module.scss';
 
 export interface ContainerProps {
   sandboxId?: string;
-  chatId?: string;
+  /** Identity the tab layout persists under (chat id, or a landing-page scope).
+      Without it tabs reset on every mount. */
+  storageScope?: string;
   worktreeCwd?: string;
   isVisible: boolean;
   panelKey: string;
@@ -50,9 +52,15 @@ function readStoredTerminals(
   }
 }
 
-export function Container({ sandboxId, chatId, worktreeCwd, isVisible, panelKey }: ContainerProps) {
+export function Container({
+  sandboxId,
+  storageScope,
+  worktreeCwd,
+  isVisible,
+  panelKey,
+}: ContainerProps) {
   const defaultTerminalId = `terminal-${panelKey}-1`;
-  const storageKey = chatId ? terminalStorageKey(chatId, panelKey) : null;
+  const storageKey = storageScope ? terminalStorageKey(storageScope, panelKey) : null;
   const [terminals, setTerminals] = useState<TerminalInstance[]>(
     () => readStoredTerminals(storageKey, defaultTerminalId).terminals,
   );

--- a/frontend/src/pages/ChatPage/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage/ChatPage.tsx
@@ -284,7 +284,7 @@ export function ChatPage() {
             <Suspense fallback={viewLoadingFallback}>
               <TerminalContainer
                 sandboxId={terminalSandboxId}
-                chatId={terminalChatId}
+                storageScope={terminalChatId}
                 worktreeCwd={terminalWorktreeCwd}
                 // Only fit/focus the terminal when its tile is actually on screen —
                 // a background tab is mounted but hidden (zero-size container).

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -494,12 +494,16 @@ export function LandingPage() {
             </Suspense>
           );
         case 'terminal':
-          // No chatId — pre-chat terminal tabs aren't persisted; the shell
-          // spawns at the workspace root.
+          // Pre-chat, so tab layout persists per sandbox (the backend PTYs are
+          // keyed by sandbox + terminal id); the shell spawns at the workspace
+          // root. Toggling the view off removes the tile from openTabs and
+          // unmounts this container, so restore-on-mount is what keeps tabs
+          // and their live sessions across toggles.
           return (
             <Suspense fallback={viewLoadingFallback}>
               <TerminalContainer
                 sandboxId={selectedSandboxId}
+                storageScope={selectedSandboxId ? `landing-${selectedSandboxId}` : undefined}
                 isVisible={isVisible}
                 panelKey={`tile-${tileId}`}
               />

--- a/frontend/src/utils/terminal.ts
+++ b/frontend/src/utils/terminal.ts
@@ -67,9 +67,11 @@ export const buildSearchDecorations = (palette: Palette): ISearchDecorationOptio
 
 // Terminal tab layouts live in their own localStorage entries outside the zustand
 // persist blob. The key scheme is owned here so the Container's writes and the
-// uiStore's delete-time sweeps can't silently drift apart.
-export const terminalStorageKey = (chatId: string, panelKey: string): string =>
-  `terminal:${chatId}:${panelKey}`;
+// uiStore's delete-time sweeps can't silently drift apart. The scope is a chat id,
+// or a `landing-<sandboxId>` scope for pre-chat terminals (those are only swept by
+// the clear-all path).
+export const terminalStorageKey = (scope: string, panelKey: string): string =>
+  `terminal:${scope}:${panelKey}`;
 
 export function clearTerminalStorage(chatId?: string): void {
   // Sweep one chat's entries, or every chat's when chatId is omitted.


### PR DESCRIPTION
## Summary
- Rename `Container`'s `chatId` prop to `storageScope` since terminal tab persistence isn't only chat-scoped.
- Give landing-page terminals a `landing-<sandboxId>` storage scope so their tab layout survives toggling the terminal tile off and on (the backend PTYs already stay alive; only the tab layout was resetting).
- `ChatPage` continues to pass the chat id as the scope, unchanged behavior there.

## Test plan
- [ ] On the landing page, open a sandbox, add/rename terminal tabs, toggle the terminal tile off then back on, and confirm the tab layout persists.
- [ ] In a chat, confirm terminal tab persistence still works as before.