### PR TITLE
Show live tool title and cloud badge on recent chats

### DIFF
--- a/frontend/src/pages/LandingPage/RecentChats.module.scss
+++ b/frontend/src/pages/LandingPage/RecentChats.module.scss
@@ -82,6 +82,15 @@
   color: var(--theme-text-tertiary);
 }
 
+// Kept inline (not flex on .meta) so type-overflow's ellipsis still applies
+// to the meta text; inline-block overrides the global `svg { display: block }`
+// reset, and vertical-align seats the icon on the text line.
+.cloud-icon {
+  display: inline-block;
+  vertical-align: -0.125em;
+  margin-right: var(--space-1);
+}
+
 .time {
   @include type.type-meta;
   color: var(--theme-text-quaternary);

--- a/frontend/src/pages/LandingPage/RecentChats.tsx
+++ b/frontend/src/pages/LandingPage/RecentChats.tsx
@@ -6,6 +6,7 @@ import { useModelMap } from '@/hooks/queries/useModelQueries';
 import { formatRelativeTime } from '@/utils/date';
 import { stripMarkdownTitle } from '@/utils/format';
 import type { WorkspaceBadge } from '@/hooks/queries/useSidebarChatLists';
+import { Cloud } from 'lucide-react';
 import {
   ChatStatusDot,
   chatStatusTone,
@@ -26,6 +27,7 @@ export interface RecentChatsProps {
 
 export function RecentChats({ chats, workspaceBadgeById, onChatSelect }: RecentChatsProps) {
   const activeStreamMetadata = useStreamStore((state) => state.activeStreamMetadata);
+  const lastToolTitleByChatId = useStreamStore((state) => state.lastToolTitleByChatId);
   const completedChatIds = useStreamStore((state) => state.completedChatIds);
   // Empty queues are deleted from the store, so every remaining key is a chat
   // blocked on a plan/question/permission answer.
@@ -63,9 +65,11 @@ export function RecentChats({ chats, workspaceBadgeById, onChatSelect }: RecentC
               ) : null}
             </span>
           );
-          const meta = [workspaceBadgeById.get(chat.workspace_id)?.name, modelLabel(chat)]
-            .filter(Boolean)
-            .join(' · ');
+          const workspaceBadge = workspaceBadgeById.get(chat.workspace_id);
+          const meta = [workspaceBadge?.name, modelLabel(chat)].filter(Boolean).join(' · ');
+          const baseTitle = stripMarkdownTitle(chat.title);
+          const title =
+            status === 'running' ? (lastToolTitleByChatId.get(chat.id) ?? baseTitle) : baseTitle;
           return (
             <Button
               key={chat.id}
@@ -80,8 +84,14 @@ export function RecentChats({ chats, workspaceBadgeById, onChatSelect }: RecentC
                 statusSlot
               )}
               <span className={styles.text}>
-                <span className={styles.title}>{stripMarkdownTitle(chat.title)}</span>
-                <span className={styles.meta}>{meta}</span>
+                <span className={styles.title}>{title}</span>
+                <span className={styles.meta}>
+                  {/* Same source of truth as SidebarChatItem's cloud marker. */}
+                  {workspaceBadge?.isCloud && (
+                    <Cloud size={12} aria-label="Cloud" className={styles['cloud-icon']} />
+                  )}
+                  {meta}
+                </span>
               </span>
               <span className={styles.time}>{formatRelativeTime(chat.updated_at)}</span>
             </Button>

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -1,6 +1,7 @@
 import { useStreamStore } from '@/store/streamStore';
 import { useMessageQueueStore } from '@/store/messageQueueStore';
 import type { ChatRequest } from '@/types/chat.types';
+import type { ToolEventPayload } from '@/types/tools.types';
 import type {
   ActiveStream,
   ApiStreamResponse,
@@ -200,6 +201,20 @@ class StreamService {
     const isForActiveMessage = parsed.messageId === currentStream.messageId;
     if (!isForActiveMessage) {
       return;
+    }
+
+    // Feeds the landing-page "last tool call" title; after the active-message
+    // guard so replayed envelopes for a stale turn can't overwrite it.
+    if (
+      parsed.kind === 'tool_started' &&
+      parsed.payload.tool &&
+      typeof parsed.payload.tool === 'object'
+    ) {
+      const tool = parsed.payload.tool as ToolEventPayload;
+      const toolTitle = tool.title || tool.name;
+      if (toolTitle) {
+        useStreamStore.getState().setLastToolTitle(chatId, toolTitle);
+      }
     }
 
     currentStream.callbacks?.onEnvelope?.(parsed);

--- a/frontend/src/store/streamStore.test.ts
+++ b/frontend/src/store/streamStore.test.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
     activeStreams: new Map(),
     streamIdByChatMessage: new Map(),
     activeStreamMetadata: [],
+    lastToolTitleByChatId: new Map(),
     completedChatIds: new Set(),
   });
 });
@@ -68,12 +69,14 @@ describe('removeStream', () => {
   it('shuts down the stream and drops it from every index', () => {
     const stream = makeStream('s1', 'c1', 'm1');
     useStreamStore.getState().addStream(stream);
+    useStreamStore.getState().setLastToolTitle('c1', 'Reading');
     useStreamStore.getState().removeStream('s1');
 
     const state = useStreamStore.getState();
     expect(state.getStream('s1')).toBeUndefined();
     expect(state.getStreamByChatAndMessage('c1', 'm1')).toBeUndefined();
     expect(state.activeStreamMetadata).toEqual([]);
+    expect(state.lastToolTitleByChatId.has('c1')).toBe(false);
     expect(stream.isActive).toBe(false);
     expect(stream.callbacks).toBeUndefined();
   });
@@ -81,9 +84,11 @@ describe('removeStream', () => {
   it('keeps chat metadata while another active stream remains for the chat', () => {
     useStreamStore.getState().addStream(makeStream('s1', 'c1', 'm1'));
     useStreamStore.getState().addStream(makeStream('s2', 'c1', 'm2'));
+    useStreamStore.getState().setLastToolTitle('c1', 'Reading');
     useStreamStore.getState().removeStream('s2');
     // s1 is still active for c1, so its rollup metadata must survive.
     expect(useStreamStore.getState().activeStreamMetadata).toHaveLength(1);
+    expect(useStreamStore.getState().lastToolTitleByChatId.get('c1')).toBe('Reading');
   });
 
   it('drops chat metadata when the only remaining sibling stream is inactive', () => {
@@ -148,6 +153,7 @@ describe('updateStreamMessageId', () => {
     vi.setSystemTime(new Date('2020-01-01T00:00:05Z'));
     const stream = makeStream('s1', 'c1', 'old');
     useStreamStore.getState().addStream(stream);
+    useStreamStore.getState().setLastToolTitle('c1', 'Reading');
 
     useStreamStore.getState().updateStreamMessageId('c1', 'old', 'new');
     const state = useStreamStore.getState();
@@ -160,6 +166,9 @@ describe('updateStreamMessageId', () => {
     expect(state.activeStreamMetadata).toEqual([
       { chatId: 'c1', messageId: 'new', startTime: now },
     ]);
+    // Handoff = a new assistant turn on the same stream — the previous turn's
+    // tool title must not leak into it.
+    expect(state.lastToolTitleByChatId.has('c1')).toBe(false);
     vi.useRealTimers();
   });
 
@@ -178,6 +187,8 @@ describe('removeStreamMetadata', () => {
     useStreamStore.getState().addStream(s1);
     useStreamStore.getState().addStream(s2);
     useStreamStore.getState().addStream(other);
+    useStreamStore.getState().setLastToolTitle('c1', 'Reading');
+    useStreamStore.getState().setLastToolTitle('c2', 'Writing');
 
     useStreamStore.getState().removeStreamMetadata('c1');
     const state = useStreamStore.getState();
@@ -185,6 +196,8 @@ describe('removeStreamMetadata', () => {
     expect(state.getStream('s2')).toBeUndefined();
     expect(state.getStream('s3')).toBe(other);
     expect(state.activeStreamMetadata.map((m) => m.chatId)).toEqual(['c2']);
+    expect(state.lastToolTitleByChatId.has('c1')).toBe(false);
+    expect(state.lastToolTitleByChatId.get('c2')).toBe('Writing');
   });
 });
 

--- a/frontend/src/store/streamStore.ts
+++ b/frontend/src/store/streamStore.ts
@@ -5,6 +5,7 @@ interface StreamState {
   activeStreams: Map<string, ActiveStream>;
   streamIdByChatMessage: Map<string, string>;
   activeStreamMetadata: StreamMetadata[];
+  lastToolTitleByChatId: Map<string, string>;
   completedChatIds: Set<string>;
   markCompleted: (chatId: string) => void;
   clearCompleted: (chatId: string) => void;
@@ -20,6 +21,7 @@ interface StreamState {
   ) => void;
   updateStreamMessageId: (chatId: string, oldMessageId: string, newMessageId: string) => void;
   abortStream: (streamId: string) => void;
+  setLastToolTitle: (chatId: string, title: string) => void;
   removeStreamMetadata: (chatId: string) => void;
   addStreamMetadata: (metadata: StreamMetadata) => void;
   addStreamMetadataIfAbsent: (metadata: StreamMetadata) => void;
@@ -57,6 +59,7 @@ export const useStreamStore = create<StreamState>((set, get) => ({
   activeStreams: new Map<string, ActiveStream>(),
   streamIdByChatMessage: new Map<string, string>(),
   activeStreamMetadata: [],
+  lastToolTitleByChatId: new Map<string, string>(),
   // Chats whose stream finished successfully since the user last viewed them —
   // drives the sidebar "Done" badge until the chat is opened.
   completedChatIds: new Set<string>(),
@@ -113,10 +116,16 @@ export const useStreamStore = create<StreamState>((set, get) => ({
       const hasOtherStreamsForChat = Array.from(nextStreams.values()).some(
         (item) => item.chatId === stream.chatId && item.isActive,
       );
+      let nextLastToolTitles = state.lastToolTitleByChatId;
+      if (!hasOtherStreamsForChat) {
+        nextLastToolTitles = new Map(state.lastToolTitleByChatId);
+        nextLastToolTitles.delete(stream.chatId);
+      }
 
       return {
         activeStreams: nextStreams,
         streamIdByChatMessage: nextIndex,
+        lastToolTitleByChatId: nextLastToolTitles,
         activeStreamMetadata: hasOtherStreamsForChat
           ? state.activeStreamMetadata
           : removeStreamMetadataEntry(state.activeStreamMetadata, stream.chatId),
@@ -171,9 +180,14 @@ export const useStreamStore = create<StreamState>((set, get) => ({
       nextIndex.delete(getChatMessageKey(chatId, oldMessageId));
       nextIndex.set(getChatMessageKey(chatId, newMessageId), streamId);
 
+      // The new turn hasn't run a tool yet — the previous turn's title is stale.
+      const nextLastToolTitles = new Map(state.lastToolTitleByChatId);
+      nextLastToolTitles.delete(chatId);
+
       return {
         activeStreams: nextStreams,
         streamIdByChatMessage: nextIndex,
+        lastToolTitleByChatId: nextLastToolTitles,
         activeStreamMetadata: upsertStreamMetadata(state.activeStreamMetadata, {
           chatId: stream.chatId,
           messageId: newMessageId,
@@ -185,6 +199,14 @@ export const useStreamStore = create<StreamState>((set, get) => ({
 
   abortStream: (streamId: string) => {
     get().removeStream(streamId);
+  },
+
+  setLastToolTitle: (chatId: string, title: string) => {
+    set((state) => {
+      const next = new Map(state.lastToolTitleByChatId);
+      next.set(chatId, title);
+      return { lastToolTitleByChatId: next };
+    });
   },
 
   removeStreamMetadata: (chatId: string) => {
@@ -200,9 +222,13 @@ export const useStreamStore = create<StreamState>((set, get) => ({
         }
       }
 
+      const nextLastToolTitles = new Map(state.lastToolTitleByChatId);
+      nextLastToolTitles.delete(chatId);
+
       return {
         activeStreams: nextStreams,
         streamIdByChatMessage: nextIndex,
+        lastToolTitleByChatId: nextLastToolTitles,
         activeStreamMetadata: removeStreamMetadataEntry(state.activeStreamMetadata, chatId),
       };
     });


### PR DESCRIPTION
## Summary
- Landing page "Recent Chats" now shows the title of the most recently started tool call in place of the static chat title while a stream is actively running, so users can see progress at a glance.
- Adds a cloud icon to the meta line for chats in cloud workspaces, matching the sidebar's existing cloud marker.
- Tracks the last tool title per chat in `streamStore`, clearing it when the stream/metadata is removed or a new assistant turn starts on the same stream (message id handoff) so stale titles don't leak across turns.

## Test plan
- [x] `streamStore.test.ts` updated/passing for `setLastToolTitle` clearing on `removeStream`, `updateStreamMessageId`, and `removeStreamMetadata`.
- [ ] Manually verify in browser: start a chat, confirm the landing page recent-chats row shows the live tool title, then reverts/updates correctly after completion.