### PR TITLE
chore: trim verbose comments across backend and frontend

### DIFF
--- a/backend/app/admin/views.py
+++ b/backend/app/admin/views.py
@@ -67,16 +67,14 @@ class UserAdmin(ModelView, model=User):
     ]
 
     async def scaffold_form(self, rules: list[str] | None = None) -> type[Form]:
-        # This sqladmin version has no form_extra_fields support, so graft the
-        # password field onto the scaffolded form — without it, creating a user
-        # fails on the NOT NULL hashed_password column.
+        # No form_extra_fields in this sqladmin; graft password or create fails
+        # on NOT NULL hashed_password.
         form: type[Form] = await super().scaffold_form(rules)
         form.password = PasswordField("Password")
         return form
 
     def _url_for_delete(self, request: Request, obj: Any) -> str:
-        # SQLAdmin renders absolute delete URLs; proxied admin pages need
-        # same-origin AJAX so browser requests keep flowing through /admin.
+        # Absolute delete URLs break under proxy; keep AJAX same-origin /admin.
         query_params = urlencode({"pks": get_object_identifier(obj)})
         url = urlsplit(str(request.url_for("admin:delete", identity=self.identity)))
         return f"{url.path}?{query_params}"
@@ -84,10 +82,8 @@ class UserAdmin(ModelView, model=User):
     async def on_model_change(
         self, data: dict[str, Any], model: User, is_created: bool, request: Request
     ) -> None:
-        # Always strip password from form data — it is not a model column.
-        # Leaving an empty password in data makes SQLAdmin crash with
-        # "'NoneType' object has no attribute 'nullable'" when it looks up
-        # the column on the mapper.
+        # Not a model column — empty password left in data crashes SQLAdmin
+        # looking up column.nullable on the mapper.
         password = data.pop("password", None)
         if password:
             data["hashed_password"] = get_password_hash(password)

--- a/backend/app/api/endpoints/attachments.py
+++ b/backend/app/api/endpoints/attachments.py
@@ -25,9 +25,7 @@ async def preview_temp_attachment(
         response = await attachment_service.get_temp_preview(path, current_user.id)
     except AttachmentException as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
-    # The file body streams after the handler returns while yield deps stay
-    # open — release the auth chain's session so a slow download doesn't pin
-    # a DB connection (and its aiosqlite thread).
+    # Body streams after return while yield deps stay open — release DB first.
     await db.close()
     return response
 

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -183,8 +183,7 @@ async def generate_chat_title(
     ai_service: AgentService = Depends(get_agent_service),
     chat_service: ChatService = Depends(get_chat_service),
 ) -> dict[str, str]:
-    # Title from the first user message — same source the automatic
-    # background titling uses when a chat starts.
+    # Same source as automatic background titling on chat start.
     prompt = await chat_service.get_title_source(chat.id)
     if prompt is None:
         raise HTTPException(
@@ -208,8 +207,7 @@ async def ask_about_code(
     current_user: User = Depends(get_current_user),
     ai_service: AgentService = Depends(get_agent_service),
 ) -> dict[str, str]:
-    # Editor inline chat: one-off Q&A about a code selection — no chat turn or
-    # message rows; the chat only supplies workspace context and access control.
+    # Inline editor Q&A — no turn/message rows; chat is for workspace access only.
     try:
         answer = await ai_service.answer_code_question(
             request.question,
@@ -248,8 +246,7 @@ async def search_chats(
     current_user: User = Depends(get_current_user),
     chat_service: ChatService = Depends(get_chat_service),
 ) -> ChatSearchResponse:
-    # Strip and re-validate so whitespace-only queries (e.g. "  ") don't bypass
-    # min_length and reach the DB as an empty %LIKE% that matches everything.
+    # Whitespace-only would bypass min_length and match everything via %LIKE%.
     stripped = q.strip()
     if len(stripped) < 2:
         raise HTTPException(
@@ -273,9 +270,7 @@ async def get_active_streams(
     current_user: User = Depends(get_current_user),
     chat_service: ChatService = Depends(get_chat_service),
 ) -> list[ActiveStreamStatus]:
-    # Bulk variant of /chats/{chat_id}/status: the runtime registry already knows
-    # every active chat, so startup restoration needs one call instead of a
-    # per-chat (and per-sub-thread) polling fan-out.
+    # Bulk status: one registry read instead of per-chat/sub-thread polling.
     active_ids = ChatStreamRuntime.active_chat_ids()
     if not active_ids:
         return []
@@ -290,13 +285,8 @@ async def stream_user_chat_events(
     chat_service: ChatService = Depends(get_chat_service),
     db: AsyncSession = Depends(get_db),
 ) -> EventSourceResponse:
-    # Global per-user feed of chat lifecycle events (chats created / turns started
-    # out-of-band, e.g. via MCP). Declared before /chats/{chat_id} so "events"
-    # isn't parsed as a UUID.
-    # `db` is the same cached session the auth chain used; FastAPI keeps yield
-    # deps open until the response finishes, so a long-lived SSE connection would
-    # pin its DB connection and aiosqlite thread until disconnect. Auth is
-    # done — release it.
+    # Before /chats/{chat_id} so "events" isn't parsed as a UUID. Release the
+    # auth-chain DB session — FastAPI keeps yield deps open for the SSE lifetime.
     await db.close()
     return EventSourceResponse(
         chat_service.create_chat_events_stream(current_user.id),
@@ -315,10 +305,8 @@ async def stream_user_streams(
     chat_service: ChatService = Depends(get_chat_service),
     db: AsyncSession = Depends(get_db),
 ) -> EventSourceResponse:
-    # Single multiplexed SSE feed carrying every active stream for the user —
-    # envelopes self-route client-side via chatId, so N streaming chats share one
-    # connection instead of exhausting the browser's per-origin HTTP/1.1 pool.
-    # `cursors` is a JSON object of chat id -> last seen seq for backlog replay.
+    # Multiplexed SSE for all active streams (chatId-routed client-side) so N
+    # chats share one connection. `cursors`: chat id -> last seen seq for replay.
     try:
         requested = parse_stream_cursors(cursors)
     except ValueError as e:
@@ -328,8 +316,7 @@ async def stream_user_streams(
     owned = await chat_service.filter_owned_chat_ids(current_user.id, list(requested))
     replay_cursors = {cid: seq for cid, seq in requested.items() if cid in owned}
 
-    # Same rationale as /chats/events: auth is done — release the DB session
-    # so the long-lived SSE connection doesn't pin it until disconnect.
+    # Same as /chats/events: release DB session before long-lived SSE.
     await db.close()
     return EventSourceResponse(
         chat_service.create_user_streams_feed(current_user.id, replay_cursors),
@@ -397,9 +384,7 @@ async def get_chat_context_usage(
             cache_key = REDIS_KEY_CHAT_CONTEXT_USAGE.format(chat_id=str(chat_id))
             cached = await cache.get(cache_key)
             if cached:
-                # Cache entries are written by the backend with all fields
-                # present. If a payload is partial or malformed, raise so this
-                # endpoint falls back to DB data.
+                # Partial/malformed cache payloads must raise so we fall back to DB.
                 data = json.loads(cached)
                 return ContextUsage(
                     tokens_used=int(data["tokens_used"]),
@@ -447,7 +432,6 @@ async def mark_chat_viewed(
     _chat: Chat = Depends(ensure_chat_access),
     chat_service: ChatService = Depends(get_chat_service),
 ) -> None:
-    # Stamps the read marker the sidebar's unread indicator is computed from.
     await chat_service.mark_chat_viewed(chat_id)
 
 
@@ -488,10 +472,8 @@ async def get_stream_status(
     current_user: User = Depends(get_current_user),
     chat_service: ChatService = Depends(get_chat_service),
 ) -> dict[str, Any]:
-    # In-memory gate first: every open chat polls this endpoint on a short
-    # interval, but a stream is almost never live. Short-circuit inactive polls
-    # before any chat/message DB query so the bursts don't drain the connection
-    # pool. Ownership is validated only on the rare active path below.
+    # Poll-hot path: short-circuit inactive chats before any DB hit; ownership
+    # is checked only when a stream is actually live.
     if not ChatStreamRuntime.has_active_chat(str(chat_id)):
         return INACTIVE_TASK_RESPONSE.copy()
 
@@ -582,8 +564,7 @@ async def cancel_stream(
     ) and not await chat_service.has_cancelable_pending_start(chat_id):
         return
 
-    # Stop can arrive after the assistant row exists but before the runtime task
-    # starts; the registry carries that pending cancel into the task.
+    # Cancel may race the runtime task start; registry holds a pending flag.
     await session_registry.cancel_generation(str(chat_id))
 
 
@@ -736,9 +717,7 @@ async def send_now_queued_message(
         )
 
     if ChatStreamRuntime.has_active_chat(str(chat_id)):
-        # Cancel the active generation so the runtime picks up the
-        # send-now flag immediately instead of waiting for the agent
-        # to finish its current turn.
+        # Cancel so send-now is picked up without waiting for the current turn.
         await session_registry.cancel_generation(str(chat_id))
     else:
         try:

--- a/backend/app/api/endpoints/skills.py
+++ b/backend/app/api/endpoints/skills.py
@@ -17,8 +17,7 @@ async def list_skills(
     current_user: User = Depends(get_current_user),
     skill_service: SkillService = Depends(get_skill_service),
 ) -> list[CustomSkillDict]:
-    # SkillService does blocking filesystem walks — offload so the event loop
-    # (including active streams) isn't stalled. Matches workspace.py.
+    # Blocking FS walks — offload so streams on the event loop aren't stalled.
     return await asyncio.to_thread(skill_service.list_all)
 
 

--- a/backend/app/api/endpoints/websocket.py
+++ b/backend/app/api/endpoints/websocket.py
@@ -38,11 +38,8 @@ async def terminal_websocket(
     websocket: WebSocket,
     sandbox_id: str,
 ) -> None:
-    # Client protocol: after accept, the first frame must be an auth message
-    # (handled by wait_for_websocket_auth). Subsequent frames are either raw
-    # bytes (forwarded to the PTY stdin) or JSON control messages
-    # (init / refresh / resize / close / detach). A 30s receive-timeout drives a
-    # server→client ping so idle connections keep NAT/LB state alive.
+    # After accept: first frame = auth; then raw PTY stdin or JSON control
+    # (init/refresh/resize/close/detach). 30s receive timeout → keepalive ping.
     await websocket.accept()
 
     user = await wait_for_websocket_auth(websocket)
@@ -55,9 +52,7 @@ async def terminal_websocket(
         return
     provider_type, workspace_path = access
 
-    # Workspace-relative start dir for the shell — a worktree-backed chat
-    # passes its worktree_cwd so the terminal lands in the worktree, not the
-    # shared workspace root.
+    # worktree_cwd lands the shell in a worktree-backed chat's tree, not root.
     try:
         cwd = normalize_relative_path(websocket.query_params.get("cwd"))
     except ValueError:
@@ -84,8 +79,7 @@ async def terminal_websocket(
                 try:
                     await websocket.send_text(json.dumps({"type": WS_MSG_PING}))
                 except (RuntimeError, OSError):
-                    # Ping hit a dead connection — exit so `finally` detaches
-                    # instead of the error propagating out of the endpoint.
+                    # Dead peer: break so finally detaches instead of raising.
                     break
                 continue
 
@@ -137,11 +131,8 @@ async def terminal_websocket(
                 )
 
             elif data_type == WS_MSG_REFRESH:
-                # Client-requested repaint after its xterm is open and sized —
-                # a reattach with an unchanged size emits nothing on its own,
-                # and repainting at init time can land on a connection that a
-                # racing reconnect is about to replace. Goes through tmux, not
-                # the pane's stdin: a foreground TUI would swallow injected keys.
+                # Client-driven repaint once xterm is sized (not at init — race
+                # with reconnect). Via tmux, not pane stdin (TUI would swallow keys).
                 await session.refresh_tmux_client()
 
             elif data_type == WS_MSG_RESIZE:
@@ -172,8 +163,7 @@ async def terminal_websocket(
         try:
             await websocket.close()
         except RuntimeError:
-            # Already closed server-side (attach() takeover or PTY exit) —
-            # starlette raises on a second close.
+            # Already closed (attach takeover / PTY exit); second close raises.
             pass
         except OSError as exc:
             if exc.errno != errno.EPIPE:

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -138,9 +138,8 @@ MODELS: dict[str, ModelInfo] = {
     "opus": ModelInfo("Opus", AgentKind.CLAUDE, 1_000_000),
     "haiku": ModelInfo("Haiku", AgentKind.CLAUDE, 200_000),
     "claude-fable-5": ModelInfo("Fable 5", AgentKind.CLAUDE, 1_000_000),
-    # GPT-5.6 supports 1M context via the model_context_window override in
-    # ~/.codex/config.toml (Codex's registry defaults to 372k without it).
-    # Codex's live-reported window takes precedence over these fallbacks anyway.
+    # 1M via model_context_window in ~/.codex/config.toml (registry default 372k).
+    # Live-reported window still wins over these fallbacks.
     "gpt-5.6-sol": ModelInfo("GPT 5.6 Sol", AgentKind.CODEX, 1_050_000),
     "gpt-5.6-terra": ModelInfo("GPT 5.6 Terra", AgentKind.CODEX, 1_050_000),
     "gpt-5.6-luna": ModelInfo("GPT 5.6 Luna", AgentKind.CODEX, 1_050_000),
@@ -1531,17 +1530,9 @@ MODELS: dict[str, ModelInfo] = {
     ),
 }
 
-# Built-in slash commands exposed to the frontend per agent kind.
-# Claude commands sourced from the Claude SDK's supportedCommands()
-# (Claude Code ~2.1.206+), filtered by what claude-agent-acp exposes via
-# ACP (excludes cost, keybindings-help, login, logout, output-style:new,
-# release-notes, todos, and local-only commands like context, heapdump,
-# extra-usage). Also omit TUI/session chrome that AgentRove already covers
-# or that only affects the Claude CLI UI (model, effort, fast, config, mcp,
-# color, rename, usage, usage-credits). User/plugin skills are discovered at
-# runtime, not listed here.
-# Codex commands sourced from codex-acp's built-in command list (excludes
-# logout — signing out of Codex from a chat autocomplete is too easy to hit).
+# Built-in slash commands per agent kind for the frontend. Claude/Codex lists
+# are filtered ACP-exposed subsets (not full CLI/TUI chrome); skills are runtime.
+# Codex omits logout — too easy to hit from chat autocomplete.
 BUILTIN_SLASH_COMMANDS: dict[AgentKind, list[dict[str, str]]] = {
     AgentKind.CLAUDE: [
         {
@@ -1786,13 +1777,10 @@ BUILTIN_SLASH_COMMANDS: dict[AgentKind, list[dict[str, str]]] = {
             "description": "Enable all permissions for the session",
         },
     ],
-    # Cursor's slash commands live in its TUI client, not the ACP server, so
-    # cursor-agent treats them as prompt text rather than commands.
+    # Cursor slash commands are TUI-only; ACP would treat them as prompt text.
     AgentKind.CURSOR: [],
-    # Grok's ACP server advertises its commands (compact, session-info, user
-    # skills, ...) via availableCommands, so we rely on runtime discovery.
+    # Grok advertises commands via availableCommands — runtime discovery only.
     AgentKind.GROK: [],
-    # OpenCode's slash commands live in its TUI; the ACP server surfaces only
-    # user-defined commands, so we rely on runtime discovery.
+    # OpenCode slash commands are TUI-only; ACP surfaces user-defined ones.
     AgentKind.OPENCODE: [],
 }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "AI Generation API"
     VERSION: str = "1.0.0"
     API_V1_STR: str = "/api/v1"
-    ENVIRONMENT: str = "development"  # "development" or "production"
+    ENVIRONMENT: str = "development"
     REQUIRE_EMAIL_VERIFICATION: bool = False
     REGISTRATION_DISABLED: bool = False
 
@@ -81,9 +81,8 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def apply_desktop_defaults(self) -> "Settings":
-        # Desktop (Tauri) mode redirects the SQLite DB and storage path to a
-        # platform-specific user data dir, and adds Tauri origins so the
-        # webview can reach the local API.
+        # Desktop (Tauri): redirect DB/storage to the OS user-data dir and allow
+        # the webview origin.
         if not self.DESKTOP_MODE:
             return self
         data_dir = _desktop_data_dir()
@@ -119,19 +118,18 @@ class Settings(BaseSettings):
             return f"{secret_key}_session"
         return None
 
-    MAX_UPLOAD_SIZE: int = 5 * 1024 * 1024  # 5MB max file size
+    MAX_UPLOAD_SIZE: int = 5 * 1024 * 1024
     ALLOWED_IMAGE_TYPES: list[str] = [
         "image/jpeg",
         "image/png",
         "image/gif",
         "image/webp",
-    ]  # That's what Claude supports for now
+    ]  # Claude-supported image MIME types
     ALLOWED_FILE_TYPES: list[str] = ALLOWED_IMAGE_TYPES + [
         "application/pdf",
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ]
 
-    # Email configuration
     MAIL_USERNAME: str = "apikey"
     MAIL_PASSWORD: str | None = None
     MAIL_FROM: str = "noreply@agentrove.pro"
@@ -141,30 +139,23 @@ class Settings(BaseSettings):
     MAIL_STARTTLS: bool = True
     MAIL_SSL_TLS: bool = False
 
-    # Email validation settings
     BLOCK_DISPOSABLE_EMAILS: bool = True
 
-    # Logging configuration
     LOG_LEVEL: str = "INFO"
 
-    # Git configuration
     GIT_AUTHOR_NAME: str = ""
     GIT_AUTHOR_EMAIL: str = ""
-    # Resolved once at startup so host-provider subprocesses (which override
-    # HOME to the sandbox dir) still read the real user's global git config
-    # and GPG keyring for commit signing.
+    # Resolved at startup so host-provider subprocesses (HOME overridden to the
+    # sandbox) still use the real user's global git config and GPG keyring.
     GIT_CONFIG_GLOBAL: str = str(Path.home() / ".gitconfig")
     GNUPGHOME: str = str(Path.home() / ".gnupg")
 
-    # Agentrove chat MCP server — exposes its chat tools to spawned agents via a
-    # stdio MCP server (mcp-server/server.py, bundled next to the backend). Opt-in
-    # and only wired with credentials. The server logs into this same backend
-    # (reached at BASE_URL), so it needs a user's email/password.
+    # Opt-in stdio MCP server (mcp-server/server.py); needs credentials to log
+    # into this backend at BASE_URL.
     AGENTROVE_MCP_ENABLED: bool = False
     AGENTROVE_MCP_EMAIL: str | None = None
     AGENTROVE_MCP_PASSWORD: str | None = None
 
-    # Docker Sandbox configuration
     DOCKER_IMAGE: str = "ghcr.io/mng-dev-ai/agentrove-sandbox:latest"
     DOCKER_NETWORK: str = "agentrove-sandbox-net"
     DOCKER_HOST: str | None = None
@@ -173,7 +164,6 @@ class Settings(BaseSettings):
     DOCKER_CPU_QUOTA: int = 200000
     DOCKER_PIDS_LIMIT: int = 512
 
-    # Host Sandbox configuration
     HOST_SANDBOX_BASE_DIR: str | None = None
     HOST_PREVIEW_BASE_URL: str = "http://localhost"
 
@@ -193,15 +183,10 @@ class Settings(BaseSettings):
         return f"{self.STORAGE_PATH.rstrip('/')}/host-sandboxes"
 
     def get_agent_home_dir(self, user_id: str) -> str:
-        # Per-user HOME for host-provider agents and terminal PTYs in web mode.
-        # One dir per user — not per sandbox — so CLI logins (claude/codex),
-        # MCP registrations, and skills are configured once and shared across
-        # every workspace, matching desktop mode where the real $HOME plays
-        # this role. Kept under the persistent storage volume so logins
-        # survive restarts. Desktop mode never resolves this.
+        # Web-mode per-user HOME (not per sandbox) so CLI logins/MCP/skills are
+        # shared across workspaces and survive restarts. Desktop uses real $HOME.
         return f"{self.STORAGE_PATH.rstrip('/')}/agent-homes/{user_id}"
 
-    # Security Headers Configuration
     ENABLE_SECURITY_HEADERS: bool = True
     HSTS_MAX_AGE: int = 31536000
     HSTS_INCLUDE_SUBDOMAINS: bool = True
@@ -212,16 +197,14 @@ class Settings(BaseSettings):
     REFERRER_POLICY: str = "strict-origin-when-cross-origin"
     PERMISSIONS_POLICY: str = "geolocation=(), microphone=(), camera=()"
 
-    # TTL Configuration (in seconds)
     BACKGROUND_CHAT_SHUTDOWN_TIMEOUT_SECONDS: float = 30.0
     DISPOSABLE_DOMAINS_CACHE_TTL_SECONDS: int = 3600
 
     USER_SETTINGS_CACHE_TTL_SECONDS: int = 300
     MODELS_CACHE_TTL_SECONDS: int = 3600
     CONTEXT_USAGE_CACHE_TTL_SECONDS: int = 600
-    # Reaping an idle agent process is lossless — chats persist session_id and
-    # a respawn load_sessions it — so this trades only respawn latency against
-    # the ~500MB each warm session holds (agent CLI + wrapper + MCP server).
+    # Idle reaping is lossless (session_id persists); trades respawn latency
+    # for ~500MB per warm session (agent CLI + wrapper + MCP server).
     CHAT_PROCESS_IDLE_TTL_SECONDS: float = 600.0
 
     class Config:

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -34,10 +34,8 @@ from app.utils.cache import CacheError, cache_connection
 
 logger = logging.getLogger(__name__)
 
-# Providers cached for the process lifetime — creating one per request pays
-# aiodocker client setup plus a container-inspect round-trip before any real
-# work on every sandbox operation. Keyed by workspace path so host providers
-# with different roots don't collide.
+# Process-lifetime cache: per-request providers pay aiodocker setup + inspect.
+# Keyed by workspace path so host roots don't collide.
 sandbox_provider_cache: dict[tuple[str, str | None], SandboxProvider] = {}
 
 
@@ -124,8 +122,7 @@ async def get_sandbox_service(
             detail="sandbox_id is required",
         )
 
-    # Sandbox-scoped routes must use the provider persisted with that
-    # workspace so requests never hit the wrong backend.
+    # Use the provider stored on this workspace — never the default backend.
     query = select(Workspace.sandbox_provider, Workspace.workspace_path).where(
         Workspace.sandbox_id == sandbox_id,
         Workspace.user_id == user.id,
@@ -183,8 +180,7 @@ async def get_skill_service(
     current_user: User = Depends(get_current_user),
     workspace_service: WorkspaceService = Depends(get_workspace_service),
 ) -> SkillService:
-    # Two tiers: the selected workspace's .{agent}/skills dirs, layered over
-    # the owner's agent home — the same HOME host-mode agents run with.
+    # Workspace .{agent}/skills over the owner's agent home (host-mode HOME).
     workspace = await workspace_service.get_workspace(workspace_id, current_user)
     return SkillService(
         workspace_path=Path(workspace.workspace_path),

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -25,8 +25,7 @@ class _RequestIdSend:
         self.start_time = time.perf_counter()
 
     async def __call__(self, message: Message) -> None:
-        # Stamp headers and log at response start — SSE responses never
-        # complete, so waiting for the response end would never log them.
+        # Log at response start — SSE bodies never complete.
         if message["type"] == "http.response.start":
             process_time = time.perf_counter() - self.start_time
             headers = MutableHeaders(scope=message)
@@ -52,14 +51,12 @@ class RequestIdMiddleware:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        # Pure ASGI on purpose: BaseHTTPMiddleware buffers streaming responses
-        # and deadlocks never-ending EventSourceResponse (SSE) bodies.
+        # Pure ASGI: BaseHTTPMiddleware buffers streams and deadlocks SSE.
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
         request_id = Headers(scope=scope).get("X-Request-ID") or str(uuid.uuid4())
-        # Request.state is backed by scope["state"], so handlers and exception
-        # handlers keep reading request.state.request_id unchanged.
+        # Request.state is scope["state"], so handlers still see request_id.
         scope.setdefault("state", {})["request_id"] = request_id
         await self.app(scope, receive, _RequestIdSend(send, scope, request_id))
 
@@ -92,8 +89,7 @@ class SecurityHeadersMiddleware:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        # Pure ASGI on purpose: BaseHTTPMiddleware buffers streaming responses
-        # and deadlocks never-ending EventSourceResponse (SSE) bodies.
+        # Pure ASGI: BaseHTTPMiddleware buffers streams and deadlocks SSE.
         if scope["type"] != "http" or not settings.ENABLE_SECURITY_HEADERS:
             await self.app(scope, receive, send)
             return

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -30,8 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_fernet_key() -> bytes:
-    # Derive a 32-byte Fernet key from SECRET_KEY via SHA-256 so we don't
-    # require users to set a separate Fernet-formatted key.
+    # Fernet key derived from SECRET_KEY so users need not set a separate one.
     key_bytes = hashlib.sha256(settings.SECRET_KEY.encode()).digest()
     return base64.urlsafe_b64encode(key_bytes)
 
@@ -87,9 +86,7 @@ async def get_user_from_token(token: str, db: AsyncSession) -> User | None:
 
 
 async def get_current_user(
-    # Accepts auth via either the standard Bearer header (resolved by
-    # fastapi-users into `user`) or a `?token=` query param for SSE/WebSocket
-    # endpoints where the browser can't set custom headers.
+    # Bearer (via fastapi-users) or ?token= for SSE/WebSocket (no custom headers).
     token_query: str | None = Query(None, alias="token"),
     user: User | None = Depends(optional_current_active_user),
     db: AsyncSession = Depends(get_db),
@@ -138,9 +135,7 @@ async def authenticate_websocket_user(token: str) -> User | None:
 async def wait_for_websocket_auth(
     websocket: WebSocket, timeout: float = 10.0
 ) -> User | None:
-    # WebSocket connections can't send headers after the handshake, so the
-    # client sends a JSON auth message as the first frame. This waits for
-    # that message and validates the token.
+    # First frame must be JSON auth — WS can't send headers after the handshake.
     try:
         message = await asyncio.wait_for(websocket.receive(), timeout=timeout)
         data = json.loads(message["text"])
@@ -162,11 +157,8 @@ async def resolve_websocket_sandbox_access(
     sandbox_id: str,
     user: User,
 ) -> tuple[SandboxProviderType, str] | None:
-    # Verifies the sandbox belongs to the authenticated user and resolves its
-    # provider type + workspace path. Closes the WS with a SANDBOX_NOT_FOUND
-    # code on failure and returns None so the caller can short-circuit. Lives
-    # here rather than as a FastAPI Depends because the WebSocket handshake
-    # requires accept→auth→access ordering that Depends can't enforce.
+    # Not a Depends: WS needs accept→auth→access ordering. On failure close
+    # with SANDBOX_NOT_FOUND and return None.
     async with SessionLocal() as db:
         query = select(Workspace.sandbox_provider, Workspace.workspace_path).where(
             Workspace.sandbox_id == sandbox_id,

--- a/backend/app/core/user_manager.py
+++ b/backend/app/core/user_manager.py
@@ -72,10 +72,8 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def on_after_reset_password(
         self, user: User, request: Request | None = None
     ) -> None:
-        # A password reset is the recovery path for a compromised account —
-        # refresh tokens issued under the old password must die with it.
-        # Inline import: core.security imports this module and the service
-        # imports core.security, so a top-level import would be circular.
+        # Reset implies compromise — kill refresh tokens from the old password.
+        # Inline import avoids circular import with core.security.
         from app.services.refresh_token import RefreshTokenService
 
         revoked = await RefreshTokenService().revoke_all_tokens(

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -12,9 +12,8 @@ from app.db.sqlite import configure_sqlite
 
 settings = get_settings()
 
-# NullPool: SQLite connections are cheap local file opens, and a bounded pool
-# gets exhausted when slow requests (Docker setup, LLM calls) pin connections
-# for their full duration — WAL mode handles the resulting write concurrency.
+# NullPool: cheap SQLite opens; a bounded pool exhausts under long Docker/LLM
+# holds. WAL covers the resulting write concurrency.
 engine = create_async_engine(
     settings.DATABASE_URL,
     connect_args={"check_same_thread": False},

--- a/backend/app/db/sqlite.py
+++ b/backend/app/db/sqlite.py
@@ -6,15 +6,11 @@ from sqlalchemy.engine import Engine
 
 def _set_pragmas(dbapi_connection: Any, _: Any) -> None:
     cursor = dbapi_connection.cursor()
-    # SQLite ignores FK constraints unless PRAGMA foreign_keys=ON is set per
-    # connection — required for ondelete CASCADE / SET NULL to be enforced.
+    # Per-connection: SQLite ignores FKs unless this is ON (CASCADE/SET NULL).
     cursor.execute("PRAGMA foreign_keys=ON")
-    # WAL lets readers and the writer proceed concurrently — the engine uses
-    # NullPool (one connection per session), so without WAL concurrent sessions
-    # would serialize behind the rollback journal's exclusive lock.
+    # WAL: NullPool means one conn per session; without WAL writers serialize.
     cursor.execute("PRAGMA journal_mode=WAL")
-    # Wait for a busy writer instead of failing fast with "database is locked"
-    # (the driver default is 5s, too short for bursts of stream-snapshot writes).
+    # Default 5s busy timeout is too short under stream-snapshot write bursts.
     cursor.execute("PRAGMA busy_timeout=30000")
     cursor.close()
 

--- a/backend/app/db/types.py
+++ b/backend/app/db/types.py
@@ -29,9 +29,7 @@ class UTCDateTime(TypeDecorator[datetime]):
     def process_result_value(
         self, value: datetime | None, _dialect: Dialect
     ) -> datetime | None:
-        # SQLite drops tzinfo on read, returning naive datetimes that serialize
-        # without a UTC marker and get misread as local time by clients — assume
-        # UTC for naive values so timestamps carry an explicit offset.
+        # SQLite returns naive datetimes; treat as UTC so clients get an offset.
         if value is None:
             return None
         if value.tzinfo is None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,8 +53,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         await maintenance_service.stop()
         await ChatStreamRuntime.stop_background_chats()
         await session_registry.terminate_all()
-        # Kill terminal PTYs and their tmux sessions — host-provider shells
-        # would otherwise keep running after the app exits.
+        # Host-provider shells keep running after exit unless PTYs/tmux die.
         await terminal_session_registry.terminate_all()
         await engine.dispose()
 

--- a/backend/app/models/db_models/automation.py
+++ b/backend/app/models/db_models/automation.py
@@ -42,8 +42,7 @@ class Automation(Base):
         String(100), default="Default", server_default="Default", nullable=False
     )
     cron_expression: Mapped[str] = mapped_column(String(128), nullable=False)
-    # IANA zone the cron is evaluated in, so "daily at 9am" tracks the user's
-    # local time (and DST) rather than the server clock.
+    # IANA zone for cron so "daily at 9am" follows user local time/DST.
     timezone: Mapped[str] = mapped_column(
         String(64), default="UTC", server_default="UTC", nullable=False
     )

--- a/backend/app/models/db_models/chat.py
+++ b/backend/app/models/db_models/chat.py
@@ -54,8 +54,7 @@ class Chat(Base):
     parent_chat_id: Mapped[UUID | None] = mapped_column(
         GUID(), ForeignKey("chats.id", ondelete="SET NULL"), nullable=True
     )
-    # The last turn's settings — server-side source of truth so out-of-band
-    # follow-ups (MCP) and the UI inherit them instead of their own defaults.
+    # Last turn settings — source of truth for MCP/UI follow-ups.
     last_model_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     last_thinking_mode: Mapped[str | None] = mapped_column(String(16), nullable=True)
     last_persona_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -86,8 +85,7 @@ class Chat(Base):
 
     @property
     def unread(self) -> bool:
-        # Activity since the user last opened the chat — updated_at advances on
-        # turn initiation, so out-of-band turns (automations, MCP) flag unread.
+        # updated_at advances on turn start, so automations/MCP flag unread.
         return self.last_viewed_at is None or self.updated_at > self.last_viewed_at
 
     @property
@@ -124,7 +122,7 @@ class Chat(Base):
             session_id=data.get("session_id"),
             session_agent_kind=data.get("session_agent_kind"),
         )
-        # Stash sandbox fields for streaming runtime (workspace not loaded from DB)
+        # Stash sandbox fields for streaming (workspace not loaded from DB).
         sandbox_id = data.get("sandbox_id")
         if sandbox_id is None:
             raise ValueError("Missing sandbox_id in chat data")
@@ -132,8 +130,7 @@ class Chat(Base):
         chat._workspace_path = data.get("workspace_path")
         sandbox_provider = data.get("sandbox_provider")
         if sandbox_provider is None:
-            # Stream resumes must preserve the original provider instead of
-            # silently switching to Docker when the serialized chat is invalid.
+            # Don't silently fall back to Docker on bad serialized chat data.
             raise ValueError("Missing sandbox_provider in chat data")
         chat._sandbox_provider = sandbox_provider
         chat.worktree_cwd = data.get("worktree_cwd")
@@ -177,7 +174,7 @@ class Message(Base):
     total_cost_usd: Mapped[float | None] = mapped_column(
         Float, nullable=True, default=0.0, server_default="0.0"
     )
-    # Total wall-clock run time, recorded once at the terminal snapshot.
+    # Wall-clock ms, written once with the terminal snapshot.
     duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
     stream_status: Mapped[MessageStreamStatus] = mapped_column(
         SQLAlchemyEnum(

--- a/backend/app/models/schemas/ai_model.py
+++ b/backend/app/models/schemas/ai_model.py
@@ -8,6 +8,5 @@ class AIModelResponse(BaseModel):
     name: str
     agent_kind: AgentKind
     context_window: int | None = None
-    # Supported reasoning-effort tiers, ordered lowest to highest; empty when
-    # the model has no reasoning dial (thinking_mode is ignored for it).
+    # Effort tiers low→high; empty means no dial (thinking_mode ignored).
     thinking_modes: list[str] = []

--- a/backend/app/models/schemas/automation.py
+++ b/backend/app/models/schemas/automation.py
@@ -75,9 +75,8 @@ class AutomationUpdate(BaseModel):
 
 
 class Automation(BaseModel):
-    # Standalone read model (not AutomationBase) so responses skip the input
-    # validators and stored rows survive later write-rule drift — mirrors the
-    # Workspace schema pattern.
+    # Read model (not AutomationBase): skip write validators so stored rows
+    # survive later rule drift — same pattern as Workspace.
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID

--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -107,8 +107,7 @@ class ChatCompletionResponse(BaseModel):
     message_id: UUID
     last_seq: int = 0
     checkpoint_id: UUID | None = None
-    # Set when this turn bound the chat to a worktree — lets the client update
-    # branch/terminal UI immediately instead of waiting for the stream config event.
+    # Set when this turn bound a worktree — client can update UI without waiting.
     worktree_cwd: str | None = None
 
 
@@ -119,8 +118,7 @@ class EnhancePromptResponse(BaseModel):
 class AskCodeRequest(BaseModel):
     question: str = Field(..., min_length=1, max_length=10000)
     code: str = Field(..., min_length=1, max_length=100000)
-    # Location fields exist only for editor code selections — chat-page text
-    # selections have no file identity and omit them.
+    # Editor selections only — chat-page text selections omit file identity.
     file_path: str | None = Field(None, min_length=1, max_length=1024)
     language: str | None = Field(None, min_length=1, max_length=64)
     start_line: int | None = Field(None, ge=1)
@@ -171,8 +169,7 @@ class PermissionRespondResponse(BaseModel):
 class ChatSearchMatch(BaseModel):
     message_id: UUID
     role: MessageRole
-    # Pre-split snippet so the frontend doesn't need to slice by char offsets —
-    # Python codepoint indices and JS UTF-16 units disagree on non-BMP chars.
+    # Pre-split: Python codepoints vs JS UTF-16 disagree on non-BMP offsets.
     snippet_before: str
     snippet_match: str
     snippet_after: str

--- a/backend/app/models/schemas/sandbox.py
+++ b/backend/app/models/schemas/sandbox.py
@@ -82,7 +82,6 @@ class GitCommitRequest(BaseModel):
 
 class GitRestoreFileRequest(BaseModel):
     file_path: str = Field(..., min_length=1, max_length=4096)
-    # Pre-rename path, when the change is a rename; None otherwise.
     old_path: str | None = Field(default=None, min_length=1, max_length=4096)
     cwd: str | None = None
 
@@ -113,6 +112,5 @@ class SearchFileResult(BaseModel):
 
 class SearchResponse(BaseModel):
     results: list[SearchFileResult]
-    # True when either per-file or total match caps were hit — the UI should
-    # show a "showing first N" hint so the user knows there's more.
+    # Caps hit — UI should show a "showing first N" hint.
     truncated: bool

--- a/backend/app/models/schemas/workspace.py
+++ b/backend/app/models/schemas/workspace.py
@@ -53,7 +53,6 @@ class Workspace(BaseModel):
 
 class WorkspaceResources(BaseModel):
     skills: list[CustomSkill] = Field(default_factory=list)
-    # Keyed by agent kind ("claude", "codex")
     builtin_slash_commands: dict[str, list[BuiltinSlashCommand]] = Field(
         default_factory=dict
     )

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -26,8 +26,7 @@ class CustomSkillDict(TypedDict):
     description: str
     size_bytes: int
     file_count: int
-    # Agent kinds whose scan dirs resolve to this skill's directory; overlapping
-    # namespaces mean one on-disk skill can belong to several kinds.
+    # Agent kinds that scan this skill dir (overlapping namespaces possible).
     sources: list[str]
     read_only: bool
 

--- a/backend/app/prompts/system_prompt.py
+++ b/backend/app/prompts/system_prompt.py
@@ -34,8 +34,7 @@ def build_system_prompt_for_chat(
     selected_persona_name: str = DEFAULT_PERSONA_NAME,
 ) -> str:
     persona_content = ""
-    # Only apply the persona for agents whose adapter can replace the base
-    # prompt; others silently drop replacement instructions over ACP.
+    # Persona only for adapters that can replace the base prompt over ACP.
     if (
         agent_kind in PERSONAS_SUPPORTED_AGENTS
         and selected_persona_name != DEFAULT_PERSONA_NAME

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -36,10 +36,7 @@ NATIVE_FILE_TYPES: dict[AgentKind, frozenset[str]] = {
 }
 
 
-# Maps UI permission modes to codex-acp session mode IDs. Each mode bundles
-# an approval policy and sandbox policy inside the adapter: "agent" =
-# on-request approvals + workspace write, "agent-full-access" = no approvals
-# + full disk/network access.
+# UI permission mode → codex-acp session mode (each bundles approval + sandbox policy).
 CODEX_SESSION_MODES: dict[str, str] = {
     "auto": "agent",
     "read-only": "read-only",
@@ -81,10 +78,7 @@ GROK_REASONING_MODEL_IDS = frozenset({"grok:grok-4.5"})
 # restricts edits to `.opencode/plans/*.md`, `build` has full tool access.
 OPENCODE_SESSION_MODES = frozenset({"build", "plan"})
 
-# Each agent's normal (full-execution) session mode. Used for permission-
-# irrelevant background calls — one-shot text generation makes no tool calls, so
-# we just need a mode the adapter accepts (Codex rejects unknown modes) and that
-# isn't a plan/read-only mode that could distort the response.
+# Full-execution mode per agent for unattended one-shots (Codex rejects unknown modes; avoid plan/read-only).
 NORMAL_SESSION_MODE: dict[AgentKind, PermissionMode] = {
     AgentKind.CLAUDE: "default",
     AgentKind.CODEX: "auto",
@@ -94,13 +88,7 @@ NORMAL_SESSION_MODE: dict[AgentKind, PermissionMode] = {
     AgentKind.OPENCODE: "build",
 }
 
-# Agents that can have their base system prompt replaced by a persona.
-# Claude/Codex expose a first-class mechanism (ACP _meta.systemPrompt for
-# Claude; model_instructions_file via CODEX_CONFIG for Codex). OpenCode uses a custom
-# primary agent injected through OPENCODE_CONFIG_CONTENT. Grok documents
-# session/new _meta.systemPromptOverride/rules in its ACP docs. Cursor and
-# Copilot ignore system prompt replacement over ACP, so personas would have
-# no effect.
+# Agents that support persona system-prompt replacement over ACP (Cursor/Copilot ignore it).
 PERSONAS_SUPPORTED_AGENTS: frozenset[AgentKind] = frozenset(
     {AgentKind.CLAUDE, AgentKind.CODEX, AgentKind.GROK, AgentKind.OPENCODE}
 )
@@ -110,8 +98,7 @@ THINKING_MODE_ORDER = ("low", "medium", "high", "xhigh", "max", "ultra")
 
 
 def valid_thinking_modes(agent_kind: AgentKind, model_id: str) -> frozenset[str]:
-    # The thinking tiers a model actually accepts; empty means the model has no
-    # reasoning-effort dial (thinking_mode is ignored for it).
+    # Accepted thinking tiers; empty = no effort dial (thinking_mode ignored).
     if agent_kind is AgentKind.CLAUDE:
         return (
             CLAUDE_XHIGH_VALID_THINKING_MODES
@@ -136,16 +123,14 @@ def valid_thinking_modes(agent_kind: AgentKind, model_id: str) -> frozenset[str]
 
 
 def coerce_thinking_mode(mode: str | None, valid_modes: frozenset[str]) -> str:
-    # Normalises the UI's named thinking tier to one the agent actually accepts,
-    # falling back to "medium" for None or unrecognised values.
+    # Clamp UI thinking tier to one the agent accepts (default medium).
     return mode if mode in valid_modes else "medium"
 
 
 def build_system_prompt_meta(
     system_prompt: str | None, is_full_replace: bool
 ) -> dict[str, Any]:
-    # Builds the _meta systemPrompt payload shared by Claude and Copilot:
-    # a plain string replaces the default prompt; {"append": ...} appends to it.
+    # Claude/Copilot _meta systemPrompt: str replaces; {"append": ...} appends.
     if not system_prompt:
         return {}
     if is_full_replace:
@@ -155,14 +140,12 @@ def build_system_prompt_meta(
 
 @dataclass(frozen=True)
 class PermissionConfig:
-    # ACP session mode ID sent via set_session_mode() after session creation.
     session_mode: str
 
 
 @dataclass(frozen=True)
 class LaunchConfig:
-    # Everything needed to spawn the agent process: the binary to exec,
-    # CLI flags to pass, and launch-only env vars (e.g. Codex's CODEX_CONFIG).
+    # Spawn recipe: binary, CLI flags, launch-only env (e.g. CODEX_CONFIG).
     binary: str
     cli_args: list[str] = field(default_factory=list)
     env: dict[str, str] = field(default_factory=dict)
@@ -170,9 +153,7 @@ class LaunchConfig:
 
 @dataclass(frozen=True)
 class SessionConfig:
-    # Everything needed to configure the ACP session: env overrides to
-    # inject before spawning, metadata for new_session/load_session,
-    # mapped reasoning effort, and the permission model.
+    # Session config: env overrides, session meta, effort, permission mode.
     meta: dict[str, Any] = field(default_factory=dict)
     env_overrides: dict[str, str] = field(default_factory=dict)
     reasoning_effort: str | None = None
@@ -182,10 +163,7 @@ class SessionConfig:
 
 
 class AgentAdapter(ABC):
-    # Each agent binary (claude-agent-acp, codex-acp) speaks ACP over stdio but
-    # differs in CLI flags, env vars, session metadata, and permission models.
-    # Adapters encapsulate those differences so the rest of the codebase works
-    # with a uniform AcpSessionConfig regardless of which agent is running.
+    # Per-agent ACP differences (flags/env/meta/permissions) behind a uniform AcpSessionConfig.
 
     def __init__(self, kind: AgentKind) -> None:
         self.kind = kind
@@ -215,14 +193,11 @@ class AgentAdapter(ABC):
 
     @abstractmethod
     def map_session_mode(self, permission_mode: str) -> str:
-        # Maps a UI permission mode string to the ACP session mode ID.
-        # Used mid-stream for plan-mode transitions where only the mode
-        # string is needed, not the full SessionConfig.
+        # UI permission mode → ACP session mode id (plan-mode transitions).
         raise NotImplementedError
 
     def map_model_id(self, model_id: str) -> str:
-        # Translates the internal model registry key (e.g., "copilot:claude-sonnet-4.6")
-        # to the model ID the ACP agent expects. Default: passthrough.
+        # Registry key → agent model id (default passthrough).
         return model_id
 
 
@@ -238,7 +213,7 @@ class ClaudeAgentAdapter(AgentAdapter):
         instructions_file_path: str | None = None,
         reasoning_effort: str | None = None,
     ) -> LaunchConfig:
-        # Claude doesn't use CLI args — all config is via env vars and session meta.
+        # Config via env + session meta only (no CLI args).
         return LaunchConfig(binary="claude-agent-acp")
 
     def build_session_config(
@@ -271,7 +246,6 @@ class ClaudeAgentAdapter(AgentAdapter):
         )
 
     def map_session_mode(self, permission_mode: str) -> str:
-        # Claude session modes are a direct passthrough from the UI.
         return permission_mode
 
 
@@ -287,10 +261,7 @@ class CodexAgentAdapter(AgentAdapter):
         instructions_file_path: str | None = None,
         reasoning_effort: str | None = None,
     ) -> LaunchConfig:
-        # codex-acp ignores CLI args entirely — customization goes through the
-        # CODEX_CONFIG env var, a JSON object merged into the Codex session
-        # config. Approval/sandbox policy and reasoning effort no longer belong
-        # here: modes bundle approval+sandbox, and effort rides on the model ID.
+        # codex-acp uses CODEX_CONFIG only; modes bundle approval/sandbox, effort is on the model ID.
         config: dict[str, Any] = {}
         if system_prompt:
             if system_prompt_is_full_replace and instructions_file_path:
@@ -319,8 +290,7 @@ class CodexAgentAdapter(AgentAdapter):
             thinking_mode, valid_thinking_modes(AgentKind.CODEX, model_id)
         )
 
-        # Codex config rides on the CODEX_CONFIG launch env var and the model
-        # ID, not session meta.
+        # Config via CODEX_CONFIG + model ID, not session meta.
         return SessionConfig(
             reasoning_effort=reasoning_effort,
             permission=PermissionConfig(
@@ -337,9 +307,7 @@ class CodexAgentAdapter(AgentAdapter):
 
 
 class CopilotCliAdapter(AgentAdapter):
-    # Copilot CLI reuses the same ACP transport, but its ACP session modes and
-    # reasoning controls differ from Claude. Keep that mapping explicit here so
-    # we only send values the Copilot ACP server actually advertises.
+    # Copilot modes/reasoning differ from Claude — only send advertised values.
 
     def __init__(self) -> None:
         super().__init__(kind=AgentKind.COPILOT)
@@ -365,7 +333,6 @@ class CopilotCliAdapter(AgentAdapter):
     ) -> SessionConfig:
         meta = build_system_prompt_meta(system_prompt, system_prompt_is_full_replace)
 
-        # Copilot ACP exposes reasoning effort as a CLI/ACP value directly.
         reasoning_effort = coerce_thinking_mode(
             thinking_mode, valid_thinking_modes(AgentKind.COPILOT, model_id)
         )
@@ -387,17 +354,12 @@ class CopilotCliAdapter(AgentAdapter):
         return COPILOT_SESSION_MODE_IDS[permission_mode]
 
     def map_model_id(self, model_id: str) -> str:
-        # Internal keys use "copilot:" prefix to namespace; the CLI expects
-        # the raw model name (e.g., "claude-sonnet-4.6" not "copilot:claude-sonnet-4.6").
+        # Strip "copilot:" namespace for the CLI.
         return model_id.removeprefix("copilot:")
 
 
 class CursorAgentAdapter(AgentAdapter):
-    # Cursor CLI runs as an ACP server via `cursor-agent acp` and speaks the
-    # same ACP transport as Claude/Codex/Copilot. Unlike the others, Cursor
-    # bakes reasoning effort into the model ID itself (e.g. `-low`, `-high`,
-    # `-thinking-max`), so there is no separate thinking-mode CLI flag or env
-    # var — the UI's thinking selector is hidden for this adapter.
+    # Cursor bakes effort into the model ID (`-low`/`-high`/…); no separate thinking flag.
 
     def __init__(self) -> None:
         super().__init__(kind=AgentKind.CURSOR)
@@ -438,18 +400,12 @@ class CursorAgentAdapter(AgentAdapter):
         return permission_mode
 
     def map_model_id(self, model_id: str) -> str:
-        # Internal keys use the "cursor:" prefix to namespace models in the
-        # shared registry; the CLI expects the raw Cursor model name.
+        # Strip "cursor:" namespace for the CLI.
         return model_id.removeprefix("cursor:")
 
 
 class GrokAgentAdapter(AgentAdapter):
-    # Grok Build (xAI) runs as an ACP server via `grok agent stdio`. Reasoning
-    # effort is a launch-only flag (`grok agent --reasoning-effort <tier> stdio`)
-    # — there is no ACP method to change it mid-session, so effort changes take
-    # effect through the session fingerprint respawning the process. In `auto`
-    # mode Grok prompts for risky tool calls via session/request_permission
-    # (handled by the shared permission flow); `always-approve` never prompts.
+    # Effort is launch-only (`--reasoning-effort`); mid-session changes respawn via fingerprint.
 
     def __init__(self) -> None:
         super().__init__(kind=AgentKind.GROK)
@@ -509,18 +465,12 @@ class GrokAgentAdapter(AgentAdapter):
         return permission_mode
 
     def map_model_id(self, model_id: str) -> str:
-        # Internal keys use "grok:" prefix to namespace; the CLI expects the
-        # raw model ID (e.g. "grok-4.5" not "grok:grok-4.5").
+        # Strip "grok:" namespace for the CLI.
         return model_id.removeprefix("grok:")
 
 
 class OpencodeAgentAdapter(AgentAdapter):
-    # OpenCode CLI runs as an ACP server via `opencode acp` and speaks the same
-    # ACP transport as the other adapters. OpenCode's "primary agents" (build,
-    # plan) map to ACP session modes; reasoning effort is controlled per-model
-    # by the underlying provider (opencode itself doesn't expose a uniform
-    # reasoning dial via ACP), so there's no separate thinking-mode control —
-    # the UI's thinking selector is hidden for this adapter.
+    # Primary agents map to session modes; no uniform ACP reasoning dial (thinking UI hidden).
 
     def __init__(self) -> None:
         super().__init__(kind=AgentKind.OPENCODE)
@@ -597,9 +547,7 @@ class OpencodeAgentAdapter(AgentAdapter):
         return permission_mode
 
     def map_model_id(self, model_id: str) -> str:
-        # Internal keys use "opencode:" prefix to namespace; opencode expects
-        # the raw provider/model ID (e.g. "openai/gpt-5.4" not
-        # "opencode:openai/gpt-5.4").
+        # Strip "opencode:" namespace for the CLI.
         return model_id.removeprefix("opencode:")
 
 

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -35,8 +35,7 @@ from app.services.streaming.types import StreamEvent, StreamEventType, ToolPaylo
 
 logger = logging.getLogger(__name__)
 
-# Placed on event_queue to signal that the ACP prompt has finished
-# (either completed or errored) so consumers know to stop reading.
+# Sentinel on event_queue when the ACP prompt finishes (success or error).
 _SENTINEL = object()
 
 # Valid ACP option_ids that match our PermissionMode literals directly.
@@ -54,8 +53,7 @@ VALID_PERMISSION_MODES: set[str] = {
     "ask",
 }
 
-# Normalizes human-readable option names (e.g. "Accept Edits") to our
-# PermissionMode literals when the option_id doesn't match directly.
+# Human option labels → PermissionMode when option_id isn't already a literal.
 PERMISSION_MODE_BY_OPTION_NAME: dict[str, PermissionMode] = {
     "default": "default",
     "accept edits": "acceptEdits",
@@ -77,28 +75,22 @@ GROK_ASK_USER_QUESTION_METHOD = "x.ai/ask_user_question"
 
 
 class AcpClientHandler:
-    # Implements the ACP client-side handler interface. The ACP SDK calls
-    # methods on this class as the agent emits events (text chunks, tool calls,
-    # permission requests, usage updates). Each method translates the ACP event
-    # into a StreamEvent and enqueues it for the SSE layer to forward to the frontend.
+    # ACP client handler: SDK events → StreamEvent on event_queue for SSE.
 
     def __init__(self, agent_kind: AgentKind) -> None:
         self.agent_kind = agent_kind
         self.event_queue: asyncio.Queue[StreamEvent | object] = asyncio.Queue()
         self._active_tools: dict[str, ToolPayload] = {}
         self._pending_permissions: dict[str, asyncio.Future[str]] = {}
-        # Tracks which permission mode the user selected for each tool call,
-        # so we can include it in the tool_completed/tool_failed event.
+        # Permission mode chosen per tool call (for tool_completed/failed events).
         self._resolved_permissions: dict[str, PermissionMode | None] = {}
-        # Maps request_id → {option_id → permission_mode} so resolve_permission
-        # can look up the mode that request_permission already derived.
+        # request_id → option_id → permission_mode (filled in request_permission).
         self._permission_option_modes: dict[str, dict[str, PermissionMode | None]] = {}
         self.total_cost_usd: float = 0.0
         self.usage: dict[str, int] | None = None
-        # Set to True during load_session to suppress replayed history events.
+        # Suppress replayed history events during load_session.
         self.muted: bool = False
 
-    # Required by ACP Client protocol interface
     def on_connect(self, conn: Any) -> None:
         pass
 
@@ -169,9 +161,7 @@ class AcpClientHandler:
         tool_call: ToolCallUpdate,
         **kwargs: Any,
     ) -> RequestPermissionResponse:
-        # Called by the ACP SDK when the agent wants to perform a gated action
-        # (file write, shell command, etc.). We forward the options to the
-        # frontend as a permission_request event and block until the user responds.
+        # Emit permission_request and block until the user responds via SSE.
         request_id = tool_call.tool_call_id
         tool_name = self._extract_tool_name(tool_call)
         tool_input = self._extract_raw_input(tool_call.raw_input)
@@ -218,8 +208,7 @@ class AcpClientHandler:
         return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
 
     async def _wait_for_user_choice(self, request_id: str) -> str:
-        # Blocks until resolve_permission() delivers the user's selection for
-        # this request; empty string means the user cancelled/dismissed.
+        # Empty option_id means cancelled/dismissed.
         future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
         self._pending_permissions[request_id] = future
         try:
@@ -233,9 +222,7 @@ class AcpClientHandler:
         *,
         option_id: str = "",
     ) -> bool:
-        # Called from the SSE endpoint when the user responds to a permission
-        # request or user question. Unblocks the matching _wait_for_user_choice()
-        # awaiter; an empty option_id means the request was cancelled.
+        # Unblock _wait_for_user_choice; empty option_id = cancelled.
         future = self._pending_permissions.get(request_id)
         if future is None or future.done():
             return False
@@ -257,9 +244,7 @@ class AcpClientHandler:
         line: int | None = None,
         **kwargs: Any,
     ) -> ReadTextFileResponse:
-        # ACP protocol stubs — the agent binary handles file I/O and terminal
-        # operations internally. These no-op implementations satisfy the ACP
-        # client interface contract without duplicating sandbox logic here.
+        # Agent owns file/terminal I/O; no-ops satisfy the ACP client interface.
         return ReadTextFileResponse(content="", line_count=0)
 
     async def write_text_file(
@@ -417,10 +402,7 @@ class AcpClientHandler:
         return StreamEvent(type="tool_started", tool=payload)
 
     def _map_tool_call_progress(self, tc: ToolCallProgress) -> StreamEvent | None:
-        # Handles both in-progress updates and terminal states (completed/failed).
-        # ACP may send multiple progress events per tool call — e.g. Codex's
-        # fetch tool sends title updates as it navigates pages. We track
-        # accumulated state in _active_tools and only re-emit when something changed.
+        # Multiple progress events per tool possible; re-emit only when title/input changes.
         status = tc.status
 
         existing = self._active_tools.get(tc.tool_call_id)

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -76,7 +76,7 @@ CODEX_FAST_MODE_OFF = "off"
 
 @dataclass
 class AcpSessionConfig:
-    # Everything needed to spawn an ACP agent process and create a session.
+    # Config to spawn an ACP agent and open a session.
     # Built by AgentService._build_acp_config() from chat/user/model state.
     sandbox_id: str
     sandbox_provider: SandboxProviderType
@@ -103,10 +103,7 @@ class AcpSessionConfig:
 
 
 class AcpSession:
-    # Manages the lifecycle of a single ACP agent process: spawns the binary
-    # (via Docker exec or direct host subprocess), negotiates the ACP handshake,
-    # creates or resumes a session, and provides methods to send prompts,
-    # change models/modes, cancel, and tear down cleanly.
+    # One ACP agent process per chat: spawn, handshake, prompt, teardown.
 
     def __init__(
         self,
@@ -604,8 +601,7 @@ class AcpSession:
     async def _spawn_host(config: AcpSessionConfig) -> asyncio.subprocess.Process:
         launch = AcpSession._build_launch_config(config)
 
-        # Start from the host environment so auth tokens, proxy vars,
-        # TLS settings, and tool paths are available to the agent process.
+        # Inherit host env (auth, proxy, TLS, PATH).
         env = dict(os.environ)
         if config.sandbox_id and not settings.DESKTOP_MODE:
             # Web mode: HOME is the per-user agent home, shared by every

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -198,10 +198,7 @@ class AgentService:
         event_queue: asyncio.Queue[StreamEvent | object],
         prompt_task: asyncio.Task[None],
     ) -> AsyncIterator[StreamEvent]:
-        # Yield events from the queue while the prompt task is running. Uses
-        # asyncio.wait so we notice if the prompt task finishes (or fails) while
-        # we're blocked waiting for the next event. Once the prompt task completes,
-        # drain any remaining queued events until the sentinel.
+        # asyncio.wait so a finished/failed prompt is noticed while blocked on the queue; then drain to sentinel.
         get_event: asyncio.Task[StreamEvent | object] | None = None
         try:
             while True:

--- a/backend/app/services/attachment.py
+++ b/backend/app/services/attachment.py
@@ -17,11 +17,10 @@ settings = get_settings()
 class AttachmentService:
     def __init__(self, message_service: MessageService) -> None:
         self._message_service = message_service
-        # Pre-resolve once so per-request path checks can compare against a canonical base
+        # Canonical base for per-request path checks.
         self._storage_base = Path(settings.STORAGE_PATH).resolve()
 
     async def get_temp_preview(self, path: str, user_id: UUID) -> FileResponse:
-        # Serves temp files uploaded during message composition before they're persisted as attachments
         user_temp_base = (self._storage_base / "temp" / str(user_id)).resolve()
         # resolve() normalises ".." segments so path-traversal attacks can't escape the user's temp dir
         file_path = (self._storage_base / path).resolve()
@@ -61,8 +60,6 @@ class AttachmentService:
     async def _get_attachment_with_path(
         self, attachment_id: UUID, user_id: UUID, db: AsyncSession
     ) -> tuple[MessageAttachment, Path]:
-        # Loads an attachment from DB and resolves its on-disk path, enforcing ownership
-        # and path-traversal safety before returning both to the caller
         attachment = await self._message_service.get_attachment(attachment_id, db)
 
         if not attachment:
@@ -72,7 +69,6 @@ class AttachmentService:
                 status_code=404,
             )
 
-        # Attachments belong to a chat which belongs to a user — verify the chain
         if attachment.message.chat.user_id != user_id:
             raise AttachmentException(
                 "Access denied",

--- a/backend/app/services/automation.py
+++ b/backend/app/services/automation.py
@@ -22,7 +22,7 @@ from app.services.exceptions import AutomationException, ErrorCode
 
 logger = logging.getLogger(__name__)
 
-# Fields whose change invalidates the previously computed next_run_at.
+# Changing these invalidates the cached next_run_at.
 SCHEDULE_FIELDS = frozenset({"cron_expression", "timezone", "enabled"})
 
 

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -60,8 +60,7 @@ logger = logging.getLogger(__name__)
 
 TERMINAL_STREAM_EVENT_TYPES = frozenset({"cancelled", "complete", "error"})
 
-# Snippet windowing for chat message search results — keep some context before
-# the match so the user sees what surrounds it without ballooning the payload.
+# Context chars kept before a search match in snippets.
 SEARCH_SNIPPET_CONTEXT_BEFORE = 30
 SEARCH_SNIPPET_MAX_LENGTH = 160
 # Safety cap on rows fetched for a single search — prevents a common query
@@ -81,8 +80,6 @@ class ChatService(BaseDbService[Chat]):
 
     @staticmethod
     def sandbox_for_workspace(workspace: Workspace) -> SandboxService:
-        # Create a short-lived SandboxService bound to the workspace's
-        # provider and container — used for file ops and cleanup.
         provider = SandboxProvider.create_provider(
             workspace.sandbox_provider, workspace_path=workspace.workspace_path
         )
@@ -95,10 +92,7 @@ class ChatService(BaseDbService[Chat]):
         workspace_id: UUID | None = None,
         pinned: bool | None = None,
     ) -> PaginatedResponse[ChatSchema]:
-        # Paginated list of non-deleted top-level chats (sub-threads excluded),
-        # pinned first, then by most recent.
-        # When workspace_id is provided, results are scoped to that workspace only.
-        # When pinned is provided, results are filtered to pinned (True) or unpinned (False).
+        # Top-level chats only; pinned first, then recency. Optional workspace/pinned filters.
         if pagination is None:
             pagination = PaginationParams()
 
@@ -167,12 +161,7 @@ class ChatService(BaseDbService[Chat]):
         limit: int = 50,
         per_chat_limit: int = 5,
     ) -> ChatSearchResponse:
-        # Searches plain-text message bodies (content_text) across all of the
-        # user's non-deleted chats and workspaces. Order: most recent matching
-        # message first; then in Python we group per-chat, capping matches per
-        # chat and total chats. The frontend further groups results by workspace
-        # for display. Caller is expected to pass a non-empty trimmed query.
-        # +1 lookahead lets us flag truncation when more chats exist than the cap
+        # content_text search across the user's chats; group/cap in Python. +1 lookahead for truncation
         chat_cap = limit + 1
 
         async with self.session_factory() as db:
@@ -201,7 +190,6 @@ class ChatService(BaseDbService[Chat]):
             result = await db.execute(stmt)
             rows = result.all()
 
-        # Group by chat in insertion order (which is desc by created_at).
         grouped: dict[UUID, ChatSearchResult] = {}
         # Hitting the SQL cap means there may be older matches we never saw —
         # report truncation even if the per-chat / chat-cap loop never trips.
@@ -255,9 +243,7 @@ class ChatService(BaseDbService[Chat]):
 
     @staticmethod
     def _build_snippet(content: str, query_lower: str) -> tuple[str, str, str]:
-        # Slide a window around the first match so long messages don't bloat
-        # the payload. Returns (before, match, after) — pre-split so consumers
-        # don't need to reason about codepoint vs UTF-16 indices.
+        # Window around first match; pre-split so consumers ignore codepoint vs UTF-16.
         idx = content.lower().find(query_lower)
         if idx < 0:
             # Shouldn't happen since the SQL filter matched, but fall back to head.
@@ -375,9 +361,7 @@ class ChatService(BaseDbService[Chat]):
             logger.warning("Failed to publish %s user chat event", payload.get("kind"))
 
     async def get_sub_threads(self, chat_id: UUID, user: User) -> list[Chat]:
-        # Returns ORM objects — sub_thread_count defaults to 0 in ChatSchema,
-        # which is correct since nesting is limited to one level (sub-threads
-        # cannot have their own sub-threads).
+        # sub_thread_count defaults to 0 (nesting is one level only).
         async with self.session_factory() as db:
             parent_exists = await db.execute(
                 select(Chat.id).filter(
@@ -409,8 +393,7 @@ class ChatService(BaseDbService[Chat]):
     async def get_active_streams(
         self, user: User, chat_ids: list[UUID]
     ) -> list[ActiveStreamStatus]:
-        # Bulk startup discovery: one ownership query for all runtime-active chats,
-        # then resolve the in-progress message per surviving chat (rarely more than a few).
+        # One ownership query for runtime-active chats, then in-progress message per survivor.
         async with self.session_factory() as db:
             result = await db.execute(
                 select(Chat.id).filter(
@@ -440,7 +423,6 @@ class ChatService(BaseDbService[Chat]):
     async def update_chat(
         self, chat_id: UUID, chat_update: ChatUpdate, user: User
     ) -> Chat:
-        # Update title and/or pin state for a chat owned by the user.
         async with self.session_factory() as db:
             result = await db.execute(
                 select(Chat)
@@ -481,10 +463,7 @@ class ChatService(BaseDbService[Chat]):
             return chat
 
     async def get_chat(self, chat_id: UUID, user: User) -> Chat:
-        # Fetch a single chat with its workspace eagerly loaded (sandbox_id reads it).
-        # Messages aren't loaded here — the Chat schema has no message field; the
-        # paginated /messages endpoint serves the visible history. sub_thread_count
-        # is computed only by callers that serialize it (see count_sub_threads).
+        # Workspace eager-loaded for sandbox_id; messages via /messages. sub_thread_count is caller-side.
         async with self.session_factory() as db:
             query = (
                 select(Chat)
@@ -536,8 +515,7 @@ class ChatService(BaseDbService[Chat]):
             return result.scalar() or 0
 
     async def get_title_source(self, chat_id: UUID) -> str | None:
-        # Title prompt is the first non-empty user message. Queried directly so
-        # callers don't need the full message history loaded.
+        # First non-empty user message — avoids loading full history for titles.
         async with self.session_factory() as db:
             prompt = (
                 await db.execute(
@@ -562,8 +540,6 @@ class ChatService(BaseDbService[Chat]):
         return MODELS[last_msg.model_id].context_window
 
     async def delete_chat(self, chat_id: UUID, user: User) -> None:
-        # Soft-delete a chat and its messages, terminate the active session,
-        # and destroy the workspace container if no other chats reference it.
         async with self.session_factory() as db:
             result = await db.execute(
                 select(Chat)
@@ -671,8 +647,6 @@ class ChatService(BaseDbService[Chat]):
                     )
 
     async def delete_all_chats(self, user: User) -> int:
-        # Bulk soft-delete all chats, messages, and workspaces for a user,
-        # then fire-and-forget session termination and sandbox cleanup.
         async with self.session_factory() as db:
             chat_query = select(Chat.id, Chat.workspace_id, Chat.worktree_cwd).filter(
                 Chat.user_id == user.id,
@@ -741,7 +715,6 @@ class ChatService(BaseDbService[Chat]):
     async def get_chat_messages(
         self, chat_id: UUID, user: User, cursor: str | None = None, limit: int = 20
     ) -> CursorPaginatedResponse[MessageSchema]:
-        # Cursor-paginated message list — verify ownership then delegate to MessageService.
         async with self.session_factory() as db:
             result = await db.execute(
                 select(
@@ -855,10 +828,7 @@ class ChatService(BaseDbService[Chat]):
         chat_id: UUID,
         after_seq: int,
     ) -> AsyncIterator[dict[str, Any]]:
-        # Catch-up mechanism for SSE reconnection: when a client reconnects
-        # (network blip, page refresh) it sends the last seq it saw, and this
-        # method pages through all persisted events after that seq so the
-        # client doesn't miss anything before switching to live Redis pub/sub.
+        # SSE reconnection catch-up: page events after the client's last seq, then live pub/sub.
         page_size = 5000
         cursor = after_seq
 
@@ -907,9 +877,7 @@ class ChatService(BaseDbService[Chat]):
         kind: str,
         payload: dict[str, Any],
     ) -> dict[str, Any]:
-        # Canonical builder for the SSE envelope shape sent to the frontend.
-        # The live path in _stream_live_user_envelopes constructs the same
-        # {id, event, data} shape directly from pre-serialized envelope JSON.
+        # SSE envelope shape; live path builds the same {id, event, data} from pre-serialized JSON.
         return {
             "id": str(seq),
             "event": StreamEventKind.STREAM.value,
@@ -1063,10 +1031,6 @@ class ChatService(BaseDbService[Chat]):
         request: ChatRequest,
         current_user: User,
     ) -> ChatCompletionResult:
-        # Main entry point for a user sending a message: validates keys, saves
-        # the user message and an empty assistant message, uploads any attached
-        # files to the sandbox, then kicks off the background stream task.
-        # Returns the IDs the frontend needs to connect to the SSE stream.
         user_settings = await self._user_service.get_user_settings(current_user.id)
         chat = await self.get_chat(request.chat_id, current_user)
 
@@ -1221,9 +1185,7 @@ class ChatService(BaseDbService[Chat]):
         context_window: int | None = None,
         selected_persona_name: str = DEFAULT_PERSONA_NAME,
     ) -> None:
-        # Package the chat state into a ChatStreamRequest and kick off the
-        # background streaming task. Separate method so tests can override it
-        # to run synchronously without the background task machinery.
+        # Extracted so tests can override and run the stream synchronously.
         stream_attachments = (
             [dict(item) for item in attachments] if attachments else None
         )

--- a/backend/app/services/maintenance.py
+++ b/backend/app/services/maintenance.py
@@ -93,7 +93,7 @@ class MaintenanceService:
                     )
             except Exception:
                 logger.exception("Maintenance job %s crashed", job.name)
-            # Sleep until the next interval, but wake immediately on shutdown.
+            # Interval sleep; wake immediately on shutdown.
             try:
                 await asyncio.wait_for(
                     self._stop_event.wait(),

--- a/backend/app/services/message.py
+++ b/backend/app/services/message.py
@@ -60,8 +60,7 @@ class MessageService(BaseDbService[Message]):
         session_id: str | None = None,
         stream_status: MessageStreamStatus | None = None,
     ) -> Message:
-        # Assistant messages start empty and get populated by the streaming
-        # pipeline via update_message_snapshot; user messages go in whole.
+        # Assistants start empty (stream fills via update_message_snapshot); users go in whole.
         async with self.session_factory() as db:
             if role == MessageRole.ASSISTANT:
                 content_text = ""

--- a/backend/app/services/queue.py
+++ b/backend/app/services/queue.py
@@ -133,8 +133,7 @@ class QueueService:
         return next_msg
 
     async def mark_send_now(self, chat_id: str, message_id: str) -> bool:
-        # Flag a queued message for immediate processing — the runtime checks this
-        # key to skip the normal queue order and process this message next.
+        # Runtime checks this key to skip normal queue order.
         key = self._queue_key(chat_id)
         queue = await self._read_queue(key)
         if not any(item["id"] == message_id for item in queue):
@@ -169,8 +168,7 @@ class QueueService:
         return target
 
     async def requeue_message(self, chat_id: str, message_data: dict[str, Any]) -> None:
-        # Re-insert at the front so it's retried next — used when processing fails
-        # and the message shouldn't be lost.
+        # Front of queue so a failed process is retried next.
         key = self._queue_key(chat_id)
         queue = await self._read_queue(key)
         queue.insert(0, message_data)

--- a/backend/app/services/sandbox.py
+++ b/backend/app/services/sandbox.py
@@ -106,8 +106,7 @@ class SandboxService:
     async def send_pty_input(
         self, sandbox_id: str, pty_session_id: str, data: bytes
     ) -> None:
-        # Forward user keystrokes to the PTY; if the write fails the session
-        # is likely dead, so clean it up rather than leaving a zombie.
+        # Clean up on write failure so a dead session isn't left as a zombie.
         try:
             await self.provider.send_pty_input(sandbox_id, pty_session_id, data)
         except Exception as e:

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -29,17 +29,11 @@ class SandboxProvider:
 
     @property
     def workspace_root(self) -> str:
-        # Absolute path of the file-tree root inside whichever namespace the
-        # provider operates in (container path for Docker, host path for
-        # local). Callers need this to translate between cwd-relative and
-        # workspace-relative paths (e.g. mapping search results back to
-        # file-tree entries).
+        # Container path (Docker) or host path (local); used to ground relative paths.
         raise NotImplementedError
 
     def resolve_workspace_path(self, rel_path: str | None) -> str:
-        # Workspace-relative path → runtime-absolute path. Used for agent cwd,
-        # file reads/writes, and list-files targets — any path the app hands
-        # to runtime that needs grounding in the provider's workspace root.
+        # Workspace-relative → runtime-absolute under this provider's root.
         rel = normalize_relative_path(rel_path)
         return posixpath.join(self.workspace_root, rel) if rel else self.workspace_root
 
@@ -63,9 +57,7 @@ class SandboxProvider:
         provider_type: SandboxProviderType | str,
         workspace_path: str | None = None,
     ) -> "SandboxProvider":
-        # Factory that returns the appropriate provider (Docker or Host)
-        # based on the configured sandbox type.
-        # Inline import to avoid circular dependency — both providers import from base.
+        # Inline import avoids circular dependency (providers import base).
         from app.services.sandbox_providers.docker_provider import (
             DockerConfig,
             LocalDockerProvider,
@@ -116,10 +108,7 @@ class SandboxProvider:
         raise NotImplementedError
 
     async def write_temp_file(self, sandbox_id: str, content: str) -> str:
-        # Write content to a unique temp path OUTSIDE the workspace and return its
-        # runtime-absolute path (host tempdir for local, container /tmp for
-        # Docker). Used for the Codex model_instructions_file so the file never
-        # lands in the user's project workspace.
+        # Temp path outside the workspace (Codex model_instructions_file must not pollute the project).
         raise NotImplementedError
 
     async def read_file(
@@ -134,7 +123,7 @@ class SandboxProvider:
         sandbox_id: str,
         path: str = "",
     ) -> list[FileMetadata]:
-        # `path` is workspace-relative. Empty string means the workspace root.
+        # path is workspace-relative; "" = workspace root.
         raise NotImplementedError
 
     async def create_pty(
@@ -148,12 +137,8 @@ class SandboxProvider:
         on_exit: PtyExitCallbackType,
         user_id: str = "",
     ) -> str:
-        # Returns the new PTY session id. `cwd` is workspace-relative; ""
-        # means the provider's default start dir. `on_exit` fires when the
-        # PTY stream ends on its own (shell exit, container gone) — never on
-        # kill_pty's own cancellation. `user_id` keys the per-user agent home
-        # used as HOME in web host mode (unused by Docker — container HOME is
-        # fixed).
+        # cwd workspace-relative ("" = default). on_exit is natural exit only, not kill_pty.
+        # user_id keys per-user agent HOME in web host mode (unused by Docker).
         raise NotImplementedError
 
     @staticmethod
@@ -218,13 +203,11 @@ class SandboxProvider:
 
     @staticmethod
     def parse_git_ls_files(git_output: str) -> list[FileMetadata]:
-        # Build file metadata from git ls-files -z output. Derives directories
-        # from file paths since git only tracks files.
+        # git only tracks files — synthesize parent directories from paths.
         items: list[FileMetadata] = []
         seen_dirs: set[str] = set()
 
         for rel_path in filter(None, git_output.split("\0")):
-            # Add parent directories that haven't been seen yet.
             parts = rel_path.split("/")
             for i in range(1, len(parts)):
                 dir_rel = "/".join(parts[:i])
@@ -246,8 +229,6 @@ class SandboxProvider:
 
     @staticmethod
     def encode_file_content(path: str, content_bytes: bytes) -> tuple[str, bool]:
-        # Return file content as a string — base64-encoded for binary files,
-        # UTF-8 decoded for text files.
         is_binary = Path(path).suffix.lstrip(".").lower() in SANDBOX_BINARY_EXTENSIONS
         if is_binary:
             content = base64.b64encode(content_bytes).decode("utf-8")
@@ -258,7 +239,6 @@ class SandboxProvider:
     def get_pty_session(
         self, sandbox_id: str, session_id: str
     ) -> dict[str, Any] | None:
-        # Look up a PTY session from the in-memory tracking dict.
         return self._pty_sessions.get(sandbox_id, {}).get(session_id)
 
     def register_pty_session(
@@ -267,8 +247,7 @@ class SandboxProvider:
         self._pty_sessions.setdefault(sandbox_id, {})[session_id] = session_data
 
     def cleanup_pty_session_tracking(self, sandbox_id: str, session_id: str) -> None:
-        # Remove a PTY session from tracking. Cleans up the parent dict
-        # when the last session for a sandbox is removed.
+        # Drop empty sandbox keys after the last session is removed.
         sandbox_sessions = self._pty_sessions.get(sandbox_id)
         if not sandbox_sessions:
             return
@@ -278,8 +257,7 @@ class SandboxProvider:
             self._pty_sessions.pop(sandbox_id, None)
 
     async def cleanup(self) -> None:
-        # Tear down all active PTY sessions. Subclasses call super().cleanup()
-        # then handle their own resources (e.g. Docker client).
+        # Subclasses call super() then free their own resources.
         for sandbox_id in list(self._pty_sessions.keys()):
             for session_id in list(self._pty_sessions[sandbox_id].keys()):
                 try:

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -57,7 +57,6 @@ class LocalDockerProvider(SandboxProvider):
         return f"{self.config.user_home}/workspace"
 
     async def _get_docker(self) -> aiodocker.Docker:
-        # Lazily create the aiodocker client on first use.
         if self._docker is None:
             try:
                 if self.config.host:
@@ -70,8 +69,7 @@ class LocalDockerProvider(SandboxProvider):
 
     @staticmethod
     def _parse_mem_limit(mem_str: str) -> int:
-        # Convert human-readable memory strings (e.g. "4g", "512m") to bytes
-        # for Docker's Memory host config field.
+        # "4g"/"512m" → bytes for Docker Memory.
         mem_str = mem_str.strip().lower()
         if not mem_str:
             return 0
@@ -81,9 +79,7 @@ class LocalDockerProvider(SandboxProvider):
         return int(mem_str)
 
     async def _get_container(self, sandbox_id: str) -> Any:
-        # Central entry point for all container operations. Reconnects to
-        # the container if it's not in the local cache, and restarts it
-        # if it has exited (e.g. idle timeout, OOM kill).
+        # Reconnect if uncached; restart if the container has exited.
         if sandbox_id not in self._containers:
             connected = await self.connect_sandbox(sandbox_id)
             if not connected:
@@ -100,8 +96,6 @@ class LocalDockerProvider(SandboxProvider):
         sandbox_id: str,
         workspace_path: str | None = None,
     ) -> Any:
-        # Build and start a sandbox container with port bindings, resource
-        # limits, and an optional host workspace bind mount.
         docker = await self._get_docker()
 
         host_config: dict[str, Any] = {
@@ -117,8 +111,6 @@ class LocalDockerProvider(SandboxProvider):
         if self.config.pids_limit > 0:
             host_config["PidsLimit"] = self.config.pids_limit
 
-        # Bind mount the host workspace into the container so the sandbox
-        # has access to the project files.
         workspace_mount_dir = f"{self.config.user_home}/workspace"
         if workspace_path:
             workspace_dir = Path(workspace_path).expanduser().resolve()
@@ -146,7 +138,6 @@ class LocalDockerProvider(SandboxProvider):
         return container
 
     async def create_sandbox(self, workspace_path: str | None = None) -> str:
-        # Generate a short unique ID, spin up a container, and cache the handle.
         sandbox_id = str(uuid.uuid4())[:12]
         container = await self._create_container(
             sandbox_id, workspace_path=workspace_path
@@ -155,8 +146,7 @@ class LocalDockerProvider(SandboxProvider):
         return sandbox_id
 
     async def _get_container_by_id(self, sandbox_id: str) -> Any | None:
-        # Look up an existing container by name from the Docker daemon
-        # when it's not in the in-memory cache (e.g. after API restart).
+        # Daemon lookup when missing from the in-memory cache (e.g. after API restart).
         docker = await self._get_docker()
         try:
             return await docker.containers.get(
@@ -166,11 +156,8 @@ class LocalDockerProvider(SandboxProvider):
             return None
 
     async def connect_sandbox(self, sandbox_id: str) -> bool:
-        # Reconnect to an existing container — checks the in-memory cache first,
-        # evicts if stopped, then looks up by name from the Docker daemon.
         if sandbox_id in self._containers:
             container = self._containers[sandbox_id]
-            # Check the container's live status via the Docker API.
             info = await container.show()
             status: str = info.get("State", {}).get("Status", "")
             if status == DOCKER_STATUS_RUNNING:
@@ -185,8 +172,6 @@ class LocalDockerProvider(SandboxProvider):
         return False
 
     async def delete_sandbox(self, sandbox_id: str) -> None:
-        # Stop and remove the container, then clear it from the cache.
-        # No-op if the container doesn't exist.
         container = self._containers.get(sandbox_id)
 
         if not container:
@@ -214,7 +199,7 @@ class LocalDockerProvider(SandboxProvider):
     ) -> list[FileMetadata]:
         target_path = self.resolve_workspace_path(path)
 
-        # Try git ls-files — handles .gitignore natively.
+        # Prefer git ls-files so .gitignore is honored.
         git_result = await self.execute_command(
             sandbox_id,
             f"cd {shlex.quote(target_path)} && {GIT_LS_FILES_CMD}",
@@ -223,7 +208,7 @@ class LocalDockerProvider(SandboxProvider):
         if git_result.exit_code == 0 and git_result.stdout:
             return SandboxProvider.parse_git_ls_files(git_result.stdout)
 
-        # Fallback: simple find for non-git directories.
+        # Non-git fallback.
         find_command = (
             f"find {shlex.quote(target_path)} -mindepth 1 -printf '%P\\0%y\\0'"
         )
@@ -232,11 +217,9 @@ class LocalDockerProvider(SandboxProvider):
 
     @staticmethod
     def _parse_find_output(find_output: str) -> list[FileMetadata]:
-        # Fallback for non-git directories — parses null-delimited pairs
-        # (path, type) from GNU find's -printf '%P\0%y\0'.
+        # Parse GNU find -printf '%P\0%y\0' pairs.
         items: list[FileMetadata] = []
         parts = find_output.split("\0")
-        # Pairs: [path, type, path, type, ...]
         for i in range(0, len(parts) - 1, 2):
             file_path = parts[i]
             file_type = parts[i + 1]
@@ -258,7 +241,6 @@ class LocalDockerProvider(SandboxProvider):
         return items
 
     async def _collect_exec_output(self, exec_obj: Any) -> tuple[int, str]:
-        # Read all output from a Docker exec stream, then inspect for the exit code.
         stream = exec_obj.start()
         output_parts: list[bytes] = []
         try:
@@ -284,8 +266,7 @@ class LocalDockerProvider(SandboxProvider):
         envs: dict[str, str] | None = None,
         timeout: int = SANDBOX_DEFAULT_COMMAND_TIMEOUT,
     ) -> CommandResult:
-        # Run a command inside the container via Docker exec. stderr is empty
-        # because aiodocker merges stdout/stderr into a single stream.
+        # aiodocker merges stdout/stderr, so stderr is always empty.
         container = await self._get_container(sandbox_id)
         env_list = [f"{k}={v}" for k, v in (envs or {}).items()]
 
@@ -310,8 +291,7 @@ class LocalDockerProvider(SandboxProvider):
 
     @staticmethod
     def _build_file_tar(filename: str, content_bytes: bytes) -> bytes:
-        # Docker's put_archive API requires a tar stream — we create a single-file
-        # tar in memory with uid/gid 1000 (the sandbox "user" account).
+        # put_archive needs a tar; uid/gid 1000 is the sandbox user.
         tar_stream = io.BytesIO()
         with tarfile.open(fileobj=tar_stream, mode="w") as tar:
             info = tarfile.TarInfo(name=filename)
@@ -357,7 +337,7 @@ class LocalDockerProvider(SandboxProvider):
         sandbox_id: str,
         path: str,
     ) -> FileContent:
-        # Docker's get_archive returns a tar — extract the first member's content.
+        # get_archive returns a tar; take the first member.
         container = await self._get_container(sandbox_id)
         normalized_path = self.resolve_workspace_path(path)
 
@@ -390,10 +370,7 @@ class LocalDockerProvider(SandboxProvider):
         on_exit: PtyExitCallbackType,
         user_id: str = "",
     ) -> str:
-        # Spawn a PTY-attached shell inside the container via docker exec.
-        # Tries tmux for session persistence across WebSocket reconnections,
-        # falls back to bare bash if tmux is not installed. `user_id` is
-        # unused: the container's HOME is fixed at image build time.
+        # tmux for reconnect persistence; bare bash if missing. user_id unused (fixed container HOME).
         container = await self._get_container(sandbox_id)
         session_id = str(uuid.uuid4())
 
@@ -440,9 +417,6 @@ class LocalDockerProvider(SandboxProvider):
         on_data: PtyDataCallbackType,
         on_exit: PtyExitCallbackType,
     ) -> None:
-        # Background task that continuously reads container exec output
-        # and forwards it to the WebSocket callback. Exits when the
-        # stream closes (read_out returns None) or the task is cancelled.
         try:
             while True:
                 msg = await stream.read_out()
@@ -450,7 +424,6 @@ class LocalDockerProvider(SandboxProvider):
                     break
                 await on_data(msg.data)
         except asyncio.CancelledError:
-            # kill_pty tearing us down — the owner already knows.
             return
         except Exception as e:
             # A dead exec stream (container restarted/removed) is also a
@@ -464,8 +437,6 @@ class LocalDockerProvider(SandboxProvider):
         pty_id: str,
         data: bytes,
     ) -> None:
-        # Forward user keystrokes from the WebSocket to the container's
-        # exec stream (stdin). Silently drops input if the session is gone.
         session = self.get_pty_session(sandbox_id, pty_id)
         if not session:
             return
@@ -478,8 +449,7 @@ class LocalDockerProvider(SandboxProvider):
         pty_id: str,
         size: PtySize,
     ) -> None:
-        # Resize the container's PTY when the frontend terminal viewport changes.
-        # Docker rejects zero dimensions, so clamp to at least 1.
+        # Docker rejects zero dimensions — clamp to at least 1.
         session = self.get_pty_session(sandbox_id, pty_id)
         if not session:
             return
@@ -491,9 +461,7 @@ class LocalDockerProvider(SandboxProvider):
         sandbox_id: str,
         pty_id: str,
     ) -> None:
-        # Tear down a PTY session: cancel the reader task, close the exec
-        # stream, then remove tracking. Best-effort — ignores errors since
-        # the stream or container may already be gone.
+        # Best-effort teardown — stream/container may already be gone.
         session = self.get_pty_session(sandbox_id, pty_id)
         if not session:
             return
@@ -513,8 +481,6 @@ class LocalDockerProvider(SandboxProvider):
         self.cleanup_pty_session_tracking(sandbox_id, pty_id)
 
     async def cleanup(self) -> None:
-        # Tear down all PTY sessions (via base class) then close the
-        # aiodocker client connection to the Docker daemon.
         await super().cleanup()
         if self._docker:
             await self._docker.close()

--- a/backend/app/services/sandbox_providers/host_provider.py
+++ b/backend/app/services/sandbox_providers/host_provider.py
@@ -46,8 +46,7 @@ class LocalHostProvider(SandboxProvider):
 
     @staticmethod
     def _signal_process_group(pid: int, sig: signal.Signals) -> None:
-        # Valid as a pgid because every process we signal here was spawned
-        # with start_new_session=True, making it its own group leader.
+        # start_new_session=True makes the pid its own process-group leader.
         try:
             os.killpg(pid, sig)
         except ProcessLookupError:
@@ -59,8 +58,7 @@ class LocalHostProvider(SandboxProvider):
                 os.kill(pid, sig)
 
     def _resolve_path(self, path: str) -> Path:
-        # Turn a relative path from the frontend into an absolute host path,
-        # rejecting anything that would escape the workspace via ../ or symlinks.
+        # Resolve relative paths; reject ../ and symlink escapes of the workspace.
         if path.startswith("/"):
             raise SandboxException(f"Path must be relative: {path}")
         resolved = (self._workspace / path).resolve()
@@ -75,8 +73,6 @@ class LocalHostProvider(SandboxProvider):
         envs: dict[str, str] | None = None,
         timeout: int = SANDBOX_DEFAULT_COMMAND_TIMEOUT,
     ) -> CommandResult:
-        # Run a shell command in the workspace directory via a login shell,
-        # merging any caller-provided env vars into the host environment.
         workspace_dir_str = str(self._workspace)
         process_env = os.environ.copy()
         if envs:
@@ -117,8 +113,6 @@ class LocalHostProvider(SandboxProvider):
         path: str,
         content: str | bytes,
     ) -> None:
-        # Write a file to the workspace, creating parent directories as needed.
-        # Path is validated by _resolve_path to prevent escaping the workspace.
         resolved = self._resolve_path(path)
         resolved.parent.mkdir(parents=True, exist_ok=True)
         payload = content.encode("utf-8") if isinstance(content, str) else content
@@ -129,7 +123,7 @@ class LocalHostProvider(SandboxProvider):
 
     @staticmethod
     def _write_temp_file(payload: bytes) -> str:
-        # Write through the fd mkstemp already opened — no close-and-reopen.
+        # Write via the fd mkstemp opened (no close-and-reopen race).
         fd, path = tempfile.mkstemp(prefix="agentrove-codex-", suffix=".md")
         with os.fdopen(fd, "wb") as f:
             f.write(payload)
@@ -140,8 +134,6 @@ class LocalHostProvider(SandboxProvider):
         sandbox_id: str,
         path: str,
     ) -> FileContent:
-        # Read a file from the workspace, returning base64 for binary files
-        # and UTF-8 text for everything else.
         resolved = self._resolve_path(path)
         if not resolved.exists() or not resolved.is_file():
             raise SandboxException(f"File not found: {path}")
@@ -150,9 +142,7 @@ class LocalHostProvider(SandboxProvider):
         content, is_binary = self.encode_file_content(path, content_bytes)
         return FileContent(path=path, content=content, type="file", is_binary=is_binary)
 
-    # Directories to skip in the os.walk fallback (non-git repos).
-    # Mirrors the most common .gitignore entries to avoid returning
-    # thousands of files from dependency/build directories.
+    # os.walk skip list (non-git) — mirrors common .gitignore entries.
     WALK_SKIP_DIRS = frozenset(
         {
             ".git",
@@ -174,8 +164,6 @@ class LocalHostProvider(SandboxProvider):
 
     @staticmethod
     def _walk_files(base_dir: Path) -> list[FileMetadata]:
-        # Fallback for non-git directories. Skips common build/dependency
-        # directories to avoid returning thousands of irrelevant files.
         items: list[FileMetadata] = []
         for root, dirnames, filenames in os.walk(base_dir, topdown=True):
             dirnames[:] = [
@@ -206,8 +194,7 @@ class LocalHostProvider(SandboxProvider):
         sandbox_id: str,
         path: str = "",
     ) -> list[FileMetadata]:
-        # Use git ls-files for repos — handles .gitignore, global excludes,
-        # and .git/info/exclude natively. Falls back to os.walk for non-git dirs.
+        # git ls-files honors ignore rules; os.walk for non-git dirs.
         rel = normalize_relative_path(path)
         target_dir = self._workspace if not rel else self._resolve_path(rel)
 
@@ -234,14 +221,10 @@ class LocalHostProvider(SandboxProvider):
         on_exit: PtyExitCallbackType,
         user_id: str = "",
     ) -> str:
-        # Spawn a PTY-attached shell in the workspace directory (or a
-        # workspace-relative cwd, e.g. a chat's worktree). Tries tmux
-        # for session persistence across WebSocket reconnections, falls back
-        # to the user's default shell if tmux is not installed.
+        # tmux for reconnect persistence; default shell if missing.
         session_id = str(uuid.uuid4())
         master_fd, slave_fd = pty.openpty()
-        # Set initial terminal size so the shell starts with the correct
-        # dimensions (struct winsize: rows, cols, xpixel, ypixel).
+        # struct winsize: rows, cols, xpixel, ypixel.
         fcntl.ioctl(
             slave_fd,
             termios.TIOCSWINSZ,
@@ -297,8 +280,6 @@ class LocalHostProvider(SandboxProvider):
         on_data: PtyDataCallbackType,
         on_exit: PtyExitCallbackType,
     ) -> None:
-        # Continuously read PTY output and forward to the WebSocket via on_data.
-        # Runs as a background task until the process exits or kill_pty cancels it.
         try:
             while True:
                 chunk = await asyncio.to_thread(os.read, master_fd, 4096)
@@ -306,7 +287,6 @@ class LocalHostProvider(SandboxProvider):
                     break
                 await on_data(chunk)
         except asyncio.CancelledError:
-            # kill_pty tearing us down — the owner already knows.
             return
         except OSError as e:
             # On Linux the master fd raises EIO instead of returning EOF when
@@ -320,7 +300,6 @@ class LocalHostProvider(SandboxProvider):
         pty_id: str,
         data: bytes,
     ) -> None:
-        # Forward user keystrokes from the WebSocket to the PTY shell.
         session = self.get_pty_session(sandbox_id, pty_id)
         if not session:
             return
@@ -332,7 +311,6 @@ class LocalHostProvider(SandboxProvider):
         pty_id: str,
         size: PtySize,
     ) -> None:
-        # Update the PTY window size and signal the shell to redraw.
         session = self.get_pty_session(sandbox_id, pty_id)
         if not session:
             return
@@ -354,8 +332,6 @@ class LocalHostProvider(SandboxProvider):
         sandbox_id: str,
         pty_id: str,
     ) -> None:
-        # Tear down a PTY session: cancel the reader task, terminate the
-        # shell process (SIGTERM then SIGKILL), close the fd, and remove tracking.
         session = self.get_pty_session(sandbox_id, pty_id)
         if not session:
             return

--- a/backend/app/services/search.py
+++ b/backend/app/services/search.py
@@ -47,11 +47,7 @@ class SearchService:
         max_file_matches: int = DEFAULT_MAX_FILE_MATCHES,
         max_total_matches: int = DEFAULT_MAX_TOTAL_MATCHES,
     ) -> SearchResponse:
-        # Runs `rg --json` in the sandbox and parses the stream into
-        # SearchFileResult groups. Relies on rg's default .gitignore-aware
-        # filtering so users don't get matches from node_modules, dist, etc.
-        # Result paths are normalized to workspace-root-relative form so they
-        # line up with the frontend file tree.
+        # rg --json (gitignore-aware); paths normalized to workspace-root-relative.
         rel_cwd = normalize_relative_path(cwd)
         cd_prefix = f"cd '{rel_cwd}' && " if rel_cwd else ""
 
@@ -94,8 +90,7 @@ class SearchService:
         max_file_matches: int,
         path_prefix: str,
     ) -> SearchResponse:
-        # rg --json emits one object per line: "begin"/"match"/"end"/"summary".
-        # We only care about "match" — the others are redundant for our UI.
+        # Only "match" lines matter for the UI.
         results: list[SearchFileResult] = []
         file_index: dict[str, int] = {}
         total_matches = 0

--- a/backend/app/services/session_registry.py
+++ b/backend/app/services/session_registry.py
@@ -32,11 +32,7 @@ class ChatSession:
     last_used_at: float = field(default_factory=time.monotonic)
 
 
-# In-process registry of active ACP sessions keyed by chat_id. A single
-# session is reused across consecutive messages in the same chat so the
-# agent keeps its conversation context. Sessions are fingerprinted by
-# config — if the user changes model provider, env vars, MCP servers, etc.,
-# the old session is torn down and a fresh one is created.
+# In-process ACP sessions by chat_id. Fingerprint changes (model/env/MCP/etc.) tear down and recreate.
 class SessionRegistry:
     def __init__(self) -> None:
         self._sessions: dict[str, ChatSession] = {}

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -183,7 +183,6 @@ class SkillService:
         return list(by_path.values())
 
     def get_files(self, source: str, skill_name: str) -> list[SkillFileEntry]:
-        # Text files are returned as-is, binary files as base64-encoded strings.
         skill_dir = self._find_skill_dir(source, skill_name)
         if skill_dir is None:
             raise FileNotFoundError(f"Skill '{skill_name}' not found")

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -77,13 +77,9 @@ class StorageService:
         file_url = AttachmentURL.build_temp_preview_url(relative_file_path)
 
         if sandbox_id and file_type not in NATIVE_FILE_TYPES[agent_kind]:
-            # Attachments are advertised to the agent as readable from the
-            # sandbox, so fail the upload if the sandbox copy is unavailable.
-            # Skip the write when the agent consumes this file type inline
-            # (base64-embedded in the ACP prompt) — the sandbox copy would be
-            # dead data and, in desktop mode, would pollute the user's workspace.
-            # Pass a relative filename so both providers resolve it under the
-            # workspace dir (absolute paths are rejected by Host).
+            # Fail if sandbox copy unavailable (agent reads from sandbox).
+            # Skip write for inline ACP types (dead data; pollutes desktop workspaces).
+            # Relative filename so both providers resolve under workspace (Host rejects abs).
             await self.sandbox_service.provider.write_file(
                 sandbox_id=sandbox_id, path=unique_filename, content=contents
             )

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -53,9 +53,7 @@ TRANSPORT_FATAL_TYPES = (
     OSError,
 )
 
-# Events that contribute to the accumulated message snapshot (text, tools, etc.).
-# These are buffered and flushed in batches rather than persisted one-by-one,
-# unlike control events (stream_started, complete, error) which go to DB immediately.
+# Snapshot-contributing events (text/tools/etc.) — batched; control events persist immediately.
 SNAPSHOT_EVENT_KINDS = frozenset(
     {
         "assistant_text",
@@ -71,9 +69,7 @@ SNAPSHOT_EVENT_KINDS = frozenset(
 
 
 class ChatStreamRuntime:
-    # Class-level registry of in-process background stream tasks, keyed by task
-    # so we can track which chats are actively streaming, await them on shutdown,
-    # and prevent duplicate streams for the same chat.
+    # Background stream tasks by asyncio.Task — track chats, await shutdown, block duplicates.
     _background_task_chat_ids: dict[asyncio.Task[str], str] = {}
 
     def __init__(
@@ -361,10 +357,7 @@ class ChatStreamRuntime:
                 )
 
     async def _flush_snapshot(self, *, force: bool) -> None:
-        # Debounced persistence: batch buffered events and snapshot to DB at most
-        # every 200ms or 24 events, whichever comes first. This avoids a DB write
-        # per token while keeping the persisted state reasonably fresh for SSE
-        # reconnection catch-up.
+        # Debounce DB writes (max every 200ms or 24 events) for SSE catch-up freshness.
         if not self.assistant_message_id:
             return
         if not force:
@@ -390,8 +383,7 @@ class ChatStreamRuntime:
         stream_result: StreamResult,
         stream_status: MessageStreamStatus,
     ) -> int | None:
-        # Returns the persisted run duration so the terminal event can carry it
-        # to the live client without waiting for a refetch.
+        # Persist duration so the terminal event can carry it without a refetch.
         if not self.assistant_message_id:
             return None
         await self._flush_event_buffer()
@@ -429,10 +421,7 @@ class ChatStreamRuntime:
                     apply_snapshot=False,
                 )
         elif status == MessageStreamStatus.INTERRUPTED:
-            # Close the stream generator before starting the send-now
-            # replacement. This ensures the old prompt_task is fully
-            # cancelled (and its handler.finish() sentinel already fired)
-            # before the new prompt begins on the same shared handler.
+            # Close generator first so the old prompt_task finishes before the new prompt shares the handler.
             await self._close_stream()
             if await self._process_next_queued(
                 send_now_only=True, prior_duration_ms=duration_ms
@@ -531,7 +520,7 @@ class ChatStreamRuntime:
                 model_id=next_msg["model_id"],
                 stream_status=MessageStreamStatus.IN_PROGRESS,
             )
-            # Inline import to avoid circular dependency with chat.py.
+            # Avoid circular import with chat.py.
             from app.services.chat import ChatService
 
             checkpoint_id = await ChatService.create_checkpoint_for_message(
@@ -672,7 +661,7 @@ class ChatStreamRuntime:
             )
             await db.commit()
 
-        # Inline import to avoid circular dependency with chat.py.
+        # Avoid circular import with chat.py.
         from app.services.chat import ChatService
 
         # Push the title to open sessions so the sidebar/tab update mid-stream
@@ -883,7 +872,7 @@ class ChatStreamRuntime:
                 if not chat:
                     raise AgentException(f"Chat {chat_id} not found for idle send-now")
 
-            # Inline import to avoid circular dependency with chat.py.
+            # Avoid circular import with chat.py.
             from app.services.chat import ChatService
 
             await ChatService.create_checkpoint_for_message(

--- a/backend/app/services/streaming/types.py
+++ b/backend/app/services/streaming/types.py
@@ -25,9 +25,7 @@ StreamEventType = Literal[
     "plan",
 ]
 MAX_AUDIT_STRING_LENGTH = 4096
-# The agent embeds prompt suggestions as an XML tag at the end of its response.
-# This regex extracts them so they can be sent as a structured event and stripped
-# from the visible assistant text.
+# Extract trailing XML prompt suggestions for a structured event (strip from visible text).
 PROMPT_SUGGESTIONS_RE = re.compile(
     r"<prompt_suggestions>\s*(.*?)\s*</prompt_suggestions>",
     re.DOTALL,
@@ -85,9 +83,7 @@ class StreamEvent(TypedDict, total=False):
     suggestions: list[str]
 
 
-# Accumulates stream events during a generation so the runtime can persist
-# a complete snapshot to DB periodically (for SSE reconnection catch-up)
-# without replaying the entire event history each time.
+# Snapshot buffer for periodic DB persist (SSE catch-up without full history replay).
 @dataclass
 class StreamSnapshotAccumulator:
     events: list[dict[str, Any]] = field(default_factory=list)
@@ -156,9 +152,7 @@ class StreamEnvelope:
 
     @staticmethod
     def sanitize_payload(value: Any) -> Any:
-        # Recursively redact sensitive keys (tokens, passwords) and truncate
-        # long strings with a sha256 hash for traceability. Used to build the
-        # audit_payload stored alongside the render_payload in message_events.
+        # Redact secrets and hash-truncate long strings for message_events audit_payload.
         if isinstance(value, dict):
             redacted: dict[str, Any] = {}
             for key, nested in value.items():

--- a/backend/app/services/terminal.py
+++ b/backend/app/services/terminal.py
@@ -232,8 +232,7 @@ class TerminalSessionRecord:
 
     @staticmethod
     def _force_enqueue(queue: "asyncio.Queue[_T]", item: "_T") -> bool:
-        # Drop the oldest item if the queue is full so fast producers (PTY output,
-        # user keystrokes) never block — losing a stale frame is better than backpressure.
+        # Drop oldest when full — lose a stale frame rather than block producers.
         try:
             queue.put_nowait(item)
             return True
@@ -250,9 +249,7 @@ class TerminalSessionRecord:
 
     @staticmethod
     async def _drain(queue: "asyncio.Queue[_T]") -> "list[_T]":
-        # Wait for at least one item, then grab everything else available without
-        # blocking. This batches rapid bursts (e.g. fast terminal output) into a
-        # single WebSocket frame or PTY write.
+        # Batch: wait for one item, then drain the rest without blocking.
         first = await queue.get()
         buffer = [first]
         while True:

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -284,7 +284,6 @@ class WorkspaceService(BaseDbService[Workspace]):
             now = datetime.now(timezone.utc)
             workspace.deleted_at = now
 
-            # Soft-delete all chats in this workspace
             chat_ids_query = select(Chat.id, Chat.worktree_cwd).filter(
                 Chat.workspace_id == workspace_id, Chat.deleted_at.is_(None)
             )
@@ -307,7 +306,6 @@ class WorkspaceService(BaseDbService[Workspace]):
                 .values(deleted_at=now)
             )
 
-            # Soft-delete messages in those chats
             if chat_ids:
                 await db.execute(
                     update(Message)
@@ -320,11 +318,9 @@ class WorkspaceService(BaseDbService[Workspace]):
 
             await db.commit()
 
-            # Terminate sessions for all chats
             for cid in chat_ids:
                 asyncio.create_task(session_registry.terminate(str(cid)))
 
-            # Destroy the container using the workspace's actual provider
             if workspace.sandbox_id:
                 provider = SandboxProvider.create_provider(
                     workspace.sandbox_provider, workspace_path=workspace.workspace_path

--- a/backend/app/utils/cache.py
+++ b/backend/app/utils/cache.py
@@ -66,8 +66,7 @@ class MemoryPubSub:
         pass
 
 
-# In-memory Redis-compatible store for desktop mode where Redis isn't available.
-# Uses asyncio.TimerHandle for key expiry so TTLs work without a background sweep.
+# Desktop stand-in for Redis; TTL via asyncio.TimerHandle (no background sweep).
 class MemoryStore:
     _instance: "MemoryStore | None" = None
 

--- a/backend/app/utils/parsing.py
+++ b/backend/app/utils/parsing.py
@@ -3,8 +3,7 @@ from uuid import UUID
 
 
 def parse_stream_cursors(value: str | None) -> dict[UUID, int]:
-    # Query-param JSON object of chat id -> last seen seq, used by the multiplexed
-    # SSE feed to decide which chats need backlog replay and from where.
+    # Query JSON: chat id -> last seen seq for multiplexed SSE backlog replay.
     if not value:
         return {}
     try:

--- a/backend/app/utils/sandbox.py
+++ b/backend/app/utils/sandbox.py
@@ -1,16 +1,12 @@
 import re
 
-# Guard against shell injection in branch names and workspace-relative cwd
-# paths passed to exec.
+# Reject shell-injectable branch names / cwd paths passed to exec.
 BRANCH_NAME_RE = re.compile(r"^[\w./-]+$")
 
 
 def normalize_relative_path(path: str | None) -> str:
-    # Empty / None / "." / "./" all mean the workspace root. Rejecting absolute
-    # paths, `..` escapes, and quote/control characters protects the
-    # single-quoted `cd` prefix built in git_cd_prefix from breaking out while
-    # still allowing normal repo filenames like @scoped packages or names with
-    # punctuation.
+    # Empty/None/"."/"./" = workspace root. Reject abs/`..`/quotes/controls so
+    # the single-quoted `cd` in git_cd_prefix can't break out.
     if path is None:
         return ""
     if path.startswith("/"):

--- a/backend/seed_data.py
+++ b/backend/seed_data.py
@@ -46,8 +46,7 @@ async def seed_admin(session: AsyncSession) -> None:
 
 
 async def seed_data() -> None:
-    # Reuse the app engine so seeding runs with the same SQLite pragmas
-    # (foreign keys, WAL) instead of a bare unconfigured connection.
+    # App engine so seed gets the same SQLite pragmas (FK, WAL) as runtime.
     async with SessionLocal() as session:
         await seed_admin(session)
         await session.commit()

--- a/backend/tests/fake_acp_agent.py
+++ b/backend/tests/fake_acp_agent.py
@@ -49,9 +49,7 @@ SCENARIO = os.environ.get("FAKE_ACP_SCENARIO", "normal")
 LOG_PATH = os.environ.get("FAKE_ACP_LOG")
 NEW_SESSION_ID = "fake-acp-session-1"
 
-# Per-turn behavior is picked by looking for one of these markers inside the
-# prompt text the real client sent — lets one fake binary cover every branch
-# in client.py/session.py without spawning a different process per case.
+# Prompt markers select per-turn behavior so one fake covers all branches.
 MARKER_TOOL_DIFF = "MARKER_TOOL_DIFF"
 MARKER_TOOL_TEXT_RESULT = "MARKER_TOOL_TEXT_RESULT"
 MARKER_TOOL_CODEX_ERROR = "MARKER_TOOL_CODEX_ERROR"
@@ -241,11 +239,7 @@ class FakeAgent:
         )
 
         if MARKER_CRASH_MID_PROMPT in text:
-            # A hard os._exit() here would leave the client's pending prompt()
-            # request unresolved forever (the ACP SDK's receive loop doesn't
-            # reject in-flight requests on a clean EOF) — a real agent crash
-            # would wedge the turn. Erroring the request instead exercises the
-            # same finish(prompt_completed=False) path deterministically.
+            # Don't os._exit — pending prompt() would hang; error the request.
             await self._emit_tool_started(session_id, "tool-crash", "Doing risky work")
             raise RuntimeError("simulated mid-prompt agent failure")
         if MARKER_CANCEL in text:
@@ -262,9 +256,7 @@ class FakeAgent:
         return await self._run_default_turn(session_id, text)
 
     async def _call_fs_terminal_stubs(self, session_id: str) -> None:
-        # Exercises every ACP client-side stub in client.py — real agents call
-        # these for file/terminal access; ours never needs to, so drive them
-        # directly to prove the no-op implementations satisfy the protocol.
+        # Drive client.py fs/terminal no-op stubs to prove protocol compliance.
         assert self._client is not None
         client = self._client
         try:
@@ -345,10 +337,7 @@ class FakeAgent:
         await client.ext_notification("agentrove.debug_note", {"probe": True})
 
     async def _run_enter_plan_mode_turn(self, session_id: str) -> PromptResponse:
-        # AgentService._get_plan_mode_transition() only fires on a completed
-        # tool literally named EnterPlanMode — reachable only through the
-        # adapter's map_session_mode(), which Claude's build_session_config()
-        # never calls directly (it passes permission_mode straight through).
+        # EnterPlanMode tool completion is the only path to map_session_mode().
         assert self._client is not None
         await self._client.session_update(
             session_id=session_id,
@@ -407,10 +396,7 @@ class FakeAgent:
             pass
         finally:
             self._cancel_events.pop(session_id, None)
-        # Let already-scheduled notification-processing tasks land before
-        # the response resolves the client's pending prompt() future — the
-        # ACP SDK dispatches notifications as fire-and-forget tasks, so a
-        # response arriving right behind them can race ahead undelivered.
+        # Yield so fire-and-forget notifications land before prompt() resolves.
         await asyncio.sleep(0.05)
         return PromptResponse(stop_reason="cancelled")
 
@@ -426,9 +412,7 @@ class FakeAgent:
             PermissionOption(
                 kind="reject_once", name="Reject", option_id="reject-once"
             ),
-            # A resolvable mode (unlike reject-once) that the "user" can still
-            # pick and have the underlying command go on to fail — covers
-            # tool_failed with a *resolved* permission_mode in client.py.
+            # Resolvable mode then fail — tool_failed with resolved permission.
             PermissionOption(kind="allow_always", name="Plan", option_id="plan"),
         ]
         response = await self._client.request_permission(
@@ -473,10 +457,7 @@ class FakeAgent:
         return PromptResponse(stop_reason="end_turn")
 
     async def _run_ask_user_question_turn(self, session_id: str) -> PromptResponse:
-        # Mirrors Grok's ask_user_question flow: the question arrives as an
-        # `_x.ai/ask_user_question` extension request (the SDK's ext_method
-        # adds the underscore prefix) while the tool call is still active, and
-        # the client must answer with an AskUserQuestionExtResponse.
+        # Grok ask_user_question via ext_method (SDK adds `_` prefix).
         assert self._client is not None
         tool_call_id = "tool-ask-user"
         await self._emit_tool_started(session_id, tool_call_id, "Ask: Pick a color")
@@ -543,9 +524,7 @@ class FakeAgent:
             ),
         )
         if MARKER_IMAGE_CONTENT in text:
-            # Non-text content on these three chunk kinds maps to None in
-            # client.py (_map_agent_message/_map_agent_thought/_map_user_message)
-            # — no event should reach the frontend for any of them.
+            # Non-text on message/thought/user chunks maps to None — no FE event.
             image_block = ImageContentBlock(
                 type="image", data=TINY_PNG_BASE64, mimeType="image/png"
             )
@@ -618,10 +597,7 @@ class FakeAgent:
             ),
         )
         if MARKER_RAW_INPUT_STRING not in text and MARKER_RAW_INPUT_INVALID not in text:
-            # A later raw_input change (as opposed to the one on the initial
-            # ToolCallStart) is a distinct client.py code path in
-            # _map_tool_call_progress — cover it whenever the raw-input-on-start
-            # variants above aren't the thing being asserted on.
+            # Progress-time raw_input (distinct from ToolCallStart path).
             await client.session_update(
                 session_id=session_id,
                 update=ToolCallProgress(
@@ -654,9 +630,7 @@ class FakeAgent:
 
         await self._emit_tool_started(session_id, "tool-secondary", "Running a command")
         if MARKER_TOOL_LEFT_OPEN in text:
-            # Never sent a terminal update for tool-secondary — it's still
-            # "active" when finish(prompt_completed=True) runs below, exercising
-            # the leftover-tool auto-complete branch in client.py.
+            # Leave tool-secondary active for finish()'s leftover auto-complete.
             pass
         elif MARKER_TOOL_TEXT_ERROR in text:
             await client.session_update(
@@ -754,10 +728,7 @@ class FakeAgent:
             )
             return
         if MARKER_TOOL_EMPTY_RESULT in text or MARKER_TOOL_START_DIFF in text:
-            # No raw_output, no diff/text content — _extract_tool_result falls
-            # all the way through to its empty-content "return None" fallback.
-            # For START_DIFF the diffs captured from the ToolCallStart must
-            # survive this bare terminal update (Codex edit shape).
+            # Empty terminal update → _extract_tool_result None; START_DIFF keeps start diffs.
             await self._client.session_update(
                 session_id=session_id,
                 update=ToolCallProgress(
@@ -781,10 +752,7 @@ class FakeAgent:
 async def main() -> None:
     reader, writer = await stdio_streams()
     agent = FakeAgent()
-    # listening=False + explicit listen() below — the constructor's default
-    # (listening=True) would start its own receive-loop task, racing this one
-    # for the same stdin reader ("readuntil() called while another coroutine
-    # is already waiting for incoming data").
+    # listening=False: default True races a second receive loop on stdin.
     conn = AgentSideConnection(
         agent, writer, reader, listening=False, use_unstable_protocol=True
     )

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -63,9 +63,7 @@ PDF_BYTES = b"%PDF-1.4\n%fake\n"
 
 @pytest.fixture(scope="session")
 def acp_bin_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    # Wrapper executables named after each real agent binary so the real
-    # AcpSession._spawn_host() PATH lookup resolves to our fake ACP agent
-    # regardless of which adapter/model a test exercises.
+    # PATH wrappers so AcpSession._spawn_host resolves to the fake agent.
     bin_dir = tmp_path_factory.mktemp("acp-fake-bin")
     launcher = (
         f"#!{sys.executable}\n"
@@ -96,10 +94,7 @@ class FakeAgentHandle:
         return [e for e in self.events() if e.get("event") == event]
 
     def main_turn_prompts(self) -> list[dict[str, Any]]:
-        # A chat's first turn also triggers background title generation, an
-        # independent ACP session/prompt through this same fake agent binary
-        # — filter its "Generate a title..." prompt out when a test wants the
-        # actual chat turn's prompt event.
+        # Filter background title-gen prompts out of the fake agent log.
         return [
             e
             for e in self.events_of("prompt")
@@ -122,10 +117,7 @@ def fake_agent(
 
 @pytest.fixture(autouse=True)
 def pin_ambient_settings() -> Iterator[None]:
-    # A developer's own shell/.env can export real AGENTROVE_MCP_* creds and
-    # DESKTOP_MODE=true for the desktop app; Settings() picks those up
-    # regardless of bootstrap.py, so pin a deterministic web-mode baseline
-    # here. The tests that care about MCP/desktop-mode override explicitly.
+    # Pin web-mode baseline — shell/.env may export real MCP/desktop settings.
     settings = get_settings()
     original = (
         settings.AGENTROVE_MCP_ENABLED,
@@ -172,9 +164,7 @@ async def auth_workspace(
     headers, _user, workspace = await create_authenticated_workspace(
         db_session, create_user, login
     )
-    # AcpSession._spawn_host() uses this as the subprocess cwd — it must exist
-    # on disk for both the fake agent spawn and the (best-effort, no-op here)
-    # git checkpoint probe.
+    # Spawn cwd must exist (agent + best-effort git checkpoint probe).
     Path(workspace.workspace_path).mkdir(parents=True, exist_ok=True)
     return headers, workspace
 
@@ -259,13 +249,7 @@ async def wait_for_message(
 
 
 async def _settle_background_chat_work(timeout: float = 5.0) -> None:
-    # A chat's first turn kicks off background title generation — a second,
-    # independent ACP round trip through the same fake agent — as a detached
-    # asyncio task the API doesn't expose a "done" signal for. Left running,
-    # it can still be spawning/writing after the test returns, racing the next
-    # test's autouse database fixture (which drops all tables). Everything
-    # runs in-process on this same event loop (ASGITransport, no real
-    # network), so waiting out whatever tasks are still pending is exact.
+    # Drain pending title-gen tasks so they don't race the next test's DB drop.
     pending = [
         t
         for t in asyncio.all_tasks()
@@ -330,9 +314,7 @@ async def test_enhance_prompt_round_trips_through_real_acp_session(
     fake_agent: FakeAgentHandle,
     model_id: str,
 ) -> None:
-    # Drives client.py + session.py + adapters.py for real: spawns the fake
-    # agent over stdio, does the ACP handshake, creates a session, streams a
-    # full turn back, and tears the process down — once per adapter kind.
+    # Real stdio ACP path through client/session/adapters, per agent kind.
     headers, _user, _workspace = await create_authenticated_workspace(
         db_session,
         create_user,
@@ -549,9 +531,7 @@ async def test_chat_tool_left_active_is_auto_completed_on_finish(
     fake_agent: FakeAgentHandle,
     acp_cache: EndpointCache,
 ) -> None:
-    # A tool that never receives a terminal update but whose turn otherwise
-    # ends normally exercises AcpClientHandler.finish(prompt_completed=True)'s
-    # leftover-active-tool auto-close, distinct from the prompt-failure path.
+    # Tool never terminals — finish(prompt_completed=True) auto-closes it.
     headers, workspace = auth_workspace
     chat = await create_chat(client, headers, workspace, model_id="sonnet")
 
@@ -580,9 +560,7 @@ async def test_chat_agent_calls_fs_and_terminal_stubs_without_error(
     fake_agent: FakeAgentHandle,
     acp_cache: EndpointCache,
 ) -> None:
-    # The client implements ACP's fs/terminal methods as no-op stubs (the
-    # sandbox handles file/terminal I/O directly) — drive every one of them
-    # from the agent side and confirm the turn still completes cleanly.
+    # Agent-side calls to fs/terminal no-ops must still complete the turn.
     headers, workspace = auth_workspace
     chat = await create_chat(client, headers, workspace, model_id="sonnet")
 
@@ -607,9 +585,7 @@ async def test_chat_non_text_content_chunks_produce_no_events(
     fake_agent: FakeAgentHandle,
     acp_cache: EndpointCache,
 ) -> None:
-    # AgentMessageChunk/AgentThoughtChunk/UserMessageChunk all map to None in
-    # client.py when their content block isn't text — image content must not
-    # add any extra assistant_text/assistant_thinking events.
+    # Non-text content blocks map to None — no extra text/thinking events.
     headers, workspace = auth_workspace
     chat = await create_chat(client, headers, workspace, model_id="sonnet")
 
@@ -637,10 +613,7 @@ async def test_chat_enter_plan_mode_tool_triggers_mid_stream_mode_switch(
     fake_agent: FakeAgentHandle,
     acp_cache: EndpointCache,
 ) -> None:
-    # AgentService._get_plan_mode_transition() reacts to a completed
-    # "EnterPlanMode" tool by calling adapter.map_session_mode() and
-    # session.set_mode() mid-turn — the only caller of Claude's
-    # map_session_mode() passthrough (build_session_config never uses it).
+    # Completed EnterPlanMode → map_session_mode + set_mode mid-turn.
     headers, workspace = auth_workspace
     chat = await create_chat(client, headers, workspace, model_id="sonnet")
 
@@ -689,10 +662,7 @@ async def test_chat_permission_mode_unsupported_by_adapter(
     expect_raises: bool,
     expect_mapped_modes: list[str] | None,
 ) -> None:
-    # "bypassPermissions" is a globally valid PermissionMode literal but isn't
-    # in every adapter's own session-mode set: Codex raises (a caller bug must
-    # fail loudly), Copilot/Cursor/OpenCode fall back to their normal mode so
-    # an agent switch never silently widens permissions.
+    # Cross-agent bypassPermissions: Codex raises; others fall back safely.
     headers, workspace = auth_workspace
     chat = await create_chat(client, headers, workspace, model_id=model_id)
 
@@ -717,9 +687,7 @@ async def test_chat_permission_mode_unsupported_by_adapter(
     set_modes = fake_agent.events_of("set_session_mode")
     assert set_modes
     assert expect_mapped_modes is not None
-    # Leading mode-sets belong to the chat session — background title
-    # generation opens a second session afterwards (opencode's uses a persona
-    # mode).
+    # Leading mode-sets are the chat session; title-gen opens another later.
     leading = [m["mode_id"] for m in set_modes[: len(expect_mapped_modes)]]
     assert leading == expect_mapped_modes
 
@@ -730,9 +698,7 @@ async def test_chat_attachments_with_only_native_files_skip_the_note(
     fake_agent: FakeAgentHandle,
     acp_cache: EndpointCache,
 ) -> None:
-    # _build_attachment_note() returns "" when every attachment is natively
-    # embeddable — no sandbox-path note is needed. Codex only treats images
-    # as native, so a single image-only upload exercises that empty branch.
+    # Codex image-only: all native → empty attachment note.
     headers, workspace = auth_workspace
     chat = await create_chat(client, headers, workspace, model_id="gpt-5.4")
 
@@ -765,9 +731,7 @@ async def test_chat_native_pdf_attachment_is_embedded_not_noted(
     fake_agent: FakeAgentHandle,
     acp_cache: EndpointCache,
 ) -> None:
-    # Claude treats pdf as natively embeddable (unlike Codex) — this drives
-    # _build_attachment_blocks()'s EmbeddedResourceContentBlock/BlobResourceContents
-    # branch instead of the sandbox-note path.
+    # Claude PDF is native embed → EmbeddedResource/Blob path, not sandbox note.
     headers, workspace = auth_workspace
     chat = await create_chat(client, headers, workspace, model_id="sonnet")
 
@@ -872,10 +836,7 @@ async def test_chat_ask_user_question_flow(
     option_id: str,
     expect_response: dict[str, Any],
 ) -> None:
-    # Grok's ask_user_question arrives as an ACP extension request and must be
-    # answered with an AskUserQuestionExtResponse: the question is surfaced as
-    # a permission_request whose options are the question's choices, and the
-    # user's selection (or dismissal → skip_interview) becomes the response.
+    # Grok ask_user_question ext → permission_request; answer is the response.
     headers, workspace = auth_workspace
     chat = await create_chat(client, headers, workspace, model_id="grok:grok-4.5")
 
@@ -911,11 +872,7 @@ async def test_chat_ask_user_question_flow(
     )
     assert message["stream_status"] == "completed"
 
-    # The fake agent completes the tool with raw_output=<the client's ext
-    # response>, so this message's own tool result is the response the client
-    # returned. Don't assert on the fake-agent log: background title generation
-    # re-runs the marker turn (its prompt embeds the user message) and its
-    # auto-denied question appends a stray skip_interview entry.
+    # Tool raw_output is the client's ext response; skip fake-agent log (title-gen noise).
     tool = last_tool(message, "tool-ask-user")
     assert tool["status"] == "completed"
     assert tool["result"] == expect_response
@@ -989,9 +946,7 @@ async def test_chat_resume_after_session_eviction_mutes_replayed_history(
     # hands back the same fixed id, which load_session() below must be handed.
     session_id = NEW_SESSION_ID
 
-    # Simulate the in-process session being evicted (idle timeout / restart) —
-    # the next turn must go through AcpSession.create() with resume_session_id
-    # set, exercising the real load_session() path instead of session reuse.
+    # Evict in-process session so next turn uses create(resume_session_id).
     await session_registry.terminate(chat["id"])
     monkeypatch.setenv("FAKE_ACP_SCENARIO", "load_session_replay")
 
@@ -1024,9 +979,7 @@ async def test_chat_mid_session_model_and_mode_switch_survives_config_errors(
     acp_cache: EndpointCache,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Codex's env doesn't vary by model, so the in-process session is reused
-    # across a model/permission_mode change — the only way to reach
-    # AcpSession.set_model()/set_mode() (as opposed to the create()-time calls).
+    # Codex reuses session across model/mode change → hits set_model/set_mode.
     monkeypatch.setenv("FAKE_ACP_SCENARIO", "config_error")
     headers, workspace = auth_workspace
     chat = await create_chat(client, headers, workspace, model_id="gpt-5.4")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -744,9 +744,7 @@ async def test_register_blocks_disposable_email_using_stale_cache_when_refetch_f
     settings_override: SettingsOverride,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Pre-populate the cache but with a timestamp older than the TTL, so a
-    # refetch is attempted; when it fails, the stale (still non-empty) cache
-    # is served instead of an empty set.
+    # Stale non-empty cache past TTL: refetch fails → serve stale, not empty.
     monkeypatch.setattr(EmailService, "_disposable_domains_cache", {"mailinator.com"})
     monkeypatch.setattr(
         EmailService,

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -193,9 +193,7 @@ class RaisingMessageService:
 
 
 class StreamStatusServiceOverride:
-    # Wraps a real Chat row (so get_chat succeeds) while forcing the
-    # in-progress-message lookup to fail, isolating the endpoint's
-    # SQLAlchemyError branch from the ChatException branch.
+    # Real Chat row + failing in-progress lookup → SQLAlchemyError branch.
     def __init__(self, chat: Chat, exc: Exception) -> None:
         self._chat = chat
         self.message_service = RaisingMessageService(exc)

--- a/backend/tests/test_infra.py
+++ b/backend/tests/test_infra.py
@@ -301,9 +301,7 @@ async def test_admin_edit_user_username_without_password(
     monkeypatch: pytest.MonkeyPatch,
     db_session: AsyncSession,
 ) -> None:
-    # Empty password field is not a model column; leaving it in form data
-    # previously crashed SQLAdmin with "'NoneType' object has no attribute
-    # 'nullable'" on update.
+    # Empty password left in form data crashed SQLAdmin on column.nullable.
     monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
     admin_user = User(
         email="edit-admin@example.com",

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -45,9 +45,7 @@ pytestmark = pytest.mark.anyio
 
 
 class ScriptedSandboxProvider(FakeSandboxProvider):
-    # Extends FakeSandboxProvider with per-test scripted command responses and
-    # optional forced exceptions — helpers.py can't be edited, so error-path
-    # coverage (git/search failures, provider errors) lives here instead.
+    # Scripted responses/exceptions (helpers.py not editable for error paths).
     def __init__(self) -> None:
         super().__init__()
         self.command_overrides: list[tuple[str, CommandResult]] = []
@@ -1280,9 +1278,7 @@ async def test_host_provider_serves_real_files_from_disk(
     create_user: UserFactory,
     login: LoginClient,
 ) -> None:
-    # Exercises the real LocalHostProvider (no fake) against real files on
-    # disk inside the pytest tmp dir — file read/write, os.walk fallback for
-    # non-git dirs, WALK_SKIP_DIRS pruning, and the symlink-escape guard.
+    # Real LocalHostProvider on tmp disk (walk fallback, skip dirs, symlink guard).
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
     (workspace_dir / "README.md").write_text("real readme")
@@ -1367,9 +1363,7 @@ async def test_host_provider_runs_real_git_commands(
         ["git", "config", "user.name", "Test"], cwd=workspace_dir, check=True
     )
     (workspace_dir / "app.py").write_text("print('v1')\n")
-    # Two nested tracked files under the same dir so `git ls-files` output
-    # exercises both the parent-directory synthesis and the seen_dirs dedup
-    # branch in SandboxProvider.parse_git_ls_files.
+    # Nested tracked files exercise parent-dir synthesis + seen_dirs dedup.
     (workspace_dir / "src").mkdir()
     (workspace_dir / "src" / "nested.py").write_text("print('nested')\n")
     (workspace_dir / "src" / "other.py").write_text("print('other')\n")
@@ -1388,11 +1382,7 @@ async def test_host_provider_runs_real_git_commands(
         username="hostgit",
     )
 
-    # A custom env var forces SandboxService to pass non-empty envs into
-    # execute_command, exercising the process_env.update(envs) merge path.
-    # Seed via DB (same pattern as the github-token inject test) — PATCH
-    # /settings/ goes through Redis cache invalidation, which host-provider
-    # tests don't wire up.
+    # Seed custom env via DB (not PATCH — Redis invalidation not wired here).
     user_settings = await get_user_settings(db_session, workspace.user_id)
     assert user_settings is not None
     user_settings.custom_env_vars = [{"key": "MY_VAR", "value": "hello"}]
@@ -1413,9 +1403,7 @@ async def test_host_provider_runs_real_git_commands(
         json={"message": "v2"},
         headers=headers,
     )
-    # After the commit the tree is clean, so `git ls-files` succeeds and
-    # list_files takes the git-tracked-files branch instead of the os.walk
-    # fallback exercised by test_host_provider_serves_real_files_from_disk.
+    # Clean tree → list_files uses git ls-files, not os.walk fallback.
     metadata_response = await client.get(
         f"/api/v1/sandbox/{workspace.sandbox_id}/files/metadata", headers=headers
     )
@@ -1448,10 +1436,7 @@ async def test_git_diff_unborn_head_emits_each_file_once(
     create_user: UserFactory,
     login: LoginClient,
 ) -> None:
-    # Real git against a repo with no commits: `git diff HEAD` fails, so "all"
-    # mode falls back to diffing the worktree against the empty tree. The old
-    # `--cached` + plain-diff fallback emitted a staged-then-modified file
-    # twice, which downstream parsing (keyed by path) can't represent.
+    # No commits: "all" diffs empty tree (old fallback double-emitted paths).
     workspace_dir = tmp_path / "unborn-workspace"
     workspace_dir.mkdir()
     subprocess.run(
@@ -1498,11 +1483,7 @@ async def test_git_endpoint_injects_github_token_env(
     fake_provider: FakeSandboxProvider,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # SandboxService.build_env_vars only injects GITHUB_TOKEN/GIT_ASKPASS when
-    # a github_personal_access_token is configured AND DESKTOP_MODE is off —
-    # seed both directly (no endpoint here sets a token) then confirm the
-    # env reaches the provider exec call. Mirrors conftest's SettingsOverride
-    # pattern for toggling settings outside the HTTP boundary.
+    # PAT + server mode injects GITHUB_TOKEN/GIT_ASKPASS into provider env.
     monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
     headers, user, workspace = await create_authenticated_workspace(
         db_session, create_user, login
@@ -1536,9 +1517,7 @@ async def test_download_zip_includes_binary_files(
     headers, _user, workspace = await create_authenticated_workspace(
         db_session, create_user, login
     )
-    # write_file always stores is_binary=False on FakeSandboxProvider — set
-    # the FileContent directly with is_binary=True so list_files/
-    # generate_zip_download take the base64-decode branch.
+    # Force is_binary=True (write_file always stores False on the fake).
     provider.files["logo.zip"] = FileContent(
         path="logo.zip",
         content=base64.b64encode(b"binary-bytes").decode(),

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -190,9 +190,7 @@ async def test_get_settings_returns_legacy_plaintext_github_token(
 ) -> None:
     user = await create_user(email="legacy-token@example.com", username="legacytoken")
     tokens = await login(email="legacy-token@example.com")
-    # Raw SQL bypasses the EncryptedString bind, simulating a pre-encryption
-    # legacy row so decrypt_value raises InvalidToken and the type falls
-    # back to returning the stored value as-is.
+    # Raw SQL legacy ciphertext → InvalidToken → return stored value as-is.
     await db_session.execute(
         text(
             "UPDATE user_settings SET github_personal_access_token = :token "

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -99,10 +99,7 @@ def real_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def real_skill_service(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
-    # The autouse fake_skill_service fixture above overrides get_skill_service
-    # for every test in this module. Real SkillService also branches on
-    # DESKTOP_MODE — force server mode so the global skill dir resolves under
-    # STORAGE_PATH regardless of DESKTOP_MODE leaking from the host shell env.
+    # Force server mode so global skills resolve under STORAGE_PATH.
     monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
     del app.dependency_overrides[get_skill_service]
 
@@ -611,9 +608,7 @@ async def test_real_skill_service_discovers_enabled_claude_plugin_skills(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    # Server mode resolves the plugin config under the owner's agent home —
-    # isolate under the per-test tmp dir, and create the workspace first since
-    # the agent home is keyed by the owner's user id.
+    # Plugin config under owner agent home — create workspace first (user id).
     monkeypatch.setattr(get_settings(), "STORAGE_PATH", str(tmp_path))
     headers, workspace_id, workspace_path = await create_real_workspace(
         client,

--- a/backend/tests/test_streaming.py
+++ b/backend/tests/test_streaming.py
@@ -74,9 +74,7 @@ class PermissionStep:
 
 
 class FakeAcpSession:
-    # Duck-types AcpSession's public surface (session.py) so AgentService and
-    # SessionRegistry drive it exactly like a real ACP subprocess session,
-    # without ever spawning one.
+    # Duck-types AcpSession so AgentService/SessionRegistry run without spawn.
     def __init__(
         self,
         scripts: list[list[Any]],
@@ -210,9 +208,7 @@ def acp_factory(monkeypatch: pytest.MonkeyPatch) -> FakeAcpSessionFactory:
 @pytest.fixture
 def streaming_cache(monkeypatch: pytest.MonkeyPatch) -> EndpointCache:
     cache = EndpointCache()
-    # cache_connection is imported by value into each of these modules, so the
-    # global patch in utils.cache doesn't reach them — patch every call site
-    # that the send/stream/queue pipeline actually uses.
+    # cache_connection is import-by-value — patch each call site, not utils.cache.
     monkeypatch.setattr(chat_endpoint, "cache_connection", cache.connect)
     monkeypatch.setattr(deps, "cache_connection", cache.connect)
     monkeypatch.setattr(chat_service_module, "cache_connection", cache.connect)
@@ -309,9 +305,7 @@ async def test_send_message_streams_full_turn_and_persists_final_snapshot(
     headers, user, workspace = await create_authenticated_workspace(
         db_session, create_user, login
     )
-    # session_id pre-set so this turn isn't treated as "new chat" — keeps the
-    # test focused on the main-turn pipeline instead of also needing a second
-    # scripted session for background title generation.
+    # Pre-set session_id so this isn't a "new chat" (avoids title-gen session).
     chat = await create_chat_row(db_session, user, workspace, session_id="resumed-1")
 
     tool_payload = {
@@ -363,9 +357,7 @@ async def test_send_message_streams_full_turn_and_persists_final_snapshot(
     assert status_response.status_code == 200
     assert status_response.json()["has_active_task"] is False
 
-    # Terminal-event persistence: the pre-completion buffered events are wiped
-    # by the final snapshot, but the "complete" control event is emitted after
-    # that cleanup, so exactly one row should remain.
+    # Snapshot wipes buffered events; "complete" after cleanup leaves one row.
     terminal_events_response = await client.get(
         f"/api/v1/chat/messages/{message_id}/events", headers=headers
     )
@@ -659,10 +651,7 @@ async def test_stream_failure_marks_message_failed_and_emits_bootstrap_error(
     assert events[-1]["type"] == "assistant_text"
     assert "Error: boom" in events[-1]["text"]
 
-    # emit_bootstrap_error's own terminal snapshot save deletes the "error"
-    # MessageEvent row it just inserted (same terminal-cleanup path as any
-    # other stream_status transition), so no rows survive for a reconnect —
-    # only the content_render text carries the error after completion.
+    # Terminal snapshot deletes the error MessageEvent; only content_render remains.
     error_events_response = await client.get(
         f"/api/v1/chat/messages/{message_id}/events", headers=headers
     )
@@ -682,9 +671,7 @@ async def test_queued_message_is_processed_automatically_after_stream_completes(
     )
     chat = await create_chat_row(db_session, user, workspace, session_id="resumed-6")
 
-    # Two scripts on the SAME fake session: the fingerprint (model, mode,
-    # persona, system prompt) is identical across both turns, so the runtime
-    # reuses the one ACP session instead of creating a second one.
+    # Same fingerprint across turns → one ACP session reused, not two.
     first_script = [StreamEvent(type="assistant_text", text="First turn done")]
     second_script = [StreamEvent(type="assistant_text", text="Second turn done")]
     acp_factory.queue(
@@ -736,9 +723,7 @@ async def test_queued_message_is_processed_automatically_after_stream_completes(
     )
     assert second_user is not None
 
-    # The handoff event on the first message survives (it's emitted after the
-    # terminal-snapshot cleanup) and no "complete" event fires for turn one —
-    # completion is deferred to the drained follow-up turn.
+    # Handoff survives snapshot; turn-one "complete" deferred to follow-up.
     first_events_response = await client.get(
         f"/api/v1/chat/messages/{first_message_id}/events", headers=headers
     )
@@ -995,9 +980,7 @@ async def test_stream_with_no_events_raises_and_marks_message_failed(
     )
     chat = await create_chat_row(db_session, user, workspace, session_id="resumed-13")
 
-    # An empty script finishes the ACP prompt without emitting a single
-    # stream event — the runtime must treat that as a hard failure rather
-    # than silently completing.
+    # Empty ACP script (no stream events) must hard-fail, not silent complete.
     acp_factory.queue(FakeAcpSession([[]], session_id="resumed-13"))
 
     result = await send_message(client, headers, chat)
@@ -1033,9 +1016,7 @@ async def test_mid_stream_system_event_updates_chat_session_id(
         StreamEvent(type="system", data={"session_id": "pivoted-session"}),
         StreamEvent(type="assistant_text", text="Pivoted"),
     ]
-    # acp_session_id stays "resumed-14" (the resumed id) — the pivot is
-    # signalled purely through the mid-stream "system" event payload, as a
-    # provider would when it hands off to a new underlying session.
+    # Pivot via mid-stream "system" event; acp_session_id stays resumed id.
     acp_factory.queue(FakeAcpSession([script], session_id="resumed-14"))
 
     await send_message(client, headers, chat)
@@ -1081,9 +1062,7 @@ async def test_send_message_with_worktree_persists_cwd_and_emits_system_event(
         headers=headers,
     )
     assert response.status_code == 200
-    # AgentService.ensure_worktree_cwd resolves the cwd (and persists it)
-    # before the background stream even starts, so this is already set by
-    # the time initiate_chat_completion responds.
+    # worktree_cwd is resolved/persisted before the stream task starts.
     assert response.json()["worktree_cwd"] is not None
 
     await run_background_task(chat.id)
@@ -1098,9 +1077,7 @@ async def test_send_message_with_worktree_persists_cwd_and_emits_system_event(
 
 @pytest_asyncio.fixture
 async def live_server_url(app: FastAPI) -> AsyncIterator[str]:
-    # httpx's ASGITransport buffers the whole response before returning, so an
-    # unbounded SSE body can never be read through it — live-stream tests need
-    # a real socket server.
+    # ASGITransport buffers whole body — live SSE needs a real socket server.
     config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error")
     server = uvicorn.Server(config)
     serve_task = asyncio.create_task(server.serve())
@@ -1178,9 +1155,7 @@ async def test_stream_sse_replays_backlog_then_delivers_live_events(
                 REDIS_KEY_USER_STREAMS_LIVE.format(user_id=user.id), live_envelope
             )
 
-            # The multiplexed feed stays open across terminal events (other
-            # chats may still be streaming), so read exactly one live event
-            # instead of draining until server-side close.
+            # Feed stays open; read one live event, don't drain to close.
             async for line in lines:
                 if line.startswith("data:"):
                     envelopes.append(json.loads(line.removeprefix("data:").strip()))
@@ -1196,11 +1171,7 @@ async def test_sse_endpoints_release_db_connection_while_streaming(
     streaming_cache: EndpointCache,
     live_server_url: str,
 ) -> None:
-    # Regression: FastAPI holds the get_db yield dependency open until the
-    # response completes, so an open SSE connection used to pin the auth
-    # chain's pooled DB connection for its whole lifetime — a handful of open
-    # tabs exhausted the default 5+10 pool and every request then timed out at
-    # auth. The SSE handlers must release the session before streaming starts.
+    # Regression: SSE must release get_db before stream or tabs pin the pool.
     headers, user, workspace = await create_authenticated_workspace(
         db_session, create_user, login
     )
@@ -1226,10 +1197,7 @@ async def test_sse_endpoints_release_db_connection_while_streaming(
             ):
                 assert events_response.status_code == 200
                 assert chat_stream_response.status_code == 200
-                # The chat stream's backlog replay briefly opens its own session,
-                # so poll rather than assert instantly. Without the release fix
-                # each open stream pins a connection forever, the count never
-                # returns to zero, and asyncio.timeout fails the test.
+                # Backlog replay opens a brief session — poll for pool drain.
                 while counter.active > 0:
                     await asyncio.sleep(0.01)
     finally:

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -55,10 +55,7 @@ async def wait_until(predicate: Callable[[], bool], timeout: float = 2.0) -> Non
 
 
 class LiveFakeWebSocket:
-    # Unlike FakeWebSocket (a static frame list), this queues frames so a
-    # test can push auth/control/input frames while the endpoint coroutine
-    # is already running as a background task — needed to interleave PTY
-    # output arriving mid-connection with client frames.
+    # Queueable frames while the endpoint runs as a task (interleave PTY out).
     def __init__(
         self,
         query_params: dict[str, str] | None = None,
@@ -110,10 +107,7 @@ class LiveFakeWebSocket:
 
 
 class FakePtySandboxProvider(SandboxProvider):
-    # Real TerminalSessionRegistry/TerminalSessionRecord run against this —
-    # unlike FakeSandboxProvider (static pty-1 id, no on_data callback
-    # tracking), this records every pty lifecycle call and lets tests drive
-    # PTY output by invoking the registered on_data callback directly.
+    # Records pty lifecycle; tests drive output via the registered on_data.
     def __init__(self) -> None:
         self._workspace_root = "/tmp/agentrove-pty-test"
         self._pty_sessions: dict[str, dict[str, Any]] = {}
@@ -181,10 +175,7 @@ class FakePtySandboxProvider(SandboxProvider):
 
 
 class FailingPtySandboxProvider(FakePtySandboxProvider):
-    # Exercises SandboxService's own error handling (send_pty_input /
-    # resize_pty_session / cleanup_pty_session) — every pty operation is
-    # attempted (recorded) and then raises, so the terminal session must
-    # keep running instead of crashing the websocket connection.
+    # Every pty op raises after recording — session must keep the WS up.
     async def send_pty_input(self, sandbox_id: str, pty_id: str, data: bytes) -> None:
         self.sent_inputs.append((sandbox_id, pty_id, data))
         raise RuntimeError("send failed")
@@ -512,9 +503,7 @@ async def test_terminal_websocket_real_session_lifecycle(
     login: LoginClient,
     pty_provider: FakePtySandboxProvider,
 ) -> None:
-    # Runs the real TerminalSessionRegistry/TerminalSessionRecord against
-    # FakePtySandboxProvider — attach, input queueing, resize, PTY output
-    # forwarding, and terminate (pty kill + tmux kill-session).
+    # Real registry/record against FakePtySandboxProvider (full pty lifecycle).
     headers, _user, workspace = await create_authenticated_workspace(
         db_session,
         create_user,
@@ -644,9 +633,7 @@ async def test_terminal_websocket_concurrent_inits_share_one_pty(
     login: LoginClient,
     pty_provider: FakePtySandboxProvider,
 ) -> None:
-    # A page refresh can race two connections into the same session record —
-    # ensure_started must serialize so only one PTY/tmux client is spawned
-    # and the second connection reattaches instead.
+    # Two connections racing ensure_started: one PTY, second reattaches.
     headers, _user, workspace = await create_authenticated_workspace(
         db_session,
         create_user,
@@ -831,9 +818,7 @@ async def test_terminal_websocket_new_attach_closes_stale_websocket(
     assert first_ws.close_code == 1000
     assert len(pty_provider.created_ptys) == 1
 
-    # The first task's own receive loop is still parked on `receive()` since
-    # our fake doesn't simulate a real disconnect — detach it manually so
-    # the test ends deterministically instead of waiting for the ping timeout.
+    # Fake has no real disconnect — detach manually (don't wait for ping).
     first_ws.push_text(json.dumps({"type": WS_MSG_DETACH}))
     await asyncio.wait_for(first_task, timeout=2.0)
 
@@ -870,9 +855,7 @@ async def test_terminal_websocket_output_queue_drops_oldest_when_full(
     websocket.push_text(json.dumps({"type": WS_MSG_DETACH}))
     await asyncio.wait_for(task, timeout=2.0)
 
-    # Fill the output queue (PTY_OUTPUT_QUEUE_SIZE) well past capacity while
-    # nobody is attached to drain it — must drop the oldest entries rather
-    # than block or grow unbounded.
+    # Overflow PTY_OUTPUT_QUEUE_SIZE unattached — drop oldest, don't block.
     on_data = pty_provider.on_data_callbacks[pty_id]
     for i in range(PTY_OUTPUT_QUEUE_SIZE + 20):
         await on_data(f"{i}\n".encode())
@@ -902,10 +885,7 @@ async def test_terminal_websocket_survives_provider_pty_errors(
     login: LoginClient,
     failing_pty_provider: FailingPtySandboxProvider,
 ) -> None:
-    # SandboxService.send_pty_input/resize_pty_session/cleanup_pty_session
-    # each catch provider errors and log rather than propagate — the
-    # terminal connection must keep working through input, resize, and a
-    # clean close even when every underlying pty call fails.
+    # Pty ops catch provider errors — WS must survive input/resize/close.
     headers, _user, workspace = await create_authenticated_workspace(
         db_session,
         create_user,
@@ -948,11 +928,7 @@ async def test_terminal_websocket_ignores_malformed_frames_and_handles_disconnec
     login: LoginClient,
     pty_provider: FakePtySandboxProvider,
 ) -> None:
-    # Malformed control frames (no text/bytes key, non-dict JSON, dict with
-    # no "type") must be silently skipped, and an abrupt client disconnect
-    # (WebSocketDisconnect from receive()) must be handled gracefully rather
-    # than propagating out of the endpoint — including a close() that itself
-    # raises a non-EPIPE OSError during the best-effort final close.
+    # Bad control frames skipped; WebSocketDisconnect + failing close handled.
     headers, _user, workspace = await create_authenticated_workspace(
         db_session,
         create_user,
@@ -982,9 +958,7 @@ async def test_terminal_websocket_ignores_malformed_frames_and_handles_disconnec
 
     await asyncio.wait_for(task, timeout=2.0)
 
-    # Session stayed alive through the junk frames — only one pty, never
-    # torn down by a bad frame — and the final close was attempted despite
-    # raising.
+    # Junk frames: one pty kept; final close still attempted despite raise.
     assert len(pty_provider.created_ptys) == 1
     assert websocket.close_code == 1000
 
@@ -995,9 +969,7 @@ async def test_terminal_websocket_pty_exit_drops_session_and_reconnect_starts_fr
     login: LoginClient,
     pty_provider: FakePtySandboxProvider,
 ) -> None:
-    # A PTY that dies on its own (shell `exit`, sandbox restart) must tear
-    # down the record and close the attached client — the next connect starts
-    # a fresh PTY instead of silently "reattaching" to the dead one.
+    # Dead PTY tears down the record; next connect starts a fresh one.
     headers, _user, workspace = await create_authenticated_workspace(
         db_session,
         create_user,
@@ -1144,9 +1116,7 @@ async def test_terminal_websocket_ping_send_failure_detaches_cleanly(
     login: LoginClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # The keepalive ping is what discovers a silently-dead connection — its
-    # send failure must detach the session and end the endpoint cleanly
-    # instead of propagating out of the handler.
+    # Keepalive ping send failure detaches cleanly (no raise out of handler).
     headers, _user, workspace = await create_authenticated_workspace(
         db_session,
         create_user,

--- a/backend/tests/test_workspace.py
+++ b/backend/tests/test_workspace.py
@@ -364,9 +364,7 @@ async def test_create_workspace_clones_https_repo_with_github_token(
     workspace_sandbox: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Desktop mode ignores the stored PAT and uses host git credentials instead —
-    # force server mode so this test exercises the GIT_ASKPASS token path
-    # regardless of the DESKTOP_MODE value inherited from the host shell.
+    # Force server mode so GIT_ASKPASS/PAT path is tested (not host git creds).
     monkeypatch.setattr(get_settings(), "DESKTOP_MODE", False)
     await create_user(email="git-https@example.com", username="githttps")
     tokens = await login(email="git-https@example.com")

--- a/frontend/src-tauri/src/desktop.rs
+++ b/frontend/src-tauri/src/desktop.rs
@@ -143,8 +143,7 @@ fn spawn_backend(
     let backend_bin = resolve_backend_binary(app_handle);
     let mut backend_path = std::env::var("PATH").unwrap_or_default();
     if let Some(home) = dirs::home_dir() {
-        // OpenCode installs to ~/.opencode/bin on macOS and updates shell rc
-        // files, but the desktop backend gets an explicit PATH from Tauri.
+        // OpenCode lives in ~/.opencode/bin; Tauri gives the backend an explicit PATH.
         backend_path.push_str(&format!(":{}/.opencode/bin", home.display()));
         backend_path.push_str(&format!(":{}/.local/bin", home.display()));
     }
@@ -201,8 +200,6 @@ fn build_tray(app: &tauri::App) -> tauri::Result<()> {
         .icon(app.default_window_icon().unwrap().clone())
         .tooltip("Agentrove")
         .menu(&menu)
-        // Click the tray to open the menu (standard macOS menu-bar behavior);
-        // "Show Agentrove" brings the window back.
         .on_menu_event(|app, event| match event.id.as_ref() {
             "show" => show_main_window(app),
             "quit" => app.exit(0),
@@ -231,17 +228,15 @@ pub fn run() {
         .manage(backend_port.clone())
         .invoke_handler(tauri::generate_handler![get_backend_port])
         .on_window_event(|window, event| {
-            // Closing the window hides it to the tray; the app keeps running.
-            // Real exit goes through the tray "Quit" item (app.exit), which bypasses this.
+            // Close = hide to tray; real exit is tray Quit (app.exit bypasses this).
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 api.prevent_close();
                 let _ = window.hide();
             }
         })
         .setup(move |app| {
-            // The window stays titled (overlay title bar in tauri.conf.json) so minimize works —
-            // borderless windows can't miniaturize on macOS. Hide the native traffic lights here
-            // since the frontend renders custom ones.
+            // Keep a titled overlay bar so minimize works (borderless can't on macOS);
+            // hide native traffic lights — frontend draws custom ones.
             #[cfg(target_os = "macos")]
             if let Some(window) = app.get_webview_window("main") {
                 if let Ok(ns_window) = window.ns_window() {

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,8 +1,7 @@
 #[cfg(desktop)]
 mod desktop;
 
-// Entry point for every platform. Mobile (iOS/Android) calls this through the
-// generated `tauri::mobile_entry_point`; desktop calls it from main.rs.
+// Shared entry: mobile via tauri::mobile_entry_point; desktop from main.rs.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(desktop)]
@@ -10,9 +9,7 @@ pub fn run() {
         desktop::run();
     }
 
-    // Mobile has no local backend sidecar — the frontend talks to a remote
-    // backend whose URL is baked in at build time (.env.mobile). So we only wire
-    // up the plugins that work on mobile and let the webview load the app.
+    // Mobile has no local sidecar — remote backend URL is build-time (.env.mobile).
     #[cfg(mobile)]
     {
         tauri::Builder::default()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,12 +58,8 @@ function AppContent() {
     retry: false,
   });
 
-  // NOTE: This effect intentionally syncs auth state via useEffect rather than deriving during
-  // render (rerender-derived-state-no-effect). The persisted Zustand store provides an optimistic
-  // cached isAuthenticated on first load to prevent flash of unauthenticated content, then this
-  // effect corrects it after the user query resolves. Moving to render-time derivation would
-  // require calling an external store setter during render, which re-triggers subscribers
-  // synchronously and risks cascading updates.
+  // Sync auth via effect (not render): Zustand is optimistic on first paint; correcting after
+  // the user query must not set external store state during render (cascading updates).
   useEffect(() => {
     if (hasToken && user) {
       useAuthStore.getState().setAuthenticated(true);
@@ -156,7 +152,7 @@ function AppContent() {
   );
 }
 
-// The window starts hidden (visible:false) on every shell — reveal it once the shell is ready.
+// Window starts hidden (visible:false); call once the shell can talk to a backend.
 function revealAppWindow() {
   getCurrentWindow()
     .show()
@@ -166,7 +162,7 @@ function revealAppWindow() {
 export default function App() {
   const resolvedTheme = useResolvedTheme();
   const theme = useUIStore((state) => state.theme);
-  // Ready = the shell can talk to a backend: web/mobile immediately, desktop after the sidecar port resolves
+  // Web/mobile ready immediately; desktop waits for sidecar port.
   const [shellReady, setShellReady] = useState(!isTauri());
   const [desktopError, setDesktopError] = useState<string | null>(null);
   const [authHydrated, setAuthHydrated] = useState(false);
@@ -183,13 +179,10 @@ export default function App() {
       .finally(() => {
         if (cancelled) return;
         useAuthStore.getState().setAuthenticated(!!authStorage.getToken());
-        // Drop the cloud connection if its refresh token didn't hydrate —
-        // otherwise the UI shows a connected state we can't use.
+        // No hydrated refresh token → drop cloud UI state and origin routing IDs.
         const cloud = useCloudSettingsStore.getState();
         if (cloud.connectedEmail && !cloudAuthStorage.getRefreshToken()) {
           cloud.clearCloud();
-          // Drop persisted cloud origin IDs too — otherwise stale IDs keep routing
-          // through remoteApiClient after the UI shows cloud as disconnected.
           clearCloudOrigins();
         }
         setAuthHydrated(true);
@@ -202,7 +195,7 @@ export default function App() {
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', resolvedTheme);
-    // data-palette drives the per-theme CSS-var overrides (dim/sepia); base modes have no override block
+    // data-palette selects CSS-var overrides; light/dark/system have no override block.
     document.documentElement.setAttribute('data-palette', theme);
     const metaThemeColor = document.querySelector('meta[name="theme-color"]');
     if (metaThemeColor) {
@@ -216,11 +209,9 @@ export default function App() {
   }, [resolvedTheme, theme]);
 
   useMountEffect(() => {
-    // Mobile has no local sidecar — the backend URL is baked in at build time
-    // (.env.mobile), so just mark ready and skip the desktop backend startup.
+    // Mobile: backend URL is build-time (.env.mobile); no sidecar port wait.
     if (isMobileApp()) {
       setShellReady(true);
-      // Mobile has no backend-port step to trigger the reveal — show it directly.
       revealAppWindow();
       return;
     }
@@ -258,7 +249,7 @@ export default function App() {
 
   useDesktopZoom();
 
-  // Cmd+R / Ctrl+R reloads the webview — Tauri release builds disable this by default
+  // Tauri release builds disable Cmd/Ctrl+R reload by default.
   useMountEffect(() => {
     if (!isTauri()) return;
 
@@ -275,7 +266,7 @@ export default function App() {
     return () => window.removeEventListener('keydown', handler);
   });
 
-  // Open external links in the system browser — Tauri doesn't handle target="_blank" natively
+  // Tauri doesn't open target="_blank" in the system browser by itself.
   useMountEffect(() => {
     if (!isTauri()) return;
 
@@ -318,7 +309,6 @@ export default function App() {
   return (
     <BrowserRouter>
       <Toaster {...toasterConfig} />
-      {/* Root boundary — a render crash anywhere in the route tree must not white-screen the shell */}
       <ErrorBoundary>
         <AppContent />
       </ErrorBoundary>

--- a/frontend/src/components/chat/branch-selector/BranchSelector.tsx
+++ b/frontend/src/components/chat/branch-selector/BranchSelector.tsx
@@ -26,7 +26,6 @@ export const BranchSelector = memo(function BranchSelector({
   const { data: branchesData } = useGitBranchesQuery(sandboxId, !!sandboxId, worktreeCwd);
   const checkoutBranch = useCheckoutBranchMutation();
 
-  // Pin current branch at top with a divider separating it from the rest
   const groupedItems = useMemo<DropdownItemType<string>[]>(() => {
     if (!branchesData) return [];
     const current = branchesData.current_branch;

--- a/frontend/src/components/chat/chat-window/AgentPane.tsx
+++ b/frontend/src/components/chat/chat-window/AgentPane.tsx
@@ -11,9 +11,7 @@ interface AgentPaneProps {
   chatId: string;
 }
 
-// Each instance subscribes to its own messages query and SSE stream via
-// useChatStreaming inside ChatSessionOrchestrator. Streaming demuxes by
-// envelope.chatId so two panes can stream concurrently.
+// Own messages query + SSE via ChatSessionOrchestrator; demux by envelope.chatId for split panes.
 export const AgentPane = memo(function AgentPane({ chatId }: AgentPaneProps) {
   const { currentChat, fetchedMessages, hasFetchedMessages, messagesQuery } = useChatData(chatId);
   const { fileStructure } = useSandboxFiles(currentChat, chatId);

--- a/frontend/src/components/chat/chat-window/ChatSelectionActions.tsx
+++ b/frontend/src/components/chat/chat-window/ChatSelectionActions.tsx
@@ -32,8 +32,7 @@ interface ChatSelectionActionsProps {
   scrollerRef: RefObject<HTMLDivElement | null>;
 }
 
-// Floating "Add to chat" / "Ask" actions over text selected in rendered chat
-// messages — the chat-page counterpart of the editor's selection actions.
+// Chat-page counterpart of the editor selection actions ("Add to chat" / "Ask").
 export const ChatSelectionActions = memo(function ChatSelectionActions({
   chatId,
   scrollerRef,

--- a/frontend/src/components/chat/chat-window/FindInChat.tsx
+++ b/frontend/src/components/chat/chat-window/FindInChat.tsx
@@ -28,9 +28,7 @@ interface FindInChatProps {
   scrollerRef: RefObject<HTMLDivElement | null>;
 }
 
-// In-chat find bar (⌘F): matches rendered message text via the CSS Custom Highlight
-// API — markdown splits content across arbitrary DOM nodes, so highlighting through
-// the registry avoids wrapping <mark> elements inside React-owned DOM.
+// ⌘F over rendered messages via CSS Custom Highlight (avoids <mark> in React-owned DOM).
 export const FindInChat = memo(function FindInChat({ messages, scrollerRef }: FindInChatProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');

--- a/frontend/src/components/chat/chat-window/QueueMessageCard.test.tsx
+++ b/frontend/src/components/chat/chat-window/QueueMessageCard.test.tsx
@@ -91,14 +91,12 @@ describe('QueueMessageCard', () => {
   it('saves an edit on Enter and abandons it on Escape', () => {
     const { onEdit } = renderCard({ content: 'first' });
 
-    // Enter commits.
     fireEvent.click(screen.getByLabelText('Edit message'));
     let input = screen.getByLabelText('Edit message') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'committed' } });
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(onEdit).toHaveBeenCalledWith('msg-1', 'committed');
 
-    // Escape discards: the original preview is restored and no further edit fires.
     onEdit.mockReset();
     fireEvent.click(screen.getByLabelText('Edit message'));
     input = screen.getByLabelText('Edit message') as HTMLInputElement;

--- a/frontend/src/components/chat/chat-window/useChatScroll.ts
+++ b/frontend/src/components/chat/chat-window/useChatScroll.ts
@@ -15,9 +15,7 @@ interface UseChatScrollParams {
   fetchNextPage: () => void;
 }
 
-// Owns the message scroller's stick-to-bottom, top-pagination, and send-anchor
-// behavior. Kept as a single hook so Chat can consume the refs/state without
-// re-deriving the delicate scroll bookkeeping.
+// Stick-to-bottom, top-pagination, and send-anchor for the message scroller.
 export function useChatScroll({
   chatId,
   messages,
@@ -38,7 +36,6 @@ export function useChatScroll({
   const [showScrollButton, setShowScrollButton] = useState(false);
 
   const turnRef = useRef<HTMLDivElement | null>(null);
-  // Send id whose anchor scroll hasn't run yet, and whether the animation is in flight
   const anchorTurnRef = useRef<string | null>(null);
   const anchoringRef = useRef(false);
   const anchorTargetRef = useRef(0);
@@ -115,14 +112,13 @@ export function useChatScroll({
     lastScrollTopRef.current = scrollTop;
   }, []);
 
-  // Initial scroll to bottom when messages first load
   useEffect(() => {
     if (hasInitializedToBottomRef.current || messages.length === 0) return;
 
     const container = scrollerRef.current;
     if (!container) return;
 
-    // Use requestAnimationFrame to ensure DOM has rendered
+    // rAF so layout has committed before measuring scrollHeight.
     const raf = requestAnimationFrame(() => {
       container.scrollTop = container.scrollHeight;
       hasInitializedToBottomRef.current = true;
@@ -132,7 +128,7 @@ export function useChatScroll({
     return () => cancelAnimationFrame(raf);
   }, [messages]);
 
-  // Prepend anchoring: restore scroll position after older messages are prepended
+  // Keep viewport stable when older pages prepend above the fold.
   useLayoutEffect(() => {
     const prevHeight = prevScrollHeightRef.current;
     if (prevHeight === null) return;

--- a/frontend/src/components/chat/inline-ask/InlineAskPanel.tsx
+++ b/frontend/src/components/chat/inline-ask/InlineAskPanel.tsx
@@ -18,8 +18,7 @@ interface InlineAskPanelProps {
   onClose: () => void;
 }
 
-// One-off ask panel over a selection — hosted by the editor's Monaco content
-// widget and the chat page's selection overlay.
+// Selection ask panel — Monaco content widget or chat-page selection overlay.
 export function InlineAskPanel({ chatId, selection, inputRef, onClose }: InlineAskPanelProps) {
   const [question, setQuestion] = useState('');
   const { selectedModelId } = useChatSessionState();

--- a/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
+++ b/frontend/src/components/chat/message-bubble/MessageRenderer.tsx
@@ -65,10 +65,7 @@ export const MessageRenderer = memo(function MessageRenderer({
   const agentTools = React.useMemo(
     () =>
       segments.reduce<ToolAggregate[]>((acc, seg) => {
-        // Collect subagent-spawning tools across agents so the expand-modal
-        // sibling list works for all of them: Claude's `Agent`, opencode's
-        // `task`. Codex/Copilot/Cursor don't surface subagent spawns as
-        // named tool calls.
+        // Claude `Agent` / opencode `task` — expand-modal sibling list (others don't surface spawns).
         if (seg.kind === 'tool' && (seg.tool.name === 'Agent' || seg.tool.name === 'task')) {
           acc.push(seg.tool);
         }
@@ -77,9 +74,7 @@ export const MessageRenderer = memo(function MessageRenderer({
     [segments],
   );
 
-  // Split a completed turn at its last tool/thinking/plan segment: everything
-  // up to it is the collapsible work trace, everything after is the final
-  // answer. While streaming, the trace stays empty so the live work renders flat.
+  // Completed turns: collapsible work trace ends at last tool/thinking/plan; streaming stays flat.
   const { traceSegments, tailSegments } = React.useMemo(() => {
     if (isStreaming) return { traceSegments: [], tailSegments: segments };
     let traceEnd = -1;

--- a/frontend/src/components/chat/message-bubble/WorkedRollup.tsx
+++ b/frontend/src/components/chat/message-bubble/WorkedRollup.tsx
@@ -10,8 +10,7 @@ interface WorkedRollupProps {
   children: React.ReactNode;
 }
 
-// Collapses the tool/thinking trace of a completed turn behind a single header,
-// so the transcript leads with the final answer and the work expands on demand.
+// Completed-turn tool/thinking trace behind one header so the final answer leads.
 export function WorkedRollup({ durationMs, children }: WorkedRollupProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   // Older messages persisted before duration tracking have no duration_ms.
@@ -27,7 +26,6 @@ export function WorkedRollup({ durationMs, children }: WorkedRollupProps) {
         className={styles['rollup-button']}
       >
         <span>{label}</span>
-        {/* Disclosure chevron: points right when collapsed, rotates down when open. */}
         <ChevronRight
           className={clsx(
             styles['rollup-chevron'],

--- a/frontend/src/components/chat/message-bubble/segmentBuilder.ts
+++ b/frontend/src/components/chat/message-bubble/segmentBuilder.ts
@@ -79,11 +79,7 @@ const statusMap: Record<'tool_started' | 'tool_completed' | 'tool_failed', ToolE
   tool_failed: 'failed',
 };
 
-// Context object passed through tool processing functions to maintain state
-// - toolMap: Quick lookup of tools by ID for parent-child linking
-// - pendingChildren: Queue for child tools that arrive before their parent (out-of-order events)
-// - segmentIndexByToolId: Maps tool IDs to their position in segments array for O(1) updates
-// - segments: The output array being built
+// pendingChildren holds tools whose parent_id arrived before the parent tool event.
 interface ProcessToolEventContext {
   toolMap: Map<string, ToolAggregate>;
   pendingChildren: Map<string, ToolAggregate[]>;
@@ -106,9 +102,6 @@ const updateSegmentTool = (
   }
 };
 
-// Recursively updates all ancestors when a child tool changes.
-// When a nested tool updates, its parent's children array must reflect the change,
-// and that parent's parent must also update, continuing up the chain.
 const updateParentChain = (
   childAggregate: ToolAggregate,
   toolMap: Map<string, ToolAggregate>,
@@ -151,9 +144,6 @@ const createToolAggregate = (
   children: [],
 });
 
-// Attaches any children that arrived before this parent tool was created.
-// Tool events can arrive out of order (child before parent), so we queue
-// orphaned children in pendingChildren and attach them when the parent arrives.
 const attachPendingChildren = (
   aggregate: ToolAggregate,
   pendingChildren: Map<string, ToolAggregate[]>,
@@ -169,8 +159,6 @@ const attachPendingChildren = (
   return updated;
 };
 
-// Links a child tool to its parent. If the parent exists, adds child to its children array.
-// If the parent hasn't arrived yet, queues the child in pendingChildren for later attachment.
 const addChildToParent = (
   child: ToolAggregate,
   parentId: string,
@@ -222,8 +210,7 @@ const removeFromPreviousParent = (
   }
 };
 
-// Removes a tool from the root-level segments array when it becomes a child of another tool.
-// After removal, shifts all subsequent segment indices down by 1 to maintain correct mappings.
+// Drop from root segments when reparented; reindex so later O(1) updates stay correct.
 const removeToolFromRootSegments = (
   toolId: string,
   segmentIndexByToolId: Map<string, number>,
@@ -235,7 +222,6 @@ const removeToolFromRootSegments = (
   segments.splice(rootIndex, 1);
   segmentIndexByToolId.delete(toolId);
 
-  // Shift indices for all segments after the removed one
   segmentIndexByToolId.forEach((idx, id) => {
     if (idx > rootIndex) {
       segmentIndexByToolId.set(id, idx - 1);
@@ -243,10 +229,7 @@ const removeToolFromRootSegments = (
   });
 };
 
-// Handles reassignment of a tool's parent when the parent_id changes mid-stream.
-// This can happen when the backend corrects tool hierarchy. The function:
-// 1. Removes the tool from its previous parent's children (if any)
-// 2. Either adds it to the new parent or promotes it to root level
+// Backend can correct parent_id mid-stream — re-home under the new parent or promote to root.
 const handleParentChange = (
   aggregate: ToolAggregate,
   incomingParentId: string | null,
@@ -331,8 +314,6 @@ const processExistingTool = (
   }
 };
 
-// Main entry point for processing tool events. Routes to either processNewTool
-// (first time seeing this tool ID) or processExistingTool (updating status/result).
 const processToolEvent = (
   event: Extract<AssistantStreamEvent, { type: 'tool_started' | 'tool_completed' | 'tool_failed' }>,
   context: ProcessToolEventContext,
@@ -350,9 +331,7 @@ const processToolEvent = (
   }
 };
 
-// Transforms a flat array of stream events into structured segments for rendering.
-// Handles text batching, tool hierarchy construction (including out-of-order events),
-// and produces segments of type: text, thinking, tool, or review.
+// Flat stream events → text/thinking/tool/plan/suggestions segments (incl. out-of-order tool parents).
 export const buildSegments = (events: AssistantStreamEvent[]): MessageSegment[] => {
   const segments: MessageSegment[] = [];
   const toolMap = new Map<string, ToolAggregate>();

--- a/frontend/src/components/chat/message-input/SendButton.tsx
+++ b/frontend/src/components/chat/message-input/SendButton.tsx
@@ -28,7 +28,6 @@ export function SendButton({
   const showSpinnerIcon = showLoadingSpinner && status === 'loading';
   const showStopIcon = !showSpinnerIcon && isActive;
 
-  // Spinner, stop and ready share the inverted "filled" look; idle stays a muted pill.
   const isPrimary = showSpinnerIcon || showStopIcon || hasMessage;
   let ariaLabel: string;
   let icon: React.ReactNode;

--- a/frontend/src/components/chat/model-selector/ModelSelector.tsx
+++ b/frontend/src/components/chat/model-selector/ModelSelector.tsx
@@ -42,7 +42,7 @@ export const ModelSelector = memo(function ModelSelector({
   // effect and persist models[0] before the owner derives the model from history.
   const { data: models = [], isLoading } = useModelsQuery({ enabled: isAuthenticated });
   const favoriteModelIds = useModelStore((state) => state.favoriteModelIds);
-  // Panel-local agent filter driven by the chip row; null = all agents.
+
   const [agentFilter, setAgentFilter] = useState<AgentKind | null>(null);
 
   const filteredModels = useMemo(
@@ -160,12 +160,10 @@ export const ModelSelector = memo(function ModelSelector({
               aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
               aria-pressed={isFavorite}
               onClick={(event) => {
-                // Stop the row's onClick from selecting the model when the star is clicked.
                 event.stopPropagation();
                 useModelStore.getState().toggleFavoriteModel(model.model_id);
               }}
               onKeyDown={(event) => {
-                // Keep the row's Enter/Space handler from firing in addition to this button's.
                 if (event.key === 'Enter' || event.key === ' ') {
                   event.stopPropagation();
                 }

--- a/frontend/src/components/chat/tools/codex/OtherTool.tsx
+++ b/frontend/src/components/chat/tools/codex/OtherTool.tsx
@@ -14,7 +14,6 @@ import styles from './OtherTool.module.scss';
 interface ImageGenerationOutput {
   status?: string;
   revisedPrompt?: string | null;
-  // Base64-encoded PNG of the generated image.
   result?: string;
   savedPath?: string | null;
 }

--- a/frontend/src/components/chat/tools/common/ToolCard/ToolCard.tsx
+++ b/frontend/src/components/chat/tools/common/ToolCard/ToolCard.tsx
@@ -51,7 +51,6 @@ export const ToolCard = memo(function ToolCard({
           (React.isValidElement(error) ? (
             error
           ) : (
-            // Multiline error output belongs inside the collapsible body alongside normal results
             <pre className={toolText['error-pre']}>{error}</pre>
           ))}
       </div>

--- a/frontend/src/components/chat/tools/registry.tsx
+++ b/frontend/src/components/chat/tools/registry.tsx
@@ -70,7 +70,6 @@ const opencodeToolLoaders: Record<string, ToolModuleLoader> = {
 };
 
 const toolLoaders: Record<string, ToolModuleLoader> = {
-  // Claude Code tools
   Agent: () => import('./claude/AgentTool').then((m) => ({ default: m.AgentTool })),
   WebSearch: () => import('./claude/WebSearch').then((m) => ({ default: m.WebSearch })),
   TodoWrite: () => import('./claude/TodoWrite').then((m) => ({ default: m.TodoWrite })),
@@ -93,7 +92,6 @@ const toolLoaders: Record<string, ToolModuleLoader> = {
   ExitPlanMode: () =>
     import('./claude/PlanModeTool').then((m) => ({ default: m.ExitPlanModeTool })),
 
-  // Codex tools (lowercase kind values from ACP)
   execute: codexShellLoader,
   search: () => import('./codex/SearchTool').then((m) => ({ default: m.SearchTool })),
   read: () => import('./codex/ReadTool').then((m) => ({ default: m.ReadTool })),
@@ -119,10 +117,7 @@ const getOrCreateLazy = (key: string, loader: ToolModuleLoader) => {
 };
 
 export const getToolComponent = (toolName: string, agentKind?: AgentKind): ToolComponent => {
-  // Copilot and Cursor both speak the lowercase ACP kinds (execute/read/edit/
-  // fetch) that Codex uses, but emit different rawInput/rawOutput shapes.
-  // Route each agent's tools to its own renderers before falling through to
-  // the Codex/Claude table.
+  // Same ACP kind names across agents, different rawInput/rawOutput — prefer agent-specific loaders.
   if (agentKind === 'codex' && codexToolLoaders[toolName]) {
     return getOrCreateLazy(`codex:${toolName}`, codexToolLoaders[toolName]);
   }

--- a/frontend/src/components/chat/workspace-selector/CloudWorkspaceSelector.tsx
+++ b/frontend/src/components/chat/workspace-selector/CloudWorkspaceSelector.tsx
@@ -13,8 +13,6 @@ interface CloudWorkspaceSelectorProps {
   disabled?: boolean;
 }
 
-// Shown on the landing composer when running on cloud: pick a workspace that
-// exists on the VPS, or prompt the user to connect a cloud instance first.
 export function CloudWorkspaceSelector({
   selectedWorkspaceId,
   onWorkspaceChange,

--- a/frontend/src/components/chat/workspace-selector/CreateWorkspaceFooter.tsx
+++ b/frontend/src/components/chat/workspace-selector/CreateWorkspaceFooter.tsx
@@ -17,9 +17,7 @@ import styles from './CreateWorkspaceFooter.module.scss';
 
 type CreationMode = 'none' | 'menu' | 'empty' | 'git';
 
-// Creation flows for local workspaces: empty, local folder (desktop only), and
-// git clone (browse GitHub repos when a token is configured, otherwise paste a URL).
-// onCreated selects the new workspace and dismisses the picker.
+// Local empty / folder (desktop) / git-clone creation; onCreated selects and dismisses.
 export function CreateWorkspaceFooter({ onCreated }: { onCreated: (id: string) => void }) {
   const isDesktop = isDesktopApp();
   const { data: settings } = useSettingsQuery({ enabled: true });

--- a/frontend/src/components/chat/workspace-selector/CreateWorkspaceProviderToggle.tsx
+++ b/frontend/src/components/chat/workspace-selector/CreateWorkspaceProviderToggle.tsx
@@ -2,7 +2,6 @@ import clsx from 'clsx';
 import { Button } from '@/components/ui/primitives/Button/Button';
 import styles from './CreateWorkspaceProviderToggle.module.scss';
 
-// Sandbox provider picker shared by the empty-workspace and git-clone creation forms.
 export function CreateWorkspaceProviderToggle({
   value,
   onChange,

--- a/frontend/src/components/chat/workspace-selector/WorkspaceItem.tsx
+++ b/frontend/src/components/chat/workspace-selector/WorkspaceItem.tsx
@@ -62,7 +62,6 @@ export function WorkspaceItem({
   const showBranchSelector = showBranches && branchesData?.is_git_repo === true;
   const branches = branchesData?.branches ?? EMPTY_BRANCHES;
 
-  // Pin current branch at top so it's always visible without scrolling
   const currentBranch = branchesData?.current_branch;
   const sortedBranches = useMemo(() => {
     const searchLower = branchSearch.toLowerCase();
@@ -166,7 +165,6 @@ export function WorkspaceItem({
                       <div className={styles['branch-rows']}>
                         {sortedBranches.map((branch, index) => {
                           const isCurrent = branch === branchesData.current_branch;
-                          // Divider after pinned current branch to visually separate it
                           const showDivider = isCurrent && index === 0 && sortedBranches.length > 1;
                           return (
                             <div key={branch}>

--- a/frontend/src/components/chat/workspace-selector/WorkspacePicker.tsx
+++ b/frontend/src/components/chat/workspace-selector/WorkspacePicker.tsx
@@ -12,14 +12,11 @@ interface WorkspacePickerProps {
   workspaces: Workspace[];
   selectedWorkspaceId: string | null;
   onSelect: (id: string) => void;
-  // Shows "Loading…" in the trigger while the workspace list is in flight (cloud).
   isLoading?: boolean;
-  // Disables the trigger when there's nothing to pick yet (cloud loading/empty).
   triggerDisabled?: boolean;
-  // Local-only git branch sub-row on each item; cloud workspaces have no reachable sandbox.
+  // Local only — cloud workspaces have no reachable sandbox for branch switching.
   showBranches: boolean;
-  // Creation flows rendered below the list (local only). Receives `close` so a
-  // freshly-created workspace can dismiss the modal.
+  // Local creation flows; receives `close` so a new workspace can dismiss the modal.
   footer?: (close: () => void) => ReactNode;
 }
 

--- a/frontend/src/components/editor/editor-core/EditorPane.tsx
+++ b/frontend/src/components/editor/editor-core/EditorPane.tsx
@@ -6,13 +6,9 @@ import { useEditorState } from '@/hooks/useEditorState';
 import { useFirstPaint } from '@/hooks/useFirstPaint';
 import { viewLoadingFallback } from '@/components/ui/shared/ViewLoadingFallback/ViewLoadingFallback';
 
-// Self-contained editor for a chat, rendered once per pane in split view. It
-// owns its file data and selection so each pane tracks its own chat (mirrors
-// how AgentPane wraps split chats).
+// Per-pane editor: owns its file data/selection so each split tracks its own chat.
 export const EditorPane = memo(function EditorPane({ chatId }: { chatId: string | undefined }) {
-  // Chat switches remount this pane with the lazy chunk already cached, so the
-  // heavy editor subtree (pierre tree model, Monaco) would mount inside the
-  // navigation's commit and block its first paint for seconds on large workspaces.
+  // Defer heavy mount past navigation paint (lazy chunk is already cached on chat switch).
   const hasPainted = useFirstPaint();
 
   const { data: currentChat } = useChatQuery(chatId);

--- a/frontend/src/components/editor/editor-view/DiffContent.tsx
+++ b/frontend/src/components/editor/editor-view/DiffContent.tsx
@@ -41,7 +41,6 @@ const DIFF_OPTIONS = {
 } as const;
 
 export interface DiffContentProps {
-  // HEAD version of the file; undefined until the baseline query resolves.
   original: string | undefined;
   modified: string;
   language: string;

--- a/frontend/src/components/editor/editor-view/EditorTabs.tsx
+++ b/frontend/src/components/editor/editor-view/EditorTabs.tsx
@@ -37,7 +37,6 @@ export const EditorTabs = memo(function EditorTabs({
       {openFiles.map((file) => {
         const isActive = file.path === selectedPath;
         const name = getFileName(file.path);
-        // A dirty tab shows the unsaved dot at rest, swapped for the close button on hover.
         const showDot = dirtyPaths.has(file.path);
         return (
           <div key={file.path} className={clsx(styles.tab, isActive && styles['tab--active'])}>

--- a/frontend/src/components/editor/editor-view/EmptyState.tsx
+++ b/frontend/src/components/editor/editor-view/EmptyState.tsx
@@ -10,8 +10,7 @@ export interface EmptyStateProps {
 }
 
 export const EmptyState = memo(function EmptyState({
-  // `theme` is retained on the public API but the surface token is now theme-aware,
-  // so the background no longer needs the resolved theme.
+  // `theme` kept on the public API; surface token is theme-aware now.
   onToggleFileTree,
   isFileTreeCollapsed = false,
 }: EmptyStateProps) {

--- a/frontend/src/components/editor/editor-view/Header.tsx
+++ b/frontend/src/components/editor/editor-view/Header.tsx
@@ -25,8 +25,7 @@ export interface HeaderProps {
   onTogglePreview?: (showPreview: boolean) => void;
   showDiff?: boolean;
   onToggleDiff?: () => void;
-  // Whether the file has uncommitted or unsaved changes — shows the dot on the
-  // Changes toggle so users can tell the diff view has content before opening it.
+  // Dot on Changes when there are uncommitted or unsaved edits.
   hasChanges?: boolean;
   hasUnsavedChanges?: boolean;
   isSaving?: boolean;

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -24,12 +24,10 @@ import { isPreviewableFile, isHtmlFile } from '@/utils/fileTypes';
 import toast from 'react-hot-toast';
 import styles from './View.module.scss';
 
-// The content area's mutually-exclusive modes — a single union so an illegal
-// combination (e.g. preview+diff) can't be represented.
+// Single union so illegal combos (e.g. preview+diff) can't be represented.
 type ViewMode = 'code' | 'preview' | 'diff';
 
-// Previewable types open in preview; HTML opens raw (its preview is opt-in
-// via the toggle).
+// Previewable → preview; HTML stays raw (preview is opt-in via the toggle).
 function defaultViewMode(file: FileStructure | null): ViewMode {
   return file && isPreviewableFile(file) && !isHtmlFile(file) ? 'preview' : 'code';
 }
@@ -112,7 +110,6 @@ export const View = memo(function View({
       ? fileContentData.content
       : undefined;
 
-  // Per-file unsaved drafts, the dirty set, and the close-confirm flow live in this hook.
   const {
     currentContent,
     displayContent,
@@ -273,7 +270,6 @@ export const View = memo(function View({
   const prevViewModeRef = useRef(viewMode);
   const prevFilePathRef = useRef(selectedFile?.path);
 
-  // Reset fullscreen when the mode or file changes
   if (prevViewModeRef.current !== viewMode || prevFilePathRef.current !== selectedFile?.path) {
     const fileChanged = prevFilePathRef.current !== selectedFile?.path;
     const enteredDiff = prevViewModeRef.current !== 'diff' && viewMode === 'diff';
@@ -282,10 +278,8 @@ export const View = memo(function View({
     if (isPreviewFullscreen) {
       setIsPreviewFullscreen(false);
     }
-    // Sole inline-chat reset: mode toggles and file switches all remount
-    // Content, so the widget's captured editor would go stale either way.
+    // Mode/file changes remount Content — clear inline chat so it doesn't hold a disposed editor.
     if (inlineChat !== null) setInlineChat(null);
-    // Each file opens in its own default mode (preview for previewable types).
     if (fileChanged) {
       setViewMode(defaultViewMode(selectedFile));
     }

--- a/frontend/src/components/editor/editor-view/ViewContentArea.tsx
+++ b/frontend/src/components/editor/editor-view/ViewContentArea.tsx
@@ -40,9 +40,7 @@ export interface ViewContentAreaProps {
   onTogglePreviewFullscreen: () => void;
 }
 
-// The editor pane's mutually-exclusive content modes (loading overlay, inline chat
-// widget, diff, code editor, preview). Split out of View so View owns the file/draft
-// state while this component owns only the presentation of that state.
+// Presentation of View modes (diff/code/preview/inline chat); View owns file/draft state.
 export function ViewContentArea({
   isLoadingContent,
   viewMode,

--- a/frontend/src/components/layout/ChatTabs/ChatTabs.tsx
+++ b/frontend/src/components/layout/ChatTabs/ChatTabs.tsx
@@ -36,31 +36,25 @@ interface ChatTabProps {
 }
 
 function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: ChatTabProps) {
-  // Shares the chat-query cache with the sidebar and panes; only the title is read.
   const chatQuery = useChatQuery(chatId);
-  // Only a confirmed 404 (chat gone on the backend) closes the tab — transient
-  // network/auth failures must not wipe the persisted working set.
+  // Close only on confirmed 404 — transient network/auth errors must not wipe tabs.
   const isChatGone = (chatQuery.error as (Error & { status?: number }) | null)?.status === 404;
   useEffect(() => {
     if (isChatGone) useUIStore.getState().closeChatTab(chatId);
   }, [isChatGone, chatId]);
 
   const title = chatQuery.data?.title ? stripMarkdownTitle(chatQuery.data.title) : '…';
-  // Streaming renders the braille spinner separately; blocked/completed are
-  // already ChatStatusTone values, so they map straight to a dot.
+  // Streaming uses AsciiSpinner; blocked/completed map straight to ChatStatusDot.
   const statusDotTone: ChatStatusTone | null = status && status !== 'streaming' ? status : null;
   const agentKind = useChatAgentKind(chatId, chatQuery.data?.session_agent_kind);
 
   return (
     <div
-      // Middle-click closes, matching browser/editor tab conventions.
+      // Middle-click closes (browser/editor tab convention).
       onAuxClick={(e) => {
         if (e.button === 1) onClose(chatId);
       }}
-      // Full height so the label centers on the title bar's optical line (with
-      // the traffic lights / sidebar controls); only the underline hugs the edge.
-      // The underline indicator marks the active tab — no fill, so the strip
-      // stays a single flat band.
+      // Full height centers the label on the title bar; underline-only active state.
       className={clsx(styles['chat-tab'], isActive && stateClasses.ACTIVE)}
     >
       <FloatingTooltip
@@ -73,12 +67,9 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
           aria-current={isCurrent ? 'page' : undefined}
           className={styles['tab-select']}
         >
-          {/* The status glyph claims the icon slot while a status is live; at rest
-              the chat's provider glyph (Claude, Codex…) matches the sidebar. */}
           {status === 'streaming' ? (
             <AsciiSpinner className={styles['tab-spinner']} />
           ) : statusDotTone ? (
-            // h-3 w-3 box centers the 8px dot in the provider icon's footprint
             <ChatStatusDot tone={statusDotTone} className={styles['tab-status-dot']} />
           ) : (
             agentKind && (
@@ -88,8 +79,7 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
           <span className={styles['tab-title']}>{title}</span>
         </Button>
       </FloatingTooltip>
-      {/* focus-visible keeps the hidden close button perceivable for keyboard
-          users — it stays in the tab order even while opacity-0. */}
+      {/* Close stays focusable (opacity-0) so keyboard users can still reach it. */}
       <Button
         variant="unstyled"
         onClick={() => onClose(chatId)}
@@ -107,29 +97,21 @@ function ChatTab({ chatId, isActive, isCurrent, status, onSelect, onClose }: Cha
   );
 }
 
-// Title-bar chat tabs — the working set of open chats (the sidebar stays the
-// full archive). Each tab is also the chat's agent-view tab: clicking the
-// current chat's tab surfaces the agent pane. A live status icon fed by the
-// global stream and permission stores keeps background chats glanceable.
+// Working-set tabs (sidebar is the archive); re-clicking the current chat surfaces the agent pane.
 export function ChatTabs() {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
-  // TitleBar renders outside the /chat/:chatId route element, so match the
-  // location directly instead of relying on route params.
+  // TitleBar sits outside /chat/:chatId, so read the route from the location.
   const routedChatId = useMatch('/chat/:chatId')?.params.chatId;
   const chatTabs = useUIStore((s) => s.chatTabs);
   const splitChatIds = useUIStore((s) => s.splitChatIds);
   const visibleLayout = useUIStore((s) => s.visibleLayout);
   const activeStreamMetadata = useStreamStore((s) => s.activeStreamMetadata);
-  // Shared with the sidebar: marked by the stream service on successful
-  // completion, cleared by the sidebar when the chat is viewed.
+  // Marked on stream success; sidebar clears when the chat is viewed.
   const completedChatIds = useStreamStore((s) => s.completedChatIds);
   const pendingRequests = usePermissionStore((s) => s.pendingRequests);
 
-  // Chats with a pane on screen: split tiles belong to their bound chat, all
-  // others to the routed chat. Derived from the layout, not splitChatIds —
-  // a split chat hidden behind a full-screen primary view is off screen, so its
-  // tab must drop the active highlight.
+  // From layout (not splitChatIds): a split chat under a full-screen primary is off-screen.
   const visibleChatIds = useMemo(() => {
     const ids = new Set<string>();
     for (const tileId of visibleLayout.flat()) {
@@ -152,8 +134,7 @@ export function ChatTabs() {
         navigate(`/chat/${chatId}`);
         return;
       }
-      // The chat tab doubles as the agent tab — re-clicking it surfaces the
-      // agent pane: focus it if already on screen, otherwise bring it up full.
+      // Re-clicking the current chat surfaces the agent pane.
       const ui = useUIStore.getState();
       if (ui.visibleLayout.flat().includes('agent:primary')) ui.focusTile('agent:primary');
       else ui.activateTab('agent:primary');
@@ -164,14 +145,12 @@ export function ChatTabs() {
   const handleClose = useCallback(
     (chatId: string) => {
       const ui = useUIStore.getState();
-      // Closing the split chat's tab also tears the split down — a closed tab
-      // means "out of the working set", not just "hide the tab".
+      // Closed tab leaves the working set — tear down its split too.
       if (ui.splitChatIds.includes(chatId)) ui.closeSplitChat(chatId);
       const tabs = ui.chatTabs;
       const index = tabs.indexOf(chatId);
       ui.closeChatTab(chatId);
       if (chatId !== routedChatId) return;
-      // Land on the neighbor tab (next, else previous), or back on the landing page.
       const remaining = tabs.filter((id) => id !== chatId);
       const next = remaining[Math.min(index, remaining.length - 1)];
       navigate(next ? `/chat/${next}` : '/');

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -13,7 +13,7 @@ export interface HeaderProps {
 }
 
 function ThemeToggleButton({ theme, onToggle }: { theme: Theme; onToggle: () => void }) {
-  // Show the current theme's icon (matches the profile menu); the title names what's next.
+  // Icon is the current theme (matches profile menu); tooltip names the next.
   const Icon = getThemeMeta(theme).icon;
   const next = THEME_CYCLE[(THEME_CYCLE.indexOf(theme) + 1) % THEME_CYCLE.length];
   return (
@@ -54,10 +54,9 @@ export function Header({ isAuthPage = false }: HeaderProps) {
   const theme = useUIStore((state) => state.theme);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
-  // Pages with their own nav + UserProfileMenu — no Header needed
+  // Sidebar pages use TitleBar + Sidebar footer instead of Header.
   const isSidebarPage = isChatPage || isLandingPage || isSettingsPage;
 
-  // Sidebar pages have controls in TitleBar + Sidebar footer — no header needed
   if (!isAuthPage && isAuthenticated && isSidebarPage) return null;
 
   return (

--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -224,7 +224,7 @@ export function Sidebar({
           onLoadMore={loadMore}
         />
 
-        {/* User profile — fixed at sidebar bottom; always rendered so settings/logout are accessible even if the user query is loading or failed */}
+        {/* Always render footer so settings/logout work even if the user query fails. */}
         <div className={styles.footer}>
           <UserProfileMenu
             displayName={userDisplayName}

--- a/frontend/src/components/layout/Sidebar/SidebarActions.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarActions.tsx
@@ -7,7 +7,6 @@ interface SidebarActionsProps {
   onOpenSearch: () => void;
 }
 
-// Sidebar header controls: start a new thread or open the command-menu search.
 export function SidebarActions({ onNewChat, onOpenSearch }: SidebarActionsProps) {
   return (
     <div className={styles.actions}>

--- a/frontend/src/components/layout/Sidebar/SidebarChatItem.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarChatItem.tsx
@@ -145,15 +145,12 @@ export const SidebarChatItem = memo(function SidebarChatItem({
       onMouseEnter={() => onMouseEnter(chat.id)}
       onMouseLeave={onMouseLeave}
     >
-      {/* Right padding reserves room for the timestamp/dropdown so long titles
-          truncate before reaching them. */}
+      {/* Pad for timestamp/dropdown so long titles truncate before them. */}
       <div className={styles['title-col']}>
         <div className={styles['title-row']}>
-          {/* One leading slot keeps all row titles flush: caret on hover/expand,
-              otherwise the provider icon + a persistent status dot (or spinner). */}
+          {/* Single leading slot keeps titles flush (caret vs icon+status). */}
           {leadingIcon}
-          {/* Tooltip wraps only the title, not the icon — so the icon's own status
-              tooltip fires on its own hover instead of stacking with this one. */}
+          {/* Tooltip on title only — icon has its own status tooltip. */}
           <FloatingTooltip
             content={
               onOpenInSplit && canOpenInSplit
@@ -183,15 +180,14 @@ export const SidebarChatItem = memo(function SidebarChatItem({
               >
                 {stripMarkdownTitle(chat.title)}
               </span>
-              {/* Resting hint that sub-threads exist; the caret conveys it on hover/expand */}
+              {/* Resting sub-thread hint; caret covers this on hover/expand. */}
               {hasSubThreads && !isHovered && !isSubThreadsExpanded && (
                 <CornerDownRight className={styles['subthread-hint']} />
               )}
             </Button>
           </FloatingTooltip>
         </div>
-        {/* Clicking the badge opens the workspace context menu (new thread, rename,
-            delete) — the flat list has no group headers to hang those actions on. */}
+        {/* Badge opens workspace menu (flat list has no group headers for those actions). */}
         {workspaceBadge && (
           <Button
             variant="unstyled"
@@ -210,8 +206,7 @@ export const SidebarChatItem = memo(function SidebarChatItem({
         )}
       </div>
 
-      {/* Right slot shows the timestamp — status now lives on the leading
-          dot/spinner. Hides on hover to reveal the dropdown. */}
+      {/* Timestamp; hides on hover for the dropdown. Status is on the leading icon. */}
       <span
         className={clsx(
           styles.timestamp,

--- a/frontend/src/components/layout/Sidebar/SidebarChatList.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarChatList.tsx
@@ -26,8 +26,6 @@ interface SidebarChatListProps {
   onLoadMore: () => void;
 }
 
-// Scrollable body of the sidebar: pinned + recents sections, the filter menu,
-// empty/no-match states, and the paginated "Load more" control.
 export function SidebarChatList({
   scrollContainerRef,
   isLoadingChats,
@@ -65,8 +63,7 @@ export function SidebarChatList({
             </div>
           )}
 
-          {/* Header always renders — it anchors the filter menu, which must stay
-              reachable when active filters empty the list */}
+          {/* Header always renders so the filter menu stays reachable when filters empty the list. */}
           <div>
             <div className={styles['recents-header']}>
               <span className={styles['section-title']}>Recents</span>
@@ -88,7 +85,7 @@ export function SidebarChatList({
                 ))}
               </div>
             ) : !hasVisibleContent ? (
-              // Filters only narrow loaded pages — Load more below can still surface matches
+              // Filters only narrow loaded pages — Load more may still surface matches.
               <div className={styles['no-match']}>
                 <p className={styles['no-match-text']}>No chats match the current filters</p>
                 <Button
@@ -101,8 +98,7 @@ export function SidebarChatList({
               </div>
             ) : null}
           </div>
-          {/* Outside the Recents block: when a loaded cloud page holds only pinned
-              chats, Recents is empty but more pages may still exist. */}
+          {/* Outside Recents: a cloud page of only pinned chats still needs Load more. */}
           {hasMore && (
             <Button
               variant="unstyled"

--- a/frontend/src/components/layout/Sidebar/SidebarChatRow.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarChatRow.tsx
@@ -3,9 +3,7 @@ import type { WorkspaceBadge } from '@/hooks/queries/useSidebarChatLists';
 import { SidebarChatItem } from './SidebarChatItem';
 import { SubThreadList } from './SubThreadList';
 
-// Selection + handler bundle every chat row needs, threaded through the pinned and
-// recent sections unchanged. Kept as one object so sections forward it instead of
-// re-listing a dozen props.
+// Bundle row handlers/state so pinned and recent sections forward one object.
 export interface ChatRowProps {
   selectedChatId: string | null;
   splitChatIds: string[];
@@ -26,7 +24,6 @@ export interface ChatRowProps {
   onToggleSubThreads: (chatId: string) => void;
 }
 
-// One chat row: the item plus its expanded sub-thread list.
 export function SidebarChatRow({ chat, rowProps }: { chat: Chat; rowProps: ChatRowProps }) {
   const {
     selectedChatId,

--- a/frontend/src/components/layout/Sidebar/SidebarFilterSubmenu.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarFilterSubmenu.tsx
@@ -7,8 +7,6 @@ import type { SidebarFilters, SidebarGroupBy, SidebarStatusFilter } from '@/stor
 import type { AgentKind } from '@/types/chat.types';
 import styles from './SidebarFilterSubmenu.module.scss';
 
-// Category flyouts: hovering (or clicking, for touch) a root row opens its
-// option list beside the panel.
 export type FilterCategory = 'status' | 'agent' | 'source' | 'workspace' | 'groupBy';
 
 export const STATUS_OPTIONS: { value: SidebarStatusFilter; label: string }[] = [
@@ -41,7 +39,6 @@ interface WorkspaceOption {
   isCloud: boolean;
 }
 
-// Option row in a category flyout: label left, check right when selected.
 function FilterOptionRow({
   selected,
   onSelect,

--- a/frontend/src/components/layout/Sidebar/SidebarOverlays.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarOverlays.tsx
@@ -13,8 +13,6 @@ interface SidebarOverlaysProps {
   cloudWorkspaces: Workspace[] | undefined;
 }
 
-// Portaled sidebar overlay layer: the chat/workspace context menus and the
-// delete/rename modals they drive.
 export function SidebarOverlays({
   chat,
   workspace,

--- a/frontend/src/components/layout/Sidebar/WorkspaceContextMenu.tsx
+++ b/frontend/src/components/layout/Sidebar/WorkspaceContextMenu.tsx
@@ -10,8 +10,7 @@ interface WorkspaceContextMenuProps {
   onDelete: () => void;
 }
 
-// Fixed-position context menu for a workspace badge: new thread, rename, delete.
-// The flat chat list has no group headers to hang these actions on.
+// Flat list has no group headers — badge menu holds new thread / rename / delete.
 export function WorkspaceContextMenu({
   ref,
   position,

--- a/frontend/src/components/layout/Sidebar/useSidebarChatActions.ts
+++ b/frontend/src/components/layout/Sidebar/useSidebarChatActions.ts
@@ -25,8 +25,6 @@ interface UseSidebarChatActionsParams {
   onDeleteChat?: (chatId: string) => void;
 }
 
-// Owns per-chat state (hover, dropdown, delete/rename targets, sub-thread
-// expansion) and every chat mutation handler for the sidebar.
 export function useSidebarChatActions({
   selectedChatId,
   selectedChatParentId,

--- a/frontend/src/components/layout/Sidebar/useSidebarWorkspaceActions.ts
+++ b/frontend/src/components/layout/Sidebar/useSidebarWorkspaceActions.ts
@@ -23,8 +23,6 @@ interface UseSidebarWorkspaceActionsParams {
   scrollContainerRef: RefObject<HTMLDivElement | null>;
 }
 
-// Owns workspace-badge context-menu state plus workspace/cloud thread, rename,
-// and delete handlers for the sidebar.
 export function useSidebarWorkspaceActions({
   selectedChatId,
   selectedChatWorkspaceId,

--- a/frontend/src/components/layout/TitleBar/TitleBar.tsx
+++ b/frontend/src/components/layout/TitleBar/TitleBar.tsx
@@ -118,7 +118,6 @@ export function TitleBar() {
   const sidebarOpen = useUIStore((state) => state.sidebarOpen);
 
   const hasContent = IS_MACOS_DESKTOP || (isAuthenticated && showSidebar);
-  // Don't render an empty bar when there are no controls to show
   if (!hasContent) return null;
 
   // Uses native startDragging API — data-tauri-drag-region doesn't work on frameless windows in Tauri v2
@@ -143,9 +142,7 @@ export function TitleBar() {
       onMouseDown={handleMouseDown}
       onDoubleClick={handleDoubleClick}
     >
-      {/* Left section — same secondary surface as the main band. While the sidebar is
-          open it doubles as the sidebar's header strip (border-r, no hairline below so
-          it merges into the sidebar); when closed the band's hairline runs to the edge. */}
+      {/* When docked, merges into the sidebar header (border-r, no hairline). */}
       <div
         className={clsx(
           styles.left,
@@ -162,8 +159,7 @@ export function TitleBar() {
               position="left"
               ariaLabel="Toggle sidebar"
             />
-            {/* Search + new chat only when the sidebar is closed — open, the sidebar
-                already exposes both actions. Landing is the "new tab page". */}
+            {/* Search/new chat only when sidebar is closed (it already has both). */}
             {!sidebarOpen && (
               <>
                 <FloatingTooltip content="Search">
@@ -195,23 +191,17 @@ export function TitleBar() {
           </div>
         )}
 
-        {/* Spacing after traffic lights when no sidebar controls are shown */}
+        {/* Spacer after traffic lights when sidebar controls are absent. */}
         {IS_MACOS_DESKTOP && !(isAuthenticated && showSidebar) && <div className={styles.spacer} />}
       </div>
 
-      {/* Main content area — a secondary-surface band with a hairline below, which
-          the active chat tab's underline indicator crosses. Chat tabs (the open
-          working set) sit on the left; the view switcher stays pinned right. */}
       <div className={styles.band}>
         <div className={styles['tabs-area']}>
-          {/* Auth gate: on macOS desktop the bar renders even when logged out, and
-              persisted chatTabs would fire protected chat queries (and self-close
-              on the resulting 401s, wiping the working set). */}
+          {/* Auth gate: macOS desktop still renders the bar logged out; without this,
+              persisted chatTabs would hit protected queries and 401-self-close. */}
           {isAuthenticated && (isChatPage || isLandingPage) && <ChatTabs />}
         </div>
-        {/* Views have no tabs — the switcher is the only affordance to open and
-            close them, so landing (which renders every view against the selected
-            workspace's sandbox) needs it too. */}
+        {/* No per-view tabs — switcher opens/closes views (landing needs it too). */}
         {(isChatPage || isLandingPage) && <ViewSwitcher />}
       </div>
     </div>

--- a/frontend/src/components/layout/ViewSwitcher/ViewSwitcher.tsx
+++ b/frontend/src/components/layout/ViewSwitcher/ViewSwitcher.tsx
@@ -10,12 +10,9 @@ import styles from './ViewSwitcher.module.scss';
 
 type SwitchableView = Exclude<ViewType, 'agent'>;
 
-// Non-agent views, in the order Cursor lays them out: diff (git),
-// editor (file), terminal.
 const SWITCHABLE_VIEWS: SwitchableView[] = ['diff', 'editor', 'terminal'];
 
-// Reuse the command palette's shortcut bindings so the tooltips can't drift from
-// the real keys (⌘⇧E etc.).
+// Same shortcut bindings as the command palette so tooltips can't drift.
 const VIEW_SHORTCUTS = new Map<ViewType, string>(
   ALL_COMMANDS.flatMap((cmd) =>
     cmd.type === 'view' ? [[cmd.id, formatShortcut(cmd.shortcut)] as const] : [],
@@ -34,11 +31,9 @@ export function ViewSwitcher() {
   const visibleLayout = useUIStore((s) => s.visibleLayout);
   const isMobile = useIsMobile();
 
-  // Resolve active state against the exact tile toggleView() will act on, so the
-  // highlight (and the close-on-click) tracks the focused pane in split-chat mode.
+  // Active state matches the tile toggleView() will act on (focused split pane).
   const slot = activeSplitSlot(activeAgentTile, splitChatIds);
-  // Views have no tabs, so the highlight means "on screen" — a view kept mounted
-  // in the background stays unlit and a click surfaces it instead of closing it.
+  // Highlight = on screen; background-mounted views stay unlit (click surfaces).
   const visibleSet = useMemo(() => new Set(visibleLayout.flat()), [visibleLayout]);
 
   return (
@@ -50,9 +45,7 @@ export function ViewSwitcher() {
           <Tooltip key={view} content={viewTooltip(view)} position="bottom-end">
             <Button
               variant="unstyled"
-              // Left-click toggles the view full; shift-click or right-click
-              // opens it beside the active pane (with no view tabs, these and
-              // the command palette are the only split gestures).
+              // Left-click toggles full; shift/right-click splits beside the active pane.
               onClick={(e) => {
                 if (e.shiftKey && !isMobile) {
                   useUIStore.getState().addViewToSplit(view, 'row');

--- a/frontend/src/components/sandbox/git/DiffCommentComposer/DiffCommentComposer.tsx
+++ b/frontend/src/components/sandbox/git/DiffCommentComposer/DiffCommentComposer.tsx
@@ -11,8 +11,7 @@ interface DiffCommentComposerProps {
   onCancel: () => void;
 }
 
-// Inline comment card rendered as a pierre line annotation under the selected
-// diff lines — mirrors the editor InlineChatWidget's frosted-card look.
+// Pierre line annotation under selected lines; frosted-card look matches InlineChatWidget.
 export function DiffCommentComposer({ lineLabel, onSubmit, onCancel }: DiffCommentComposerProps) {
   const [comment, setComment] = useState('');
   const trimmed = comment.trim();

--- a/frontend/src/components/sandbox/git/DiffView/DiffToolbar.tsx
+++ b/frontend/src/components/sandbox/git/DiffView/DiffToolbar.tsx
@@ -74,7 +74,6 @@ export function DiffToolbar({
 
   return (
     <div className={styles.toolbar}>
-      {/* Scope cluster — refresh + which changes to show. */}
       <FloatingTooltip content="Refresh diff" className={styles['tooltip-inline']}>
         <Button
           onClick={onRefetch}
@@ -96,7 +95,7 @@ export function DiffToolbar({
         className={styles.segmented}
       />
 
-      {/* Narrow tiles collapse the sidebar into this file switcher. */}
+      {/* Narrow: sidebar collapses into this file switcher. */}
       {isNarrow && showFiles && currentFile && (
         <>
           <Button
@@ -138,16 +137,14 @@ export function DiffToolbar({
         </>
       )}
 
-      {/* Wide: diffstat sits beside the scope. Narrow: it's pushed right,
-          next to the overflow menu (rendered after the spacer below). */}
+      {/* Wide: diffstat beside scope; narrow: after spacer, next to overflow. */}
       {!isNarrow && diffstat}
 
       <div className={styles.spacer} />
 
       {isNarrow && diffstat}
 
-      {/* Review progress — a glanceable "how far through this diff am I".
-          Hidden on narrow tiles where the toolbar is already tight. */}
+      {/* Review progress — hidden on narrow where the toolbar is tight. */}
       {!isNarrow && showFiles && (
         <div className={styles.progress}>
           <div className={styles['progress-track']}>
@@ -163,8 +160,7 @@ export function DiffToolbar({
         </div>
       )}
 
-      {/* Diff style stays inline on wide (the primary always-on preference);
-          narrow tucks it into the overflow menu to save room. */}
+      {/* Diff style inline on wide; narrow tucks it into the overflow menu. */}
       {!isNarrow && (
         <SegmentedControl
           options={DIFF_STYLE_OPTIONS}
@@ -175,9 +171,7 @@ export function DiffToolbar({
         />
       )}
 
-      {/* Secondary actions (collapse/discard, plus diff style on narrow)
-          live in one overflow menu instead of cryptic toolbar icons. On
-          wide it only exists when there are files to act on. */}
+      {/* Overflow: collapse/discard (+ diff style on narrow). Wide only when files exist. */}
       {(isNarrow || showFiles) && (
         <>
           <Button

--- a/frontend/src/components/sandbox/git/DiffView/DiffView.tsx
+++ b/frontend/src/components/sandbox/git/DiffView/DiffView.tsx
@@ -46,21 +46,16 @@ const WORKER_POOL_OPTIONS: WorkerPoolOptions = {
 const WORKER_HIGHLIGHTER_OPTIONS: WorkerInitializationRenderOptions = {};
 
 interface DiffViewProps {
-  // The chat this tile renders — resolves the sandbox/cwd it diffs and binds it
-  // to jumps so diff tiles for different chats never consume each other's.
+  // Binds sandbox/cwd and jump targeting so multi-chat tiles don't cross-talk.
   chatId: string | undefined;
-  // Chat-less contexts (the landing page) supply the sandbox directly — diffs run
-  // at the workspace root and review comments are disabled (they need a chat).
+  // Landing page supplies sandbox directly (workspace root; no review comments).
   sandboxId?: string;
-  // Whether this tile is currently on screen — background tiles stay mounted, so
-  // visibility is how we know the user just switched to the diff view.
+  // Background tiles stay mounted — visibility detects a switch onto this view.
   isVisible: boolean;
 }
 
 export const DiffView = memo(function DiffView(props: DiffViewProps) {
-  // Chat switches remount this tile with the lazy chunk already cached, so patch
-  // parsing + pierre diff rendering would mount inside the navigation's commit
-  // and block its first paint (same deferral as EditorPane).
+  // Defer heavy mount past navigation paint (same pattern as EditorPane).
   const hasPainted = useFirstPaint();
 
   if (!hasPainted) return viewLoadingFallback;
@@ -76,12 +71,11 @@ const DiffViewContent = memo(function DiffViewContent({
   const { data: chat } = useChatQuery(chatId);
   const sandboxId = chat?.sandbox_id ?? workspaceSandboxId;
   const cwd = chat?.worktree_cwd ?? undefined;
-  // Files render expanded by default (continuous review scroll) — track the
-  // exceptions the user collapsed instead of the ones they opened.
+  // Expanded by default; set tracks user-collapsed exceptions.
   const [collapsedFiles, toggleCollapsed, setCollapsedFiles] = useToggleSet<string>();
   const [mode, setMode] = useState<DiffMode>('all');
   const [diffStyle, setDiffStyle] = useState<'unified' | 'split'>('unified');
-  // Scrollspy target — the file whose diff currently tops the pane.
+  // Scrollspy: file whose diff currently tops the pane.
   const [activeFile, setActiveFile] = useState<string | null>(null);
   const [isNarrow, setIsNarrow] = useState(false);
   const {

--- a/frontend/src/components/sandbox/git/DiffView/useDiffDiscard.ts
+++ b/frontend/src/components/sandbox/git/DiffView/useDiffDiscard.ts
@@ -12,8 +12,6 @@ interface UseDiffDiscardParams {
   cwd: string | undefined;
 }
 
-// Discard/restore actions (single file + all) against HEAD, plus the confirm
-// dialog state each one opens.
 export function useDiffDiscard({ sandboxId, cwd }: UseDiffDiscardParams) {
   const [discardTarget, setDiscardTarget] = useState<FileDiffMetadata | null>(null);
   const [discardAllOpen, setDiscardAllOpen] = useState(false);

--- a/frontend/src/components/sandbox/git/DiffView/useDiffReview.ts
+++ b/frontend/src/components/sandbox/git/DiffView/useDiffReview.ts
@@ -19,15 +19,11 @@ interface UseDiffReviewParams {
   collapsedFiles: Set<string>;
   setCollapsedFiles: Dispatch<SetStateAction<Set<string>>>;
   toggleCollapsed: (name: string) => void;
-  // Files we collapsed because they were marked reviewed. Owned by the parent
-  // (its scope-reset clears it) and shared with the scroll hook, so it's passed
-  // in rather than created here.
+  // Parent-owned (scope-reset clears it); shared with the scroll hook.
   reviewCollapsedRef: RefObject<Set<string>>;
 }
 
-// GitHub-style "Viewed" tracking: which files are marked reviewed, plus the
-// collapse ownership that mirrors it (auto-collapse on review, reopen on
-// un-review / content-invalidation) without fighting the user's manual choices.
+// GitHub-style "Viewed" + auto-collapse that yields to the user's manual toggles.
 export function useDiffReview({
   parsedFiles,
   scopeKey,

--- a/frontend/src/components/sandbox/terminal/Container/Container.tsx
+++ b/frontend/src/components/sandbox/terminal/Container/Container.tsx
@@ -8,8 +8,7 @@ import styles from './Container.module.scss';
 
 export interface ContainerProps {
   sandboxId?: string;
-  /** Identity the tab layout persists under (chat id, or a landing-page scope).
-      Without it tabs reset on every mount. */
+  /** Persist key (chat id or landing scope). Without it tabs reset every mount. */
   storageScope?: string;
   worktreeCwd?: string;
   isVisible: boolean;
@@ -69,9 +68,7 @@ export function Container({
   );
   const [closingTerminalIds, setClosingTerminalIds] = useState<Set<string>>(() => new Set());
 
-  // Re-restore during render when the storage identity changes (chat/panel
-  // switch): React re-renders before running effects, so the persist effect
-  // below can never observe the new key paired with the old chat's state.
+  // Restore during render on identity change — effects run too late (would persist old state).
   const restoreKey = `${storageKey}|${defaultTerminalId}`;
   const prevRestoreKeyRef = useRef(restoreKey);
   if (prevRestoreKeyRef.current !== restoreKey) {

--- a/frontend/src/components/settings/dialogs/AutomationEditDialog/AutomationEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/AutomationEditDialog/AutomationEditDialog.tsx
@@ -80,11 +80,8 @@ export function AutomationEditDialog({
   const workspaces = form.onCloud ? cloudWorkspaces : localWorkspaces;
   const personas = form.onCloud ? cloudPersonas : localPersonas;
 
-  // Form-state init: seed new automations and ones whose saved model left the
-  // registry — ModelSelector no longer commits one, and save requires a model_id.
-  // Effect, not render-phase seeding: onChange writes parent-owned state.
-  // Never reseed an existing cloud automation: the VPS model registry can lag
-  // the local one, and a silent swap here would persist the wrong model on save.
+  // Seed model when missing/left registry. Effect (onChange writes parent state).
+  // Never reseed cloud edits — VPS registry lag would silently swap the model on save.
   useEffect(() => {
     if (isEditing && form.onCloud) return;
     if (models.length > 0 && !models.some((m) => m.model_id === form.model_id)) {
@@ -92,10 +89,8 @@ export function AutomationEditDialog({
     }
   }, [models, form.model_id, form.onCloud, isEditing, onChange]);
 
-  // Same for the workspace — also re-seeds when toggling local/cloud, since the
-  // selected workspace only exists on one backend. Unlike the model effect this
-  // needs no cloud-edit guard: workspaces are queried from the owning backend,
-  // so a missing id means the workspace was deleted, not a registry skew.
+  // Workspace only exists on one backend; re-seed on local/cloud toggle. No cloud-edit
+  // guard — workspaces come from the owning backend, so missing id means deleted.
   useEffect(() => {
     if (workspaces.length > 0 && !workspaces.some((w) => w.id === form.workspace_id)) {
       onChange('workspace_id', workspaces[0].id);

--- a/frontend/src/components/settings/dialogs/StreamActionEditDialog/StreamActionEditDialog.tsx
+++ b/frontend/src/components/settings/dialogs/StreamActionEditDialog/StreamActionEditDialog.tsx
@@ -52,17 +52,12 @@ export function StreamActionEditDialog({
   onActionChange,
 }: StreamActionEditDialogProps) {
   const { data: models = [] } = useModelsQuery();
-  // Builtin slash commands are static per agent, so any workspace's resources
-  // surface the same set. Custom skills are intentionally excluded — stream actions
-  // are global and run in the clicked chat's workspace, where a skill suggested here
-  // may not exist; builtins are valid everywhere.
+  // Builtins only — stream actions are global and the clicked chat may lack a custom skill.
   const workspaces = useWorkspacesList();
   const { data: resources } = useWorkspaceResourcesQuery(workspaces[0]?.id);
   const builtinSlashCommands = resources?.builtin_slash_commands ?? EMPTY_BUILTIN_COMMANDS;
 
-  // Form-state init: seed new actions and actions whose saved model left the
-  // registry — ModelSelector no longer commits one, and save requires a model_id.
-  // Effect, not render-phase seeding: onActionChange writes parent-owned state.
+  // Seed model when missing/left registry. Effect: onActionChange writes parent state.
   useEffect(() => {
     if (models.length > 0 && !models.some((m) => m.model_id === action.model_id)) {
       onActionChange('model_id', models[0].model_id);

--- a/frontend/src/components/settings/tabs/AutomationsSettingsTab/AutomationsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/AutomationsSettingsTab/AutomationsSettingsTab.tsx
@@ -43,8 +43,7 @@ const AutomationEditDialog = lazyNamed(
   'AutomationEditDialog',
 );
 
-// An automation belongs to one backend; onCloud tags each row with its origin
-// so edits/deletes/runs route back to it.
+// onCloud tags origin so edits/deletes/runs hit the owning backend.
 interface AutomationListItem {
   automation: Automation;
   onCloud: boolean;

--- a/frontend/src/components/settings/tabs/CloudSettingsTab/CloudSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/CloudSettingsTab/CloudSettingsTab.tsx
@@ -43,8 +43,7 @@ function SetupStep({ step, children }: { step: number; children: React.ReactNode
 }
 
 export function CloudSettingsTab() {
-  // Connects the desktop to a remote AgentRove (VPS) instance so chats can run
-  // there with "Cloud" execution mode. Connection state is client-side only.
+  // Client-side only connection state for a remote AgentRove (VPS) instance.
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
   const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
   const isConnected = !!connectedEmail;

--- a/frontend/src/components/settings/tabs/SkillsSettingsTab/SkillsSettingsTab.tsx
+++ b/frontend/src/components/settings/tabs/SkillsSettingsTab/SkillsSettingsTab.tsx
@@ -17,9 +17,7 @@ interface EmptyStateProps {
   message: string;
 }
 
-// Stable empty fallback so a loading/undefined `skills` doesn't yield a new `[]`
-// each render — a fresh reference retriggers useSkillsFilter's render-phase setState
-// (via availableSources' useMemo) into an infinite loop while the query is in flight.
+// Stable [] — a fresh array each render loops useSkillsFilter's render-phase setState.
 const EMPTY_SKILLS: CustomSkill[] = [];
 
 function EmptyState({ icon: Icon, message }: EmptyStateProps) {
@@ -34,8 +32,7 @@ function EmptyState({ icon: Icon, message }: EmptyStateProps) {
 export function SkillsSettingsTab() {
   const workspaces = useWorkspacesList();
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>();
-  // Skills are per-workspace, so default to the first workspace until the user
-  // picks another instead of tracking selection in a sync effect.
+  // Default to first workspace without a sync effect.
   const workspaceId = selectedWorkspaceId ?? workspaces[0]?.id;
 
   const { data: skills, isLoading, refetch } = useSkillsQuery(workspaceId);

--- a/frontend/src/components/ui/AsciiSpinner/AsciiSpinner.tsx
+++ b/frontend/src/components/ui/AsciiSpinner/AsciiSpinner.tsx
@@ -3,8 +3,6 @@ import clsx from 'clsx';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import styles from './AsciiSpinner.module.scss';
 
-// Braille frames give a smooth terminal-style spin — the CLI-agent aesthetic,
-// shown in place of a chat's icon while its agent is working.
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const FRAME_INTERVAL_MS = 80;
 

--- a/frontend/src/components/ui/ChatStatusDot/ChatStatusDot.tsx
+++ b/frontend/src/components/ui/ChatStatusDot/ChatStatusDot.tsx
@@ -3,8 +3,7 @@ import styles from './ChatStatusDot.module.scss';
 
 export type ChatStatusTone = 'blocked' | 'running' | 'completed' | 'unread';
 
-// Precedence for a chat's status tone (shared by the sidebar rows and sub-threads):
-// needs-you > running > done > unread. Running normally renders the spinner, not a dot.
+// Precedence: needs-you > running > done > unread (running uses the spinner, not a dot).
 export function chatStatusTone(flags: {
   blocked: boolean;
   streaming: boolean;
@@ -18,7 +17,6 @@ export function chatStatusTone(flags: {
   return null;
 }
 
-// Human word for each tone, shown in tooltips next to the dot/spinner.
 export const CHAT_STATUS_LABEL: Record<ChatStatusTone, string> = {
   blocked: 'Needs you',
   running: 'Running',
@@ -26,9 +24,7 @@ export const CHAT_STATUS_LABEL: Record<ChatStatusTone, string> = {
   unread: 'Unread',
 };
 
-// Shared status dot for the sidebar rows and the title-bar tabs so both read the
-// same: red (pulsing) = needs you, amber = running, green = done, blue = unread.
-// (Running normally shows the braille spinner; the amber dot is its compact form.)
+// red+ping=needs you, amber=running (compact; usually spinner), green=done, blue=unread
 const TONE_STYLE: Record<ChatStatusTone, { tone: ChatStatusTone; ping: boolean }> = {
   blocked: { tone: 'blocked', ping: true },
   running: { tone: 'running', ping: false },
@@ -36,8 +32,7 @@ const TONE_STYLE: Record<ChatStatusTone, { tone: ChatStatusTone; ping: boolean }
   unread: { tone: 'unread', ping: false },
 };
 
-// className positions the whole dot (e.g. absolute corner overlay, or a sizing box
-// to center it); ringClassName punches it out from an icon it overlays.
+// ringClassName punches the dot out from an overlayed icon.
 export function ChatStatusDot({
   tone,
   className,
@@ -50,8 +45,7 @@ export function ChatStatusDot({
   const { tone: toneKey, ping } = TONE_STYLE[tone];
   return (
     <span className={clsx(styles['chat-status-dot'], className)}>
-      {/* Inner box owns the ping's positioning context so the ring stays dot-sized
-          regardless of how the outer span is positioned. */}
+      {/* Inner box sizes the ping/ring independent of outer positioning. */}
       <span className={styles['dot-inner']}>
         {ping && <span className={clsx(styles.ping, styles[`dot--${toneKey}`])} />}
         <span className={clsx(styles['dot-ring'], ringClassName, styles[`dot--${toneKey}`])} />

--- a/frontend/src/components/ui/FloatingTooltip/FloatingTooltip.tsx
+++ b/frontend/src/components/ui/FloatingTooltip/FloatingTooltip.tsx
@@ -29,13 +29,10 @@ interface FloatingTooltipProps {
   className?: string;
 }
 
-// Themed replacement for the native title attribute. Unlike Tooltip (pure CSS,
-// absolute), it renders position:fixed so triggers inside overflow-y-auto lists
-// (e.g. the sidebar) don't clip the bubble or add phantom scroll space.
+// Fixed-position title replacement — unlike CSS Tooltip, won't clip inside overflow lists.
 export function FloatingTooltip({ content, children, className }: FloatingTooltipProps) {
   const [position, setPosition] = useState<TooltipPosition | null>(null);
-  // Tracks the whole hover interaction (show delay + visible) so the scroll
-  // listener can also cancel a pending show timer, not just an open tooltip
+  // Covers show delay + visible so scroll can cancel a pending show, not just an open tip.
   const [hovering, setHovering] = useState(false);
   const triggerRef = useRef<HTMLDivElement>(null);
   const bubbleRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/ui/ListManagementTab/ListManagementTab.tsx
+++ b/frontend/src/components/ui/ListManagementTab/ListManagementTab.tsx
@@ -6,8 +6,7 @@ import { Plus, Loader2, LucideIcon, Edit2, Trash2 } from 'lucide-react';
 import { logger } from '@/utils/logger';
 import styles from './ListManagementTab.module.scss';
 
-// Delay-reveal spinner: starts at opacity 0, fades in after 300ms; forwards keeps
-// it visible when the animation ends
+// Delay-reveal spinner (300ms); forwards keeps it visible after the animation.
 const SPINNER_STYLE: CSSProperties = { animationDelay: '300ms', animationFillMode: 'forwards' };
 
 interface ListManagementTabProps<T> {
@@ -25,7 +24,6 @@ interface ListManagementTabProps<T> {
   onEdit?: (index: number) => void;
   onDelete: (index: number) => void | Promise<void>;
   renderItem: (item: T, index: number) => ReactNode;
-  // Extra controls rendered before the edit/delete buttons (e.g. an enable toggle)
   renderItemActions?: (item: T, index: number) => ReactNode;
   footerContent?: ReactNode;
   logContext: string;

--- a/frontend/src/components/ui/SplitViewContainer/SplitViewContainer.tsx
+++ b/frontend/src/components/ui/SplitViewContainer/SplitViewContainer.tsx
@@ -16,12 +16,7 @@ export const SplitViewContainer = memo(function SplitViewContainer({
   const focusedTile = useUIStore((state) => state.focusedTile);
   const isMobile = useIsMobile();
 
-  // Mobile shows exactly one pane regardless of the stored layout — collapse a
-  // multi-pane split (e.g. carried over from a desktop session that resized down)
-  // to the focused tile, falling back to the first visible one. Render-only, so
-  // the split returns intact when the viewport grows back. The store also owns
-  // mobile semantics (uiStore.toggleView accumulates tabs differently on mobile);
-  // this collapse only governs what's painted.
+  // Mobile paints one pane (focused, else first). Render-only — store layout stays intact.
   const layout = useMemo(() => {
     if (!isMobile) return visibleLayout;
     const flat = visibleLayout.flat();

--- a/frontend/src/components/ui/WorkspaceSplit/WorkspaceSplit.tsx
+++ b/frontend/src/components/ui/WorkspaceSplit/WorkspaceSplit.tsx
@@ -4,13 +4,10 @@ import type { TileId } from '@/types/ui.types';
 import styles from './WorkspaceSplit.module.scss';
 
 interface WorkspaceSplitProps {
-  // All open tabs — every one is mounted so background panes keep their state.
+  // Every open tab is mounted so background panes keep state.
   openTabs: TileId[];
-  // Rows of on-screen tiles: rows stack vertically, tiles in a row sit side by side.
   visibleLayout: TileId[][];
-  // `isVisible` tells the renderer whether this tile is currently on screen — a
-  // background tab is mounted but hidden, so visibility-driven effects (terminal
-  // fit/focus) must not fire for it.
+  // isVisible false for mounted-but-hidden tabs (skip terminal fit/focus, etc.).
   renderView: (tileId: TileId, isVisible: boolean) => ReactNode;
 }
 
@@ -30,10 +27,8 @@ function lcm(a: number, b: number): number {
   return (a * b) / gcd(a, b);
 }
 
-// Flat split via CSS grid: every open tab renders in a stable position (no remount
-// when it moves between visible and background, or between rows); only its grid
-// placement and `display` change. Rows share a column grid sized to the LCM of the
-// row lengths so tiles in differently-sized rows stay equal-width within their row.
+// Stable CSS-grid positions (no remount when visibility/row changes). Column count
+// is LCM of row lengths so tiles stay equal-width within each row.
 export function WorkspaceSplit({ openTabs, visibleLayout, renderView }: WorkspaceSplitProps) {
   const { placements, rows, cols } = useMemo(() => {
     const rowCount = visibleLayout.length;
@@ -65,7 +60,6 @@ export function WorkspaceSplit({ openTabs, visibleLayout, renderView }: Workspac
       {openTabs.map((tileId) => {
         const p = placements.get(tileId);
         if (!p) {
-          // Mounted but off-screen — kept alive so its state survives.
           return (
             <div key={tileId} className={styles['tile-hidden']}>
               {renderView(tileId, false)}

--- a/frontend/src/components/ui/attachment-viewer/AttachmentViewer.tsx
+++ b/frontend/src/components/ui/attachment-viewer/AttachmentViewer.tsx
@@ -16,8 +16,7 @@ import styles from './AttachmentViewer.module.scss';
 interface AttachmentViewerProps {
   attachments: MessageAttachment[];
   uploadingAttachmentIds?: string[];
-  // Routes attachment fetch/download to the chat's backend — cloud messages carry
-  // relative /api/v1/attachments URLs that only resolve on the owning VPS.
+  // Routes fetch/download to the chat's backend (cloud relative URLs need the VPS).
   chatId?: string;
 }
 
@@ -29,7 +28,7 @@ export const AttachmentViewer = memo(function AttachmentViewer({
   chatId,
 }: AttachmentViewerProps) {
   const [imageStates, setImageStates] = useState<Record<string, ImageState>>({});
-  // Index into imageAttachments of the image currently shown in the lightbox; null means closed.
+  // Lightbox index into imageAttachments; null = closed.
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const loadedIdsRef = useRef<Set<string>>(new Set());
   const ownedObjectUrlsRef = useRef<Set<string>>(new Set());

--- a/frontend/src/components/ui/command-menu/CommandMenuList.tsx
+++ b/frontend/src/components/ui/command-menu/CommandMenuList.tsx
@@ -26,7 +26,6 @@ interface CommandMenuListProps {
   query: string;
   trimmedQuery: string;
   isMobile: boolean;
-  // Main mode
   listItems: MenuListItem[];
   leafTileIds: Set<string>;
   activeSlot: SplitSlot | null;
@@ -34,13 +33,11 @@ interface CommandMenuListProps {
   onSelectFile: (file: FlatFileItem) => void;
   onRunCommand: (cmd: CommandItem) => void;
   onSplit: (viewId: ViewType, direction: SplitDirection) => void;
-  // Branches mode
   filteredBranches: string[];
   branchesData: GitBranchesData | undefined;
   sandboxId: string | undefined;
   checkoutPending: boolean;
   onSelectBranch: (branch: string) => void;
-  // Themes mode
   filteredThemes: ThemeMeta[];
   theme: Theme;
   onSelectTheme: (value: Theme) => void;

--- a/frontend/src/components/ui/command-menu/MenuRow.tsx
+++ b/frontend/src/components/ui/command-menu/MenuRow.tsx
@@ -11,13 +11,11 @@ export interface MenuRowProps {
   onActivate: (index: number, e: ReactMouseEvent) => void;
   onSelect: () => void;
   disabled?: boolean;
-  // Controls rendered outside the option button (shortcut hint, split buttons).
   trailing?: ReactNode;
   children: ReactNode;
 }
 
-// Shared row shell — active highlight, synthetic-hover guard, option semantics.
-// Only the button content (and optional trailing controls) differ per row type.
+// Shared row shell: active highlight, synthetic-hover guard, option semantics.
 export function MenuRow({
   id,
   index,

--- a/frontend/src/components/ui/command-menu/commandMenuModes.ts
+++ b/frontend/src/components/ui/command-menu/commandMenuModes.ts
@@ -12,6 +12,6 @@ export const FILTER_LABELS: Record<MainFilter, string> = {
 export const isMainMode = (mode: MenuMode): mode is MainFilter =>
   (MAIN_FILTERS as MenuMode[]).includes(mode);
 
-// Panel filters swap the unified list for an embedded search panel with its own input.
+// Panel filters swap the list for an embedded search panel with its own input.
 export const isPanelMode = (mode: MenuMode): mode is 'messages' | 'grep' =>
   mode === 'messages' || mode === 'grep';

--- a/frontend/src/components/ui/command-menu/commandRegistry.ts
+++ b/frontend/src/components/ui/command-menu/commandRegistry.ts
@@ -53,14 +53,11 @@ export interface ActionCommandItem {
 
 export type CommandItem = ViewCommandItem | ActionCommandItem;
 
-// Main-mode filter tabs; ⌘[/⌘] cycle through them in this order. Chats/Files match
-// titles/filenames in the unified list; Messages/Grep host the content-search panels
-// (chat messages / file contents) — named so they don't read as duplicates of Chats/Files.
+// Main-mode filter tabs (⌘[/⌘] cycle). Messages/Grep are content search, not Chats/Files.
 export type MainFilter = 'all' | 'chats' | 'messages' | 'files' | 'grep' | 'actions';
 export const MAIN_FILTERS: MainFilter[] = ['all', 'chats', 'messages', 'files', 'grep', 'actions'];
 
-// Sub-modes (branch picker, theme picker) replace the whole menu surface; main
-// filters only narrow the unified list or swap in a search panel.
+// Sub-modes replace the whole surface; main filters narrow the list or swap a panel.
 export type MenuMode = MainFilter | 'branches' | 'themes';
 
 export interface FlatFileItem {
@@ -68,16 +65,14 @@ export interface FlatFileItem {
   name: string;
 }
 
-// Loaded chat lists (instant title fuzzy match) normalized to one display shape;
-// message-content search lives in the Messages tab, not here.
+// Title fuzzy-match rows; message-content search is the Messages tab.
 export interface ChatRowItem {
   id: string;
   title: string;
   workspaceName?: string;
 }
 
-// One flat list drives both keyboard navigation and rendering of the sectioned
-// main-mode results, so their ordering can never diverge.
+// One list for keyboard nav and sectioned rendering so order can't diverge.
 export type MenuListItem =
   | { kind: 'chat'; chat: ChatRowItem }
   | { kind: 'file'; file: FlatFileItem }

--- a/frontend/src/components/ui/command-menu/useCommandMenu.ts
+++ b/frontend/src/components/ui/command-menu/useCommandMenu.ts
@@ -104,7 +104,6 @@ export function useCommandMenu() {
   useEffect(() => {
     if (isOpen) {
       previousFocusRef.current = document.activeElement;
-      // switchMode also focuses the right input for the target mode.
       const ui = useUIStore.getState();
       switchMode(ui.pendingMenuMode ?? 'all');
       ui.setPendingMenuMode(null);
@@ -126,7 +125,6 @@ export function useCommandMenu() {
     [close, queryClient, navigate, sandboxId, worktreeCwd],
   );
 
-  // Commands either dispatch an action or switch the menu into a sub-mode/filter.
   const runCommand = useCallback(
     (cmd: CommandItem) => {
       const nextMode = COMMAND_TO_MODE[cmd.id];

--- a/frontend/src/components/ui/markdown/MarkDown.tsx
+++ b/frontend/src/components/ui/markdown/MarkDown.tsx
@@ -29,8 +29,7 @@ const MarkdownBlock = memo(function MarkdownBlock({
   remarkPlugins,
   rehypePlugins,
 }: MarkdownBlockProps) {
-  // Memoized per block so a streaming message only re-parses its growing tail
-  // block each flush; completed blocks keep identical props and bail out.
+  // Per-block memo: streaming only re-parses the growing tail block each flush.
   return (
     <ReactMarkdown
       remarkPlugins={remarkPlugins}
@@ -45,11 +44,9 @@ const MarkdownBlock = memo(function MarkdownBlock({
 interface MarkDownProps {
   content: string;
   className?: string;
-  // True only while this content is actively receiving stream output — block
-  // splitting trades cross-block references for cheap incremental re-parses,
-  // so static content parses as one document.
+  // While streaming, split blocks for cheap incremental re-parse (breaks cross-block refs).
   streaming?: boolean;
-  // Render @mention and leading /command tokens as pills — user messages only.
+  // @mention /command pills — user messages only.
   highlightMentions?: boolean;
 }
 

--- a/frontend/src/components/ui/markdown/markdownParsing.ts
+++ b/frontend/src/components/ui/markdown/markdownParsing.ts
@@ -6,22 +6,17 @@ import { MENTION_PILL_CLASSNAME } from '../shared/HighlightedText/HighlightedTex
 
 export const MATH_PATTERN = /(^|[^\\])(\$[^$\n]+\$|\$\$[\s\S]*?\$\$|\\\(|\\\[)/;
 
-// Matches an unclosed ```visualizer block at the end of streaming content.
-// Captures the partial content so it can be rendered as a live preview.
+// Unclosed ```visualizer at stream end — partial body for live preview.
 const UNCLOSED_VISUALIZER_RE = /```visualizer\n([\s\S]*)$/;
 
-// Matches just the opening fence without any content yet (no newline after "visualizer").
+// Opening fence only (no newline after "visualizer").
 const OPENING_VISUALIZER_RE = /```visualizer$/;
 
-// Matches a complete ```visualizer ... ``` block.
 const CLOSED_VISUALIZER_RE = /```visualizer\n([\s\S]*?)```/g;
 
-// Matches a line that can safely start a new markdown block. Indented lines,
-// list items, and blockquote lines must stay attached to the previous block —
-// splitting a loose list or nested content would change how it renders.
+// Safe to start a new block; indented/list/blockquote lines must stay attached.
 const SAFE_BLOCK_START_RE = /^(?![ \t]|[-*+] |\d+[.)] |>)\S/;
-// Captures the fence marker and any trailing info string separately — closing
-// a fence requires matching the opening marker, not just any 3+ fence chars.
+// Fence marker + info string separate — closer must match opener, not any 3+ fence.
 const CODE_FENCE_LINE_RE = /^\s*(`{3,}|~{3,})(.*)$/;
 const MATH_FENCE_LINE_RE = /^\s*\$\$\s*$/;
 
@@ -38,10 +33,8 @@ export const createImageAttachment = (url: string, alt?: string): MessageAttachm
   };
 };
 
-// Split content into segments: markdown text and visualizer blocks.
-// Completed blocks are rendered with stable keys outside react-markdown so they
-// survive parent re-renders during streaming without iframe remount.
-// Unclosed visualizer fences (still streaming) are rendered as live previews.
+// Split md vs visualizer blocks; completed visualizers stay keyed outside react-markdown
+// so streaming parent re-renders don't remount iframes.
 export function splitVisualizerBlocks(raw: string): MarkdownSegment[] {
   const segments: MarkdownSegment[] = [];
   let lastIndex = 0;
@@ -55,14 +48,13 @@ export function splitVisualizerBlocks(raw: string): MarkdownSegment[] {
 
   const remainder = raw.slice(lastIndex);
 
-  // Check for an unclosed visualizer fence with partial content (live preview)
   const unclosedMatch = remainder.match(UNCLOSED_VISUALIZER_RE);
   if (unclosedMatch) {
     const before = remainder.slice(0, unclosedMatch.index);
     if (before) segments.push({ type: 'md', content: before });
     if (unclosedMatch[1]) segments.push({ type: 'visualizer', content: unclosedMatch[1] });
   } else if (OPENING_VISUALIZER_RE.test(remainder)) {
-    // Just the opening fence, no content yet — strip it from markdown
+    // Opening fence only — strip it from markdown
     const before = remainder.replace(OPENING_VISUALIZER_RE, '');
     if (before) segments.push({ type: 'md', content: before });
   } else {
@@ -72,12 +64,8 @@ export function splitVisualizerBlocks(raw: string): MarkdownSegment[] {
   return segments;
 }
 
-// Split markdown into block-level chunks at blank lines outside code/math
-// fences. Streaming only appends text, so completed chunks stay byte-identical
-// across flushes and their memoized renderers skip re-parsing entirely.
-// Blocks parse in isolation, breaking cross-block reference links/footnotes —
-// so this only runs on actively streaming content; static renders and the
-// final parse at stream end get full document semantics.
+// Chunk at blank lines outside fences so streaming keeps completed blocks byte-identical
+// (memo skips re-parse). Isolation breaks cross-block refs — only use while streaming.
 export function splitMarkdownBlocks(md: string): string[] {
   const lines = md.split('\n');
   const blocks: string[] = [];
@@ -125,7 +113,7 @@ export function splitMarkdownBlocks(md: string): string[] {
 }
 
 function buildMentionPillNodes(value: string): ElementContent[] | null {
-  // Null when the text holds no tokens so the caller can keep the original node.
+  // null → caller keeps the original node (no tokens)
   const segments = buildHighlightSegments(value);
   if (!segments.some((segment) => segment.isToken)) return null;
   return segments.map((segment) =>

--- a/frontend/src/components/ui/primitives/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/ui/primitives/Dropdown/Dropdown.tsx
@@ -45,7 +45,6 @@ export interface DropdownProps<T> {
   searchPlaceholder?: string;
   searchVariant?: 'boxed' | 'underline';
   selectionStyle?: 'check' | 'accent';
-  // Rendered pinned at the top of the panel, above the search field
   renderHeader?: () => ReactNode;
   renderFooter?: () => ReactNode;
   onOpenChange?: (isOpen: boolean) => void;

--- a/frontend/src/components/ui/shared/ApprovalFooter/ApprovalFooter.tsx
+++ b/frontend/src/components/ui/shared/ApprovalFooter/ApprovalFooter.tsx
@@ -5,8 +5,7 @@ import { FloatingTooltip } from '@/components/ui/FloatingTooltip/FloatingTooltip
 import type { PermissionOption } from '@/types/chat.types';
 import styles from './ApprovalFooter.module.scss';
 
-// Generic, agent-agnostic subtitles keyed by option kind — reinforces the
-// server-provided title with a plain-English outcome line.
+// Agent-agnostic outcome lines that reinforce the server-provided title.
 const KIND_SUBTITLES: Record<PermissionOption['kind'], string> = {
   allow_once: 'Proceed with this request.',
   allow_always: "Allow and don't ask again.",
@@ -36,9 +35,7 @@ export function PermissionApprovalButtons({
 }: PermissionApprovalButtonsProps) {
   const sortedAllow = sortByPriority(allowOptions, ALLOW_PRIORITY);
   const sortedReject = sortByPriority(rejectOptions, REJECT_PRIORITY);
-  // Only show "Allow" / "Reject" group labels when the user has to choose
-  // between multiple options in a group; a single-option footer (e.g. plan
-  // mode) doesn't need the extra visual grouping.
+  // Group labels only when there's a real Allow/Reject choice (skip single-option plan mode).
   const showGroupLabels = sortedAllow.length + sortedReject.length > 2;
   const primaryAllowId = sortedAllow[0]?.option_id ?? null;
 

--- a/frontend/src/components/ui/shared/HighlightedText/HighlightedText.tsx
+++ b/frontend/src/components/ui/shared/HighlightedText/HighlightedText.tsx
@@ -1,14 +1,11 @@
 import { buildHighlightSegments } from '@/utils/mentionParser';
 
-// Canonical highlight for @mention and /command tokens. Also consumed by
-// MarkDown's rehype transform, which builds hast nodes and can't render
-// this component — so it's a global class (defined in styles/app.scss),
-// not a CSS module.
+// Global class (styles/app.scss) so MarkDown's hast transform can reuse it.
 export const MENTION_PILL_CLASSNAME = 'mention-pill';
 
 interface HighlightedTextProps {
   text: string;
-  // The input backdrop overrides this because its styles live in a CSS module.
+  // Input backdrop overrides this (its styles are CSS-module scoped).
   tokenClassName?: string;
 }
 

--- a/frontend/src/components/ui/shared/ToggleDropdown/ToggleDropdown.tsx
+++ b/frontend/src/components/ui/shared/ToggleDropdown/ToggleDropdown.tsx
@@ -15,9 +15,8 @@ interface ToggleDropdownProps {
   options: readonly [ToggleDropdownOption, ToggleDropdownOption];
   value: boolean;
   onSelect: (value: boolean) => void;
-  // Fixed trigger icon; a per-option icon takes precedence when provided.
   icon?: ComponentType<SVGProps<SVGSVGElement>>;
-  // CSS width for the panel (e.g. '8rem'), not a class name
+  // CSS length for the panel (e.g. '8rem'), not a class name
   width: string;
   disabled?: boolean;
 }
@@ -30,8 +29,7 @@ export const ToggleDropdown = memo(function ToggleDropdown({
   width,
   disabled = false,
 }: ToggleDropdownProps) {
-  // Compact two-option dropdown for the landing composer toolbar. Hand-styled to
-  // match the adjacent workspace selector trigger, not the Dropdown primitive.
+  // Hand-styled for the landing composer (not Dropdown) to match the workspace selector.
   const { isOpen, dropdownRef, setIsOpen } = useDropdown();
   const selected = options[value ? 1 : 0];
   const TriggerIcon = selected.icon ?? icon;

--- a/frontend/src/config/stateClasses.ts
+++ b/frontend/src/config/stateClasses.ts
@@ -1,5 +1,4 @@
 // TS mirror of src/styles/globals/_state-classes.scss — keep the two in sync.
-// Usage: clsx(styles['chat-row'], isSelected && stateClasses.SELECTED)
 export const stateClasses = {
   HOVER: 'is-hover',
   ACTIVE: 'is-active',

--- a/frontend/src/config/toaster.ts
+++ b/frontend/src/config/toaster.ts
@@ -1,14 +1,11 @@
 import type { ToasterProps } from 'react-hot-toast';
 
-// Surface via the global .app-toast class (styles/app.scss) so every palette
-// re-themes toasts; react-hot-toast owns the DOM, so no CSS module can reach it.
+// Global .app-toast (app.scss) — rht owns the DOM so CSS modules can't theme it.
 const toastSurfaceClass = 'app-toast';
 
 export const toasterConfig: ToasterProps = {
   position: 'top-right',
-  // Push toasts below the iOS status-bar/notch inset (env() is 0 on web/desktop).
-  // The +1rem is just the gap below that inset — it does NOT account for the
-  // TitleBar height, so on chat screens toasts still sit partly over the bar.
+  // Below safe-area inset (+1rem gap). Does not clear TitleBar height on chat screens.
   containerStyle: {
     top: 'calc(env(safe-area-inset-top) + 1rem)',
   },

--- a/frontend/src/hooks/queries/useAutomationQueries.ts
+++ b/frontend/src/hooks/queries/useAutomationQueries.ts
@@ -9,8 +9,7 @@ import type {
   AutomationUpdateRequest,
 } from '@/types/automation.types';
 
-// Each automation is owned by one backend, so mutations carry onCloud and
-// invalidate only that backend's list.
+// Invalidate only the backend that owns the automation.
 function invalidateAutomations(queryClient: QueryClient, onCloud: boolean) {
   if (onCloud) {
     const { cloudUrl, connectedEmail } = useCloudSettingsStore.getState();
@@ -29,8 +28,7 @@ export const useAutomationsQuery = () =>
     staleTime: 30_000,
   });
 
-// Keyed by cloudUrl + connectedEmail so switching instance or account never
-// serves the previous connection's cached list.
+// Keyed by instance + account so switches don't serve stale cache.
 export const useCloudAutomationsQuery = (enabled: boolean) => {
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
   const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
@@ -77,8 +75,6 @@ export const useRunAutomationMutation = createMutation<
 >(
   ({ automationId, onCloud }) => automationService.runAutomation(automationId, onCloud),
   (queryClient, _data, variables) => {
-    // Refresh last_run_at on the list, plus the sidebar chats of the backend
-    // the run landed on.
     invalidateAutomations(queryClient, variables.onCloud);
     if (variables.onCloud) {
       void queryClient.invalidateQueries({ queryKey: queryKeys.cloudChatsAll });

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -27,17 +27,13 @@ import { queryKeys } from './queryKeys';
 const CHATS_PER_PAGE = 25;
 const GLOBAL_WORKSPACE_SENTINEL = 'all';
 
-// Matches the global (non-workspace-scoped, unpinned) infinite chats query.
-// Key shape: [chats, 'infinite', perPage, workspaceId, pinned]
-//   — index 3 = GLOBAL_WORKSPACE_SENTINEL for unscoped queries
-//   — index 4 = null for unpinned (true for pinned-only)
+// Global infinite chats: key[3]=GLOBAL_WORKSPACE_SENTINEL, key[4]=null (unpinned).
 function isGlobalChatsQuery(query: Query): boolean {
   const key = query.queryKey;
   return key.length >= 5 && key[3] === GLOBAL_WORKSPACE_SENTINEL && key[4] === null;
 }
 
-// Cloud chats live in a separate query the local infinite-chats cache patches don't touch.
-// Centralized so a new chat mutation can't silently forget to refresh the cloud sidebar.
+// Cloud sidebar is a separate query local infinite-chats patches don't touch.
 function invalidateCloudChats(queryClient: QueryClient, chatId: string) {
   if (isCloudChat(chatId)) {
     queryClient.invalidateQueries({ queryKey: queryKeys.cloudChatsAll });
@@ -78,10 +74,7 @@ export const useInfiniteChatsQuery = (options?: {
     initialPageParam: 1,
     enabled: options?.enabled ?? true,
     gcTime: 1000 * 60 * 1,
-    // The list hydrates from the persisted localStorage snapshot for a fast
-    // first paint; always refetch behind it so chats created out-of-band
-    // (another device, MCP) surface on load even when the snapshot is fresher
-    // than the default staleTime.
+    // Snapshot hydrates first paint; always refetch so out-of-band creates surface.
     refetchOnMount: 'always',
   });
 };
@@ -142,17 +135,13 @@ export const useContextUsageQuery = (
   });
 };
 
-// Shared by the create-chat mutation and the chat_created SSE feed — both must
-// patch the same caches. The prepend dedups by id because both paths fire for a
-// chat created in this session (mutation onSuccess + its own broadcast event);
-// the second pass's redundant invalidations are the accepted cost of keeping
-// the backend broadcast unconditional — don't "fix" it by suppressing them.
+// Shared by create-chat mutation + chat_created SSE. Dedup by id — both paths fire
+// for local creates; second-pass invalidations are intentional (don't suppress).
 export async function applyCreatedChat(queryClient: QueryClient, newChat: Chat): Promise<void> {
   queryClient.setQueryData(queryKeys.chat(newChat.id), newChat);
 
   if (newChat.parent_chat_id) {
-    // Workspaces too: creating a sub-thread bumps the parent's updated_at,
-    // which drives workspace ordering/last-activity.
+    // Sub-thread create bumps parent updated_at (workspace ordering).
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: queryKeys.subThreads(newChat.parent_chat_id) }),
       queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] }),
@@ -185,9 +174,7 @@ export async function applyCreatedChat(queryClient: QueryClient, newChat: Chat):
   queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
 }
 
-// Canonical "patch one chat everywhere" — applies the same updater to the
-// single-chat query and every infinite chats list, so callers can't update
-// one cache and silently miss the other.
+// Patch single-chat query + every infinite chats list together.
 export function patchChatInCache(
   queryClient: QueryClient,
   chatId: string,
@@ -209,9 +196,7 @@ export function patchChatInCache(
   );
 }
 
-// Optimistically clears the unread flag in every cache the chat appears in,
-// then stamps the server-side read marker. Best-effort fire-and-forget: it
-// never rejects — a failed stamp just resurfaces the dot on the next refetch.
+// Optimistic unread clear + server stamp; fire-and-forget (failed stamp resurfaces on refetch).
 export async function markChatViewed(queryClient: QueryClient, chatId: string): Promise<void> {
   patchChatInCache(queryClient, chatId, (chat) =>
     chat.unread ? { ...chat, unread: false } : chat,
@@ -261,8 +246,6 @@ export const useUpdateChatMutation = createMutation<
     );
 
     queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
-    // Search results embed the chat title, so a rename leaves a stale title
-    // visible until the search query is refetched.
     queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
     invalidateCloudChats(queryClient, updatedChat.id);
 
@@ -279,10 +262,7 @@ export const usePinChatMutation = createMutation<Chat, Error, { chatId: string; 
   (queryClient, updatedChat) => {
     queryClient.setQueryData(queryKeys.chat(updatedChat.id), updatedChat);
 
-    // Invalidate all chat caches: global (pinned section needs re-sort and may need
-    // to include a chat that wasn't in the cache) and workspace-scoped (pinning/unpinning
-    // changes pinned_at and updated_at, which affects backend sort order).
-    // Also invalidate workspaces since last_chat_at may have changed.
+    // Pin changes sort (pinned_at/updated_at) and may move chats into/out of cached pages.
     queryClient.invalidateQueries({
       queryKey: [queryKeys.chats, 'infinite'],
     });
@@ -309,9 +289,7 @@ export const useDeleteChatMutation = createMutation<void, Error, string>(
       },
     );
 
-    // Single scan of all ['chat', ...] entries to:
-    // 1. Find the parent of the deleted chat (if it's a sub-thread)
-    // 2. Clean up caches for child sub-threads (if deleting a parent)
+    // One pass: find parent if sub-thread, clean child caches if deleting a parent.
     let parentId = queryClient.getQueryData<Chat>(queryKeys.chat(chatId))?.parent_chat_id;
     const allCachedEntries = queryClient.getQueriesData<Chat | Chat[]>({ queryKey: ['chat'] });
     for (const [key, data] of allCachedEntries) {
@@ -344,18 +322,14 @@ export const useDeleteChatMutation = createMutation<void, Error, string>(
   },
 );
 
-// The sidebar presents one merged list, so "delete all" must reach both
-// backends. Each backend's wipe reconciles its own caches as it succeeds: a
-// partial failure is real (e.g. VPS offline) and the successful side's chats
-// are already gone server-side, so the UI must drop them even while the
-// aggregate error still surfaces to the caller.
+// Wipe both backends; drop successful side's caches even if the other fails (partial wipe is real).
 export const useDeleteAllChatsMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<void, Error, void>({
     mutationFn: async () => {
       const wipes = [
         chatService.deleteAllChats().then(() => {
-          // removeQueries on the prefix ['chats'] also clears chatsSearch entries.
+          // Prefix ['chats'] also clears chatsSearch.
           queryClient.removeQueries({ queryKey: [queryKeys.chats] });
           queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
         }),
@@ -372,7 +346,6 @@ export const useDeleteAllChatsMutation = () => {
         );
       }
       const results = await Promise.allSettled(wipes);
-      // Tabs/layouts are ephemeral — reset them whenever anything was wiped.
       if (results.some((result) => result.status === 'fulfilled')) {
         useUIStore.getState().cleanupAllChats();
       }
@@ -415,8 +388,7 @@ export const useCreateSubThreadMutation = (parentChatId: string) => {
         queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] }),
         queryClient.invalidateQueries({ queryKey: queryKeys.workspaces }),
       ]);
-      // A cloud parent lives in the cloud sidebar list, not the local infinite query —
-      // refetch it so the parent's bumped sub_thread_count unlocks the expand control.
+      // Cloud parent isn't in local infinite query — refresh so sub_thread_count unlocks expand.
       invalidateCloudChats(queryClient, parentChatId);
     },
   });

--- a/frontend/src/hooks/queries/useCloudQueries.ts
+++ b/frontend/src/hooks/queries/useCloudQueries.ts
@@ -14,8 +14,7 @@ import type { ChatSearchResponse } from '@/types/chat.types';
 
 const CLOUD_CHATS_PER_PAGE = 25;
 
-// Keyed by cloudUrl + connectedEmail so switching instance or account never
-// serves the previous connection's cached list.
+// Keyed by cloudUrl + connectedEmail so instance/account switches don't serve stale cache.
 export const useCloudWorkspacesQuery = (enabled: boolean) => {
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
   const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
@@ -27,8 +26,7 @@ export const useCloudWorkspacesQuery = (enabled: boolean) => {
   });
 };
 
-// Rename/delete a VPS workspace. cloudUrl + connectedEmail are read at cache-update
-// time so the invalidation targets the same instance/account the query is keyed by.
+// Read cloudUrl/email at invalidate time so the key matches the active instance.
 export const useCloudUpdateWorkspaceMutation = createMutation<
   Workspace,
   Error,
@@ -51,16 +49,12 @@ export const useCloudDeleteWorkspaceMutation = createMutation<void, Error, strin
       queryClient.invalidateQueries({
         queryKey: queryKeys.cloudWorkspaces(cloudUrl, connectedEmail),
       }),
-      // Prefix-invalidate every project's cloud chats — the deleted workspace's
-      // chats are gone server-side and the sidebar list must drop them.
       queryClient.invalidateQueries({ queryKey: queryKeys.cloudChatsAll }),
     ]);
   },
 );
 
-// VPS workspace skills and builtin slash-commands for the landing composer
-// before a chat exists. Keyed by cloudUrl + connectedEmail + workspaceId so
-// switching instance or account never serves the previous connection's cache.
+// Landing composer resources before a chat exists; keyed by instance + account + workspace.
 export const useCloudWorkspaceResourcesQuery = (
   workspaceId: string | undefined,
   enabled: boolean,
@@ -75,9 +69,7 @@ export const useCloudWorkspaceResourcesQuery = (
   });
 };
 
-// VPS user settings. Only personas are consumed on the landing page — local
-// settings (env vars, GitHub token, etc.) are separate. Keyed by cloudUrl +
-// connectedEmail so switching instance or account never serves stale cache.
+// VPS settings (landing uses personas only). Keyed by instance + account.
 export const useCloudSettingsQuery = (enabled: boolean) => {
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
   const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
@@ -89,8 +81,7 @@ export const useCloudSettingsQuery = (enabled: boolean) => {
   });
 };
 
-// Chats currently running on the VPS — the settings tab shows the count in its
-// connection overview. Polled so the number stays live while the tab is open.
+// Polled active VPS stream count for settings connection overview.
 export const useCloudActiveStreamsQuery = (enabled: boolean) => {
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
   const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
@@ -103,9 +94,7 @@ export const useCloudActiveStreamsQuery = (enabled: boolean) => {
   });
 };
 
-// Total chat count across all VPS workspaces for the settings connection
-// overview. per_page 1 keeps the payload minimal — only `total` is consumed.
-// Key extends queryKeys.cloudChats so existing invalidations prefix-match it.
+// Settings total only — per_page 1. Key under cloudChats so invalidations prefix-match.
 export const useCloudChatsTotalQuery = (enabled: boolean) => {
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
   const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
@@ -118,9 +107,7 @@ export const useCloudChatsTotalQuery = (enabled: boolean) => {
   });
 };
 
-// Cloud twin of useSearchChatsQuery — ChatSearchPanel merges the two result sets
-// like the sidebar merges its lists. Key extends queryKeys.cloudChats so
-// cloudChatsAll invalidations (deletes, renames) prefix-match it.
+// Cloud twin of useSearchChatsQuery; key under cloudChats for prefix invalidations.
 export const useSearchCloudChatsQuery = (query: string) => {
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
   const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);
@@ -129,19 +116,13 @@ export const useSearchCloudChatsQuery = (query: string) => {
     queryKey: [...queryKeys.cloudChats(cloudUrl, connectedEmail), 'search', trimmed] as const,
     queryFn: () => cloudChatService.searchChats(trimmed),
     enabled: !!cloudUrl && trimmed.length >= 2,
-    // Placeholder retention only while connected: after disconnect the origin
-    // tracking is cleared, so held-over VPS results would misroute when opened.
+    // No placeholder after disconnect — held-over VPS rows would misroute when opened.
     placeholderData: cloudUrl ? keepPreviousData : undefined,
     staleTime: 15_000,
   });
 };
 
-// Cloud chats across all VPS projects, paginated like the local sidebar list. The
-// queryFn registers returned IDs as cloud-owned (markCloudChats), so opening one
-// routes its messages/status/SSE to the VPS. New chats and runs arrive live via
-// the cloud events feed (useCloudChatEvents); the poll is a safety net for
-// changes the feed doesn't carry (titles, deletes, other-device edits). Key
-// extends queryKeys.cloudChats so the LandingPage invalidation prefix-matches it.
+// Paginated VPS chats; queryFn markCloudChats for routing. Poll safety-nets non-feed changes.
 export const useInfiniteCloudChatsQuery = (enabled: boolean = true) => {
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
   const connectedEmail = useCloudSettingsStore((state) => state.connectedEmail);

--- a/frontend/src/hooks/queries/useModelQueries.ts
+++ b/frontend/src/hooks/queries/useModelQueries.ts
@@ -34,9 +34,7 @@ export const useModelSelection = (options?: {
 
   const storedModelId = useModelStore((state) => state.modelByChat[chatId] ?? '');
 
-  // Models valid for this chat — restricted to the locked provider once the
-  // session kind is known; stale entries (retired ids, wrong-kind values
-  // persisted by old versions) count as invalid.
+  // Locked provider once session kind is known; stale/wrong-kind ids are invalid.
   const candidates = useMemo(
     () => (lockedAgentKind ? models.filter((m) => m.agent_kind === lockedAgentKind) : models),
     [models, lockedAgentKind],
@@ -44,15 +42,13 @@ export const useModelSelection = (options?: {
 
   const storedIsValid = candidates.some((m) => m.model_id === storedModelId);
 
-  // Expose invalid stored values as empty so a stale cross-provider selection
-  // can't be submitted while the real model is still resolving from history;
-  // pass stored through until the registry loads (nothing to validate yet).
+  // Empty while invalid so a stale cross-provider id can't be submitted mid-resolve.
   const selectedModelId = models.length === 0 || storedIsValid ? storedModelId : '';
 
   useEffect(() => {
     if (candidates.length === 0 || storedIsValid) return;
 
-    // Still loading initial model from message history — wait before defaulting
+    // null = still loading history; don't default yet.
     if (initialModelId === null) return;
 
     const fallback =
@@ -75,8 +71,7 @@ export const useModelSelection = (options?: {
   return { selectedModelId, selectedModel, selectModel };
 };
 
-// `/models/` is auth-protected — public-route callers must gate; default-on
-// keeps authenticated callers unchanged.
+// `/models/` is auth-protected — public callers must pass enabled=false.
 export function useModelMap(enabled: boolean = true): Map<string, Model> {
   const { data: models } = useModelsQuery({ enabled });
   return useMemo(

--- a/frontend/src/hooks/queries/useSandboxQueries.ts
+++ b/frontend/src/hooks/queries/useSandboxQueries.ts
@@ -26,8 +26,7 @@ export const useFileContentQuery = (
     queryKey: queryKeys.sandbox.fileContent(sandboxId, filePath),
     queryFn: () => sandboxService.getFileContent(sandboxId!, filePath!),
     enabled: !!sandboxId && !!filePath,
-    // The editor unmounts on every chat switch; outlive the default 2-minute gc
-    // so returning to a chat reopens its files from cache instead of refetching.
+    // Editor unmounts on chat switch; outlive default 2m gc so reopen hits cache.
     gcTime: 1000 * 60 * 30,
     ...options,
   });
@@ -42,8 +41,7 @@ export const useFilesMetadataQuery = (
     queryKey: queryKeys.sandbox.filesMetadata(sandboxId, cwd),
     queryFn: () => sandboxService.getSandboxFilesMetadata(sandboxId!, cwd),
     enabled: !!sandboxId,
-    // The listing is the slow sandbox call in the editor's reopen path; keep it
-    // cached across chat switches (ChatPage refetches it when the editor re-activates).
+    // Slow listing on reopen — keep across chat switches.
     gcTime: 1000 * 60 * 30,
     ...options,
   });
@@ -70,9 +68,7 @@ export const useUpdateFileMutation = createMutation<UpdateFileResult, Error, Upd
   },
 );
 
-// Every query derived from git state (diff content, per-file HEAD baselines,
-// change indicators) — git actions must refresh them together; one forgotten
-// key leaves the diff view or indicators stale.
+// All git-derived caches — refresh together or diff/indicators go stale.
 export const invalidateGitState = (queryClient: QueryClient, sandboxId: string) =>
   Promise.all([
     queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitDiffAll(sandboxId) }),
@@ -89,8 +85,7 @@ export const useGitBranchesQuery = (
     queryKey: queryKeys.sandbox.gitBranches(sandboxId, cwd),
     queryFn: () => sandboxService.getGitBranches(sandboxId!, cwd),
     enabled: !!sandboxId && enabled,
-    // Branches can change out-of-band (terminal `git checkout`, external tools), so refetch on
-    // window focus with a short stale window to pick those up without aggressive polling.
+    // Out-of-band branch changes (terminal/external) — focus refetch, short stale.
     staleTime: 30_000,
     refetchOnWindowFocus: true,
   });
@@ -104,9 +99,7 @@ export const useCheckoutBranchMutation = () => {
     onSuccess: async (data, variables) => {
       if (!data.success) return;
       await Promise.all([
-        // Checkout rewrites file contents wholesale; reset (not remove — remove
-        // doesn't refetch active observers) so an open editor file reloads from
-        // the new branch instead of keeping the old branch's buffer.
+        // reset (not remove) so open editors refetch the new branch's content.
         queryClient.resetQueries({
           queryKey: queryKeys.sandbox.fileContentAll(variables.sandboxId),
         }),
@@ -139,22 +132,18 @@ export const useGitDiffQuery = (
   });
 };
 
-// Repo-relative paths with uncommitted changes — powers change indicators
-// without fetching diff content.
+// Uncommitted paths for change indicators (no full diff).
 export const useGitChangedPathsQuery = (sandboxId: string | undefined, cwd?: string) => {
   return useQuery({
     queryKey: queryKeys.sandbox.gitChangedPaths(sandboxId, cwd),
     queryFn: () => sandboxService.getGitChangedPaths(sandboxId!, cwd),
     enabled: !!sandboxId,
-    // The working tree changes out-of-band (terminal commands, external tools),
-    // so refetch on window focus with a short stale window like branches do.
     staleTime: 30_000,
     refetchOnWindowFocus: true,
   });
 };
 
-// The committed (HEAD) version of a single file — the diff baseline the editor
-// compares the working buffer against.
+// HEAD content of a file — editor diff baseline.
 export const useGitFileBaselineQuery = (
   sandboxId: string | undefined,
   path: string | undefined,
@@ -165,8 +154,7 @@ export const useGitFileBaselineQuery = (
     queryKey: queryKeys.sandbox.gitFileBaseline(sandboxId, path, cwd),
     queryFn: () => sandboxService.getGitFileBaseline(sandboxId!, path!, cwd),
     enabled: !!sandboxId && !!path,
-    // HEAD only moves on explicit git actions (which invalidate this key); the
-    // short stale window still picks up out-of-band terminal commits on re-toggle.
+    // Invalidated on git actions; short stale still picks up terminal commits on re-toggle.
     staleTime: 30_000,
     ...options,
   });
@@ -241,7 +229,6 @@ export const useSearchInFilesQuery = (
       params.exclude,
     ),
     queryFn: () => sandboxService.searchInFiles(sandboxId!, params),
-    // Require at least 2 chars so we don't fire a giant match set on first keystroke.
     enabled: !!sandboxId && params.query.trim().length >= 2,
     placeholderData: keepPreviousData,
     staleTime: 15_000,
@@ -249,11 +236,8 @@ export const useSearchInFilesQuery = (
   });
 };
 
-// Diff paths are cwd-relative while the editor caches workspace-root-relative
-// paths (e.g. `.worktrees/<id>/src/App.tsx`), so targeting a specific
-// `fileContent` key would miss worktree entries. Invalidate the whole
-// file-content space under this sandbox instead. Restore doesn't move HEAD,
-// so gitFileBaselineAll is deliberately not refreshed here.
+// Diff paths are cwd-relative; editor caches are workspace-root-relative — invalidate all
+// fileContent under this sandbox. Restore doesn't move HEAD, so skip gitFileBaselineAll.
 export const invalidateAfterGitRestore = (queryClient: QueryClient, sandboxId: string) =>
   Promise.all([
     queryClient.invalidateQueries({ queryKey: queryKeys.sandbox.gitDiffAll(sandboxId) }),

--- a/frontend/src/hooks/queries/useSidebarChatLists.ts
+++ b/frontend/src/hooks/queries/useSidebarChatLists.ts
@@ -6,16 +6,12 @@ import {
 } from '@/hooks/queries/useCloudQueries';
 import type { Workspace } from '@/types/workspace.types';
 
-// The workspace a chat belongs to, shown as a badge on the row; cloud workspaces
-// live on the connected VPS and get a cloud icon. Identified by chat.workspace_id.
 export interface WorkspaceBadge {
   name: string;
   isCloud: boolean;
 }
 
-// Sidebar chat data: local and cloud chats live on separate backends, so three
-// queries (local pinned, local unpinned, cloud) are merged client-side into the
-// Pinned and Recents lists, with one loadMore advancing both paginated sources.
+// Merge local pinned/unpinned + cloud into Pinned/Recents; one loadMore advances both pages.
 export function useSidebarChatLists(workspaces: Workspace[], enabled: boolean = true) {
   const { data: pinnedChatsData } = useInfiniteChatsQuery({ pinned: true, enabled });
   const {

--- a/frontend/src/hooks/queries/useWorkspaceQueries.ts
+++ b/frontend/src/hooks/queries/useWorkspaceQueries.ts
@@ -37,8 +37,7 @@ export const useWorkspacesQuery = (
   });
 };
 
-// Memoize the items array so a missing `data` doesn't yield a new `[]` reference
-// each render — keeps downstream useMemo/useEffect deps stable.
+// Stable [] when data is missing — avoids new-ref churn for downstream deps.
 export const useWorkspacesList = (
   options?: Partial<UseQueryOptions<PaginatedResponse<Workspace>>>,
 ): Workspace[] => {

--- a/frontend/src/hooks/stream/cachePatch.ts
+++ b/frontend/src/hooks/stream/cachePatch.ts
@@ -4,10 +4,7 @@ import { patchChatInCache } from '@/hooks/queries/useChatQueries';
 import type { Message } from '@/types/chat.types';
 import type { PaginatedMessages } from '@/types/api.types';
 
-// Cross-chat cache mutators: unlike the hook-scoped useMessageCache (which
-// closes over the currently viewed chatId), these target a specific chat by
-// explicit parameter — needed when off-screen streams flush or finalize into
-// a chat the user has navigated away from.
+// Explicit chatId (unlike useMessageCache) — needed when off-screen streams flush.
 export function updateMessageInCacheForChat(
   queryClient: QueryClient,
   chatId: string,

--- a/frontend/src/hooks/stream/envelopeTranslation.ts
+++ b/frontend/src/hooks/stream/envelopeTranslation.ts
@@ -10,9 +10,7 @@ export function extractPayloadData(
     : undefined;
 }
 
-// Side-effect-only envelope kinds (system, permission_request) are handled
-// upstream in onEnvelope — this function only converts content-bearing kinds
-// into the AssistantStreamEvent shape consumed by the buffer.
+// Content-bearing kinds only; system/permission_request are handled in onEnvelope.
 export function envelopeToRenderEvent(envelope: StreamEnvelope): AssistantStreamEvent | null {
   const payload = envelope.payload as Record<string, unknown>;
 

--- a/frontend/src/hooks/useActiveChat.ts
+++ b/frontend/src/hooks/useActiveChat.ts
@@ -6,12 +6,7 @@ import type { Chat } from '@/types/chat.types';
 
 const NO_SPLIT_CHATS: string[] = [];
 
-// Resolves the chat for the pane the user last interacted with. In split view a
-// split pane is a different chat with its own sandbox/worktree, so actions
-// (git, sub-threads, …) target it when it's the active pane.
-//
-// `enabled` lets always-mounted callers (e.g. CommandMenu) gate the subscriptions
-// to stable values while inactive, so pane/split churn doesn't re-render them.
+// Active pane's chat (split panes are separate chats). `enabled` gates always-mounted callers.
 export function useActiveChat(enabled = true): Chat | null {
   const primaryChat = useChatStore((s) => (enabled ? s.currentChat : null));
   const activeAgentTile = useUIStore((s) => (enabled ? s.activeAgentTile : 'agent:primary'));

--- a/frontend/src/hooks/useActiveViews.ts
+++ b/frontend/src/hooks/useActiveViews.ts
@@ -3,10 +3,7 @@ import { useUIStore } from '@/store/uiStore';
 import { tileViewKinds } from '@/utils/tileHelpers';
 import type { ViewType } from '@/types/ui.types';
 
-// Derives the deduped list of on-screen view *kinds* (ViewType) from the visible
-// tiles. Two agent panes collapse to a single 'agent' entry here — consumers that
-// need per-tile awareness should read visibleLayout directly. useShallow keeps the
-// result referentially stable while the kinds are unchanged.
+// Deduped on-screen ViewTypes (two agent panes → one 'agent'). useShallow for stable ref.
 export function useActiveViews(): ViewType[] {
   return useUIStore(useShallow((state) => tileViewKinds(state.visibleLayout.flat())));
 }

--- a/frontend/src/hooks/useAnchoredPanel.ts
+++ b/frontend/src/hooks/useAnchoredPanel.ts
@@ -1,9 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-// Fixed-position panel anchored to a trigger, rendered via portal so it escapes
-// overflow-clipping ancestors (e.g. an overflow-x-auto toolbar — CSS clips both
-// axes). useDropdown can't cover this: it only handles outside-click for
-// panels positioned inside their trigger's stacking context.
+// Portal-anchored panel that escapes overflow-clipping ancestors (useDropdown can't).
 export function useAnchoredPanel(
   computePos: (triggerRect: DOMRect) => { top: number; left: number },
 ) {

--- a/frontend/src/hooks/useChatAgentKind.ts
+++ b/frontend/src/hooks/useChatAgentKind.ts
@@ -5,10 +5,7 @@ export function useChatAgentKind(
   chatId: string,
   sessionAgentKind: AgentKind | null | undefined,
 ): AgentKind | null {
-  // session_agent_kind is only persisted server-side mid-stream and refetched after
-  // completion — until then, derive the kind from the locally selected model so the
-  // provider glyph shows during a chat's first stream. No stored model means the kind
-  // is genuinely unknown (e.g. pre-existing chat from another device) — show no icon.
+  // session_agent_kind arrives mid-stream/after complete; until then derive from local model.
   const storedModelId = useModelStore((s) => s.modelByChat[chatId]);
   return sessionAgentKind ?? (storedModelId ? getAgentKindForModelId(storedModelId) : null);
 }

--- a/frontend/src/hooks/useChatData.ts
+++ b/frontend/src/hooks/useChatData.ts
@@ -15,10 +15,7 @@ export function useChatData(chatId: string | undefined): UseChatDataResult {
 
   const fetchedMessages = useMemo(() => {
     if (!messagesQuery.data?.pages) return [];
-    // Backend returns pages in DESC order (newest first). To display chronologically:
-    // 1. Reverse pages array so oldest page comes first
-    // 2. Reverse items within each page so oldest message comes first
-    // Result: [oldest...newest] for proper chat display order
+    // Backend pages are DESC (newest first); reverse pages and items for chronological UI.
     const reversedPages = [...messagesQuery.data.pages].reverse();
     const allMessages = reversedPages.flatMap((page) => [...page.items].reverse());
     const seen = new Set<string>();

--- a/frontend/src/hooks/useChatEvents.ts
+++ b/frontend/src/hooks/useChatEvents.ts
@@ -10,9 +10,7 @@ import { resyncActiveStreams } from '@/utils/activeStreams';
 import { logger } from '@/utils/logger';
 import type { ChatEvent } from '@/types/chat.types';
 
-// Subscribes to the backend's per-user chat lifecycle SSE feed so chats created
-// and turns started out-of-band (e.g. by agents via the MCP server) surface
-// live — sidebar entry, chat tab, and running indicator — without a refresh.
+// Per-user chat lifecycle SSE: out-of-band creates/turns (MCP, agents) surface live.
 export function useChatEvents(options?: { enabled?: boolean }) {
   const enabled = options?.enabled ?? true;
   const queryClient = useQueryClient();
@@ -43,8 +41,7 @@ export function useChatEvents(options?: { enabled?: boolean }) {
       }
 
       if (parsed.kind === 'title_updated') {
-        // Backfilled mid-stream by the background titling task — patch caches
-        // directly so the sidebar/tab rename without waiting for a refetch.
+        // Mid-stream title backfill — patch caches so sidebar/tab rename without refetch.
         patchChatInCache(queryClient, parsed.chat_id, (chat) => ({
           ...chat,
           title: parsed.title,
@@ -53,19 +50,14 @@ export function useChatEvents(options?: { enabled?: boolean }) {
       }
 
       if (parsed.kind === 'stream_started') {
-        // Turns started out-of-band on existing chats emit no chat_created,
-        // so the running chat must join the tab strip here.
+        // Out-of-band turns on existing chats skip chat_created — open the tab here.
         useUIStore.getState().openChatTab(parsed.chat_id);
-        // The turn bumps updated_at ordering server-side — refetch the sidebar
-        // lists so the chat surfaces even from outside the loaded pages.
+        // Server bumps updated_at — refetch so chats outside loaded pages surface.
         queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
         queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
-        // The turn also records its model/thinking/persona on the chat — drop
-        // the cached detail so the toolbar seeds from what actually ran
-        // instead of a copy cached before the turn (5-minute staleTime).
+        // Drop cached detail so toolbar seeds model/thinking/persona from this turn.
         queryClient.invalidateQueries({ queryKey: queryKeys.chat(parsed.chat_id) });
-        // Self-started turns are already tracked via addStream; settled turns
-        // are cleaned up by useGlobalStream's orphan pruning.
+        // Self-starts already have addStream; settled orphans pruned by useGlobalStream.
         useStreamStore.getState().addStreamMetadataIfAbsent({
           chatId: parsed.chat_id,
           messageId: parsed.message_id,
@@ -77,11 +69,7 @@ export function useChatEvents(options?: { enabled?: boolean }) {
     const unsubscribe = subscribeChatEventsFeed({
       createSource: () => chatService.createChatEventsSource(),
       onChatEvent,
-      // Events published while the feed was down are lost — refetch the sidebar
-      // lists, refetch active per-chat caches (titles, sub-threads, context
-      // usage — the live path patches those directly), and re-register active
-      // streams so a missed stream_started still gets its running indicator
-      // (startup restoration only runs once).
+      // Missed events while feed was down — refetch lists/caches and re-register streams.
       onResync: () => {
         void queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
         void queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });

--- a/frontend/src/hooks/useChatStreaming.ts
+++ b/frontend/src/hooks/useChatStreaming.ts
@@ -61,10 +61,7 @@ interface UseChatStreamingResult {
   streamState: StreamState;
 }
 
-// Top-level hook that wires together the streaming pipeline for a single chat view.
-// Composes useStreamCallbacks (envelope processing), useStreamReconnect (resume on
-// navigation), useMessageActions (send/stop), and useInputState (draft persistence).
-// Returns the full set of state and handlers consumed by the chat UI components.
+// Per-chat streaming pipeline: useStreamCallbacks, useStreamReconnect, useMessageActions, useInputState.
 export function useChatStreaming({
   chatId,
   currentChat,
@@ -133,9 +130,7 @@ export function useChatStreaming({
     onPendingUserMessageIdChange: setPendingUserMessageIdState,
   });
 
-  // Keep the global stream store's callbacks in sync with the latest hook closures.
-  // Streams outlive individual renders, so without this the store would dispatch
-  // events through stale callbacks that close over outdated chatId/messages.
+  // Streams outlive renders — keep store callbacks pointed at the latest closures.
   useEffect(() => {
     if (!chatId) return;
 
@@ -197,9 +192,6 @@ export function useChatStreaming({
     }
   }, [chatId]);
 
-  // Subscribes to the stream store and mirrors active-stream presence into
-  // local React state (streamState, currentMessageId). This is the bridge
-  // between the global EventSource lifecycle and the per-chat UI indicators.
   useEffect(() => {
     if (!chatId) return;
 
@@ -255,10 +247,7 @@ export function useChatStreaming({
     setPendingUserMessageId(null);
   }, [setPendingUserMessageId]);
 
-  // Sends stop requests for one or all active streams in the current chat.
-  // Immediately marks the UI as idle (optimistic) and tracks pending stops
-  // so active stream presence does not flip the UI back to streaming while
-  // the stop request is in flight.
+  // Track pending stops so store presence doesn't flip UI back to streaming mid-flight.
   const stopActiveStreams = useCallback(
     async (messageId?: string) => {
       const pendingIds = new Set<string>();
@@ -345,7 +334,6 @@ export function useChatStreaming({
         draftFiles,
       );
       if (!result?.success) {
-        // Send failed or was rejected (validation toast) — restore the draft.
         setInputMessageWithRef(draftMessage);
         setInputFiles(draftFiles);
         if (chatId) {

--- a/frontend/src/hooks/useCloudChatEvents.ts
+++ b/frontend/src/hooks/useCloudChatEvents.ts
@@ -12,8 +12,7 @@ import { resyncActiveStreams } from '@/utils/activeStreams';
 import { logger } from '@/utils/logger';
 import type { ChatEvent } from '@/types/chat.types';
 
-// Cloud lists reorder server-side and refetch on invalidation anyway, so a full
-// refetch is simpler than the local feed's optimistic first-page insert.
+// Full refetch is simpler than local's optimistic insert — cloud lists reorder server-side.
 function invalidateCloudLists(queryClient: QueryClient): void {
   const { cloudUrl, connectedEmail } = useCloudSettingsStore.getState();
   void queryClient.invalidateQueries({ queryKey: queryKeys.cloudChatsAll });
@@ -22,9 +21,7 @@ function invalidateCloudLists(queryClient: QueryClient): void {
   });
 }
 
-// Cloud twin of useChatEvents: subscribes to the VPS's per-user chat lifecycle
-// SSE feed so chats created and turns started on the VPS (agents, other devices)
-// surface live instead of waiting for the next sidebar poll.
+// Cloud twin of useChatEvents — VPS lifecycle SSE so remote creates/turns surface live.
 export function useCloudChatEvents(options?: { enabled?: boolean }) {
   const enabled = options?.enabled ?? true;
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
@@ -33,9 +30,7 @@ export function useCloudChatEvents(options?: { enabled?: boolean }) {
   useEffect(() => {
     if (!enabled || !cloudUrl) return;
 
-    // Guards in-flight resync snapshots across disconnect/VPS switch — a late
-    // response from the old instance must not register ghost stream indicators
-    // (same generation guard useCloudStreamRestoration uses).
+    // Cancel in-flight resync on disconnect/VPS switch (same guard as useCloudStreamRestoration).
     let cancelled = false;
 
     const onChatEvent = (event: MessageEvent) => {
@@ -66,8 +61,7 @@ export function useCloudChatEvents(options?: { enabled?: boolean }) {
       }
 
       if (parsed.kind === 'title_updated') {
-        // Patch reaches the single-chat cache (tabs/header); cloud sidebar rows
-        // live in their own list query, so refetch those.
+        // Single-chat cache for tabs/header; cloud sidebar is a separate list query.
         patchChatInCache(queryClient, parsed.chat_id, (chat) => ({
           ...chat,
           title: parsed.title,
@@ -77,17 +71,11 @@ export function useCloudChatEvents(options?: { enabled?: boolean }) {
       }
 
       if (parsed.kind === 'stream_started') {
-        // Out-of-band turns can hit chats this device never listed (e.g. fresh
-        // sub-threads) — mark before the global watcher reconnects to them.
+        // Mark cloud-owned before reconnect — turn may be on a chat this device never listed.
         markCloudChats([parsed.chat_id]);
         useUIStore.getState().openChatTab(parsed.chat_id);
         invalidateCloudLists(queryClient);
-        // The turn also records its model/thinking/persona on the chat — drop
-        // the cached detail so the toolbar seeds from what actually ran
-        // instead of a copy cached before the turn (5-minute staleTime).
         void queryClient.invalidateQueries({ queryKey: queryKeys.chat(parsed.chat_id) });
-        // Self-started turns are already tracked via addStream; settled turns
-        // are cleaned up by useGlobalStream's orphan pruning.
         useStreamStore.getState().addStreamMetadataIfAbsent({
           chatId: parsed.chat_id,
           messageId: parsed.message_id,
@@ -99,12 +87,7 @@ export function useCloudChatEvents(options?: { enabled?: boolean }) {
     const unsubscribe = subscribeChatEventsFeed({
       createSource: () => cloudChatService.createChatEventsSource(),
       onChatEvent,
-      // Events published while the feed was down are lost — refetch the cloud
-      // lists so chats created/renamed on the VPS during the gap surface,
-      // refetch active per-chat caches (titles, sub-threads), and re-register
-      // active streams so a missed stream_started still gets its running
-      // indicator (connection-time restoration doesn't re-run).
-      // getActiveStreams also marks the chat IDs cloud-owned before reconnect.
+      // Missed events while down; getActiveStreams also marks chat IDs cloud-owned.
       onResync: () => {
         invalidateCloudLists(queryClient);
         void queryClient.invalidateQueries({ queryKey: ['chat'] });

--- a/frontend/src/hooks/useCloudStreamRestoration.ts
+++ b/frontend/src/hooks/useCloudStreamRestoration.ts
@@ -4,11 +4,7 @@ import { registerActiveStreams } from '@/utils/activeStreams';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import { cloudChatService } from '@/services/cloudChatService';
 
-// Restores active VPS streams in one bulk request — the cloud instance runs the
-// same backend as local, so its registry-backed active-streams endpoint covers
-// every chat and sub-thread without a per-chat status fan-out. Runs once per
-// connection (keyed by cloudUrl); streams started while the app is open arrive
-// live via useCloudChatEvents.
+// Bulk restore active VPS streams once per connection; live starts go via useCloudChatEvents.
 export function useCloudStreamRestoration({ enabled }: { enabled: boolean }) {
   const cloudUrl = useCloudSettingsStore((state) => state.cloudUrl);
 

--- a/frontend/src/hooks/useCommandMenu.ts
+++ b/frontend/src/hooks/useCommandMenu.ts
@@ -24,7 +24,7 @@ export function useCommandMenu() {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!(e.ctrlKey || e.metaKey) || !e.shiftKey) return;
 
-      // Cmd/Ctrl+Shift+P toggles the command menu (skip inside Monaco/xterm which have their own command palette)
+      // Skip Monaco/xterm — they own their own command palette.
       if (e.code === 'KeyP') {
         if (isEmbeddedEditor(e.target)) return;
         e.preventDefault();

--- a/frontend/src/hooks/useContextUsageState.ts
+++ b/frontend/src/hooks/useContextUsageState.ts
@@ -13,11 +13,7 @@ interface UseContextUsageStateResult {
   updateContextUsage: (data: ContextUsage, chatId?: string) => void;
 }
 
-// Three sources feed token usage, each arriving at different times:
-// (1) the chat object's cached `context_token_usage` for instant display on
-// navigation, (2) the dedicated context-usage query for accurate numbers
-// after load, and (3) live SSE system envelopes during streaming via
-// `updateContextUsage`. Whichever writes last wins.
+// Token usage from chat cache (nav), context-usage query (load), or live SSE — last write wins.
 export function useContextUsageState(
   chatId: string | undefined,
   currentChat: Chat | undefined,
@@ -59,8 +55,7 @@ export function useContextUsageState(
     setTokensUsed(contextUsageData.tokens_used);
   }, [chatId, contextUsageData]);
 
-  // Called from SSE system envelopes during streaming. Ignores updates for
-  // off-screen chats so token counts don't bleed across chat switches.
+  // Ignore off-screen chat updates so counts don't bleed across switches.
   const updateContextUsage = useCallback((data: ContextUsage, incomingChatId?: string) => {
     if (incomingChatId && incomingChatId !== currentChatIdRef.current) {
       return;

--- a/frontend/src/hooks/useDebouncedValue.ts
+++ b/frontend/src/hooks/useDebouncedValue.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 
-// Debounced copy of a fast-changing string (search inputs). Empty values flush
-// immediately so clearing a search resets results without waiting out the delay.
+// Empty values flush immediately so clearing search doesn't wait out the delay.
 export function useDebouncedValue(value: string, delayMs: number): string {
   const [debounced, setDebounced] = useState(value);
   useEffect(() => {

--- a/frontend/src/hooks/useDesktopZoom.ts
+++ b/frontend/src/hooks/useDesktopZoom.ts
@@ -19,8 +19,7 @@ function applyZoom(zoom: number) {
 }
 
 export function useDesktopZoom() {
-  // Cmd/Ctrl +/-/0 zoom the webview — Tauri has no built-in zoom shortcuts,
-  // and zoom doesn't survive restarts, so the stored level is reapplied on mount.
+  // Tauri has no built-in zoom; reapply stored level on mount.
   useMountEffect(() => {
     if (!isDesktopApp()) return;
 

--- a/frontend/src/hooks/useDiffComments.ts
+++ b/frontend/src/hooks/useDiffComments.ts
@@ -19,14 +19,11 @@ function normalizeSelection(range: SelectedLineRange): SelectedLineRange {
   return { start: range.end, end: range.start, side: range.side, endSide: range.endSide };
 }
 
-// Diff-view review comments: one line selection at a time across all files;
-// `composing` flips on when the drag ends, which opens the composer. Submits
-// attach the selection + comment to the chat input as an editor-selection chip.
+// Diff review comments → editor-selection chip on the chat input. `composing` opens on drag end.
 export function useDiffComments(chatId: string | undefined, cwd: string | undefined) {
   const [pendingComment, setPendingComment] = useState<PendingDiffComment | null>(null);
 
-  // Raw (anchor-order) range during the drag — it matches the library's own
-  // representation, so the equality guards inside the manager stay effective.
+  // Keep raw anchor-order during drag so the library's equality guards stay effective.
   const handleSelectionChange = useCallback((fileName: string, range: SelectedLineRange | null) => {
     setPendingComment(range ? { fileName, range, composing: false } : null);
   }, []);

--- a/frontend/src/hooks/useDraftField.ts
+++ b/frontend/src/hooks/useDraftField.ts
@@ -1,7 +1,6 @@
 import { useRef, useState } from 'react';
 
-// Holds a local draft so typing doesn't fire a mutation per keystroke.
-// Re-syncs from savedValue on external updates; persists only when the value changed on blur.
+// Local draft so typing isn't a mutation per keystroke; persists on blur only if changed.
 export function useDraftField(savedValue: string, onPersist: (value: string) => void) {
   const [draft, setDraft] = useState(savedValue);
   const prevSavedRef = useRef(savedValue);

--- a/frontend/src/hooks/useDragAndDrop.ts
+++ b/frontend/src/hooks/useDragAndDrop.ts
@@ -7,9 +7,7 @@ interface UseDragAndDropOptions {
 
 export function useDragAndDrop({ onFilesDrop, disabled = false }: UseDragAndDropOptions = {}) {
   const [isDragging, setIsDragging] = useState(false);
-  // Tracks enter/leave balance across child elements — dragenter/dragleave
-  // fire for every descendant, so a simple boolean would flicker. Only reset
-  // isDragging when the counter reaches 0 (cursor left the drop zone entirely).
+  // enter/leave fire per descendant — counter avoids flicker; reset only at 0.
   const dragCounter = useRef(0);
 
   const handleDragIn = useCallback(

--- a/frontend/src/hooks/useEditorDrafts.ts
+++ b/frontend/src/hooks/useEditorDrafts.ts
@@ -3,16 +3,12 @@ import type { FileStructure } from '@/types/file-system.types';
 
 interface UseEditorDraftsArgs {
   selectedFile: FileStructure | null;
-  // Loaded server content for the active file, or undefined until it resolves.
   selectedFileContent: string | undefined;
   sandboxId: string | undefined;
   onCloseFile: (path: string) => void;
 }
 
-// Owns the editor's per-file unsaved buffers: the live content of the active file,
-// a draft per open path, the dirty set that drives the tab dots, and the close
-// confirmation flow. Drafts are session-scoped to one sandbox (see the reset) and are
-// NOT persisted — switching tabs preserves them, but a chat/sandbox switch drops them.
+// Session-scoped unsaved buffers (not persisted). Tab switches keep drafts; sandbox/chat switch drops them.
 export function useEditorDrafts({
   selectedFile,
   selectedFileContent,
@@ -20,24 +16,18 @@ export function useEditorDrafts({
   onCloseFile,
 }: UseEditorDraftsArgs) {
   const [currentContent, setCurrentContent] = useState('');
-  // path + baseline for the active file; the baseline is the saved content the
-  // live buffer diffs against.
+  // Active file + saved baseline the live buffer diffs against.
   const prevSelectedFileRef = useRef<FileStructure | null>(null);
-  // Per-file unsaved buffers (path -> content).
   const draftsRef = useRef<Map<string, string>>(new Map());
-  // The paths of those dirty buffers, mirrored in state so each tab renders its own
-  // unsaved dot (any open tab can be dirty, not just the active one).
+  // Mirrored in state so every tab can show its own unsaved dot.
   const [dirtyPaths, setDirtyPaths] = useState<Set<string>>(() => new Set());
-  // The dirty tab awaiting a discard confirmation before it closes (null = no prompt).
   const [pendingClosePath, setPendingClosePath] = useState<string | null>(null);
   const prevSandboxIdRef = useRef(sandboxId);
   const selectedFilePath = selectedFile?.path ?? null;
 
   if (prevSandboxIdRef.current !== sandboxId) {
-    // The editor pane is reused across chats/sandboxes without remounting (the split
-    // and landing editors aren't keyed by chat), and drafts are keyed by path only —
-    // so drop the previous sandbox's buffers to avoid bleeding edits into another
-    // sandbox's same-path file. Null prevSelectedFileRef so the content effect re-inits.
+    // Pane isn't remounted across chats; drafts are path-keyed only — drop them so
+    // same-path files don't bleed across sandboxes. Null prev so content effect re-inits.
     prevSandboxIdRef.current = sandboxId;
     draftsRef.current.clear();
     prevSelectedFileRef.current = null;
@@ -45,13 +35,10 @@ export function useEditorDrafts({
     if (pendingClosePath !== null) setPendingClosePath(null);
   }
 
-  // Active file's dirty flag, derived from the per-file dirty set (single source of truth).
   const hasUnsavedChanges = !!selectedFilePath && dirtyPaths.has(selectedFilePath);
   const hasLoadedSelectedFile = prevSelectedFileRef.current?.path === selectedFile?.path;
 
-  // Single writer for a file's draft buffer — keeps draftsRef and the dirtyPaths render
-  // mirror in lockstep so no call site has to update both. `null` content clears the
-  // draft (and drives the per-tab unsaved dot off).
+  // Single writer keeps draftsRef and dirtyPaths in lockstep; null clears the draft.
   const setDraft = useCallback((path: string, content: string | null) => {
     const isDirty = content !== null;
     if (isDirty) draftsRef.current.set(path, content);
@@ -67,9 +54,7 @@ export function useEditorDrafts({
 
   useEffect(() => {
     if (!selectedFile) {
-      // No active file (e.g. the last tab was closed/discarded): drop the stale buffer and
-      // baseline so reopening the same path reloads from the server instead of resurrecting
-      // the old content as if it were clean.
+      // Drop baseline so reopening the same path reloads from the server, not stale buffer.
       prevSelectedFileRef.current = null;
       setCurrentContent('');
       return;
@@ -85,15 +70,10 @@ export function useEditorDrafts({
 
     if (fileChanged || queryContentChanged) {
       const baseline = selectedFileContent ?? '';
-      // Restore an unsaved draft once content has loaded — covers a tab switch, a
-      // deferred load, and an external update (agent edited the file mid-draft):
-      // the user's unsaved buffer always wins over refetched content, rebased on
-      // the new baseline so the dirty diff tracks the current server state.
-      // Guarded on loaded content to not race the async fetch.
+      // User draft wins over refetch; only read once content loaded (avoid racing the fetch).
       const draft =
         selectedFileContent !== undefined ? draftsRef.current.get(selectedFile.path) : undefined;
-      // The refetch may return exactly what the draft already says (the agent
-      // made the same edit) — the buffer is no longer dirty then.
+      // Agent made the same edit — draft matches baseline, no longer dirty.
       if (draft !== undefined && draft === baseline) {
         setDraft(selectedFile.path, null);
       }
@@ -103,14 +83,11 @@ export function useEditorDrafts({
         content: baseline,
       };
 
-      // dirtyPaths already reflects this file's draft (kept in sync by handleEditorChange),
-      // so the derived hasUnsavedChanges is correct without a separate write here.
       setCurrentContent(draft ?? baseline);
     }
   }, [selectedFile, selectedFileContent, setDraft]);
 
-  // File selection updates before the content effect resets state; keep the previous
-  // file's text out of Monaco during that one render.
+  // Selection updates before the content effect; hide previous file's text for that render.
   const displayContent = hasLoadedSelectedFile ? currentContent : (selectedFileContent ?? '');
 
   const handleEditorChange = useCallback(
@@ -121,15 +98,12 @@ export function useEditorDrafts({
 
       const baseline = prevSelectedFileRef.current?.content ?? '';
       const path = prevSelectedFileRef.current?.path;
-      // Persist the draft (or clear it once it matches the saved baseline) so the buffer
-      // survives a tab switch and the tab's unsaved dot stays accurate.
       if (path) setDraft(path, value !== baseline ? value : null);
     },
     [setDraft],
   );
 
-  // Closing a clean tab is immediate; closing a dirty one prompts first, since its
-  // draft lives only in this session and would be discarded with no further warning.
+  // Dirty close prompts first — draft is session-only and would be discarded silently.
   const handleCloseTab = useCallback(
     (path: string) => {
       if (dirtyPaths.has(path)) setPendingClosePath(path);
@@ -147,9 +121,7 @@ export function useEditorDrafts({
 
   const cancelCloseTab = useCallback(() => setPendingClosePath(null), []);
 
-  // After a save succeeds: rebaseline the saved file (if still active) so further edits
-  // diff against disk, and clear its draft. Scoped to the saved path captured at submit
-  // time, not the now-active tab.
+  // Rebaseline the saved path (not the now-active tab) so further edits diff against disk.
   const commitSave = useCallback(
     (savedPath: string, submitted: string) => {
       if (prevSelectedFileRef.current?.path === savedPath) {

--- a/frontend/src/hooks/useEditorState.ts
+++ b/frontend/src/hooks/useEditorState.ts
@@ -10,13 +10,11 @@ const EMPTY_PATHS: string[] = [];
 // same store map as real chats (cleared on landing mount — see LandingPage).
 const LANDING_KEY = '__landing_editor__';
 
-// Append a path to the open-tab list, preserving order and de-duping.
 function openPath(open: string[], path: string): string[] {
   return open.includes(path) ? open : [...open, path];
 }
 
-// Remove a tab. When the active tab closes, selection falls back to its right
-// neighbor, then its left, then nothing; otherwise selection is unchanged.
+// Active tab close → right neighbor, else left, else null.
 function closeTab(open: string[], closed: string, selected: string | null): EditorPaneState {
   const idx = open.indexOf(closed);
   const next = open.filter((p) => p !== closed);
@@ -30,43 +28,31 @@ export function useEditorState(
   fileStructure: FileStructure[],
 ) {
   const [isRefreshing, setIsRefreshing] = useState(false);
-  // Both the chat editor and the landing editor stash their selection/tabs in the
-  // store keyed by chat id (or LANDING_KEY) — selection survives EditorPane unmount,
-  // and switching chatId reads a different entry so files can't bleed across chats.
+  // Store-keyed selection survives EditorPane unmount; per-chat keys prevent bleed.
   const key = chatId ?? LANDING_KEY;
   const entry = useUIStore((s) => s.editorByChat[key]);
   const selectedFilePath = entry?.selected ?? null;
   const openFilePaths = entry?.open ?? EMPTY_PATHS;
 
-  // Resolve a stored path to a tree file, falling back to a stub so a file opened
-  // before the tree loads (e.g. a tool's "open in editor") still renders.
+  // Stub fallback so "open in editor" before the tree loads still renders.
   const resolveFile = useCallback(
     (path: string): FileStructure =>
       findFileByToolPath(fileStructure, path) ?? { path, type: 'file', content: '' },
     [fileStructure],
   );
 
-  // Derived from the stashed path + fileStructure (no re-seed effect needed): the
-  // derivation recomputes when the tree loads, and pending editor opens write the
-  // path directly via setSelectedFile. Not gated on the tree being loaded — the
-  // stub fallback lets the file-content fetch run in parallel with the slow
-  // metadata listing instead of serializing behind it.
+  // Not gated on tree load — stub lets file-content fetch run in parallel with metadata.
   const selectedFile = useMemo(() => {
     if (!selectedFilePath) return null;
     return resolveFile(selectedFilePath);
   }, [selectedFilePath, resolveFile]);
 
-  // The open tabs, resolved in stored order. Tabs only track which files are open;
-  // View holds the active buffer and preserves per-file unsaved drafts across tab
-  // switches/closes within the session.
   const openFiles = useMemo(() => openFilePaths.map(resolveFile), [openFilePaths, resolveFile]);
 
   const setSelectedFile = useCallback(
     (file: FileStructure | null) => {
       useUIStore.setState((s) => {
         if (!file) {
-          // Deselect drops the whole entry — active file and tabs (landing's reset/switch).
-          // No-op when the key was never present (the common case for the mount reset).
           if (!(key in s.editorByChat)) return {};
           const next = { ...s.editorByChat };
           delete next[key];
@@ -84,14 +70,11 @@ export function useEditorState(
     [key],
   );
 
-  // Closing a tab drops it and, if it was active, re-aims selection at a neighbor.
-  // (A dirty tab is confirmed in View before this runs, and its draft discarded there.)
   const closeFile = useCallback(
     (path: string) => {
       useUIStore.setState((s) => {
         const cur = s.editorByChat[key];
         if (!cur || !cur.open.includes(path)) return {};
-        // Selection and tabs update atomically — no chance of the two drifting apart.
         return {
           editorByChat: { ...s.editorByChat, [key]: closeTab(cur.open, path, cur.selected) },
         };

--- a/frontend/src/hooks/useEditorTheme.ts
+++ b/frontend/src/hooks/useEditorTheme.ts
@@ -128,9 +128,7 @@ const DARK_THEME: monaco.editor.IStandaloneThemeData = {
   },
 };
 
-// Custom palettes reuse the light/dark syntax rules and only re-skin the surfaces,
-// so the editor canvas matches the themed chrome instead of staying white/black.
-// surface = editor.background; widget = suggest/widget popup background.
+// Reuse light/dark syntax; re-skin surfaces so canvas matches chrome (not white/black).
 function skin(
   base: monaco.editor.IStandaloneThemeData,
   tokens: PaletteTokens,
@@ -163,7 +161,6 @@ function skin(
   };
 }
 
-// editor canvas = surfaceSecondary; suggest/widget popup = the deeper surface.
 const CUSTOM_THEMES = Object.fromEntries(
   (Object.keys(CUSTOM_PALETTE_TOKENS) as CustomPalette[]).map((p) => {
     const tokens = CUSTOM_PALETTE_TOKENS[p];
@@ -181,7 +178,6 @@ const THEME_DATA: Record<Palette, monaco.editor.IStandaloneThemeData> = {
 export function useEditorTheme() {
   const resolvedTheme = useResolvedTheme();
   const rawTheme = useUIStore((s) => s.theme);
-  // Only `system` needs resolving; every other theme is itself a palette
   const palette: Palette = rawTheme === 'system' ? resolvedTheme : rawTheme;
   const themeName = `custom-${palette}`;
 
@@ -193,8 +189,7 @@ export function useEditorTheme() {
         monaco.editor.defineTheme(`custom-${name}`, data);
       }
 
-      // Monaco runs in the browser without the repo's tsconfig/node_modules, so semantic
-      // diagnostics mark valid imports and React types as missing. Keep syntax checks only.
+      // Browser Monaco has no repo tsconfig — semantic diagnostics false-flag imports/React types.
       monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
         noSemanticValidation: true,
         noSuggestionDiagnostics: true,

--- a/frontend/src/hooks/useExitPlanMode.ts
+++ b/frontend/src/hooks/useExitPlanMode.ts
@@ -8,9 +8,7 @@ export function useExitPlanMode(chatId: string | undefined) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // The ExitPlanMode request renders in its own tool card, independent of the
-  // inline permission prompt, so pick it out of the queue wherever it sits
-  // rather than only checking the head.
+  // Own tool card — find anywhere in the queue, not only the head.
   const pendingRequest = usePermissionStore((state) => {
     if (!chatId) return null;
     const queue = state.pendingRequests.get(chatId);

--- a/frontend/src/hooks/useFirstPaint.ts
+++ b/frontend/src/hooks/useFirstPaint.ts
@@ -2,10 +2,8 @@ import { useState } from 'react';
 import { useMountEffect } from '@/hooks/useMountEffect';
 
 export function useFirstPaint(): boolean {
-  // False for the mounting render, true right after first paint. Heavy views
-  // return a fallback for that one render so a navigation's commit paints
-  // immediately instead of blocking on their subtree; hooks above the early
-  // return still run, so data fetching starts during the deferred frame.
+  // False on mount, true after first paint — heavy views can fallback one frame so nav paints
+  // immediately while hooks above the early-return still start fetches.
   const [hasPainted, setHasPainted] = useState(false);
   useMountEffect(() => setHasPainted(true));
   return hasPainted;

--- a/frontend/src/hooks/useGlobalStream.ts
+++ b/frontend/src/hooks/useGlobalStream.ts
@@ -10,27 +10,19 @@ interface UseGlobalStreamOptions {
 
 const STREAM_PRUNE_INTERVAL_MS = 5000;
 
-// Re-check liveness immediately before removing — a live EventSource may have
-// attached (user opened/reconnected the sub-thread) while the status request was
-// in flight, and removeStreamMetadata would tear it down. Such streams self-clean
-// via removeStream on completion, so skip them.
+// Re-check before remove — an EventSource may attach while the status request is in flight.
 function pruneIfStillOrphan(chatId: string, markDone: boolean): void {
   const store = useStreamStore.getState();
   if (!store.getStreamByChat(chatId)) {
     store.removeStreamMetadata(chatId);
-    // Orphan streams have no EventSource, so no complete envelope ever fires —
-    // the confirmed-settled prune is their only Done signal. A failed status
-    // probe is a cleanup guess, not evidence the turn completed, so it doesn't
-    // earn the badge.
+    // Orphans have no complete envelope; only confirmed-settled prune earns the Done badge
+    // (a failed status probe is a guess, not evidence of completion).
     if (markDone) store.markCompleted(chatId);
   }
 }
 
-// Reconciles the in-memory stream store with the server, pruning metadata whose
-// backend task has settled so the UI stops showing stale "streaming" indicators.
-// Runs on an interval (not just at mount) because background sub-threads — e.g.
-// stream actions — register metadata without opening a client EventSource, so
-// the normal removeStream cleanup never fires for them.
+// Interval reconcile: background sub-threads register metadata without an EventSource,
+// so removeStream never fires for them — prune settled orphans so indicators clear.
 export function useGlobalStream(options?: UseGlobalStreamOptions) {
   const hasPrunedRef = useRef(false);
   const enabled = options?.enabled ?? true;
@@ -41,10 +33,7 @@ export function useGlobalStream(options?: UseGlobalStreamOptions) {
 
     const pruneStaleStreams = async () => {
       const store = useStreamStore.getState();
-      // Only reconcile orphan metadata (no live EventSource). Entries with an
-      // active stream self-clean via removeStream on the completion event —
-      // pruning them here would tear down a live foreground stream at its
-      // completion boundary.
+      // Only orphans — pruning a live EventSource would tear down a foreground stream.
       const orphans = store.activeStreamMetadata.filter(
         (meta) => !store.getStreamByChat(meta.chatId),
       );

--- a/frontend/src/hooks/useInputAttachments.ts
+++ b/frontend/src/hooks/useInputAttachments.ts
@@ -8,8 +8,6 @@ interface UseInputAttachmentsOptions {
   onAttach?: (files: File[]) => void;
 }
 
-// File preview URLs, attach/remove/draw operations, drag-and-drop, and paste —
-// everything that turns dropped/pasted/selected files into chat attachments.
 export function useInputAttachments({ attachedFiles, onAttach }: UseInputAttachmentsOptions) {
   const { previewUrls } = useFileHandling({
     initialFiles: attachedFiles,

--- a/frontend/src/hooks/useInputEnhance.ts
+++ b/frontend/src/hooks/useInputEnhance.ts
@@ -9,8 +9,6 @@ interface UseInputEnhanceOptions {
   hasMessage: boolean;
 }
 
-// Prompt enhancement: fire the enhance mutation, swap the enhanced text in, and
-// refocus the textarea with the caret at the end.
 export function useInputEnhance({
   setMessage,
   textareaRef,

--- a/frontend/src/hooks/useInputSubmit.ts
+++ b/frontend/src/hooks/useInputSubmit.ts
@@ -86,8 +86,7 @@ export function useInputSubmit({
     if (disabled) return;
 
     if (isStreaming && hasContent && chatId) {
-      // Mirror the send path's model guard — queueMessage is fire-and-forget
-      // and the draft is cleared below, so a rejected queue call loses the message.
+      // Fire-and-forget queue + clear draft — guard model or the message is lost.
       if (!selectedModelId) {
         toast.error('Please select an AI model');
         return;
@@ -106,7 +105,6 @@ export function useInputSubmit({
       const fastMode = settings.fastModeByChat[chatId] ?? DEFAULT_FAST_MODE;
       const storedPersona = settings.personaByChat[chatId] ?? DEFAULT_PERSONA;
       const validPersona = resolvePersona(storedPersona, personas);
-      // Queued messages are stored as plain text, so serialize chips here.
       const fullMessage = formatComposerSelections(attachedSelections, messageRef.current.trim());
       void useMessageQueueStore.getState().queueMessage(chatId, fullMessage, selectedModelId, {
         permissionMode,

--- a/frontend/src/hooks/useInputSuggestions.ts
+++ b/frontend/src/hooks/useInputSuggestions.ts
@@ -20,8 +20,6 @@ interface UseInputSuggestionsOptions {
   agentKind: AgentKind;
 }
 
-// Slash-command and @mention suggestion dropdowns, plus the shared token-insertion
-// path that replaces the active `/` or `@` query with the chosen value.
 export function useInputSuggestions({
   message,
   cursorPosition,

--- a/frontend/src/hooks/useLocalStreamRestoration.ts
+++ b/frontend/src/hooks/useLocalStreamRestoration.ts
@@ -3,9 +3,7 @@ import { logger } from '@/utils/logger';
 import { registerActiveStreams } from '@/utils/activeStreams';
 import { chatService } from '@/services/chatService';
 
-// Restores local streams in one bulk request — the backend enumerates its
-// in-process stream registry, so no per-chat or per-sub-thread status fan-out
-// is needed no matter how many chats or sub-threads exist.
+// One bulk restore against the backend's in-process registry — no per-chat status fan-out.
 export function useLocalStreamRestoration({ enabled }: { enabled: boolean }) {
   const hasRestoredRef = useRef(false);
 

--- a/frontend/src/hooks/useLogout.ts
+++ b/frontend/src/hooks/useLogout.ts
@@ -2,7 +2,6 @@ import { useNavigate } from 'react-router-dom';
 import { useLogoutMutation } from '@/hooks/queries/useAuthQueries';
 import { useAuthStore } from '@/store/authStore';
 
-// Shared logout flow: tears down the session, drops the auth flag, and routes to /login.
 export function useLogout() {
   const navigate = useNavigate();
   return useLogoutMutation({

--- a/frontend/src/hooks/useMessageActions.ts
+++ b/frontend/src/hooks/useMessageActions.ts
@@ -47,10 +47,8 @@ const isEmptyBotPlaceholder = (msg?: Message) =>
   (!msg?.content_render?.events || msg.content_render.events.length === 0) &&
   !msg.content_text;
 
-// Exposes two layers: `sendMessage` opens the SSE stream and injects the
-// assistant placeholder into state; `handleMessageSend` is the form-level
-// wrapper that validates input size, creates the optimistic user message,
-// and rolls it back on failure.
+// `sendMessage` opens the SSE stream + injects the assistant placeholder;
+// `handleMessageSend` validates, optimistically inserts the user message, and rolls back on failure.
 export function useMessageActions({
   chatId,
   selectedModelId,
@@ -146,7 +144,6 @@ export function useMessageActions({
           checkpoint_id: checkpointId,
         };
 
-        // Replace a trailing empty placeholder if present, otherwise append.
         setMessages((prev) => {
           const lastMessage = prev[prev.length - 1];
           if (isEmptyBotPlaceholder(lastMessage)) {

--- a/frontend/src/hooks/useMessageCache.ts
+++ b/frontend/src/hooks/useMessageCache.ts
@@ -9,14 +9,10 @@ interface UseMessageCacheParams {
   queryClient: QueryClient;
 }
 
-// Direct query-cache mutators for messages. These write into the react-query
-// infinite-query pages structure (pages[].items[]) so that optimistic UI updates
-// (streaming content, new messages, deletions) are visible without a refetch.
-// Scoped to the current chatId — callers needing cross-chat writes must use
-// queryClient directly with the target chatId.
+// Optimistic message writes into the infinite-query pages for the current chatId only
+// (cross-chat callers must use queryClient + target chatId directly).
 export function useMessageCache({ chatId, queryClient }: UseMessageCacheParams) {
-  // Uses unshift into page 0 so newest messages match the backend's DESC
-  // ordering. Optionally prepends the paired user message when both arrive together.
+  // unshift into page 0 matches backend DESC ordering.
   const addMessageToCache = useCallback(
     (message: Message, userMessage?: Message) => {
       if (!chatId) return;

--- a/frontend/src/hooks/useMessageInitialization.ts
+++ b/frontend/src/hooks/useMessageInitialization.ts
@@ -18,10 +18,7 @@ interface UseMessageInitializationParams {
   setInitialPrompt: (prompt: string) => void;
 }
 
-// Normalizes fetched messages (attachment file types, default fields) and
-// seeds local state. Also handles the "initial prompt" flow where a new chat
-// is created from a route param or navigation state — injects a synthetic
-// user message so the chat starts without waiting for the first API round-trip.
+// Normalize fetched messages into local state; inject synthetic user msg for route initial prompts.
 export function useMessageInitialization({
   fetchedMessages,
   chatId,
@@ -40,8 +37,7 @@ export function useMessageInitialization({
   useEffect(() => {
     if (!fetchedMessages || !chatId || isLoading || wasAborted) return;
 
-    // Skip reprocessing during streaming to preserve attachment references and prevent image flashing,
-    // but always allow initialization when switching to a different chat
+    // Skip reprocess while streaming (attachment refs / image flash), but re-init on chat switch.
     if (isStreaming && initializedChatRef.current === chatId) return;
 
     const normalizedMessages = fetchedMessages.map((msg: Message) => {

--- a/frontend/src/hooks/usePermissionRequest.ts
+++ b/frontend/src/hooks/usePermissionRequest.ts
@@ -16,18 +16,13 @@ interface UsePermissionRequestReturn {
   handleReject: (optionId: string) => Promise<void>;
 }
 
-// Manages the tool-permission approval flow for a single chat. Reads the
-// pending request from the global permission store, sends approve/reject
-// responses to the backend, and auto-dismisses 404s (expired requests where
-// the backend already timed out or the stream moved on).
+// Tool-permission approval for one chat; 404s (expired/timed-out requests) auto-dismiss.
 export function usePermissionRequest(chatId: string | undefined): UsePermissionRequestReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { data: settings } = useSettingsQuery();
 
-  // Surface the head of this chat's permission queue. Selecting only this
-  // chat's queue avoids re-renders from other chats' permission changes; we
-  // process requests one at a time in FIFO order.
+  // Select only this chat's queue so other chats' permission changes don't re-render us.
   const pendingRequest = usePermissionStore((state) => {
     if (!chatId) return null;
     const queue = state.pendingRequests.get(chatId);
@@ -35,8 +30,7 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
   });
   const prevRequestIdRef = useRef(pendingRequest?.request_id);
 
-  // Clear stale error when a new permission request arrives, so errors from
-  // a previous request don't bleed into the new approval dialog.
+  // Don't bleed a previous request's error into the next dialog.
   if (prevRequestIdRef.current !== pendingRequest?.request_id) {
     prevRequestIdRef.current = pendingRequest?.request_id;
     if (error !== null) setError(null);

--- a/frontend/src/hooks/useRunStreamAction.ts
+++ b/frontend/src/hooks/useRunStreamAction.ts
@@ -12,8 +12,7 @@ import { getAgentKindForModelId } from '@/types/chat.types';
 import type { Chat } from '@/types/chat.types';
 import type { StreamAction } from '@/types/user.types';
 
-// Spawns a stream action as a sub-thread: creates the sub-thread, fires its
-// turn server-side, then navigates to the new chat so the user lands on it.
+// Spawns a stream action as a sub-thread, starts the turn server-side, then navigates there.
 export function useRunStreamAction(parentChat: Chat | undefined) {
   const navigate = useNavigate();
   const createSubThread = useCreateSubThreadMutation(parentChat?.id ?? '');
@@ -62,8 +61,7 @@ export function useRunStreamAction(parentChat: Chat | undefined) {
         });
 
         toast.success(`Started "${action.label}"`);
-        // Land on the sub-thread — navigating also adds its tab to the title
-        // bar via loadWorkspaceForChat.
+        // Navigation also adds the tab via loadWorkspaceForChat.
         navigate(`/chat/${newChat.id}`);
       } catch (error) {
         toast.error(error instanceof Error ? error.message : `Failed to start "${action.label}"`);

--- a/frontend/src/hooks/useSkillsFilter.ts
+++ b/frontend/src/hooks/useSkillsFilter.ts
@@ -19,7 +19,6 @@ export function useSkillsFilter(items: CustomSkill[], workspaceId: string | unde
     setSearchQuery('');
   }
 
-  // Only offer chips for sources actually present in the current skills.
   const availableSources = useMemo<string[]>(() => {
     const present = new Set<string>();
     for (const skill of items) {

--- a/frontend/src/hooks/useSlashCommandSuggestions.ts
+++ b/frontend/src/hooks/useSlashCommandSuggestions.ts
@@ -25,7 +25,6 @@ export const useSlashCommandSuggestions = ({
   const allCommands = useMemo(() => {
     const builtins = builtinSlashCommands[agentKind];
 
-    // Custom skills filtered to match the active agent kind
     const skillCommands: SlashCommand[] = customSkills
       .filter((skill) => skill.sources.includes(agentKind))
       .map((skill) => ({

--- a/frontend/src/hooks/useSmoothText.ts
+++ b/frontend/src/hooks/useSmoothText.ts
@@ -12,19 +12,13 @@ const MAX_TICK_DELTA_MS = 100;
 const HIGH_SURROGATE_RE = /[\uD800-\uDBFF]/;
 
 export function useSmoothText(text: string, animate: boolean): string {
-  // Stream flushes grow `text` in multi-word chunks; this reveals it at a
-  // backlog-proportional rate so it reads word-by-word like a typewriter.
-  // When `animate` is false the input passes through untouched.
-  // Text present at mount shows immediately — reconnect/navigation mounts an
-  // in-progress stream with buffered output, and replaying it from blank would
-  // hide content the user already saw. Only post-mount appends animate.
+  // Init to full length so reconnect/nav mounts show buffered content immediately;
+  // only post-mount appends animate.
   const [visibleCount, setVisibleCount] = useState(text.length);
   const visibleCountRef = useRef(visibleCount);
   const textRef = useRef(text);
   textRef.current = text;
 
-  // Snap to the full text the moment animation stops (stream finished or the
-  // segment is no longer the tail) so nothing stays hidden.
   if (!animate && visibleCountRef.current !== text.length) {
     visibleCountRef.current = text.length;
     setVisibleCount(text.length);

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -36,11 +36,7 @@ import {
 } from '@/hooks/stream/messageUpdates';
 import { envelopeToRenderEvent, extractPayloadData } from '@/hooks/stream/envelopeTranslation';
 
-// Batching window for streaming content updates. Envelopes arrive at token-level
-// granularity (~10-50ms apart); flushing on every token would thrash React state
-// and the query cache. 50ms keeps the text cadence smooth (~20 updates/sec) —
-// affordable because memoized markdown blocks and segments mean each flush only
-// re-renders the growing tail of the message.
+// Token envelopes arrive ~10-50ms apart; 50ms batching (~20/s) avoids thrashing React/cache.
 const STREAM_FLUSH_INTERVAL_MS = 50;
 
 interface UseStreamCallbacksParams {
@@ -78,10 +74,7 @@ interface UseStreamCallbacksResult {
   setPendingUserMessageId: (id: string | null) => void;
 }
 
-// Core streaming pipeline: receives raw SSE envelopes, buffers renderable
-// content per stream, and flushes batched updates to React state and the query
-// cache on a coalescing timer. Also owns the start/replay/stop lifecycle
-// and the terminal handlers (complete, error, queue continuation).
+// SSE pipeline: buffer envelopes, flush on a coalescing timer, own start/replay/stop + terminal handlers.
 export function useStreamCallbacks({
   messages,
   chatId,
@@ -156,10 +149,7 @@ export function useStreamCallbacks({
     return envelopes ?? [];
   }, []);
 
-  // Writes the buffer's collected tokens to React state (live chat) and/or
-  // the query cache (so navigating away and back preserves progress). Only touches
-  // React state when the session's chat is on screen — off-screen streams still
-  // write to the cache so content isn't lost on chat switch.
+  // Live state only when on-screen; always can write cache so off-screen progress survives switches.
   const flushBufferedContent = useCallback(
     (streamId: string, { writeToCache }: { writeToCache: boolean }) => {
       const buffer = buffersRef.current.get(streamId);
@@ -181,8 +171,7 @@ export function useStreamCallbacks({
     [setMessages, queryClient],
   );
 
-  // Coalescing timer: only one pending flush per stream. Multiple envelopes arriving
-  // within the same window are batched into a single flushBufferedContent call.
+  // One pending flush timer per stream.
   const scheduleContentFlush = useCallback(
     (streamId: string) => {
       if (flushTimersRef.current.has(streamId)) {
@@ -199,9 +188,7 @@ export function useStreamCallbacks({
     [flushBufferedContent],
   );
 
-  // Returns (or creates) the content buffer for a stream. On first call for a
-  // given streamId, seeds the buffer from the message's existing content so that
-  // reconnections append to prior content rather than starting from blank.
+  // Seed from existing message content so reconnections append rather than blank.
   const ensureBuffer = useCallback(
     (
       streamId: string,
@@ -220,10 +207,7 @@ export function useStreamCallbacks({
         return existing;
       }
 
-      // Seed from the on-screen message (fast path) or the query cache (off-screen chat).
-      // Fall back to the cache when the on-screen lookup misses: right after a chat
-      // switch an envelope can arrive before the remounted view has populated
-      // messages state, and seeding empty would truncate the in-progress message.
+      // Cache fallback: post-switch envelopes can arrive before messages state is populated.
       let seedEvents: AssistantStreamEvent[] = [];
       let seedText = '';
       const existingMessage =
@@ -242,8 +226,7 @@ export function useStreamCallbacks({
         messageId,
         lastSeq: seq,
         chatId: streamChatId,
-        // The chat query is warm here (the stream was just started/replayed from
-        // it); resolving at completion time instead could miss after gc eviction.
+        // Resolve now while chat query is warm — completion-time resolve can miss after gc.
         sandboxId: queryClient.getQueryData<Chat>(queryKeys.chat(streamChatId))?.sandbox_id,
       });
 
@@ -262,8 +245,7 @@ export function useStreamCallbacks({
       timerIdsRef.current.forEach(clearTimeout);
       timerIdsRef.current = [];
 
-      // Flush any pending content to the query cache before clearing,
-      // so content already cursor-acked in chatStorage is not lost on unmount.
+      // Flush pending content so cursor-acked progress isn't lost on unmount.
       for (const [streamId, timer] of flushTimers.entries()) {
         clearTimeout(timer);
         const buffer = buffers.get(streamId);
@@ -289,10 +271,7 @@ export function useStreamCallbacks({
     [onPendingUserMessageIdChange],
   );
 
-  // Central dispatch for every envelope arriving from the EventSource. Handles
-  // side-effect-only events (permissions, system metadata, plan mode transitions)
-  // inline, then delegates renderable content (text, thinking, tools) to the
-  // buffer → scheduleContentFlush pipeline for batched UI updates.
+  // Side-effect kinds inline; renderable content → buffer + coalesced flush.
   const onEnvelope = useCallback(
     (envelope: StreamEnvelope) => {
       if (pendingStopRef.current.has(envelope.messageId)) {
@@ -302,13 +281,11 @@ export function useStreamCallbacks({
         return;
       }
 
-      // First envelope for a message clears the optimistic "sending…" indicator.
       if (pendingUserMessageIdRef.current && chatId === chatIdRef.current) {
         setPendingUserMessageId(null);
       }
 
-      // Permission requests are dispatched directly to the modal system and
-      // never accumulate into the message content — early return skips the pipeline.
+      // Permissions go to the modal, not message content.
       if (envelope.kind === 'permission_request' && onPermissionRequest) {
         const payload = envelope.payload as Record<string, unknown>;
         const request_id = typeof payload.request_id === 'string' ? payload.request_id : undefined;
@@ -367,8 +344,7 @@ export function useStreamCallbacks({
           useChatSettingsStore.getState().setPermissionMode(chatId, 'plan');
         } else if (tool?.name === 'ExitPlanMode' && chatId) {
           if (tool.permission_mode) {
-            // The backend's ExitPlanMode tool emits one of the known PermissionMode
-            // values; the payload types it as a plain string.
+            // Payload types as string; backend emits a known PermissionMode.
             useChatSettingsStore
               .getState()
               .setPermissionMode(chatId, tool.permission_mode as PermissionMode);
@@ -409,11 +385,7 @@ export function useStreamCallbacks({
     ],
   );
 
-  // Terminal handler for a finished stream. Flushes any buffered content,
-  // clears per-stream session state, marks the message as completed/interrupted,
-  // and triggers post-stream side effects (notifications, file metadata refresh,
-  // usage/context invalidation). Runs for both on-screen and off-screen chats
-  // so the cache stays consistent, but only resets UI state for the active chat.
+  // Terminal complete: flush, clear session, side effects. Cache always; UI state only if active chat.
   const onComplete = useCallback(
     (
       messageId?: string,
@@ -424,7 +396,6 @@ export function useStreamCallbacks({
       const resolvedStreamId = streamId ?? findStreamIdByMessage(messageId);
       const isCancelled = terminalKind === 'cancelled';
       const isCurrentChat = chatId === chatIdRef.current;
-      // Capture before clearStreamSession deletes it
       const session = resolvedStreamId
         ? streamSessionsRef.current.get(resolvedStreamId)
         : undefined;
@@ -435,13 +406,11 @@ export function useStreamCallbacks({
         flushBufferedContent(resolvedStreamId, { writeToCache: true });
       }
 
-      // Session cleanup is stateless and safe for any chat; always run it.
       clearStreamSession(resolvedStreamId);
 
       const targetChatId = sessionChatId ?? chatId;
 
-      // Cache finalization must run even for off-screen chats so returning
-      // to the chat within the staleTime window doesn't show a stuck message.
+      // Finalize cache even off-screen so return within staleTime isn't stuck.
       if (messageId) {
         pendingStopRef.current.delete(messageId);
         pendingStopEnvelopesRef.current.delete(messageId);
@@ -449,9 +418,7 @@ export function useStreamCallbacks({
           ...message,
           active_stream_id: null,
           stream_status: isCancelled ? 'interrupted' : 'completed',
-          // Backend records the run duration at the terminal snapshot and ships
-          // it on the complete event, so the rollup shows the real time without
-          // waiting for a refetch. Older messages persisted before this carry null.
+          // Prefer complete-event duration so the rollup shows real time without refetch.
           duration_ms: durationMs ?? message.duration_ms,
         });
         if (targetChatId) {
@@ -464,49 +431,35 @@ export function useStreamCallbacks({
         }
       }
 
-      // Invalidate the chat-search cache regardless of whether the completed
-      // stream belongs to the on-screen chat — otherwise off-screen completions
-      // (background turns) leave search results stale for up to staleTime.
+      // Off-screen completions would leave search stale for up to staleTime.
       queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
 
-      // Chat metadata (title, updated_at, context usage) is mutated server-side
-      // during the turn, so it must refresh even when the completion lands while
-      // the user is viewing another chat.
+      // Server mutates title/updated_at/context during the turn — refresh even if off-screen.
       if (targetChatId) {
         queryClient.invalidateQueries({ queryKey: queryKeys.chat(targetChatId), exact: true });
       }
 
-      // Sandbox state (files, branches) is mutated server-side during the turn,
-      // so refresh it even when the completion lands off-screen — the long-lived
-      // file caches would otherwise serve stale content when the user returns to
-      // that chat. Cancelled runs still leave real file/branch side effects, so
-      // this is not kind-gated — only the notification below is.
+      // Refresh sandbox caches even off-screen (incl. cancelled — real file/branch effects).
       const targetSandboxId =
         sessionSandboxId ?? (isCurrentChat ? currentChat?.sandbox_id : undefined);
       if (targetSandboxId) {
         queryClient.invalidateQueries({
           queryKey: queryKeys.sandbox.filesMetadataAll(targetSandboxId),
         });
-        // Reset, not remove — remove doesn't refetch active observers, so an
-        // open editor file would keep showing the pre-turn content.
+        // reset (not remove) so open editors refetch; remove leaves stale buffers.
         queryClient.resetQueries({
           queryKey: queryKeys.sandbox.fileContentAll(targetSandboxId),
         });
-        // Agent may have switched/created a branch during the turn (e.g. `git checkout -b`),
-        // so refresh the branch list to keep the UI in sync with HEAD.
         queryClient.invalidateQueries({
           queryKey: queryKeys.sandbox.gitBranchesAll(targetSandboxId),
         });
-        // The turn's file edits change git state (and the agent may have
-        // committed mid-turn) — refresh diff, baselines, and change indicators.
         void invalidateGitState(queryClient, targetSandboxId);
       }
 
       if (!isCurrentChat) return;
 
-      // The turn bumped updated_at at initiation and the user watched it finish —
-      // re-stamp the read marker so a later sidebar refetch doesn't flag it unread.
-      // Sub-thread completions routed through this pane weren't being viewed; skip.
+      // Re-stamp read so initiation's updated_at bump doesn't re-flag unread.
+      // Skip sub-threads routed through this pane that weren't being viewed.
       if (targetChatId && targetChatId === chatId) {
         void markChatViewed(queryClient, targetChatId);
       }
@@ -527,8 +480,7 @@ export function useStreamCallbacks({
           queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
           queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
         }
-        // Context usage aggregation runs as a background task after the stream
-        // completes; 6s gives it time to finish before we refetch.
+        // Aggregation is a post-stream background task — wait before refetch.
         timerIdsRef.current.push(
           setTimeout(() => {
             queryClient.invalidateQueries({ queryKey: queryKeys.contextUsage(chatId) });
@@ -567,10 +519,7 @@ export function useStreamCallbacks({
 
       const targetChatId = sessionChatId ?? chatId;
 
-      // Mark the assistant message as failed instead of removing it —
-      // the user message and assistant message are already persisted in
-      // the DB by the time the SSE error event arrives. Mirror the backend's
-      // persisted snapshot update here so the live UI matches a refreshed chat.
+      // Don't remove — already persisted; mirror backend snapshot so live UI matches refresh.
       if (assistantMessageId) {
         const markFailed = buildFailedMessageUpdate(streamError);
         if (targetChatId) {
@@ -585,8 +534,7 @@ export function useStreamCallbacks({
 
       if (!isCurrentChat) return;
 
-      // Same read re-stamp as onComplete — a watched failure is still seen
-      // activity, and the initiation bump would otherwise flag the chat unread.
+      // Same read re-stamp as onComplete (watched failure is still seen activity).
       if (targetChatId && targetChatId === chatId) {
         void markChatViewed(queryClient, targetChatId);
       }
@@ -611,9 +559,7 @@ export function useStreamCallbacks({
     ],
   );
 
-  // Handles queue continuation — when the backend picks up a queued follow-up
-  // message, this injects the new user+assistant message pair into both the cache
-  // and React state, and flushes any stale sessions from the previous turn.
+  // Backend picked up a queued follow-up: inject the new pair and flush prior-turn sessions.
   const onQueueProcess = useCallback(
     (data: QueueProcessingData) => {
       if (!chatId) return;
@@ -680,10 +626,7 @@ export function useStreamCallbacks({
         checkpoint_id: data.checkpointId,
       };
 
-      // Cache updates must run even for off-screen chats so returning
-      // within the staleTime window shows the queued continuation messages.
-      // Batch both messages into a single setQueryData call to avoid double
-      // cache churn and subscriber notifications.
+      // Cache even off-screen; single setQueryData for both msgs to avoid double churn.
       queryClient.setQueryData(
         queryKeys.messages(chatId),
         (oldData: { pages: PaginatedMessages[]; pageParams: unknown[] } | undefined) => {
@@ -706,8 +649,7 @@ export function useStreamCallbacks({
 
       setMessages((prev) => [...prev, userMessage, assistantMessage]);
       setCurrentMessageId(data.assistantMessageId);
-      // Anchor the queued turn to the top like a normal send — Chat's anchor
-      // handshake keys off the pending user message id.
+      // Anchor handshake keys off pending user message id (same as normal send).
       setPendingUserMessageId(data.userMessageId);
     },
     [
@@ -721,10 +663,7 @@ export function useStreamCallbacks({
     ],
   );
 
-  // Stash the latest callbacks in a ref so startStream/replayStream — which are
-  // intentionally stable (only the stable queryClient in deps) so re-renders
-  // don't re-fire the effects that consume them — always dispatch through the
-  // freshest closures.
+  // startStream/replayStream stay stable (queryClient-only deps); dispatch via freshest closures.
   optionsRef.current = chatId ? { chatId, onEnvelope, onComplete, onError, onQueueProcess } : null;
 
   const startStream = useCallback(
@@ -748,9 +687,7 @@ export function useStreamCallbacks({
       };
 
       const result = await streamService.startStream(streamOptions);
-      // A first worktree turn creates the worktree during the send request —
-      // patch the cache now so branch/terminal/editor UI switches immediately
-      // instead of waiting for the stream config event.
+      // First worktree turn creates during send — patch now so UI doesn't wait for config event.
       if (result.worktreeCwd) {
         patchChatWorktreeCwd(queryClient, currentOptions.chatId, result.worktreeCwd);
       }

--- a/frontend/src/hooks/useStreamReconnect.ts
+++ b/frontend/src/hooks/useStreamReconnect.ts
@@ -23,10 +23,7 @@ interface UseStreamReconnectParams {
   replayStream: (messageId: string, afterSeq?: number) => Promise<string>;
 }
 
-// On chat entry (navigation, page refresh), polls the server for an active task,
-// resolves the replay cursor from the highest of (server last_seq, local chatStorage
-// seq, message last_seq), then replays the SSE stream from that point so the UI
-// catches up without re-fetching the full history.
+// On chat entry: poll active task, resume SSE from max(server/local/message seq).
 export function useStreamReconnect({
   chatId,
   fetchedMessages,
@@ -84,16 +81,13 @@ export function useStreamReconnect({
         const existingMessage = messages.find((msg) => msg.id === targetMessageId);
         const messageExists = existingMessage != null;
 
-        // Pick the highest known seq across three sources: server status, local
-        // storage (persisted across page refreshes), and the message's own cursor.
-        // Whichever is highest is the safest point to resume from without duplicates.
+        // Resume from max(server, local storage, message cursor) to avoid duplicates.
         const reconnectSeq = status.last_seq ?? existingMessage?.last_seq ?? 0;
         const storedSeqRaw = chatStorage.getEventId(chatId);
         const storedSeq = storedSeqRaw ? Number(storedSeqRaw) : Number.NaN;
         const normalizedStoredSeq = Number.isFinite(storedSeq) && storedSeq > 0 ? storedSeq : 0;
         const normalizedReconnectSeq = reconnectSeq > 0 ? reconnectSeq : 0;
-        // If the active assistant message is absent locally, start replay from 0 so
-        // we rebuild the full message instead of resuming from a truncated cursor.
+        // Missing local message → replay from 0 (truncated cursor would drop content).
         const replayAfterSeq = messageExists
           ? Math.max(normalizedStoredSeq, normalizedReconnectSeq)
           : 0;
@@ -103,9 +97,7 @@ export function useStreamReconnect({
           chatStorage.removeEventId(chatId);
         }
 
-        // If the message isn't in the local cache yet (e.g., it was created while
-        // the user was on a different chat), inject a placeholder so the replay
-        // pipeline has a target message to write content into.
+        // Placeholder so replay has a target when the message was created off-screen.
         if (!messageExists) {
           const placeholderMessage: Message = {
             id: targetMessageId,
@@ -127,9 +119,7 @@ export function useStreamReconnect({
           setMessages((prev) => [...prev, placeholderMessage]);
         }
 
-        // Replay registers the stream on the shared connection and cannot fail
-        // synchronously — a connection that ultimately gives up routes through
-        // the stream's onError callback (message marked failed, UI reset there).
+        // Failures surface via onError (no sync throw from shared connection register).
         await replayStream(targetMessageId, replayAfterSeq);
       } catch (checkError) {
         logger.error('Active task check failed', 'useStreamReconnect', checkError);

--- a/frontend/src/hooks/useSuggestionBase.ts
+++ b/frontend/src/hooks/useSuggestionBase.ts
@@ -7,11 +7,8 @@ interface UseSuggestionBaseOptions<T> {
   onSelect: (item: T) => void;
 }
 
-// Shared keyboard-navigation logic for suggestion dropdowns (mentions, slash
-// commands). Manages highlighted index, arrow/enter/tab/escape key handling,
-// and wrapping. Consumers provide the filtered suggestions list and an onSelect
-// callback; this hook returns a stable handleKeyDown that integrates via refs
-// so it never causes the input to re-mount.
+// Keyboard nav for suggestion dropdowns. handleKeyDown is stable (empty deps) and
+// reads via refs so consumers don't remount the input when the list changes.
 export const useSuggestionBase = <T>({
   suggestions,
   hasSuggestions,
@@ -24,7 +21,6 @@ export const useSuggestionBase = <T>({
   const onSelectRef = useRef(onSelect);
   const highlightedIndexRef = useRef(highlightedIndex);
 
-  // Reset/clamp highlighted index when suggestions change
   if (suggestionsRef.current !== suggestions || hasSuggestionsRef.current !== hasSuggestions) {
     if (!hasSuggestions) {
       if (highlightedIndex !== 0) setHighlightedIndex(0);
@@ -33,7 +29,6 @@ export const useSuggestionBase = <T>({
     }
   }
 
-  // Always sync refs for handleKeyDown callback access
   suggestionsRef.current = suggestions;
   hasSuggestionsRef.current = hasSuggestions;
   onSelectRef.current = onSelect;

--- a/frontend/src/hooks/useXterm.ts
+++ b/frontend/src/hooks/useXterm.ts
@@ -10,10 +10,7 @@ import { buildTerminalTheme } from '@/utils/terminal';
 import type { TerminalSize } from '@/types/sandbox.types';
 import type { Palette } from '@/types/ui.types';
 
-// Write-only OSC 52: an OSC 52 query ('?') from a sandbox process must not be
-// able to read the user's clipboard back through the PTY — tmux copy-mode
-// only needs the write direction. navigator.clipboard is undefined in
-// non-secure contexts (self-hosted plain-http), so degrade to a silent no-op.
+// Write-only OSC 52 — sandbox must not read clipboard via PTY; silent no-op without secure clipboard.
 const WRITE_ONLY_CLIPBOARD: IClipboardProvider = {
   readText: () => Promise.resolve(''),
   writeText: (selection, text) =>
@@ -39,16 +36,14 @@ interface UseXtermReturn {
 
 export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): UseXtermReturn => {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
-  // Assigned only after open() succeeds, so consumers (fit, theme, writes)
-  // never touch a terminal whose renderer doesn't exist yet.
+  // Set only after open() succeeds — consumers must not touch a missing renderer.
   const terminalRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const searchAddonRef = useRef<SearchAddon | null>(null);
   const [isReady, setIsReady] = useState(false);
   const [initAttempt, setInitAttempt] = useState(0);
 
-  // Route callbacks/theme through refs so the open-once effect and the stable
-  // fitTerminal don't re-run (tearing down the terminal) on parent re-renders.
+  // Refs so open-once / stable fitTerminal don't re-run (and tear down) on re-render.
   const onDataRef = useRef(onData);
   const onFitRef = useRef(onFit);
   const modeRef = useRef(mode);
@@ -57,8 +52,7 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
   modeRef.current = mode;
 
   const hasInitializedRef = useRef(false);
-  // Once created, keep the terminal alive through visibility toggles so a
-  // hidden tab doesn't lose its scrollback.
+  // Stay alive through visibility toggles so hidden tabs keep scrollback.
   const shouldInitialize = hasInitializedRef.current || isVisible;
 
   const fitTerminal = useCallback((): TerminalSize | null => {
@@ -68,8 +62,7 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
       return null;
     }
 
-    // proposeDimensions returns undefined/NaN while the wrapper has no size
-    // (hidden tab, mid-layout) — skip instead of resizing to a garbage grid.
+    // Skip zero-size wrappers — would resize to a garbage grid.
     const proposed = fitAddon.proposeDimensions();
     if (!proposed || !Number.isFinite(proposed.rows) || !Number.isFinite(proposed.cols)) {
       return null;
@@ -91,8 +84,7 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
       return undefined;
     }
 
-    // Opening xterm into a zero-size element makes the renderer measure a
-    // broken cell grid — wait for the wrapper to gain real dimensions first.
+    // Wait for real dimensions — open into zero-size measures a broken cell grid.
     const rect = container.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) {
       const observer = new ResizeObserver((entries) => {
@@ -117,12 +109,11 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
         import('@xterm/addon-search'),
       ]);
 
-      // Wait for the Nerd Font before first paint so the renderer measures
-      // cell dimensions against the real glyphs, not the fallback (cold load).
+      // Measure cells against Nerd Font glyphs, not the cold-load fallback.
       try {
         await document.fonts?.load('12px "JetBrainsMono Nerd Font"');
       } catch {
-        // Font unavailable — open anyway; text falls back to monospace.
+        // Open anyway; text falls back to monospace.
       }
 
       if (cancelled || !container.isConnected) {
@@ -130,15 +121,12 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
       }
 
       xterm = new Terminal({
-        // The search addon's match decorations use registerDecoration, which
-        // xterm still gates as a proposed API.
+        // Search decorations use registerDecoration (still a proposed API).
         allowProposedApi: true,
-        // tmux attaches without the alternate screen (smcup@ override), so this
-        // buffer is the scroll/search history — sized to tmux's history-limit.
+        // No alternate screen (tmux smcup@) — this is scroll/search history.
         scrollback: 10000,
         fontSize: 14,
-        // Nerd Font primary so PUA icon glyphs (eza/ls icons, Starship prompt
-        // symbols) render; generic monospace is only a last-resort fallback.
+        // Nerd Font for PUA icons; monospace only as last-resort fallback.
         fontFamily: '"JetBrainsMono Nerd Font", monospace',
         theme: buildTerminalTheme(modeRef.current),
       });
@@ -146,10 +134,8 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
       xterm.loadAddon(fitAddon);
       const searchAddon = new SearchAddon();
       xterm.loadAddon(searchAddon);
-      // OSC 52 → system clipboard: inner apps (vim, keyboard copy-mode) copy
-      // through tmux's set-clipboard/Ms path and must reach navigator.clipboard.
+      // OSC 52 write path for vim/tmux copy-mode → navigator.clipboard.
       xterm.loadAddon(new ClipboardAddon(undefined, WRITE_ONLY_CLIPBOARD));
-      // Registered once for the terminal's lifetime; dispose() cleans it up.
       xterm.onData((data) => onDataRef.current(data));
       xterm.open(container);
 
@@ -159,8 +145,7 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
       terminalRef.current = xterm;
       setIsReady(true);
     })().catch((error: unknown) => {
-      // Chunk-load or open() failure — the overlay stays on "Initializing",
-      // and remounting the tab retries from scratch.
+      // Overlay stays on "Initializing"; remount retries from scratch.
       logger.error('Terminal initialization failed', 'useXterm', error);
     });
 
@@ -184,8 +169,7 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
     terminal.options.theme = buildTerminalTheme(mode);
 
     if (isVisible) {
-      // Refit after the theme swap settles — palette changes can nudge cell
-      // metrics via the renderer's measured styles.
+      // Palette can nudge cell metrics; refit after theme swap settles.
       const frame = requestAnimationFrame(() => {
         fitTerminal();
       });
@@ -225,7 +209,6 @@ export const useXterm = ({ isVisible, mode, onData, onFit }: UseXtermOptions): U
 
     if (isVisible) {
       scheduleFit();
-      // Late font loads change glyph metrics — refit once everything settled.
       void document.fonts?.ready.then(() => {
         if (!cancelled) {
           fitTerminal();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -40,9 +40,7 @@ const resolveWsBaseUrl = (rawUrl: string): string => {
   return trimTrailingSlash(normalized.toString());
 };
 
-// Auth source for an APIClient instance. The local client reads/writes the
-// shared authStorage; the remote (VPS) client uses cloudAuthStorage so the two
-// instances authenticate independently and don't clobber each other's tokens.
+// Per-client auth store: local vs VPS so tokens don't clobber each other.
 interface ClientAuth {
   getToken: () => string | null;
   getRefreshToken: () => string | null;
@@ -61,28 +59,23 @@ const cloudAuth: ClientAuth = {
   getToken: () => cloudAuthStorage.getAccessToken(),
   getRefreshToken: () => cloudAuthStorage.getRefreshToken(),
   setTokens: (accessToken, refreshToken) => cloudAuthStorage.setTokens(accessToken, refreshToken),
-  // A revoked/expired VPS refresh token can't be recovered silently — drop the
-  // cloud credentials so the settings UI reflects a disconnected state.
+  // Expired VPS refresh can't recover silently — clear cloud so UI shows disconnected.
   onSessionExpired: () => {
     cloudAuthStorage.clear();
-    // Drop persisted cloud origin IDs too, matching manual disconnect — otherwise
-    // stale IDs keep routing to the (now-gone) VPS and can misroute links after
-    // reconnecting to a different VPS/account.
+    // Match manual disconnect: drop origin IDs so stale routing can't hit a dead VPS.
     clearCloudOrigins();
     useCloudSettingsStore.getState().clearCloud();
   },
 };
 
-// Desktop reinstalls can leave stale refresh tokens in local storage while the backend
-// identity/session store resets. Treat refresh 401 as terminal to break retry loops.
+// Desktop reinstall can leave a stale refresh token after backend identity reset; 401 is terminal.
 function shouldInvalidateSession(error: unknown): boolean {
   return error instanceof RefreshTokenError && error.status === 401;
 }
 
 const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 30_000;
 
-// True when the access token can't be trusted for a new long-lived connection —
-// missing/undecodable claims or an exp within the buffer.
+// Missing/undecodable claims or exp within buffer → don't open long-lived connections on it.
 function accessTokenExpiresSoon(token: string): boolean {
   try {
     const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
@@ -121,26 +114,21 @@ class APIClient {
     return this.baseURL;
   }
 
-  // Exposes the client's own token so callers (e.g. the SSE query-param) don't
-  // re-derive the client↔token-store pairing already encoded in `auth`.
+  // Prefer this over guessing which store pairs with the client (e.g. SSE query param).
   getToken(): string | null {
     return this.auth.getToken();
   }
 
-  // For SSE openers that bypass request(): the token rides the URL and the cached
-  // one may be missing (after a restart) or expired (reopening a dead feed).
+  // For SSE openers that bypass request(): may need a refresh after restart / dead feed.
   async getValidToken(): Promise<string | null> {
     const cached = this.auth.getToken();
     if (!this.auth.getRefreshToken()) return cached;
-    // Only refresh when the cached token is actually stale — rotating on every
-    // open churns refresh tokens and multiplies the lost-response windows where
-    // a client is left holding a rotated-away token.
+    // Don't rotate on every open — churns refresh tokens and can strand clients mid-rotation.
     if (cached && !accessTokenExpiresSoon(cached)) return cached;
     try {
       return (await this.refreshTokenIfNeeded()).access_token;
     } catch (error) {
-      // Mirror request(): a terminal refresh failure means the session is dead —
-      // tear it down instead of letting SSE reopen loops retry it forever.
+      // Terminal refresh failure: tear down so SSE reopen loops don't retry forever.
       if (shouldInvalidateSession(error)) {
         this.auth.onSessionExpired();
         return null;
@@ -180,8 +168,7 @@ class APIClient {
     }
 
     const data: TokenResponse = await response.json();
-    // Awaited: on desktop the persist is a disk write, and returning before it
-    // lands lets an app quit strand the old (rotated-away) token on disk.
+    // Await: desktop persist is disk; quit mid-write can leave the rotated-away token.
     await this.auth.setTokens(data.access_token, data.refresh_token);
     return data;
   }
@@ -255,8 +242,7 @@ class APIClient {
           throw error;
         }
       }
-      // 401 with no refresh token — session is unusable, so tear it down rather
-      // than leave the UI looking connected.
+      // 401 without refresh → session dead; don't leave UI looking connected.
       this.auth.onSessionExpired();
       throw new Error('Session expired');
     }
@@ -320,42 +306,34 @@ class APIClient {
   }
 }
 
-// Desktop has no VITE_* env (the real backend port is injected at runtime via
-// setApiPort); fall back to the local default so the initial URL is well-formed.
+// Desktop has no VITE_* (port via setApiPort); default keeps the initial URL valid.
 let API_BASE_URL: string = resolveHttpBaseUrl(
   import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8081/api/v1',
 );
 export let WS_BASE_URL: string = resolveWsBaseUrl(
   import.meta.env.VITE_WS_URL ?? 'ws://localhost:8081/api/v1/ws',
 );
-// Cloud WS origin, set alongside the cloud HTTP base so sandbox terminals on the
-// VPS connect to the right host. Empty until a VPS is connected.
+// VPS WS for cloud sandbox terminals; empty until a VPS is connected.
 let CLOUD_WS_BASE_URL = '';
 
 export const apiClient = new APIClient(API_BASE_URL, localAuth);
 
-// Second client pointed at the user's remote VPS instance for cloud-run chats.
-// The persisted cloud settings hydrate synchronously, so the saved VPS is wired
-// up at startup and cloud chats work without re-connecting after a restart.
+// Cloud-run client; cloud settings hydrate sync so a saved VPS works after restart.
 export const remoteApiClient = new APIClient('', cloudAuth);
 const savedCloudUrl = useCloudSettingsStore.getState().cloudUrl;
 if (savedCloudUrl) setCloudApiBaseUrl(savedCloudUrl);
 
-// Route a per-chat request to the backend that owns the chat: the cloud VPS if
-// the chat was created there, otherwise the local instance.
+// Local vs VPS by chat origin.
 export function resolveChatClient(chatId: string | undefined): APIClient {
   return chatId && isCloudChat(chatId) ? remoteApiClient : apiClient;
 }
 
-// Same routing for per-sandbox calls (files, git, search).
+// Local vs VPS by sandbox origin (files, git, search).
 export function resolveSandboxClient(sandboxId: string | undefined): APIClient {
   return sandboxId && isCloudSandbox(sandboxId) ? remoteApiClient : apiClient;
 }
 
-// Terminal WebSockets bypass APIClient, so resolve the base URL for the
-// backend that owns the sandbox. Tokens are minted per-connect via
-// resolveSandboxClient(...).getValidToken() — the cached cloud access token
-// is memory-only and missing right after a page reload.
+// Terminals bypass APIClient; mint tokens via getValidToken() (cloud access is memory-only).
 export function resolveSandboxWs(sandboxId: string): string {
   return isCloudSandbox(sandboxId) ? CLOUD_WS_BASE_URL : WS_BASE_URL;
 }

--- a/frontend/src/lib/editorChatActions.test.ts
+++ b/frontend/src/lib/editorChatActions.test.ts
@@ -8,8 +8,7 @@ vi.mock('@/store/uiStore', () => ({
 
 import { attachAddSelectionToChat, attachAskAboutSelection } from './editorChatActions';
 
-// Minimal Monaco keybinding stand-in — the action factory only reads these to
-// build its keybinding array.
+// Keybinding constants the action factory reads.
 const monaco = { KeyMod: { CtrlCmd: 1 }, KeyCode: { KeyL: 2, KeyI: 3 } };
 
 interface FakeSelection {
@@ -20,8 +19,7 @@ interface FakeSelection {
   endColumn: number;
 }
 
-// Builds a fake editor plus a handle to invoke whatever action the module
-// registers, mimicking Monaco firing the command.
+// Fake editor + handle to invoke the registered action.
 function makeEditor(opts: {
   selection: FakeSelection | null;
   value?: string;

--- a/frontend/src/lib/editorChatActions.ts
+++ b/frontend/src/lib/editorChatActions.ts
@@ -10,8 +10,7 @@ function getSelectionSnippet(ed: monacoNs.editor.ICodeEditor): EditorCodeSelecti
   if (!selection || selection.isEmpty() || !model) return null;
   let text = model.getValueInRange(selection);
   let endLine = selection.endLineNumber;
-  // Full-line drag selections end at column 1 of the line below — don't
-  // count that empty line in the range label or the snippet.
+  // Full-line drag ends at col 1 of the next line — exclude that empty line.
   if (endLine > selection.startLineNumber && selection.endColumn === 1) {
     endLine -= 1;
     text = text.slice(0, -1);
@@ -31,16 +30,14 @@ export function attachAddSelectionToChat(
   editor: monacoNs.editor.IStandaloneCodeEditor,
   context: EditorNavigationContext,
 ): void {
-  // Registered per editor instance (disposed with it) rather than globally —
-  // the action reads chatId from the pane's mutable context object, so chat
-  // swaps on an already-mounted editor route to the right chat.
+  // Per-editor (not global): action reads chatId from mutable pane context on chat swap.
   editor.addAction({
     id: 'agentrove.addSelectionToChat',
     label: 'Add Selection to Chat',
     contextMenuGroupId: '0_chat',
     contextMenuOrder: 1,
     keybindings: [m.KeyMod.CtrlCmd | m.KeyCode.KeyL],
-    // Without a selection Cmd+L falls through to Monaco's default line-select.
+    // Without selection Cmd+L is Monaco's line-select.
     precondition: 'editorHasSelection',
     run: (ed) => {
       const snippet = getSelectionSnippet(ed);
@@ -56,8 +53,7 @@ export function attachAskAboutSelection(
   editor: monacoNs.editor.IStandaloneCodeEditor,
   onOpen: (selection: EditorCodeSelection) => void,
 ): void {
-  // Cmd+I mirrors VS Code's inline chat trigger; the pane owning the editor
-  // renders the widget, so this action only reports the captured selection.
+  // Cmd+I like VS Code inline chat; pane owns the widget — action only reports selection.
   editor.addAction({
     id: 'agentrove.askAboutSelection',
     label: 'Ask About Selection',

--- a/frontend/src/lib/editorNavigation.test.ts
+++ b/frontend/src/lib/editorNavigation.test.ts
@@ -16,16 +16,16 @@ vi.mock('@/services/sandboxService', () => ({
 vi.mock('@/lib/queryClient', () => ({
   queryClient: { fetchQuery: (...a: unknown[]) => fetchQuery(...a) },
 }));
-// Avoid pulling the file util's react-hot-toast import chain into the node run.
+// Avoid file util → react-hot-toast import chain in the node run.
 vi.mock('@/utils/file', () => ({ detectLanguage: () => 'plaintext' }));
 
-// Fresh module per test so the module-level activeContext/installed reset.
+// Fresh module per test (module-level activeContext/installed).
 async function load() {
   vi.resetModules();
   return import('./editorNavigation');
 }
 
-// Minimal Monaco stand-in capturing the handlers the module registers.
+// Monaco stand-in capturing registered handlers.
 function makeMonaco() {
   const models = new Map<string, FakeModel>();
   let opener: OpenerHandler;

--- a/frontend/src/lib/editorNavigation.ts
+++ b/frontend/src/lib/editorNavigation.ts
@@ -14,22 +14,17 @@ import { detectLanguage } from '@/utils/file';
 type Monaco = typeof import('monaco-editor');
 
 export interface EditorNavigationContext {
-  // The owning pane mutates these fields in place on prop changes (chat swap,
-  // worktree cwd) — the claim holds the object, not a snapshot, so listeners
-  // attached at mount keep routing with current values without remounting.
+  // Pane mutates in place (chat/cwd); claim holds the object so mount-time listeners stay current.
   sandboxId: string | undefined;
   chatId: string | undefined;
-  // Worktree chats operate in a subdirectory; searches must be scoped to it so
-  // results don't leak from the base checkout or sibling worktrees.
+  // Scope searches to worktree cwd so results don't leak from the base checkout.
   cwd: string | undefined;
 }
 
-// Peek previews resolve models by URI, so every result file needs a live model;
-// cap how many files get hydrated per lookup to bound fetches and memory.
+// Cap hydrations per lookup — peek needs a live model per hit.
 const MAX_RESULT_FILES = 30;
 
-// Chats in one workspace share a sandbox, so sandbox alone can't route a jump —
-// the pane the user is interacting with claims the context via editor listeners.
+// Shared sandbox across chats: the interacting pane claims context via listeners.
 let activeContext: EditorNavigationContext | null = null;
 
 let installed = false;
@@ -38,9 +33,7 @@ export function attachEditorNavigationContext(
   editor: monacoNs.editor.IStandaloneCodeEditor,
   context: EditorNavigationContext,
 ): void {
-  // Mouse-move claims cover ctrl+hover in a not-yet-focused split pane; the
-  // focus listener covers keyboard-invoked navigation (F12). Listeners are
-  // disposed with the editor, and the next interacted pane overwrites the claim.
+  // Mouse-move: ctrl+hover in unfocused split; focus: F12. Next pane overwrites claim.
   activeContext = context;
   editor.onDidFocusEditorText(() => {
     activeContext = context;
@@ -53,10 +46,8 @@ export function attachEditorNavigationContext(
 function contextForResource(
   uri: monacoNs.Uri,
 ): { sandboxId: string; chatId: string | undefined; cwd: string | undefined } | null {
-  // Editor models are `sandbox://{sandboxId}/{workspace-relative path}` (View.tsx).
-  // A mismatch means the model belongs to a pane that never claimed a context
-  // (diff views, the chat-less 'workspace' placeholder) — not navigable.
-  // Snapshot the fields: the claimed object mutates as pane props change.
+  // Models are sandbox://{sandboxId}/path (View.tsx). Mismatch / no claim → not navigable.
+  // Snapshot fields: the claimed object mutates with pane props.
   if (!activeContext) return null;
   const { sandboxId, chatId, cwd } = activeContext;
   if (!sandboxId || uri.scheme !== 'sandbox' || uri.authority !== sandboxId) return null;
@@ -67,8 +58,7 @@ async function searchQuietly(
   sandboxId: string,
   params: SearchParams,
 ): Promise<SearchFileResult[] | null> {
-  // A toast per failed hover/jump would be noisy; on error Monaco just shows
-  // its own "no definition found" affordance.
+  // Fail quietly — Monaco already shows "no definition found".
   try {
     const response = await sandboxService.searchInFiles(sandboxId, params);
     return response.results;
@@ -83,8 +73,7 @@ async function ensureModel(
   sandboxId: string,
   filePath: string,
 ): Promise<monacoNs.editor.ITextModel | null> {
-  // Hydrate missing models through the file-content query so the cache is
-  // already warm when the user actually opens the target file.
+  // Hydrate via file-content query so cache is warm if the user opens the file.
   const uri = m.Uri.parse(`sandbox://${sandboxId}/${filePath}`);
   const existing = m.editor.getModel(uri);
   if (existing) return existing;
@@ -94,7 +83,7 @@ async function ensureModel(
       queryFn: () => sandboxService.getFileContent(sandboxId, filePath),
     });
     if (data.is_binary) return null;
-    // Re-check after the await: a concurrent lookup may have created it first.
+    // Concurrent lookup may have created the model while we awaited.
     return (
       m.editor.getModel(uri) ?? m.editor.createModel(data.content, detectLanguage(filePath), uri)
     );
@@ -120,10 +109,9 @@ async function resolveLocations(
     const model = models[i];
     if (!model) return;
     for (const match of file.matches) {
-      // The model can be shorter than the on-disk hit (stale hydration, drafts).
+      // Model can be shorter than on-disk hit (stale hydration, drafts).
       if (match.line_number > model.getLineCount()) continue;
-      // Backend line_text is lstripped/windowed for the search sidebar, so its
-      // offsets aren't real columns — locate the symbol in the live model line.
+      // Backend line_text is lstripped/windowed — locate symbol in the live line.
       const column = model.getLineContent(match.line_number).search(wordPattern);
       locations.push({
         uri: model.uri,
@@ -140,13 +128,11 @@ async function resolveLocations(
 }
 
 export function setupEditorNavigation(m: Monaco): void {
-  // Providers are Monaco-global while the editor remounts per file, so install
-  // once and resolve per-call context from the claiming pane + model URI.
+  // Providers are global; editor remounts per file — install once, resolve context per call.
   if (installed) return;
   installed = true;
 
-  // Monaco calls this when a jump targets a resource the current editor isn't
-  // showing (single cross-file definition, or picking an entry in a peek).
+  // Cross-file jump / peek pick when the target isn't the current editor resource.
   m.editor.registerEditorOpener({
     openCodeEditor: (_source, resource, selectionOrPosition) => {
       const context = contextForResource(resource);

--- a/frontend/src/lib/queryClient.test.ts
+++ b/frontend/src/lib/queryClient.test.ts
@@ -5,8 +5,7 @@ import { persistOptions } from './queryClient';
 
 const shouldPersist = persistOptions.dehydrateOptions!.shouldDehydrateQuery!;
 
-// Builds a real, successful Query for `key` so defaultShouldDehydrateQuery (which
-// gates on status === 'success') passes and only the key-matching branch decides.
+// Successful Query so defaultShouldDehydrateQuery passes; then key-matching decides.
 function query(key: readonly unknown[]): Query {
   const client = new QueryClient();
   client.setQueryData(key, { ok: true });

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -15,9 +15,7 @@ export const queryClient = new QueryClient({
   },
 });
 
-// Persist only what the first paint needs (sidebar chat lists, workspaces, current user) —
-// messages, diffs, and file contents would blow past the localStorage quota, and settings
-// must stay out: its payload carries secrets (GitHub PAT, custom env vars).
+// First-paint only (chats, workspaces, user). Skip messages/diffs (quota) and settings (secrets).
 function shouldPersistQuery(query: Query): boolean {
   if (!defaultShouldDehydrateQuery(query)) return false;
   const key = query.queryKey;
@@ -33,7 +31,6 @@ export const persistOptions: Omit<PersistQueryClientOptions, 'queryClient'> = {
     key: 'agentrove-query-cache',
   }),
   dehydrateOptions: { shouldDehydrateQuery: shouldPersistQuery },
-  // Bump when a persisted query's response shape changes — stale snapshots are dropped.
-  // v2: purges v1 snapshots that briefly persisted the settings payload (contains secrets).
+  // Bump on response-shape changes. v2 purges v1 that briefly cached settings (secrets).
   buster: 'v2',
 };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,18 +1,15 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
-// Global token/reset layer must load before the component tree so module CSS
-// always comes later in the cascade and wins specificity ties against resets
+// Global tokens/resets before component CSS so modules win cascade ties.
 import './styles/app.scss';
 import App from './App.tsx';
-// Build-time-generated `data-palette` override blocks (see vite.config.ts).
+// Build-time palette CSS overrides (vite.config.ts).
 import 'virtual:palette-overrides.css';
 import { queryClient, persistOptions } from './lib/queryClient';
 import { isMobileApp } from './utils/platform';
 
-// iOS WebKit zooms into any focused input with font-size < 16px. The app's dense
-// type scale (text-xs/sm) would trigger it on every input tap, so lock the scale
-// in the native shell. Web keeps the default viewport so pinch-zoom still works.
+// iOS WebKit zooms inputs with font-size < 16px; lock scale in the native shell only.
 if (isMobileApp()) {
   document
     .querySelector('meta[name="viewport"]')

--- a/frontend/src/pages/ChatPage/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage/ChatPage.tsx
@@ -64,8 +64,7 @@ export function ChatPage() {
 
   const { currentChat, fetchedMessages, hasFetchedMessages, messagesQuery } = useChatData(chatId);
 
-  // These share AgentPane's chat-query cache and provide each split pane's
-  // sandbox/worktree metadata plus deletion error guards.
+  // Share AgentPane's chat-query cache; also drive split close-on-error.
   const splitQuery1 = useChatQuery(splitChatIds[0], {
     enabled: !!splitChatIds[0],
   });
@@ -85,18 +84,13 @@ export function ChatPage() {
     }
   }, [splitChatIds, splitQuery1.isError, splitQuery2.isError, splitQuery3.isError]);
 
-  // Each chat keeps its own tabs: restore them on entry, stash them on leave.
-  // Must run before the split-rebuild effect below — on mount it restores the
-  // primary-only layout, and the split-rebuild then reapplies a persisted
-  // split layout on top. Reversed, the restore would wipe the rebuilt split.
+  // Restore/stash per chat. Must run before split-rebuild below (else restore wipes it).
   useMountEffect(() => {
     if (chatId) useUIStore.getState().loadWorkspaceForChat(chatId);
     return () => useUIStore.getState().stashWorkspace();
   });
 
-  // A chat switch can restore a primary-only stash while split ids remain bound.
-  // Rebuild only when an agent tile is missing so normal compaction and user-
-  // activated full-screen views keep their layout and focus.
+  // Rebuild only if an agent tile is missing — keep compaction / full-screen layouts.
   useEffect(() => {
     if (chatId && splitChatIds.includes(chatId)) {
       useUIStore.getState().closeSplitChat(chatId);
@@ -113,15 +107,12 @@ export function ChatPage() {
   }, [chatId, isMobile, splitChatIds]);
 
   const queryClient = useQueryClient();
-  // Opening a chat in either pane marks it seen — stamps last_viewed_at
-  // server-side and drops the sidebar unread dot.
+  // Marks seen (last_viewed_at + clears sidebar unread).
   useEffect(() => {
     if (chatId) void markChatViewed(queryClient, chatId);
   }, [chatId, queryClient]);
   useEffect(() => {
-    // On mobile the split isn't rebuilt, so split chats are off-screen even
-    // though the store still holds their ids — don't stamp them as seen.
-    // Returning to desktop re-runs this and stamps as the pane reappears.
+    // Mobile keeps split ids but doesn't show panes — don't mark those seen.
     if (!isMobile) {
       for (const splitChatId of splitChatIds) void markChatViewed(queryClient, splitChatId);
     }
@@ -158,8 +149,7 @@ export function ChatPage() {
   }, [activeViews, currentChat?.sandbox_id, refetchFilesMetadata]);
 
   const workspaces = useWorkspacesList();
-  // Routes to the instance that owns the chat so a cloud chat's persona selector
-  // shows the VPS's personas (and sends resolve the selected name against them).
+  // Cloud chats resolve personas against the VPS settings list.
   const { data: settings } = useSettingsForChatQuery(chatId);
 
   const { data: workspaceResources } = useWorkspaceResourcesQuery(
@@ -176,9 +166,7 @@ export function ChatPage() {
   if (prevChatIdForResetRef.current !== chatId) {
     prevChatIdForResetRef.current = chatId;
     const ui = useUIStore.getState();
-    // Restore the chat's own saved tabs (stashing the outgoing chat's first).
     if (chatId) ui.loadWorkspaceForChat(chatId);
-    // Switching into a chat that's currently in a split pane closes that pane.
     if (chatId && ui.splitChatIds.includes(chatId)) {
       ui.closeSplitChat(chatId);
     }
@@ -188,9 +176,7 @@ export function ChatPage() {
       createCommitDialogOpen: false,
       createPRDialogOpen: false,
       createBranchDialogOpen: false,
-      // Ephemeral pane pointers don't belong to the new chat — a same-id tile in
-      // its split must not inherit chat A's focus. activeAgentTile (the coarse
-      // pointer) resets with focus so the two stay consistent.
+      // Don't inherit prior chat's focus onto a same-id split tile.
       focusedTile: null,
       activeAgentTile: 'agent:primary',
     });
@@ -203,7 +189,6 @@ export function ChatPage() {
     [navigate],
   );
 
-  // Sidebar is always available on chat pages — it holds navigation, settings, and logout
   const sidebarContent = useMemo(() => {
     return (
       <Sidebar
@@ -232,8 +217,7 @@ export function ChatPage() {
       if (tileIdToViewType(tileId) === 'agent') {
         return splitChatId ? <AgentPane chatId={splitChatId} /> : null;
       }
-      // Split tiles render their chat's own sandbox/cwd. The terminal
-      // is handled in renderView's terminal branch, so it's a no-op here.
+      // Terminal branch lives in renderView; missing split chat → empty.
       if (slot && !splitChatId) return null;
       const paneChatId = splitChatId ?? chatId;
       switch (tileIdToViewType(tileId)) {
@@ -268,16 +252,14 @@ export function ChatPage() {
         ? (splitChat?.sandbox_id ?? undefined)
         : currentChat?.sandbox_id;
       const terminalChatId = slot ? splitChatId : currentChat?.id;
-      // Worktree chats get their shell spawned inside the worktree so the
-      // terminal matches what the agent/editor/diff views operate on.
+      // Spawn shell in worktree so terminal matches agent/editor/diff cwd.
       const terminalWorktreeCwd = slot
         ? (splitChat?.worktree_cwd ?? undefined)
         : (currentChat?.worktree_cwd ?? undefined);
       return (
         <div
           className={styles.tile}
-          // Record focus on any interaction so shortcuts and the active tab both
-          // track the pane in use (focusTile derives the chat from the tile).
+          // focusTile keeps shortcuts + tab highlight on the pane in use.
           onPointerDownCapture={() => useUIStore.getState().focusTile(tileId)}
         >
           <div className={isTerminal ? styles.fill : styles.hidden}>
@@ -286,8 +268,7 @@ export function ChatPage() {
                 sandboxId={terminalSandboxId}
                 storageScope={terminalChatId}
                 worktreeCwd={terminalWorktreeCwd}
-                // Only fit/focus the terminal when its tile is actually on screen —
-                // a background tab is mounted but hidden (zero-size container).
+                // Background tiles are mounted but zero-size — only fit when visible.
                 isVisible={isTerminal && isVisible}
                 panelKey={`tile-${tileId}`}
               />

--- a/frontend/src/pages/ChatPage/SubThreadDialog.tsx
+++ b/frontend/src/pages/ChatPage/SubThreadDialog.tsx
@@ -2,11 +2,9 @@ import { useUIStore } from '@/store/uiStore';
 import { useActiveChat } from '@/hooks/useActiveChat';
 import { CreateSubThreadDialog } from '@/components/chat/sub-threads/CreateSubThreadDialog';
 
-// Mount-gated wrapper (matches the git dialogs' pattern) so useActiveChat's
-// pane subscriptions don't re-render the whole page on every pane switch.
+// Mount-gated (like git dialogs) so useActiveChat doesn't re-render the whole page.
 export function SubThreadDialog() {
-  // Sub-threads branch off the pane the user is in — in split view that's the
-  // split chat when it's the active pane.
+  // Parent is the focused pane's chat (split chat when that pane is active).
   const parentChat = useActiveChat();
   if (!parentChat || parentChat.parent_chat_id) return null;
   return (

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -93,16 +93,14 @@ export function LandingPage() {
   const modelMap = useModelMap(isAuthenticated);
 
   const { data: currentUser } = useCurrentUserQuery({ enabled: isAuthenticated });
-  // Recents for the "jump back in" section — the merged local + cloud list the
-  // sidebar uses, so both stay consistent. Falls back to example prompts when
-  // there are no chats yet.
+  // Same merged local+cloud list as the sidebar (empty → example prompts).
   const { recentChats, workspaceBadgeById, isLoadingChats } = useSidebarChatLists(
     workspaces,
     isAuthenticated,
   );
   const showRecents = !isLoadingChats && recentChats.length > 0;
   const greeting = getTimeGreeting();
-  // Usernames are lowercase handles ("michael") — capitalize for the greeting.
+  // Handles are lowercase — capitalize for the greeting.
   const username = currentUser?.username ?? '';
   const greetingName = username && username.charAt(0).toUpperCase() + username.slice(1);
 
@@ -119,9 +117,7 @@ export function LandingPage() {
   const initialWorkspaceId = routeState?.workspaceId ?? null;
   const initialCloudWorkspaceId = routeState?.cloudWorkspaceId ?? null;
   const initialMessage = routeState?.initialMessage ?? null;
-  // Keyed on location.key, not the target ID: React Router mints a fresh key on
-  // every navigation, so re-clicking the same workspace's "new thread" re-consumes
-  // the target and re-applies its run location even after a manual toggle.
+  // location.key (not target id) so re-clicking the same "new thread" re-applies it.
   const consumedNavKeyRef = useRef<string | null>(null);
 
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
@@ -129,16 +125,14 @@ export function LandingPage() {
   const isCloud = useChatSettingsStore((state) => state.runOnCloud);
   const [selectedCloudWorkspaceId, setSelectedCloudWorkspaceId] = useState<string | null>(null);
 
-  // Default the local workspace once the list loads or the current pick goes stale.
+  // Default local workspace when list loads or current pick is gone.
   useEffect(() => {
     if (!workspaces.length) return;
     if (selectedWorkspaceId && workspaces.some((ws) => ws.id === selectedWorkspaceId)) return;
     setSelectedWorkspaceId(workspaces[0].id);
   }, [workspaces, selectedWorkspaceId]);
 
-  // Consume the sidebar "new thread" target once per navigation: preselect its
-  // workspace and flip the run location to match (cloud target → cloud, local →
-  // local). Keyed on location.key so re-clicking the same workspace re-applies it.
+  // One-shot per navigation: preselect workspace + match run location (cloud/local).
   useEffect(() => {
     if (location.key === consumedNavKeyRef.current) return;
     consumedNavKeyRef.current = location.key;
@@ -156,9 +150,7 @@ export function LandingPage() {
     setMessage(initialMessage);
   }
 
-  // Skills and slash-commands are per-instance. Local runs fetch from the local
-  // backend; cloud runs fetch from the VPS so its skills/commands appear in the
-  // landing composer before a chat exists.
+  // Skills/commands are per-instance — VPS list for cloud before a chat exists.
   const { data: workspaceResources } = useWorkspaceResourcesQuery(
     selectedWorkspaceId ?? undefined,
     undefined,
@@ -172,15 +164,12 @@ export function LandingPage() {
   );
   const resolvedWorkspaceResources = isCloud ? cloudWorkspaceResources : workspaceResources;
 
-  // Personas are per-instance — fetch from the VPS for cloud runs so the
-  // persona selector shows the VPS's personas and chat creation resolves the
-  // selected persona against the VPS's list.
+  // Personas are per-instance — VPS list for cloud so create resolves against it.
   const { data: settings } = useSettingsQuery({ enabled: isAuthenticated });
   const { data: cloudSettings } = useCloudSettingsQuery(isAuthenticated && isCloud);
   const resolvedPersonas = isCloud ? cloudSettings?.personas : settings?.personas;
 
-  // Resolve the sandbox for both local and cloud so the editor, @file mentions,
-  // and branch selector route to the backend that owns the workspace.
+  // Sandbox for editor/@file/branch on the backend that owns the workspace.
   const { data: cloudWorkspaces } = useCloudWorkspacesQuery(isAuthenticated && isCloud);
   const selectedSandboxId = isCloud
     ? cloudWorkspaces?.find((ws) => ws.id === selectedCloudWorkspaceId)?.sandbox_id
@@ -202,17 +191,12 @@ export function LandingPage() {
   const { selectedFile, setSelectedFile, isRefreshing, handleRefresh, openFiles, closeFile } =
     useEditorState(refetchFilesMetadata, undefined, fileStructure);
 
-  // The landing editor's selection/tabs live under a shared store key (not component
-  // state), so reset them when the chosen sandbox changes and on mount — otherwise a
-  // prior session's tabs would linger. An effect (not a render-phase store write) keeps
-  // the external-store mutation off the render path.
+  // Landing editor tabs are store-backed — clear on sandbox change (effect, not render).
   useEffect(() => {
     setSelectedFile(null);
   }, [selectedSandboxId, setSelectedFile]);
 
-  // Publish the selected workspace's sandbox so the context-less global git
-  // shortcuts resolve a target on landing; clear it on unmount so it can't leak
-  // into a later chat with no sandbox of its own.
+  // Global git shortcuts need a sandbox on landing; clear on leave so it doesn't leak.
   useEffect(() => {
     useUIStore.getState().setWorkspaceSandboxId(selectedSandboxId ?? null);
     return () => useUIStore.getState().setWorkspaceSandboxId(null);
@@ -220,8 +204,7 @@ export function LandingPage() {
 
   useMountEffect(() => {
     useChatStore.getState().setCurrentChat(null);
-    // Reset to the agent (workspace selector) view — a stale split layout from a prior chat
-    // would otherwise persist into the landing screen.
+    // Drop a prior chat's split layout so it doesn't stick on landing.
     useUIStore.getState().resetWorkspace();
   });
 
@@ -265,7 +248,7 @@ export function LandingPage() {
             model_id: selectedModelId,
             workspace_id: selectedCloudWorkspaceId,
           });
-          // Coerce toolbar defaults like useMessageActions so cloud matches local.
+          // Same toolbar default coercion as useMessageActions (cloud matches local).
           await cloudChatService.startCompletion({
             prompt: trimmedPrompt,
             chat_id: newChat.id,
@@ -294,9 +277,7 @@ export function LandingPage() {
           setMessage('');
           useChatStore.getState().setAttachedFilesForChat(PENDING_NEW_CHAT_KEY, []);
 
-          // Register the chat as cloud-owned and refresh the sidebar's cloud chats
-          // and workspaces so the new chat appears and its project re-sorts to the
-          // top by last_chat_at — the merged sidebar list orders local + cloud together.
+          // Origin + invalidate so sidebar lists re-sort by last_chat_at.
           markCloudChats([newChat.id]);
           const cloud = useCloudSettingsStore.getState();
           void Promise.all([
@@ -310,9 +291,7 @@ export function LandingPage() {
 
           useModelStore.getState().selectModel(newChat.id, selectedModelId);
           useChatSettingsStore.getState().initChatFromDefaults(newChat.id);
-          // Run is already started on the VPS — open the chat without an
-          // initialPrompt so the page reconnects to the live stream instead of
-          // firing a second turn.
+          // Completion already started — navigate without initialPrompt (no second turn).
           navigate(`/chat/${newChat.id}`);
         } catch (error) {
           toast.error(error instanceof Error ? error.message : 'Failed to start cloud chat');
@@ -486,19 +465,14 @@ export function LandingPage() {
             </Suspense>
           );
         case 'diff':
-          // No chat yet — the sandbox comes from the selected workspace, so the
-          // diff runs at the workspace root and review comments are disabled.
+          // Pre-chat: workspace sandbox root; review comments off (no chatId).
           return (
             <Suspense fallback={viewLoadingFallback}>
               <DiffView chatId={undefined} sandboxId={selectedSandboxId} isVisible={isVisible} />
             </Suspense>
           );
         case 'terminal':
-          // Pre-chat, so tab layout persists per sandbox (the backend PTYs are
-          // keyed by sandbox + terminal id); the shell spawns at the workspace
-          // root. Toggling the view off removes the tile from openTabs and
-          // unmounts this container, so restore-on-mount is what keeps tabs
-          // and their live sessions across toggles.
+          // storageScope by sandbox (PTY keys); unmount on toggle — restore-on-mount keeps sessions.
           return (
             <Suspense fallback={viewLoadingFallback}>
               <TerminalContainer

--- a/frontend/src/pages/LandingPage/RecentChats.tsx
+++ b/frontend/src/pages/LandingPage/RecentChats.tsx
@@ -29,10 +29,9 @@ export function RecentChats({ chats, workspaceBadgeById, onChatSelect }: RecentC
   const activeStreamMetadata = useStreamStore((state) => state.activeStreamMetadata);
   const lastToolTitleByChatId = useStreamStore((state) => state.lastToolTitleByChatId);
   const completedChatIds = useStreamStore((state) => state.completedChatIds);
-  // Empty queues are deleted from the store, so every remaining key is a chat
-  // blocked on a plan/question/permission answer.
+  // Empty queues are dropped; remaining keys = blocked on plan/question/permission.
   const pendingRequests = usePermissionStore((state) => state.pendingRequests);
-  // Recents only render when authenticated, so the models query is safe to enable.
+  // Recents only mount when authenticated.
   const modelMap = useModelMap();
 
   const streamingChatIds = useMemo(
@@ -48,8 +47,7 @@ export function RecentChats({ chats, workspaceBadgeById, onChatSelect }: RecentC
       <div className={styles.header}>Jump back in</div>
       <div className={styles.list}>
         {chats.slice(0, MAX_RECENT_CHATS).map((chat) => {
-          // Same tone precedence as the sidebar rows and chat tabs; no chat is
-          // open on the landing page, so unread is never suppressed here.
+          // Same tone order as sidebar/tabs; no open chat, so unread is never suppressed.
           const status = chatStatusTone({
             blocked: pendingRequests.has(chat.id),
             streaming: streamingChatIds.has(chat.id),

--- a/frontend/src/pages/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage/ResetPasswordPage.tsx
@@ -45,8 +45,7 @@ export function ResetPasswordPage() {
     password: false,
     confirmPassword: false,
   });
-  // The reset token is fully owned by the URL, so deriving it avoids a mount-only sync effect
-  // and keeps the invalid-token state tied to the actual query string.
+  // Token is URL-owned — derive so invalid state tracks the query string (no sync effect).
   const token = searchParams.get('token');
   const tokenError = token ? null : 'Invalid or missing reset token';
 

--- a/frontend/src/pages/SettingsPage/SettingsMobileNav.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsMobileNav.tsx
@@ -12,7 +12,6 @@ interface SettingsMobileNavProps {
   onToggleNav: () => void;
 }
 
-// Mobile top bar + dropdown for settings nav
 export function SettingsMobileNav({
   activeTab,
   onTabChange,
@@ -22,7 +21,7 @@ export function SettingsMobileNav({
 }: SettingsMobileNavProps) {
   return (
     <>
-      {/* pt folds in the iOS top inset (no TitleBar on settings) — env() is 0 on web, so pt stays 0.625rem there */}
+      {/* bar CSS folds in safe-area-inset-top (0 on web; no TitleBar on settings). */}
       <div className={styles.bar}>
         <Button
           onClick={onBack}

--- a/frontend/src/pages/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsPage.tsx
@@ -58,7 +58,7 @@ export function SettingsPage() {
   const { data: currentUser } = useCurrentUserQuery({ enabled: isAuthenticated });
   const userDisplayName = currentUser?.username || currentUser?.email || '';
   const logoutMutation = useLogout();
-  // Honor a deep-link tab (e.g. the "Connect a cloud instance" CTA → Cloud tab).
+  // Deep-link tab from location.state (e.g. Cloud CTA).
   const [activeTab, setActiveTab] = useState<TabKey>(() => {
     const requested = (location.state as { tab?: TabKey } | null)?.tab;
     return requested && requested in TAB_LABELS ? requested : 'general';
@@ -92,8 +92,7 @@ export function SettingsPage() {
 
       for (const field of fields) {
         if (JSON.stringify(current[field]) !== JSON.stringify(previous[field])) {
-          // Indexing UserSettingsUpdate by a union key collapses the assignment target
-          // to the intersection of the value types (undefined); cast past it.
+          // Union-key index → value type collapses to undefined; cast past it.
           payload[field] = (current[field] ?? null) as never;
         }
       }
@@ -201,8 +200,7 @@ export function SettingsPage() {
     );
   }
 
-  // Covers both first load (no settings yet) and the one render where settings has resolved but the
-  // syncing effect hasn't populated localSettings yet.
+  // First load, or the frame before the sync effect copies settings → localSettings.
   if (!settings || !localSettings) {
     return (
       <div className={styles['status-screen']}>
@@ -231,7 +229,6 @@ export function SettingsPage() {
           onToggleNav={() => setMobileNavOpen(!mobileNavOpen)}
         />
 
-        {/* Main content area */}
         <div className={styles.content}>
           <div className={styles['content-inner']}>
             {errorMessage && (

--- a/frontend/src/pages/SettingsPage/SettingsSidebarNav.tsx
+++ b/frontend/src/pages/SettingsPage/SettingsSidebarNav.tsx
@@ -13,7 +13,6 @@ interface SettingsSidebarNavProps {
   onSignOut: () => void;
 }
 
-// Vertical settings navigation — desktop
 export function SettingsSidebarNav({
   activeTab,
   onTabChange,

--- a/frontend/src/services/automationService.ts
+++ b/frontend/src/services/automationService.ts
@@ -7,8 +7,7 @@ import type {
   AutomationUpdateRequest,
 } from '@/types/automation.types';
 
-// Automations live on whichever backend runs them — the local instance or the
-// connected cloud VPS (same API shape) — so every call routes by onCloud.
+// Route by onCloud — same API shape on local and VPS.
 function clientFor(onCloud: boolean) {
   return onCloud ? remoteApiClient : apiClient;
 }
@@ -56,7 +55,6 @@ async function runAutomation(automationId: string, onCloud: boolean): Promise<{ 
       `/automations/${automationId}/run`,
     );
     const payload = ensureResponse(response, 'Failed to run automation');
-    // A cloud run's chat lives on the VPS — register it so opening it routes there.
     if (onCloud) {
       markCloudChats([payload.chat_id]);
     }

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -16,8 +16,7 @@ import type { CursorPaginationParams, PaginatedChats, PaginatedMessages } from '
 import type { ComposerSelection } from '@/store/uiStore';
 
 export function buildChatFormData(request: ChatRequest): FormData {
-  // Single encoding of the /chat/chat multipart contract — shared with
-  // cloudChatService so new fields can't silently drift between local and cloud.
+  // Shared with cloudChatService so multipart fields can't drift.
   const formData = new FormData();
   formData.append('prompt', request.prompt);
 
@@ -66,8 +65,7 @@ async function createCompletion(
 
       const payload = ensureResponse(taskResponse, 'Failed to start chat completion');
 
-      // Seed the replay cursor for the multiplexed feed: events published before
-      // the shared connection (re)opens are recovered by replaying after last_seq.
+      // Seed multiplexed-feed cursor so events before (re)open can be replayed.
       const storedSeq = normalizePositiveInt(chatStorage.getEventId(payload.chat_id));
       const providedSeq = normalizePositiveInt(payload.last_seq);
       if (providedSeq > storedSeq) {
@@ -84,9 +82,7 @@ async function createCompletion(
   );
 }
 
-// Fires a turn server-side without opening a client EventSource — used to start
-// background sub-threads (e.g. stream actions). The server runs the turn as a
-// background task; the client reconnects to the stream when the chat is opened.
+// Server-side turn without a client EventSource (background sub-threads).
 async function startCompletion(request: ChatRequest): Promise<{ messageId: string }> {
   validateRequired(request.prompt, 'Prompt');
 
@@ -111,8 +107,7 @@ async function checkChatStatus(chatId: string): Promise<{
 }
 
 async function getActiveStreams(): Promise<ActiveStreamSnapshot[]> {
-  // Local backend only — its runtime registry covers every local chat and
-  // sub-thread, so startup restoration needs a single request.
+  // Local registry only — one request covers every local chat/sub-thread.
   return serviceCall(async () => {
     const streams = await apiClient.get<ActiveStreamSnapshot[]>('/chat/chats/active-streams');
     return streams ?? [];
@@ -173,8 +168,7 @@ async function getChat(chatId: string): Promise<Chat> {
   return serviceCall(async () => {
     const response = await resolveChatClient(chatId).get<Chat>(`/chat/chats/${chatId}`);
     const chat = ensureResponse(response, 'Failed to fetch chat');
-    // Register a cloud chat's sandbox so its files/git/terminal route to the VPS
-    // even on a cold deep-link, before the sidebar list has run.
+    // Deep-link: mark sandbox cloud-owned before the sidebar list has run.
     if (isCloudChat(chatId)) {
       markCloudSandboxes([chat.sandbox_id]);
     }
@@ -184,9 +178,7 @@ async function getChat(chatId: string): Promise<Chat> {
 
 async function createChat(data: CreateChatRequest): Promise<Chat> {
   return serviceCall(async () => {
-    // A sub-thread inherits its parent's backend — route to the cloud VPS when the
-    // parent lives there, then mark the child (and its sandbox) cloud-owned so its
-    // turns, files, and terminal follow it instead of falling back to local.
+    // Sub-thread inherits parent backend; mark child cloud-owned when parent is.
     const parentChatId = data.parent_chat_id;
     const response = await resolveChatClient(parentChatId).post<Chat>('/chat/chats', data);
     const chat = ensureResponse(response, 'Failed to create chat');
@@ -244,10 +236,7 @@ function normalizePositiveInt(value: unknown): number {
 }
 
 async function createChatEventsSource(): Promise<EventSource> {
-  // Local backend only — the VPS feed is opened separately via
-  // cloudChatService.createChatEventsSource, against the remote client's auth.
-  // EventSource bypasses APIClient's 401→refresh path and access tokens are
-  // short-lived, so mint a valid token up front instead of using the cached one.
+  // Local only (VPS uses cloudChatService). Mint token — EventSource skips 401 refresh.
   const token = await apiClient.getValidToken();
   if (!token) {
     throw new Error('Authentication token required');
@@ -264,8 +253,6 @@ async function getSubThreads(chatId: string): Promise<Chat[]> {
       `/chat/chats/${chatId}/sub-threads`,
     );
     const subThreads = ensureResponse(response, 'Failed to fetch sub-threads');
-    // A cloud parent's sub-threads live on the VPS too — register them so opening
-    // one routes its stream/files/terminal to the cloud, not local.
     if (isCloudChat(chatId)) {
       markCloudChats(subThreads.map((chat) => chat.id));
       markCloudSandboxes(subThreads.map((chat) => chat.sandbox_id));
@@ -333,7 +320,7 @@ async function askAboutCode(
   validateRequired(modelId, 'Model ID');
 
   return serviceCall(async () => {
-    // Chat-text selections have no file identity — the location fields stay unset.
+    // Chat-text selections have no file/line — leave location fields unset.
     const location =
       'kind' in selection
         ? {}
@@ -369,8 +356,7 @@ async function generateChatTitle(chatId: string): Promise<string> {
   });
 }
 
-// Keyed by messageId but lives on whichever backend owns the chat, so callers
-// thread chatId through purely for routing.
+// chatId is routing-only; the checkpoint is keyed by messageId on that backend.
 async function restoreMessageCheckpoint(
   chatId: string | undefined,
   messageId: string,

--- a/frontend/src/services/cloudChatService.ts
+++ b/frontend/src/services/cloudChatService.ts
@@ -14,14 +14,10 @@ import type { Chat, ChatRequest, ChatSearchResponse, CreateChatRequest } from '@
 import type { ActiveStreamSnapshot } from '@/types/stream.types';
 import type { PaginatedChats, PaginatedResponse } from '@/types/api.types';
 
-// Log into the VPS and persist its refresh token. The remote client mints
-// access tokens from it on demand, so the desktop stays connected across restarts.
+// Log into the VPS and persist its refresh token for reconnect across restarts.
 async function connect(url: string, email: string, password: string): Promise<void> {
-  // Store the URL slash-trimmed — consumers compose paths like `${cloudUrl}/chat/{id}`.
   const trimmedUrl = trimTrailingSlash(url);
-  // The login must hit the new host, but a failed attempt while connected to
-  // another VPS must not leave remoteApiClient pointed at a URL that never
-  // authenticated — existing cloud chats would misroute until reconnect/reload.
+  // On failed login, restore previous URL so existing cloud chats don't misroute.
   const previousUrl = useCloudSettingsStore.getState().cloudUrl;
   setCloudApiBaseUrl(trimmedUrl);
   const formData = new FormData();
@@ -47,9 +43,7 @@ function disconnect(): void {
   useCloudSettingsStore.getState().clearCloud();
 }
 
-// List chats on the VPS and register their chat + sandbox IDs as cloud-owned so
-// chatService and sandboxService route their reads, status checks, SSE streams,
-// stops, files, git, and terminal back to the VPS.
+// List VPS chats and mark chat/sandbox IDs cloud-owned for routing.
 async function listChats(params?: { page?: number; per_page?: number }): Promise<PaginatedChats> {
   return serviceCall(async () => {
     const queryString = buildQueryString(params);
@@ -65,15 +59,13 @@ async function listWorkspaces(): Promise<Workspace[]> {
   return serviceCall(async () => {
     const response = await remoteApiClient.get<PaginatedResponse<Workspace>>('/workspaces');
     const workspaces = ensureResponse(response, 'Failed to load cloud workspaces').items;
-    // Register sandbox IDs as cloud-owned so per-sandbox calls (git, files,
-    // terminal) route to the VPS, not the local backend.
+    // Mark sandboxes cloud-owned so git/files/terminal hit the VPS.
     markCloudSandboxes(workspaces.map((ws) => ws.sandbox_id).filter((id): id is string => !!id));
     return workspaces;
   });
 }
 
-// Search the VPS's chats — the search panel merges these with local results.
-// Marks returned chat IDs cloud-owned so opening a result routes to the VPS.
+// Search VPS chats (merged with local in the panel); mark results cloud-owned.
 async function searchChats(query: string): Promise<ChatSearchResponse> {
   return serviceCall(async () => {
     const queryString = buildQueryString({ q: query });
@@ -109,17 +101,14 @@ async function deleteWorkspace(workspaceId: string): Promise<void> {
   });
 }
 
-// Cloud half of Settings → "Delete All Chats": the sidebar presents one merged
-// list, so the wipe must reach the VPS's chats too.
+// Cloud half of "Delete All Chats" (sidebar merges local + VPS).
 async function deleteAllChats(): Promise<void> {
   await serviceCall(async () => {
     await remoteApiClient.delete('/chat/chats/all');
   });
 }
 
-// Fetch a VPS workspace's skills and builtin slash-commands. The landing
-// composer needs these before a chat exists, so there's no chatId to route by —
-// call the VPS directly instead of going through resolveChatClient.
+// Landing composer needs skills before a chat exists — call VPS directly.
 async function getWorkspaceResources(workspaceId: string): Promise<WorkspaceResources> {
   return serviceCall(async () => {
     const response = await remoteApiClient.get<WorkspaceResources>(
@@ -129,9 +118,7 @@ async function getWorkspaceResources(workspaceId: string): Promise<WorkspaceReso
   });
 }
 
-// Fetch VPS user settings. Only personas are consumed from the landing page —
-// the local settings (env vars, GitHub token, etc.) are separate. The VPS runs
-// the same backend, so the endpoint shape matches.
+// VPS settings (landing uses personas); same endpoint shape as local backend.
 async function getSettings(): Promise<UserSettings> {
   return serviceCall(async () => {
     const response = await remoteApiClient.get<UserSettings>('/settings/');
@@ -139,17 +126,14 @@ async function getSettings(): Promise<UserSettings> {
   });
 }
 
-// Start the run on the VPS. The desktop doesn't consume the stream — the VPS
-// owns and persists it.
+// Start a VPS run; the VPS owns the stream (desktop doesn't consume it).
 async function startCompletion(request: ChatRequest): Promise<void> {
   await serviceCall(async () => {
     await remoteApiClient.postForm('/chat/chat', buildChatFormData(request));
   });
 }
 
-// Bulk snapshot of every active stream on the VPS — the same registry-backed
-// endpoint local restoration uses, so no per-chat status fan-out. Marks the chat
-// IDs cloud-owned so reconnects and status checks route back to the VPS.
+// Bulk active-stream snapshot; mark chat IDs cloud-owned for reconnect routing.
 async function getActiveStreams(): Promise<ActiveStreamSnapshot[]> {
   return serviceCall(async () => {
     const response = await remoteApiClient.get<ActiveStreamSnapshot[]>(
@@ -161,9 +145,7 @@ async function getActiveStreams(): Promise<ActiveStreamSnapshot[]> {
   });
 }
 
-// Per-user chat lifecycle SSE feed from the VPS — the cloud twin of
-// chatService.createChatEventsSource. Async because EventSource bypasses
-// APIClient's 401→refresh path, so the token must be minted up front.
+// VPS chat lifecycle SSE. Mint token up front — EventSource skips 401 refresh.
 async function createChatEventsSource(): Promise<EventSource> {
   const token = await remoteApiClient.getValidToken();
   if (!token) {

--- a/frontend/src/services/desktopUpdateService.ts
+++ b/frontend/src/services/desktopUpdateService.ts
@@ -2,9 +2,7 @@ import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { useDesktopUpdateStore } from '@/store/updateStore';
 
-// Silently check for an update and stage it in the store. Does NOT download —
-// download+install runs only when the user clicks the menu item, so we don't
-// waste bandwidth re-downloading on every app launch.
+// Stage an available update without downloading (download only on user click).
 export async function checkDesktopUpdate(): Promise<void> {
   const update = await check();
   if (!update) return;
@@ -34,8 +32,7 @@ async function downloadAndInstall(update: Update): Promise<void> {
     });
     useDesktopUpdateStore.getState().setInstalling();
     await update.install();
-    // On Windows install() exits the current process; on macOS/Linux it
-    // replaces the bundle in place and requires an explicit relaunch.
+    // Windows install() exits; macOS/Linux replace in place and need relaunch.
     await relaunch();
   } catch (error) {
     useDesktopUpdateStore

--- a/frontend/src/services/githubService.ts
+++ b/frontend/src/services/githubService.ts
@@ -17,13 +17,8 @@ import type {
   GeneratePRDescriptionResponse,
 } from '@/types/github.types';
 
-// Repo search backs local workspace creation (no chat exists yet), so it always
-// targets the local instance and uses withAuth (auth failure = local session
-// dead). Everything else is invoked from a chat's git dialogs and must use the
-// GitHub credentials of the backend that owns the chat — a cloud chat's
-// PRs/commits go through the VPS's GitHub connection. Routed calls use
-// serviceCall like chatService's: withAuth would tear down the LOCAL session on
-// a VPS auth failure, while APIClient already handles per-client expiry.
+// Repo search is local-only (no chat yet) → withAuth. Chat git ops route by
+// chat ownership via serviceCall (withAuth would kill local session on VPS 401).
 async function searchRepositories(
   query: string,
   page: number,

--- a/frontend/src/services/streamConnection.ts
+++ b/frontend/src/services/streamConnection.ts
@@ -12,30 +12,23 @@ interface StreamConnectionHandlers {
 
 interface ManagedConnection {
   source: EventSource | null;
-  // Chats whose backlog the current EventSource replayed at open — a chat
-  // needing replay that isn't in here forces a reopen with fresh cursors.
+  // Chats replayed at open; missing chat forces reopen with fresh cursors.
   replayedChatIds: Set<string>;
   retryAttempts: number;
   retryTimer: ReturnType<typeof setTimeout> | null;
   stableTimer: ReturnType<typeof setTimeout> | null;
-  // Bumped on every (re)open/teardown so in-flight async opens self-cancel.
+  // Bumped on (re)open/teardown so in-flight async opens self-cancel.
   generation: number;
 }
 
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 1000;
 const RECONNECT_MAX_DELAY_MS = 15000;
-// How long a connection must stay open before its retry budget resets — an
-// instant reset on `open` would let a feed that 200s then immediately dies
-// (e.g. Redis down) loop forever without ever tripping the failure path.
+// Stay open this long before resetting retry budget (avoids open→die loops).
 const CONNECTION_STABLE_MS = 15000;
 
-// Owns the single multiplexed SSE connection per API host (local + cloud). The
-// server forwards every stream envelope for the user over one connection, so N
-// streaming chats no longer hold N sockets — browsers cap HTTP/1.1 at 6 per
-// origin, which froze all other requests once ~6 chats streamed concurrently.
-// Lifecycle is store-driven: the connection opens when a client's first active
-// stream registers in streamStore and closes when its last one is removed.
+// One multiplexed SSE per API host (browsers cap ~6 HTTP/1.1 sockets per origin).
+// Opens when streamStore has active streams; closes when the last is removed.
 class StreamConnectionManager {
   private connections = new Map<StreamApiClient, ManagedConnection>();
   private handlers: StreamConnectionHandlers | null = null;
@@ -45,15 +38,12 @@ class StreamConnectionManager {
     useStreamStore.subscribe(() => this.reconcile());
   }
 
-  // Force the next connection for this chat's host to include it in the replay
-  // cursor set — reopens a live connection, since an already-open feed only
-  // carries events published after it connected.
+  // Reopen if needed so this chat is in the replay cursor set.
   requestReplay(chatId: string): void {
     const client = resolveChatClient(chatId);
     const connection = this.connections.get(client);
     if (!connection) {
-      // reconcile() (triggered by the stream registration) opens it with this
-      // chat's cursor included; nothing to force.
+      // reconcile() will open with this chat's cursor; nothing to force.
       return;
     }
     if (!connection.replayedChatIds.has(chatId)) {
@@ -70,10 +60,7 @@ class StreamConnectionManager {
         this.teardown(client, connection);
         continue;
       }
-      // Replay membership is per registered stream, not per connection lifetime:
-      // once a chat's stream ends, a later turn in it must be able to force a
-      // replay again — its send-window events arrive before the new stream
-      // registers and would otherwise never be recovered.
+      // Drop ended streams from replay set so a later turn can force replay again.
       for (const chatId of connection.replayedChatIds) {
         if (!activeChatIds.has(chatId)) {
           connection.replayedChatIds.delete(chatId);
@@ -101,8 +88,7 @@ class StreamConnectionManager {
   }
 
   private buildCursors(chatIds: Set<string>): Record<string, number> {
-    // chatStorage cursors advance on every processed envelope, so they are the
-    // freshest resume point; 0 (no cursor) means replay the chat from the start.
+    // chatStorage is the freshest resume point; 0 means replay from start.
     const cursors: Record<string, number> = {};
     for (const chatId of chatIds) {
       const stored = Number(chatStorage.getEventId(chatId) || 0);
@@ -129,8 +115,7 @@ class StreamConnectionManager {
     }
 
     const generation = this.resetSocket(connection);
-    // Snapshot cursors synchronously so a requestReplay racing the token fetch
-    // sees exactly which chats this open will replay.
+    // Sync snapshot so a requestReplay racing token fetch sees this open's set.
     const cursors = this.buildCursors(chatIds);
     connection.replayedChatIds = new Set(chatIds);
 
@@ -149,17 +134,13 @@ class StreamConnectionManager {
     cursors: Record<string, number>,
     chatIds: Set<string>,
   ): Promise<void> {
-    // The connection is long-lived and reopens after failures, so the cached
-    // token may be expired — mint a fresh one on every open.
+    // Mint fresh token every open — long-lived feed may outlive the cached one.
     const token = await client.getValidToken();
     if (this.connections.get(client) !== connection || connection.generation !== generation) {
       return;
     }
     if (!token) {
-      // Session is dead (getValidToken already tore it down) — fail the streams
-      // instead of retrying an unauthenticatable feed forever. Use the open-time
-      // chat set: cloud session expiry clears the cloud-origin registry, so a
-      // recompute here would resolve those chats to the local client and miss them.
+      // Use open-time chat set — cloud expiry clears origin registry mid-flight.
       this.failClient(client, connection, chatIds);
       return;
     }
@@ -187,9 +168,7 @@ class StreamConnectionManager {
         clearTimeout(connection.stableTimer);
         connection.stableTimer = null;
       }
-      // Don't let EventSource auto-reconnect: its URL carries the cursors from
-      // open time, so chats subscribed since then would lose the outage window.
-      // Reopening ourselves rebuilds cursors from fresh chatStorage state.
+      // Manual reopen with fresh cursors — EventSource auto-reconnect uses stale URL.
       source.close();
       connection.source = null;
       this.scheduleReconnect(client, connection);
@@ -219,9 +198,7 @@ class StreamConnectionManager {
     affectedChatIds?: Set<string>,
   ): void {
     const chatIds = affectedChatIds ?? this.activeChatIdsByClient().get(client);
-    // Kill the socket but keep the map entry while the failure callback removes
-    // streams — each removal triggers reconcile, and a missing entry would
-    // immediately reopen a doomed connection mid-loop.
+    // Keep map entry while failing streams so reconcile doesn't reopen mid-loop.
     this.resetSocket(connection);
     if (chatIds && chatIds.size > 0) {
       this.handlers?.onConnectionFailure([...chatIds]);
@@ -234,7 +211,7 @@ class StreamConnectionManager {
     this.connections.delete(client);
   }
 
-  // Bumping the generation strands any in-flight connect() for this connection.
+  // Bump generation to strand any in-flight connect().
   private resetSocket(connection: ManagedConnection): number {
     connection.generation += 1;
     if (connection.retryTimer) {

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -154,8 +154,7 @@ class StreamService {
         content: payload.content,
         modelId: payload.model_id,
         attachments: payload.attachments,
-        // The handoff envelope is emitted by the finishing stream, so its
-        // messageId is the prior turn's assistant message.
+        // Handoff comes from the finishing stream — messageId is the prior turn.
         priorMessageId: envelope.messageId,
         priorDurationMs:
           typeof payload.prior_duration_ms === 'number' ? payload.prior_duration_ms : null,
@@ -168,10 +167,7 @@ class StreamService {
     if (!parsed?.chatId) return;
     const chatId = parsed.chatId;
 
-    // The multiplexed feed carries every stream of the user, including chats with
-    // no client-side stream registered (e.g. background sub-threads). Those must
-    // be ignored entirely — marking their seqs seen or advancing the chatStorage
-    // cursor would make a later replay of that chat skip its content.
+    // Ignore unregistered chats (e.g. sub-threads) — advancing their cursor would skip content on later replay.
     const currentStream = useStreamStore.getState().getStreamByChat(chatId);
     if (!currentStream) return;
     const streamId = currentStream.id;
@@ -190,9 +186,7 @@ class StreamService {
       chatStorage.setEventId(chatId, String(seq));
     }
 
-    // Queue handoff events are fully owned by maybeHandleQueueEvent — routing them
-    // on to onEnvelope would clear the pending id onQueueProcess just set for the
-    // queued turn's anchor, and nothing downstream consumes this kind anyway.
+    // Handoff is owned by maybeHandleQueueEvent — onEnvelope would clear its pending id.
     if (parsed.kind === 'queue_processing') {
       this.maybeHandleQueueEvent(parsed, chatId);
       return;
@@ -203,8 +197,7 @@ class StreamService {
       return;
     }
 
-    // Feeds the landing-page "last tool call" title; after the active-message
-    // guard so replayed envelopes for a stale turn can't overwrite it.
+    // Landing "last tool" title — after active-message guard so stale turns don't overwrite.
     if (
       parsed.kind === 'tool_started' &&
       parsed.payload.tool &&
@@ -224,7 +217,7 @@ class StreamService {
       const durationMs =
         typeof parsed.payload?.duration_ms === 'number' ? parsed.payload.duration_ms : null;
       useStreamStore.getState().removeStream(streamId);
-      // Cancelled turns skip the sidebar "Done" badge — only a successful finish earns it
+      // Only successful finish earns the sidebar "Done" badge.
       if (parsed.kind === 'complete') {
         useStreamStore.getState().markCompleted(chatId);
       }
@@ -243,8 +236,7 @@ class StreamService {
     }
   }
 
-  // Invoked when the shared connection gives up reconnecting — every stream
-  // riding it is unreachable, so fail them all like a fatal transport error.
+  // Shared connection gave up — fail every stream on it.
   private failStreamsForChats(chatIds: string[]): void {
     for (const chatId of chatIds) {
       const stream = useStreamStore.getState().getStreamByChat(chatId);
@@ -267,11 +259,7 @@ class StreamService {
     useStreamStore.getState().abortStream(stream.id);
   }
 
-  // Registering the stream opens the shared connection if it isn't already, and
-  // the replay request covers the already-open case — events published before
-  // this registration (send request window, pre-reconnect backlog) would
-  // otherwise be dropped, since an open feed only replays chats from its
-  // open-time cursors. The resume point is the chat's chatStorage cursor.
+  // Register + requestReplay so pre-registration events aren't dropped on an open feed.
   private registerAndReplay(
     chatId: string,
     messageId: string,
@@ -314,9 +302,7 @@ class StreamService {
   }
 
   async replayStream(options: StreamReconnectOptions): Promise<string> {
-    // A from-zero replay rebuilds the whole message, so the dedup window must
-    // not swallow the re-sent seqs. The actual resume point comes from the
-    // chatStorage cursor the reconnect flow wrote before calling this.
+    // From-zero replay must not have the dedup window swallow re-sent seqs.
     if (!options.afterSeq || options.afterSeq <= 0) {
       this.recentSeqByChat.delete(options.chatId);
     }

--- a/frontend/src/services/workspaceService.ts
+++ b/frontend/src/services/workspaceService.ts
@@ -41,8 +41,7 @@ async function deleteWorkspace(workspaceId: string): Promise<void> {
   });
 }
 
-// chatId routes by the owning chat: a cloud chat's workspace lives on the VPS, so
-// its skills/slash-commands must come from there, not the local backend.
+// chatId routes to the owning backend (cloud chat skills live on the VPS).
 async function getWorkspaceResources(
   workspaceId: string,
   chatId?: string,

--- a/frontend/src/store/chatSettingsStore.ts
+++ b/frontend/src/store/chatSettingsStore.ts
@@ -26,11 +26,9 @@ interface ChatSettingsState {
   permissionModeByChat: Record<string, PermissionMode>;
   thinkingModeByChat: Record<string, string>;
   worktreeByChat: Record<string, boolean>;
-  // Codex-only: 1.5x speed service tier. Other agents ignore it.
+  // Codex-only 1.5x tier; other agents ignore it.
   fastModeByChat: Record<string, boolean>;
-  // Where a new chat runs: locally (false) or on the remote VPS instance (true).
-  // Global, not per-chat — chosen at creation time on the landing composer, and
-  // cloud chats live on the VPS so they never get a local chat ID to key by.
+  // Global landing-composer choice (cloud chats have no local id to key by).
   runOnCloud: boolean;
   personaByChat: Record<string, string>;
   setPermissionMode: (chatId: string, mode: PermissionMode) => void;
@@ -75,10 +73,7 @@ export const useChatSettingsStore = create<ChatSettingsState>()(
         set((state) => ({
           personaByChat: { ...state.personaByChat, [chatId]: name },
         })),
-      // Copies the __default__ settings to a newly created chat so the user's
-      // toolbar defaults (permission mode, thinking, worktree, persona) carry
-      // over without requiring explicit selection each time. Only reached for
-      // local chats — cloud chats live on the VPS and aren't seeded here.
+      // Seed a new local chat from __default__ toolbar settings (not used for cloud).
       initChatFromDefaults: (chatId) => {
         const state = get();
         const permission = state.permissionModeByChat[DEFAULT_KEY];

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -11,9 +11,7 @@ type ChatStoreType = Pick<UIState, 'currentChat' | 'attachedFilesByChat'> &
     | 'promoteAttachedFiles'
   >;
 
-// Per-chat one-shot attachment slot. Files attached pre-send (landing page or
-// the "open in split" affordance) live here keyed by chatId; the orchestrator
-// consumes and clears its slot after the first message ships.
+// Pre-send attachments keyed by chatId; cleared after the first message ships.
 export const useChatStore = create<ChatStoreType>((set) => ({
   currentChat: null,
   attachedFilesByChat: {},

--- a/frontend/src/store/cloudSettingsStore.ts
+++ b/frontend/src/store/cloudSettingsStore.ts
@@ -2,9 +2,9 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 interface CloudSettingsState {
-  // VPS origin (e.g. https://vps.example.com), without the /api/v1 suffix.
+  // VPS origin without /api/v1 (e.g. https://vps.example.com).
   cloudUrl: string;
-  // Email the desktop is connected to the VPS as — display only.
+  // Display-only connected email.
   connectedEmail: string | null;
   setCloud: (url: string, email: string) => void;
   clearCloud: () => void;

--- a/frontend/src/store/diffReviewStore.ts
+++ b/frontend/src/store/diffReviewStore.ts
@@ -2,10 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 interface DiffReviewState {
-  // scopeKey (`sandbox\0cwd\0mode`) -> reviewed file keys (`path\0contentHash`).
-  // The content hash means a ✓ stops matching once the file changes, so the UI
-  // treats it as unreviewed; the stale key itself is pruned the next time that
-  // file is toggled (see below), keeping a bucket to at most one key per path.
+  // scopeKey → path\0contentHash keys. Hash mismatch = unreviewed after edits.
   reviewedByScope: Record<string, string[]>;
   toggleReviewed: (scopeKey: string, reviewKey: string) => void;
 }
@@ -18,13 +15,11 @@ export const useDiffReviewStore = create<DiffReviewState>()(
         set((state) => {
           const current = state.reviewedByScope[scopeKey] ?? [];
           const wasReviewed = current.includes(reviewKey);
-          // A file has exactly one live key, so drop every key for this path
-          // (the current one plus any stale post-edit hashes) before re-adding.
+          // One live key per path — drop stale post-edit hashes before re-adding.
           const prefix = reviewKey.slice(0, reviewKey.lastIndexOf('\0') + 1);
           const pruned = current.filter((k) => !k.startsWith(prefix));
           const next = wasReviewed ? pruned : [...pruned, reviewKey];
           const reviewedByScope = { ...state.reviewedByScope };
-          // Drop emptied buckets so storage doesn't accumulate dead scopes.
           if (next.length === 0) delete reviewedByScope[scopeKey];
           else reviewedByScope[scopeKey] = next;
           return { reviewedByScope };

--- a/frontend/src/store/messageQueueStore.ts
+++ b/frontend/src/store/messageQueueStore.ts
@@ -23,10 +23,8 @@ interface MessageQueueState {
   cleanupChat: (chatId: string) => void;
 }
 
-// Optimistic message queue: messages are added locally with a temp ID, then
-// synced to the server. If the server returns a real ID, the temp ID is swapped
-// in-place. Network errors leave the message as unsynced. fetchQueue merges
-// server state with any unsynced locals so nothing is lost across page refreshes.
+// Optimistic queue: temp IDs swap in-place on sync; network errors stay unsynced.
+// fetchQueue merges server state with unsynced locals across refreshes.
 export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
   queues: new Map<string, LocalQueuedMessage[]>(),
 
@@ -153,9 +151,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
     }
   },
 
-  // Asks the backend to immediately process this queued message instead of
-  // waiting for the stream to finish. Sets a 30s timeout guard to reset the
-  // sendingNow flag in case the request hangs without a response.
+  // Process now instead of waiting for the stream; 30s guard resets sendingNow.
   sendNow: async (chatId: string, messageId: string): Promise<boolean> => {
     const queue = get().queues.get(chatId) || [];
     const message = queue.find((m) => m.id === messageId);
@@ -233,8 +229,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
     });
   },
 
-  // Fetches the server-side queue and merges it with any unsynced local messages.
-  // Server messages replace their local counterparts; unsynced locals are appended.
+  // Server messages win; unsynced locals without a server counterpart are kept.
   fetchQueue: async (chatId: string) => {
     try {
       const serverMessages = await queueService.getQueue(chatId);

--- a/frontend/src/store/permissionStore.ts
+++ b/frontend/src/store/permissionStore.ts
@@ -2,15 +2,9 @@ import { create } from 'zustand';
 import type { PermissionRequest } from '@/types/chat.types';
 
 interface PermissionState {
-  // chatId -> FIFO queue of pending requests. Each chat can have several
-  // permission requests in flight at once (the agent may emit a batch of tool
-  // calls), so we keep a queue and surface them to the UI one at a time. Keying
-  // by a single request per chat would drop all but the last, leaving the
-  // backend blocked forever on the unanswered ones.
+  // FIFO per chat — agents may batch tool calls; a single slot would drop earlier ones.
   pendingRequests: Map<string, PermissionRequest[]>;
-  // Returns true if the request was newly enqueued, false if it was a duplicate
-  // that got deduped — callers use this to gate one-time side effects (e.g.
-  // notifications) without re-scanning the queue themselves.
+  // true if newly enqueued (gate one-time side effects like notifications).
   enqueuePermissionRequest: (chatId: string, request: PermissionRequest) => boolean;
   resolvePermissionRequest: (chatId: string, requestId: string) => void;
 }
@@ -20,8 +14,7 @@ export const usePermissionStore = create<PermissionState>((set, get) => ({
 
   enqueuePermissionRequest: (chatId: string, request: PermissionRequest) => {
     const queue = get().pendingRequests.get(chatId) ?? [];
-    // Dedupe by request_id so duplicate SSE envelopes (e.g. after a
-    // reconnect) don't enqueue the same request twice.
+    // Dedupe SSE replays after reconnect.
     if (queue.some((r) => r.request_id === request.request_id)) {
       return false;
     }

--- a/frontend/src/store/sidebarFilters.ts
+++ b/frontend/src/store/sidebarFilters.ts
@@ -1,28 +1,23 @@
 import type { AgentKind } from '@/types/chat.types';
 
-// Sidebar chat-list filter model — shared by uiStore (persistence), Sidebar
-// (count/clear), and SidebarFilterMenu (UI), so it lives outside the component.
+// Shared filter model for uiStore, Sidebar, and SidebarFilterMenu.
 
-// Status filters mirror the row badge signals: unread is the persisted server flag;
-// running/done/needs-you are session-only stream state that resets on reload.
+// unread is server-persisted; running/done/needs-you are session-only stream state.
 export type SidebarStatusFilter = 'unread' | 'running' | 'done' | 'needs-you';
 export type SidebarSourceFilter = 'all' | 'local' | 'cloud';
 export type SidebarGroupBy = 'none' | 'date' | 'workspace' | 'status';
 
-// statuses is an array (not a Set) so the whole object survives JSON
-// persistence in uiStore; it's at most 4 entries.
+// Array (not Set) so the object survives JSON persistence; max 4 entries.
 export interface SidebarFilters {
   statuses: SidebarStatusFilter[];
   agentKind: AgentKind | null;
   source: SidebarSourceFilter;
   workspaceId: string | null;
-  // Presentation mode, not a filter — excluded from countActiveSidebarFilters
-  // and preserved when filters are cleared.
+  // Presentation only — excluded from active count, kept on clear.
   groupBy: SidebarGroupBy;
 }
 
-// Never mutated — filter changes always build a fresh object, so sharing one
-// instance for the initial and cleared state is safe.
+// Immutable empty — filter changes always allocate a fresh object.
 export const EMPTY_SIDEBAR_FILTERS: SidebarFilters = {
   statuses: [],
   agentKind: null,
@@ -31,8 +26,7 @@ export const EMPTY_SIDEBAR_FILTERS: SidebarFilters = {
   groupBy: 'none',
 };
 
-// Clearing resets the filter dimensions but keeps presentation (groupBy) —
-// the same filter/presentation split countActiveSidebarFilters encodes.
+// Resets filter dimensions but keeps presentation (groupBy).
 export function clearSidebarFilters(filters: SidebarFilters): SidebarFilters {
   return { ...EMPTY_SIDEBAR_FILTERS, groupBy: filters.groupBy };
 }

--- a/frontend/src/store/streamStore.ts
+++ b/frontend/src/store/streamStore.ts
@@ -49,8 +49,7 @@ const removeStreamMetadataEntry = (metadata: StreamMetadata[], chatId: string): 
   metadata.filter((item) => item.chatId !== chatId);
 
 const shutdownStream = (stream: ActiveStream) => {
-  // The shared multiplexed connection (streamConnection) reconciles against the
-  // store, so dropping the entry is enough — no per-stream socket to close.
+  // Multiplexed connection reconciles from the store — no per-stream socket.
   stream.isActive = false;
   stream.callbacks = undefined;
 };
@@ -60,8 +59,7 @@ export const useStreamStore = create<StreamState>((set, get) => ({
   streamIdByChatMessage: new Map<string, string>(),
   activeStreamMetadata: [],
   lastToolTitleByChatId: new Map<string, string>(),
-  // Chats whose stream finished successfully since the user last viewed them —
-  // drives the sidebar "Done" badge until the chat is opened.
+  // Successful finishes since last view — sidebar "Done" badge until opened.
   completedChatIds: new Set<string>(),
 
   markCompleted: (chatId: string) => {
@@ -170,8 +168,7 @@ export const useStreamStore = create<StreamState>((set, get) => ({
       const stream = state.activeStreams.get(streamId);
       if (!stream) return state;
 
-      // A message-id swap only happens on queue handoff — the stream is reused for a
-      // new assistant turn, so restart the clock (thinking timer, cancel duration).
+      // Queue handoff reuses the stream for a new turn — restart thinking/cancel clocks.
       const updatedStream = { ...stream, messageId: newMessageId, startTime: Date.now() };
       const nextStreams = new Map(state.activeStreams);
       nextStreams.set(streamId, updatedStream);
@@ -180,7 +177,7 @@ export const useStreamStore = create<StreamState>((set, get) => ({
       nextIndex.delete(getChatMessageKey(chatId, oldMessageId));
       nextIndex.set(getChatMessageKey(chatId, newMessageId), streamId);
 
-      // The new turn hasn't run a tool yet — the previous turn's title is stale.
+      // Previous turn's tool title is stale for the new turn.
       const nextLastToolTitles = new Map(state.lastToolTitleByChatId);
       nextLastToolTitles.delete(chatId);
 
@@ -243,8 +240,7 @@ export const useStreamStore = create<StreamState>((set, get) => ({
   },
 
   addStreamMetadataIfAbsent: (metadata: StreamMetadata) => {
-    // Unlike addStreamMetadata's upsert, an already-tracked chat keeps its entry —
-    // restoration and event feeds must not reset a live stream's startTime.
+    // Keep existing entries so restoration doesn't reset a live startTime.
     set((state) =>
       state.activeStreamMetadata.some((item) => item.chatId === metadata.chatId)
         ? state

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -36,7 +36,7 @@ interface PendingFileOpen {
   path: string;
   chatId: string | undefined;
   line?: number;
-  // Re-opens can repeat the same path/line after the user scrolls away.
+  // Bumps so re-opening the same path/line still focuses after scroll-away.
   nonce: number;
 }
 
@@ -46,11 +46,11 @@ export interface EditorCodeSelection {
   endLine: number;
   languageId: string;
   text: string;
-  // Set by diff-view review comments; serialized under the code block at send time.
+  // Diff-view review comment; serialized under the code block at send.
   comment?: string;
 }
 
-// Text selected from rendered chat messages — no file/line identity.
+// Chat message selection — no file/line identity.
 export interface ChatTextSelection {
   kind: 'chat';
   text: string;
@@ -63,13 +63,12 @@ type UIStoreState = ThemeState &
   Pick<UIActions, 'setSidebarOpen' | 'setSidebarWidth'> &
   SplitViewState &
   SplitViewActions & {
-    // Sidebar chat-list filters — persisted so a reload keeps the narrowed view
+    // Persisted so reload keeps the narrowed sidebar view.
     sidebarFilters: SidebarFilters;
     setSidebarFilters: (filters: SidebarFilters) => void;
     commandMenuOpen: boolean;
     setCommandMenuOpen: (open: boolean) => void;
-    // Set by `executeCommand` when a mode-switching command (search, files, branches)
-    // reopens the menu, then consumed and cleared by CommandMenu on next open.
+    // Mode-switch commands set this; CommandMenu consumes it on next open.
     pendingMenuMode: MenuMode | null;
     setPendingMenuMode: (mode: MenuMode | null) => void;
     subThreadDialogOpen: boolean;
@@ -80,27 +79,20 @@ type UIStoreState = ThemeState &
     setCreateBranchDialogOpen: (open: boolean) => void;
     createCommitDialogOpen: boolean;
     setCreateCommitDialogOpen: (open: boolean) => void;
-    // `chatId` binds the open/jump to its chat so only that chat's editor tile
-    // claims it (the primary and split editors share these store fields).
-    // `undefined` is the chat-less landing editor, which exposes workspace files
-    // before any chat exists.
+    // chatId binds the jump to one editor tile; undefined = landing editor.
     pendingFileOpen: PendingFileOpen | null;
     openFileInEditor: (path: string, chatId: string | undefined, line?: number) => void;
     pendingChatMessage: { chatId: string; message: string } | null;
     setPendingChatMessage: (payload: { chatId: string; message: string } | null) => void;
-    // Editor snippets / chat-text selections attached to a chat's input as
-    // removable chips (VS Code "add selection to chat") — serialized into the
-    // prompt only at send time.
+    // Selection chips for a chat's input; serialized into the prompt at send.
     composerSelectionsByChat: Record<string, ComposerSelection[]>;
     addComposerSelection: (chatId: string, selection: ComposerSelection) => void;
     removeComposerSelection: (chatId: string, index: number) => void;
     clearComposerSelections: (chatId: string) => void;
-    // Sandbox of the workspace selected on the landing page. Lets context-less
-    // consumers (the global git shortcuts) resolve a target before a chat exists.
+    // Landing workspace sandbox for git shortcuts before a chat exists.
     workspaceSandboxId: string | null;
     setWorkspaceSandboxId: (sandboxId: string | null) => void;
-    // Working set of chats shown as title-bar tabs — only explicitly opened
-    // chats, ordered by open time; the sidebar remains the full archive.
+    // Title-bar working set (explicitly opened); sidebar is the full archive.
     chatTabs: string[];
     openChatTab: (chatId: string) => void;
     closeChatTab: (chatId: string) => void;
@@ -124,7 +116,6 @@ function splitSlotAt(index: number): SplitSlot {
   return 3;
 }
 
-// Which agent chat a tile belongs to.
 function agentTileFor(tileId: TileId): AgentTileId {
   const slot = splitSlotOfTile(tileId);
   return slot ? splitAgentTile(slot) : 'agent:primary';
@@ -154,25 +145,21 @@ function rebuildSplitGrid(
   };
 }
 
-// Drops tiles from the layout, removing any row left empty.
 function filterLayout(layout: TileId[][], keep: (tileId: TileId) => boolean): TileId[][] {
   return layout.map((row) => row.filter(keep)).filter((row) => row.length > 0);
 }
 
-// Appends a tile to the last row (side-by-side split).
 function appendToLastRow(layout: TileId[][], tileId: TileId): TileId[][] {
   if (layout.length === 0) return [[tileId]];
   return layout.map((row, i) => (i === layout.length - 1 ? [...row, tileId] : row));
 }
 
-// Last tile in layout order — the fallback focus target after a removal.
 function lastVisibleTile(layout: TileId[][]): TileId {
   const flat = layout.flat();
   return flat[flat.length - 1];
 }
 
-// The per-chat tabs we persist exclude transient split-chat tiles. Guards
-// against an all-split layout collapsing to empty.
+// Persist without split-chat tiles so an all-split layout can't collapse empty.
 function ownTabs(openTabs: TileId[], visibleLayout: TileId[][]): WorkspaceLayout {
   const layout = filterLayout(visibleLayout, (t) => !isSplitTile(t));
   return {
@@ -181,17 +168,14 @@ function ownTabs(openTabs: TileId[], visibleLayout: TileId[][]): WorkspaceLayout
   };
 }
 
-// The editor jump is chat-bound; a jump for a chat that's going away (its pane
-// closed/replaced) is stale and would otherwise fire in the wrong tile.
+// Drop jumps for a chat whose pane is going away (would fire in the wrong tile).
 function clearJumpsForChat(state: UIStoreState, chatId: string | null): Partial<UIStoreState> {
   const cleared: Partial<UIStoreState> = {};
   if (state.pendingFileOpen?.chatId === chatId) cleared.pendingFileOpen = null;
   return cleared;
 }
 
-// A pending jump can't survive its own tile being closed. Only the tile that
-// would have claimed it clears it: a split tile owns its bound chat, and the
-// primary owns chats not bound to any split slot.
+// Only the tile that would claim the jump clears it (split owns its chat; primary owns the rest).
 function clearJumpsForTile(state: UIStoreState, tileId: TileId): Partial<UIStoreState> {
   if (tileIdToViewType(tileId) !== 'editor') return {};
   const jump = state.pendingFileOpen;
@@ -339,8 +323,7 @@ export const useUIStore = create<UIStoreState>()(
           },
           openTabs: state.openTabs.includes(tileId) ? state.openTabs : [...state.openTabs, tileId],
         });
-        // Editor already on screen (possibly in a split) — keep the layout and just
-        // focus it; activateTab would collapse the split to a full-view editor.
+        // Already visible — focus only; activateTab would collapse a split.
         if (state.visibleLayout.flat().includes(tileId)) get().focusTile(tileId);
         else get().activateTab(tileId);
       },
@@ -366,18 +349,13 @@ export const useUIStore = create<UIStoreState>()(
 
       focusTile: (tileId) => {
         if (get().focusedTile === tileId) return;
-        // Single focus path for both tab and pane clicks. activeAgentTile is the
-        // coarsening of focusedTile (primary vs split chat). It stays a separate
-        // field because focusedTile is nullable (no interaction yet) while the ~6
-        // imperative coarse readers need an always-defined value — collapsing would
-        // scatter `?? 'agent:primary'` fallbacks across all of them.
+        // activeAgentTile is always-defined coarsening of nullable focusedTile.
         set({ focusedTile: tileId, activeAgentTile: agentTileFor(tileId) });
       },
 
       toggleView: (view, toggle) => {
         const state = get();
-        // Agent is the base view and is never torn down to nothing; toggling it
-        // just closes any split chat or re-focuses the primary pane.
+        // Agent is never torn down; toggle closes split or re-focuses primary.
         if (view === 'agent') {
           if (toggle && state.splitChatIds.length > 0) get().closeSplitChat();
           else get().activateTab('agent:primary');
@@ -385,13 +363,11 @@ export const useUIStore = create<UIStoreState>()(
         }
         const slot = activeSplitSlot(state.activeAgentTile, state.splitChatIds);
         const tileId = viewTypeToTileId(view, slot);
-        // Mobile shows one view; re-tapping the on-screen view returns to agent.
+        // Mobile: one view; re-tap returns to agent.
         if (!isDesktop()) {
           const target =
             toggle && state.visibleLayout[0]?.[0] === tileId ? 'agent:primary' : tileId;
-          // Keep agent:primary open even when a non-agent view fills the screen, so
-          // the Agent command/icon can always switch back to it (activateTab guards
-          // on openTabs membership).
+          // Keep agent:primary in openTabs so activateTab can switch back.
           set({
             openTabs: target === 'agent:primary' ? ['agent:primary'] : ['agent:primary', target],
             visibleLayout: [[target]],
@@ -401,8 +377,7 @@ export const useUIStore = create<UIStoreState>()(
           return;
         }
         if (state.openTabs.includes(tileId)) {
-          // Views have no tabs, so toggle keys on visibility: an on-screen view
-          // closes; one kept mounted in the background resurfaces instead.
+          // Toggle by visibility: on-screen closes; background resurfaces.
           if (toggle && state.visibleLayout.flat().includes(tileId)) get().removeTab(tileId);
           else get().activateTab(tileId);
         } else {
@@ -415,8 +390,7 @@ export const useUIStore = create<UIStoreState>()(
         const state = get();
         const slot = activeSplitSlot(state.activeAgentTile, state.splitChatIds);
         const tileId = viewTypeToTileId(view, slot);
-        // Already on screen — just focus it, don't duplicate it into the layout.
-        // Otherwise 'row' adds it beside the last row, 'column' starts a new row.
+        // Already visible → focus only; else row = beside last, column = new row.
         const visibleLayout = state.visibleLayout.flat().includes(tileId)
           ? state.visibleLayout
           : direction === 'row'
@@ -432,7 +406,7 @@ export const useUIStore = create<UIStoreState>()(
 
       removeTab: (tileId) => {
         const state = get();
-        // The base agent tab can't be closed; a split agent tears down its chat pane.
+        // agent:primary can't close; split agent tears down its chat pane.
         if (tileId === 'agent:primary' || !state.openTabs.includes(tileId)) return;
         const splitSlot = splitSlotOfTile(tileId);
         if (tileIdToViewType(tileId) === 'agent' && splitSlot) {
@@ -441,9 +415,7 @@ export const useUIStore = create<UIStoreState>()(
         }
         const openTabs = state.openTabs.filter((t) => t !== tileId);
         let visibleLayout = filterLayout(state.visibleLayout, (t) => t !== tileId);
-        // Never leave an empty viewport — closing a full-screen view lands back on
-        // its own chat's agent pane, not whatever background view happened to
-        // be opened last.
+        // Never empty the viewport — fall back to this chat's agent pane.
         if (visibleLayout.length === 0) {
           const owner = agentTileFor(tileId);
           visibleLayout = [[openTabs.includes(owner) ? owner : 'agent:primary']];
@@ -453,7 +425,6 @@ export const useUIStore = create<UIStoreState>()(
           visibleLayout,
           ...clearJumpsForTile(state, tileId),
         };
-        // If the focused tile went away, re-aim at a surviving visible pane.
         if (state.focusedTile === tileId) {
           const next = lastVisibleTile(visibleLayout);
           patch.focusedTile = next;
@@ -462,8 +433,7 @@ export const useUIStore = create<UIStoreState>()(
         set(patch);
       },
 
-      // Resets to a single agent view AND tears down any split chat.
-      // Detaches from any chat so the next chat entry restores its own tabs.
+      // Single agent view, no split; detaches so the next chat restores its tabs.
       resetWorkspace: () =>
         set({
           openTabs: ['agent:primary'],
@@ -476,12 +446,10 @@ export const useUIStore = create<UIStoreState>()(
 
       loadWorkspaceForChat: (chatId) => {
         const state = get();
-        // Visiting a chat adds it to the title-bar working set — runs before the
-        // early return so a rehydrated same-chat entry still keeps its tab.
+        // Before early-return so same-chat rehydrate still keeps the title tab.
         get().openChatTab(chatId);
         if (state.currentWorkspaceChatId === chatId) return;
         const layoutsByChat = { ...state.layoutsByChat };
-        // Stash the chat we're leaving before swapping in the new one's tabs.
         if (state.currentWorkspaceChatId) {
           layoutsByChat[state.currentWorkspaceChatId] = ownTabs(
             state.openTabs,
@@ -521,19 +489,14 @@ export const useUIStore = create<UIStoreState>()(
           editorByChat,
           layoutsByChat,
           chatTabs: state.chatTabs.filter((id) => id !== chatId),
-          // Deleting the on-screen chat navigates away after this runs, and
-          // ChatPage's unmount stash would write the deleted entry right back —
-          // null the live pointer so that stash no-ops (same resurrection guard
-          // as cleanupAllChats).
+          // Null live pointer so ChatPage unmount stash can't resurrect the deleted chat.
           ...(state.currentWorkspaceChatId === chatId ? { currentWorkspaceChatId: null } : {}),
         });
         clearTerminalStorage(chatId);
       },
 
       cleanupAllChats: () => {
-        // The live workspace (openTabs, currentWorkspaceChatId, split) may still
-        // reference a deleted chat — without the reset, the next
-        // loadWorkspaceForChat would stash it right back into layoutsByChat.
+        // Reset first so the next loadWorkspaceForChat can't re-stash deleted chats.
         get().resetWorkspace();
         set({ editorByChat: {}, layoutsByChat: {}, chatTabs: [] });
         clearTerminalStorage();
@@ -551,8 +514,7 @@ export const useUIStore = create<UIStoreState>()(
           return;
         }
         if (state.splitChatIds.length >= MAX_CHAT_PANES - 1) return;
-        // A chat opened in split joins the working set — it stays reachable from
-        // the tab strip after the split closes.
+        // Join working set so the chat stays in the tab strip after split closes.
         get().openChatTab(chatId);
         const splitChatIds = [...state.splitChatIds, chatId];
         const resetFocus: Pick<UIStoreState, 'activeAgentTile' | 'focusedTile'> = {
@@ -633,27 +595,19 @@ export const useUIStore = create<UIStoreState>()(
         theme: state.theme,
         sidebarOpen: state.sidebarOpen,
         sidebarWidth: state.sidebarWidth,
-        // Status filters read session-only stream state that's empty at mount —
-        // persisting them would rehydrate a view that can't match anything.
-        // Only the durable dimensions (agent/source/workspace) survive reloads.
+        // Status filters are session-only (empty at mount) — don't persist them.
         sidebarFilters: { ...state.sidebarFilters, statuses: [] },
         splitChatIds: state.splitChatIds,
-        // Persist the live workspace so a refresh restores the active view/tabs.
-        // currentWorkspaceChatId must rehydrate too: loadWorkspaceForChat
-        // early-returns when it matches the route chat, leaving this layout intact
-        // instead of resetting to the default agent view.
+        // Live workspace + currentWorkspaceChatId so refresh doesn't reset layout.
         openTabs: state.openTabs,
         visibleLayout: state.visibleLayout,
         currentWorkspaceChatId: state.currentWorkspaceChatId,
-        // Persist each chat's open files + active file so a refresh reopens what
-        // the user had open, instead of rehydrating to an empty editor.
         editorByChat: state.editorByChat,
         chatTabs: state.chatTabs,
       }),
       version: 1,
       migrate: migrateUIState,
-      // Backfill filter fields added after a user first persisted state (e.g.
-      // groupBy) — the default shallow merge would rehydrate them as undefined.
+      // Backfill new filter fields (e.g. groupBy) the shallow merge would leave undefined.
       merge: (persisted, current) => {
         const stored = persisted as Partial<UIStoreState> | undefined;
         return {

--- a/frontend/src/store/updateStore.ts
+++ b/frontend/src/store/updateStore.ts
@@ -9,10 +9,9 @@ interface DesktopUpdateState {
   releaseNotes: string | null;
   releaseDate: string | null;
   downloadedBytes: number;
-  // null when the server didn't send Content-Length
+  // null when the server omitted Content-Length
   totalBytes: number | null;
   errorMessage: string | null;
-  // Downloads and installs the staged update. Set when check() finds an update.
   triggerInstall: (() => Promise<void>) | null;
 }
 

--- a/frontend/src/types/automation.types.ts
+++ b/frontend/src/types/automation.types.ts
@@ -37,8 +37,7 @@ export interface AutomationCreateRequest {
 
 export type AutomationUpdateRequest = Partial<AutomationCreateRequest>;
 
-// Snapshot of every inputbar setting an automation replays when its schedule
-// fires — the edit-dialog form state shared between the tab and the dialog.
+// Inputbar settings an automation replays; shared edit-dialog form shape.
 export interface AutomationForm {
   name: string;
   prompt: string;

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -29,8 +29,7 @@ export interface Message {
   checkpoint_id: string | null;
 }
 
-// ACP plan entry — each plan event carries the complete list, replacing the
-// previous plan state rather than appending to it.
+// Plan events replace the whole list (not append).
 export interface PlanEntry {
   content: string;
   status: 'pending' | 'in_progress' | 'completed';
@@ -81,8 +80,7 @@ export interface Chat {
   last_persona_name: string | null;
 }
 
-// Wire contract of the per-user chat lifecycle SSE feed (/chat/chats/events),
-// consumed by useChatEvents (local) and useCloudChatEvents (VPS).
+// /chat/chats/events SSE — useChatEvents (local) / useCloudChatEvents (VPS).
 export type ChatEvent =
   | { kind: 'chat_created'; chat: Chat }
   | { kind: 'stream_started'; chat_id: string; message_id: string }
@@ -159,8 +157,7 @@ export function getAgentKindForModelId(modelId: string | null | undefined): Agen
     return 'claude';
   }
   if (CODEX_MODEL_IDS.has(modelId)) return 'codex';
-  // Copilot, Cursor, and OpenCode models use a prefix convention — detect by
-  // convention instead of maintaining a duplicate static set.
+  // Prefix convention for copilot/cursor/grok/opencode (avoids a second static set).
   if (modelId.startsWith('copilot:')) return 'copilot';
   if (modelId.startsWith('cursor:')) return 'cursor';
   if (modelId.startsWith('grok:')) return 'grok';
@@ -186,9 +183,6 @@ export interface PermissionRequest {
   tool_name: string;
   tool_input: Record<string, unknown>;
   options: PermissionOption[];
-  // Monotonic stream sequence of the originating envelope. Used to dedupe
-  // replayed permission events (the backend persists and re-streams them after
-  // `after_seq` on reconnect/refresh) without relying on request_id, which some
-  // providers reuse across turns.
+  // Envelope seq for dedupe on reconnect (request_id can be reused across turns).
   seq: number;
 }

--- a/frontend/src/types/queue.types.ts
+++ b/frontend/src/types/queue.types.ts
@@ -7,8 +7,7 @@ export interface QueueMessageAttachment {
   filename?: string;
 }
 
-// Toolbar + attachment payload for queueMessage — named fields avoid a growing
-// positional boolean list (worktree/fastMode after files).
+// Named options for queueMessage (avoids a growing positional boolean list).
 export interface QueueMessageOptions {
   permissionMode?: PermissionMode;
   thinkingMode?: string | null;

--- a/frontend/src/types/stream.types.ts
+++ b/frontend/src/types/stream.types.ts
@@ -35,8 +35,7 @@ export interface QueueProcessingData {
   content: string;
   modelId: string;
   attachments?: MessageAttachment[];
-  // The handoff suppresses the prior turn's complete event, so its persisted
-  // run duration rides along here for the "Worked for X" rollup label.
+  // Handoff suppresses prior complete; duration rides here for "Worked for X".
   priorMessageId: string;
   priorDurationMs: number | null;
 }
@@ -44,13 +43,11 @@ export interface QueueProcessingData {
 export interface ApiStreamResponse {
   messageId: string;
   checkpointId: string | null;
-  // Set when this turn bound the chat to a worktree — created server-side
-  // during the send request, before any stream event arrives.
+  // Set server-side on send when this turn binds a worktree (before stream events).
   worktreeCwd: string | null;
 }
 
-// Envelopes arrive over the shared multiplexed connection (streamConnection)
-// and route here via envelope.chatId — a stream entry no longer owns a socket.
+// Multiplexed via streamConnection + envelope.chatId (no per-stream socket).
 export interface ActiveStream {
   id: string;
   chatId: string;
@@ -76,7 +73,7 @@ export interface StreamMetadata {
   startTime: number;
 }
 
-// Wire shape of GET /chat/chats/active-streams — one entry per running turn.
+// GET /chat/chats/active-streams — one entry per running turn.
 export interface ActiveStreamSnapshot {
   chat_id: string;
   message_id: string;

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -37,8 +37,7 @@ export type Theme =
   | 'linear'
   | 'lobster';
 export type ResolvedTheme = 'light' | 'dark';
-// Active palette with `system` resolved away — used where concrete per-theme colors
-// are built outside CSS (Monaco/xterm can't read CSS vars). Theme = Palette | 'system'.
+// Palette = Theme without `system`; for Monaco/xterm which can't read CSS vars.
 export type Palette = Exclude<Theme, 'system'>;
 
 type MentionType = 'file';
@@ -68,8 +67,7 @@ export type ViewType = 'agent' | 'diff' | 'editor' | 'terminal';
 export const MAX_CHAT_PANES = 4;
 export type SplitSlot = 1 | 2 | 3;
 
-// Split tiles are scoped to one of the three additional chat panes. Primary
-// non-agent tile ids stay bare; the primary agent is the one named exception.
+// Split tiles use :split-N; primary non-agent tiles stay bare (agent:primary is the exception).
 export type AgentTileId = 'agent:primary' | `agent:split-${SplitSlot}`;
 export type SplitTileId = `${ViewType}:split-${SplitSlot}`;
 export type NonAgentTileId =
@@ -77,88 +75,65 @@ export type NonAgentTileId =
   | Exclude<SplitTileId, `agent:split-${SplitSlot}`>;
 export type TileId = AgentTileId | NonAgentTileId;
 
-// The axis a single split adds along: 'row' = side by side (split right),
-// 'column' = stacked below (split bottom).
+// 'row' = side by side; 'column' = stacked below.
 export type SplitDirection = 'row' | 'column';
 
-// A chat's saved workspace tabs — what's restored when the chat is revisited.
+// Restored when the chat is revisited.
 export interface WorkspaceLayout {
   openTabs: TileId[];
   visibleLayout: TileId[][];
 }
 
-// Per-chat editor pane state: the open file tabs (in strip order) and the active one.
 export interface EditorPaneState {
   open: string[];
   selected: string | null;
 }
 
 export interface SplitViewState {
-  // Every open view. Always holds at least 'agent:primary'. Views have no tab
-  // strip: an open-but-hidden tile stays mounted in the background (preserving
-  // editor/terminal state) until the switcher surfaces or closes it.
+  // Always includes at least 'agent:primary'. Hidden open tiles stay mounted (editor/terminal state).
   openTabs: TileId[];
-  // The on-screen layout as rows of tiles: rows stack vertically, tiles within a
-  // row sit side by side. [[A]] = full view; [[A, B]] = side by side; [[A], [B]]
-  // = stacked; [[A, B], [C]] = A│B over C. Always holds at least one tile.
+  // Rows of tiles (stack vertically; tiles in a row sit side by side). Always ≥1 tile.
   visibleLayout: TileId[][];
-  // Ordered chats in the three additional panes. Primary is always the route param.
+  // Chats in the three additional panes; primary is the route param.
   splitChatIds: string[];
-  // The agent pane the user last interacted with — targets pane-scoped actions
-  // (e.g. the diff shortcut) at the chat the user is actually in.
+  // Last-interacted agent pane — pane-scoped shortcuts (e.g. diff) target this chat.
   activeAgentTile: AgentTileId;
-  // The exact pane the user last touched — drives the focused-tab highlight.
-  // Distinct from activeAgentTile, which only tracks the active chat (primary vs
-  // a split slot), not the specific tile.
+  // Exact last-touched pane (tab highlight). Unlike activeAgentTile, not just primary vs split slot.
   focusedTile: TileId | null;
-  // Saved tabs per chat, so each chat restores its own workspace when revisited.
-  // Excludes split-chat tiles, which the split effects rebuild.
+  // Per-chat saved tabs; excludes split-chat tiles (rebuild effects restore those).
   layoutsByChat: Record<string, WorkspaceLayout>;
-  // The open file tabs + active file in each chat's editor — restored when revisiting
-  // a chat (EditorPane's selection is lost on unmount) and persisted so a page refresh
-  // reopens them. Keyed by chat id (or a landing-editor sentinel for the chat-less
-  // landing page).
+  // Per-chat editor tabs; EditorPane loses selection on unmount, so this is persisted.
+  // Keyed by chat id (or landing-editor sentinel when no chat).
   editorByChat: Record<string, EditorPaneState>;
-  // Which chat the live openTabs/visibleLayout belong to — drives save-on-switch.
+  // Which chat owns live openTabs/visibleLayout (save-on-switch).
   currentWorkspaceChatId: string | null;
 }
 
 export interface SplitViewActions {
-  // Shows a view full screen, or — when toggling — closes it if already on
-  // screen. Scoped to the active agent pane so shortcuts hit the chat the user is in.
+  // Full-screen toggle for a view on the active agent pane.
   toggleView: (view: ViewType, toggle: boolean) => void;
-  // Opens a view (if needed) and adds it to the on-screen layout: 'row' beside
-  // the last row, 'column' as a new row below.
   addViewToSplit: (view: ViewType, direction: SplitDirection) => void;
-  // Closes a view, dropping it from the open and visible sets.
   removeTab: (tileId: TileId) => void;
-  // Resets the workspace to a single agent view and tears down any split chat
-  // (used by the landing page). Detaches the live layout from any chat.
+  // Single agent view; tears down split chats (landing page).
   resetWorkspace: () => void;
-  // Saves the outgoing chat's tabs and restores the incoming chat's (defaulting
-  // to a lone agent view). Called on chat navigation.
+  // Stash outgoing + restore incoming chat tabs (chat navigation).
   loadWorkspaceForChat: (chatId: string) => void;
-  // Saves the current chat's tabs in place — used when leaving the chat page.
+  // Persist current tabs (leaving the chat page).
   stashWorkspace: () => void;
   openChatInSplit: (chatId: string) => void;
   rebuildSplitLayout: () => void;
   closeSplitChat: (chatId?: string) => void;
-  // Shows a tile full (sole visible pane) and focuses it.
   activateTab: (tileId: TileId) => void;
-  // Single focus path: records the exact pane (highlights its tab) and scopes the
-  // active chat (primary/split slot) from the tile, so tab and pane clicks agree.
+  // Sets focusedTile + activeAgentTile so tab and pane clicks stay consistent.
   focusTile: (tileId: TileId) => void;
-  // Drops a deleted chat's saved workspace tabs, editor tabs, and terminal tab
-  // layout so per-chat state doesn't accumulate in localStorage forever.
+  // Drop deleted chat's workspace/editor/terminal state so localStorage doesn't grow forever.
   cleanupChat: (chatId: string) => void;
   cleanupAllChats: () => void;
 }
 
 export interface UIState {
   currentChat: Chat | null;
-  // Per-chat one-shot attachments. Cleared after the first message for that
-  // chat ships. The PENDING_NEW_CHAT_KEY sentinel holds files attached before
-  // the chat id exists; landing page promotes them once the chat is created.
+  // One-shot per chat; cleared after first send. PENDING_NEW_CHAT_KEY holds pre-create attaches.
   attachedFilesByChat: Record<string, File[]>;
   sidebarOpen: boolean;
   sidebarWidth: number;

--- a/frontend/src/types/user.types.ts
+++ b/frontend/src/types/user.types.ts
@@ -34,7 +34,7 @@ export interface Persona {
   content: string;
 }
 
-// A post-stream action button: runs `command` on `model_id` in a new sub-thread.
+// Post-stream button: runs `command` on `model_id` in a new sub-thread.
 export interface StreamAction {
   label: string;
   enabled: boolean;

--- a/frontend/src/utils/activeStreams.ts
+++ b/frontend/src/utils/activeStreams.ts
@@ -2,9 +2,8 @@ import { useStreamStore } from '@/store/streamStore';
 import { logger } from '@/utils/logger';
 import type { ActiveStreamSnapshot } from '@/types/stream.types';
 
-// Registers a backend's active-streams snapshot so sidebar/tab streaming
-// indicators cover turns started while this client wasn't listening — startup
-// restoration and post-gap SSE resyncs. Already-tracked streams are untouched.
+// Register backend snapshot for turns started while offline (startup/resync).
+// Already-tracked streams are left alone.
 export function registerActiveStreams(streams: ActiveStreamSnapshot[]): void {
   for (const stream of streams) {
     useStreamStore.getState().addStreamMetadataIfAbsent({
@@ -15,10 +14,7 @@ export function registerActiveStreams(streams: ActiveStreamSnapshot[]): void {
   }
 }
 
-// Post-gap resync for the SSE feeds: fetch the backend's snapshot and register
-// it, skipping registration when the subscribing effect already tore down —
-// a late response from a logged-out session or switched VPS must not write
-// ghost metadata into the global store.
+// Fetch snapshot after an SSE gap; skip if the subscriber already unmounted.
 export function resyncActiveStreams(
   getStreams: () => Promise<ActiveStreamSnapshot[]>,
   isCancelled: () => boolean,

--- a/frontend/src/utils/automationSchedule.ts
+++ b/frontend/src/utils/automationSchedule.ts
@@ -1,5 +1,4 @@
-// Builds/parses the restricted cron shapes the automation schedule UI offers.
-// Anything the parser doesn't recognize round-trips through the 'custom' mode.
+// Restricted cron shapes for the automation schedule UI; unknown → 'custom'.
 
 export type ScheduleFrequency = 'hourly' | 'daily' | 'weekly' | 'monthly' | 'custom';
 

--- a/frontend/src/utils/chatEventsFeed.ts
+++ b/frontend/src/utils/chatEventsFeed.ts
@@ -2,14 +2,9 @@ import { logger } from '@/utils/logger';
 
 const REOPEN_DELAY_MS = 15_000;
 
-// Keeps a per-user chat lifecycle SSE feed alive. EventSource retries transient
-// drops itself but treats HTTP errors as fatal (readyState CLOSED) — e.g. a 401
-// once the query-param token expires — so fatal closes reopen with a freshly
-// minted token via `createSource`. The backend feed is a pub/sub relay with no
-// replay, so events published during a gap are gone: any successful open that
-// follows a failure (native retry, fatal-close reopen, or a failed first
-// attempt) calls `onResync` so the subscriber can refetch what it missed.
-// Returns a cleanup that cancels retries and closes the feed.
+// Chat lifecycle SSE: EventSource retries transients but treats HTTP errors
+// (e.g. expired query-param token) as fatal CLOSED — reopen via createSource.
+// No server-side replay, so successful open after any failure calls onResync.
 export function subscribeChatEventsFeed(options: {
   createSource: () => Promise<EventSource>;
   onChatEvent: (event: MessageEvent) => void;
@@ -44,8 +39,7 @@ export function subscribeChatEventsFeed(options: {
           }
         };
         source.onerror = () => {
-          // Any error marks a potential gap — including transient drops the
-          // EventSource retries natively without reaching the CLOSED branch.
+          // Gaps include transient drops retried natively (never hit CLOSED).
           needsResync = true;
           if (source?.readyState !== EventSource.CLOSED) return;
           scheduleReopen();

--- a/frontend/src/utils/chatOrigin.ts
+++ b/frontend/src/utils/chatOrigin.ts
@@ -1,12 +1,6 @@
-// Tracks which chat IDs and sandbox IDs live on the cloud VPS rather than the
-// local instance, so chatService and sandboxService can route per-chat and
-// per-sandbox API calls (reads, status, SSE, files, git, terminal) to the
-// backend that owns them. Single-user app: IDs are unique across the two
-// backends, so flat sets are enough — no need to namespace by origin.
-//
-// Persisted to localStorage and hydrated synchronously at module load: a reload
-// or a direct deep-link to /chat/:id must resolve origin before the chat and
-// sandbox queries fire, otherwise they would fall back to the local backend.
+// Cloud-owned chat/sandbox IDs for routing API calls to the VPS.
+// Flat sets are enough (single-user; IDs unique across backends).
+// Hydrated sync at load so deep-links don't fall back to the local backend.
 const CHATS_KEY = 'cloud-chat-ids';
 const SANDBOXES_KEY = 'cloud-sandbox-ids';
 
@@ -59,7 +53,6 @@ export function isCloudSandbox(id: string): boolean {
   return cloudSandboxIds.has(id);
 }
 
-// Reset all cloud-origin tracking — called on VPS disconnect.
 export function clearCloudOrigins(): void {
   cloudChatIds.clear();
   cloudSandboxIds.clear();

--- a/frontend/src/utils/chatRequest.ts
+++ b/frontend/src/utils/chatRequest.ts
@@ -5,7 +5,6 @@ import { getAgentKindForModelId, type ChatRequest, type Model } from '@/types/ch
 import type { PermissionMode } from '@/store/chatSettingsStore';
 import type { Persona } from '@/types/user.types';
 
-// Raw toolbar settings before agent coercion.
 interface RawChatSettings {
   permissionMode: PermissionMode;
   thinkingMode: string;
@@ -19,9 +18,7 @@ type AgentChatFields = Pick<
   'permission_mode' | 'thinking_mode' | 'worktree' | 'fast_mode' | 'selected_persona_name'
 >;
 
-// Coerce raw toolbar settings into the agent-specific ChatRequest fields. Shared
-// so local (useMessageActions) and cloud (landing) runs start with identical
-// behavior — the coercion rules can't drift between the two paths.
+// Shared coercion so local and cloud runs can't drift on agent-specific fields.
 export function buildAgentChatFields(
   selectedModelId: string,
   modelMap: Map<string, Model>,

--- a/frontend/src/utils/composerSelections.ts
+++ b/frontend/src/utils/composerSelections.ts
@@ -3,11 +3,9 @@ import type { ComposerSelection } from '@/store/uiStore';
 const BACKTICK_RUN = /`+/g;
 
 export function formatComposerSelections(selections: ComposerSelection[], message: string): string {
-  // Chips are UI-only; at send time the selections ride in the prompt as
-  // fenced blocks above the user's text.
+  // Chips are UI-only; at send, selections become fenced blocks above the message.
   const blocks = selections.map((s) => {
-    // Snippets can contain ``` (Markdown, nested fences) which would close a
-    // bare fence early — use one longer than the longest run in the text.
+    // Fence longer than any run in the text so nested ``` can't close early.
     const longestRun =
       s.text.match(BACKTICK_RUN)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
     const fence = '`'.repeat(Math.max(3, longestRun + 1));

--- a/frontend/src/utils/definitionPatterns.ts
+++ b/frontend/src/utils/definitionPatterns.ts
@@ -1,19 +1,13 @@
-// Grep-based go-to-definition: per-language regex templates that match only
-// definition sites of a symbol, never call sites. The backend runs them through
-// ripgrep (Rust regex — no lookarounds), so alternatives anchor with \b instead.
-
+// Go-to-definition regexes: definition sites only. Ripgrep has no lookarounds — use \b.
 const SYMBOL = '__SYMBOL__';
-// Global matcher for SYMBOL so we can swap in the escaped identifier without
-// relying on String.prototype.replaceAll (target lib is below es2021). Using
-// .replace with a /g regex preserves replaceAll's replacement-string ($) semantics.
+// /g replace (not replaceAll) — target lib < es2021; keeps $ replacement semantics.
 const SYMBOL_RE = /__SYMBOL__/g;
 
 const REGEX_SPECIALS = /[.*+?^${}()|[\]\\]/g;
 
 interface LanguageQuery {
   patterns: string[];
-  // Restricts the search to the language's file family so definition keywords
-  // appearing in docs or other languages don't produce junk hits.
+  // Language file globs so keywords in other languages don't produce junk hits.
   include?: string;
 }
 

--- a/frontend/src/utils/diffSelection.ts
+++ b/frontend/src/utils/diffSelection.ts
@@ -18,11 +18,7 @@ function rowMatches(row: DiffRow, lineNumber: number, side: SelectionSide | unde
 
 function buildUnifiedRows(file: FileDiffMetadata): DiffRow[] {
   const rows: DiffRow[] = [];
-  // Context gaps between hunks are only addressable when the line arrays hold
-  // complete file bodies (line number N ↔ index N-1). DiffView's
-  // rebuildWithCollapsedContext (re-diff from full contents) guarantees this
-  // for every rendered diff; partial patches can't expand gaps, so skipping
-  // them is safe.
+  // Gaps need full file bodies (N ↔ index N-1); DiffView re-diffs guarantee this.
   const fullBodies = file.hunks.every(
     (h) =>
       h.additionLineIndex === h.additionStart - 1 && h.deletionLineIndex === h.deletionStart - 1,
@@ -90,8 +86,7 @@ function buildUnifiedRows(file: FileDiffMetadata): DiffRow[] {
   return rows;
 }
 
-// Selected lines of a diff as unified-diff text (`-`/`+`/space prefixes).
-// Returns null when the range doesn't resolve against the file's hunks.
+// Unified-diff text for a selection; null if the range misses the hunks.
 export function getSelectedDiffText(
   file: FileDiffMetadata,
   range: SelectedLineRange,

--- a/frontend/src/utils/file.ts
+++ b/frontend/src/utils/file.ts
@@ -96,8 +96,7 @@ export function findFileInStructure(
   return undefined;
 }
 
-// Tool paths are absolute (/home/user/project/src/foo.ts), tree paths are relative (src/foo.ts).
-// Try the exact path first, then progressively strip leading segments to find a match.
+// Tool paths are absolute; tree paths relative — strip leading segments until match.
 export function findFileByToolPath(
   items: FileStructure[],
   toolPath: string,
@@ -206,8 +205,7 @@ const createDirectoryPath = (
 };
 
 export function buildFileStructureFromSandboxFiles(sandboxFiles: FileMetadata[]): FileStructure[] {
-  // The metadata listing carries paths/types only — file content is fetched
-  // per-file on demand, so tree nodes always start with empty content.
+  // Listing is paths/types only — content is fetched on demand.
   const fileStructure: FileStructure[] = [];
   const pathToFile: Map<string, FileStructure> = new Map();
 

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -23,8 +23,7 @@ export function formatNumberCompact(num: number): string {
   return (num / 1000000).toFixed(1).replace(/\.0$/, '') + 'M';
 }
 
-// Strips paired markdown delimiters while preserving content between them —
-// uses matched pairs so isolated chars (e.g. underscores in `my_var`) aren't mangled
+// Matched pairs only so isolated chars (e.g. underscores in my_var) stay intact.
 export function stripMarkdownTitle(title: string): string {
   return title
     .replace(/\*{1,2}(.+?)\*{1,2}/g, '$1')

--- a/frontend/src/utils/lazyNamed.ts
+++ b/frontend/src/utils/lazyNamed.ts
@@ -1,9 +1,7 @@
 import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
 
-// Wraps React.lazy for modules whose component is a named (not default) export.
-// The bound is ComponentType<any> so T is inferred as the component's concrete
-// type — a stricter prop-shaped bound makes TS fall back to the constraint and
-// reject the module's real prop type (contravariant inference).
+// React.lazy for named exports. ComponentType<any> keeps T as the concrete
+// component type (stricter props bounds break contravariant inference).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function lazyNamed<T extends ComponentType<any>>(
   factory: () => Promise<Record<string, T>>,

--- a/frontend/src/utils/mentionParser.ts
+++ b/frontend/src/utils/mentionParser.ts
@@ -3,10 +3,8 @@ export interface HighlightSegment {
   isToken: boolean;
 }
 
-// @mention or /command preceded by start-of-string or whitespace — mirrors
-// parseTokenQuery's boundary rule, so anything the suggestion panels can insert
-// also pills. Paths containing spaces truncate at the space, same as the
-// unquoted mention insertion. One regex keeps the ranges position-sorted.
+// Boundary rule mirrors parseTokenQuery so suggestion inserts also pill.
+// Paths with spaces truncate at the space (same as unquoted insertion).
 const TOKEN_REGEX = /(^|\s)([@/]\S+)/g;
 
 interface TokenQueryResult {
@@ -28,8 +26,6 @@ export const parseTokenQuery = (
   cursorPosition: number,
   trigger: '@' | '/',
 ): TokenQueryResult => {
-  // In-progress token at the cursor: trigger char at start-of-string or after
-  // whitespace, with no whitespace between it and the cursor.
   const textBeforeCursor = message.slice(0, cursorPosition);
   const lastTriggerIndex = textBeforeCursor.lastIndexOf(trigger);
 
@@ -65,8 +61,7 @@ export const insertToken = (
   startPos: number,
   endPos: number,
 ): { text: string; cursor: number } => {
-  // Replaces the in-progress [startPos, endPos) token with the selected value;
-  // the trailing space closes the suggestion query so the panel dismisses.
+  // Trailing space closes the suggestion query so the panel dismisses.
   const before = message.slice(0, startPos);
   const after = message.slice(endPos);
   const separator = after.startsWith(' ') ? '' : ' ';
@@ -77,7 +72,6 @@ export const insertToken = (
 };
 
 export const getHighlightTokenRanges = (message: string): Array<[number, number]> => {
-  // [start, end) offsets of @file mention and /command tokens.
   const tokenRanges: Array<[number, number]> = [];
 
   for (const match of message.matchAll(TOKEN_REGEX)) {
@@ -89,8 +83,7 @@ export const getHighlightTokenRanges = (message: string): Array<[number, number]
 };
 
 export const buildHighlightSegments = (message: string): HighlightSegment[] => {
-  // Split text into plain/token runs so callers can render pills behind the
-  // tokens without altering the raw value.
+  // Plain/token runs so callers can render pills without altering the raw value.
   const tokenRanges = getHighlightTokenRanges(message);
 
   const segments: HighlightSegment[] = [];

--- a/frontend/src/utils/notifications.ts
+++ b/frontend/src/utils/notifications.ts
@@ -8,8 +8,7 @@ import type { PermissionRequest } from '@/types/chat.types';
 import { logger } from '@/utils/logger';
 
 const NOTIFICATION_DURATION_MS = 10_000;
-// Recently-sent permission request IDs — checked before firing an OS notification
-// to prevent duplicates when SSE envelopes replay on reconnection.
+// Dedup OS notifications when SSE envelopes replay on reconnect.
 const NOTIFIED_PERMISSION_REQUESTS = new Set<string>();
 
 function buildPermissionNotification(request: PermissionRequest): { title: string; body: string } {

--- a/frontend/src/utils/permissionResponse.ts
+++ b/frontend/src/utils/permissionResponse.ts
@@ -7,9 +7,7 @@ function isExpiredRequestError(error: unknown): boolean {
   return (error as ApiError)?.status === 404;
 }
 
-// Wraps a permission service call with standard loading/error/cleanup behavior:
-// on success or 404 (expired), clears the pending state; on other errors, sets
-// the provided error message.
+// Loading/error wrapper: success or 404 clears pending; other errors set message.
 export async function executePermissionResponse(
   serviceFn: () => Promise<void>,
   opts: {
@@ -27,9 +25,7 @@ export async function executePermissionResponse(
     return 'success';
   } catch (err) {
     if (isExpiredRequestError(err)) {
-      // This request is already gone on the backend (timeout/session moved on),
-      // so clear the local pending state but let the caller decide whether any
-      // success-only UI transitions should still happen.
+      // Expired on backend — clear local pending; caller decides success-only UI.
       opts.clearRequest();
       return 'expired';
     } else {
@@ -41,9 +37,7 @@ export async function executePermissionResponse(
   return 'error';
 }
 
-// Called once a request has been answered (or found already-expired). Records
-// the resolved seq so a replayed permission event is not re-shown after a
-// refresh/reconnect, then drops the request from the in-memory queue.
+// Record resolved seq (blocks SSE replay after refresh) and drop from the queue.
 export function clearPermissionRequest(chatId: string, requestId: string, seq: number): void {
   addResolvedPermission(chatId, seq);
   usePermissionStore.getState().resolvePermissionRequest(chatId, requestId);

--- a/frontend/src/utils/permissionStorage.ts
+++ b/frontend/src/utils/permissionStorage.ts
@@ -7,14 +7,8 @@ export function filterOptions(
   return options.filter((o) => o.kind.startsWith(prefix));
 }
 
-// Tracks resolved permission requests by their stream sequence so that
-// permission events the backend replays after `after_seq` (page refresh,
-// reconnect from a stale cursor) are not re-shown once the user has already
-// answered them. Keyed by `${chatId}:${seq}` rather than request_id: seq is
-// monotonic per chat and unique per emission, so a new request in a later turn
-// is never blocked even when a provider reuses tool-call ids. Persisted across
-// reloads (that is the whole point — the in-memory queue is empty on refresh)
-// and capped to bound storage.
+// Resolved permission seqs so SSE replays after refresh don't re-show them.
+// Keyed by chatId:seq (not request_id) — providers may reuse tool-call ids.
 const RESOLVED_PERMISSIONS_KEY = 'agentrove_resolved_permission_seqs';
 const MAX_RESOLVED_PERMISSIONS = 200;
 
@@ -42,7 +36,7 @@ export function addResolvedPermission(chatId: string, seq: number): void {
     }
     localStorage.setItem(RESOLVED_PERMISSIONS_KEY, JSON.stringify(resolved));
   } catch {
-    // Ignore localStorage errors
+    // localStorage unavailable/full
   }
 }
 

--- a/frontend/src/utils/platform.ts
+++ b/frontend/src/utils/platform.ts
@@ -2,15 +2,10 @@ import { isTauri } from '@tauri-apps/api/core';
 
 export const IS_MAC_PLATFORM = navigator.platform.toUpperCase().startsWith('MAC');
 
-// Set at build time by Vite mode: `--mode mobile` loads .env.mobile which sets
-// VITE_PLATFORM=mobile. Mobile builds run inside a Tauri shell (isTauri() is true)
-// but have no local backend sidecar — they talk to a remote backend baked in at
-// build time, so the desktop sidecar/updater/tray boot paths must be skipped.
+// Vite `--mode mobile` sets VITE_PLATFORM=mobile. No local sidecar — skip desktop boot.
 const IS_MOBILE_BUILD = import.meta.env.VITE_PLATFORM === 'mobile';
 
-// Intentionally no isTauri() guard (unlike isDesktopApp): in browser `dev:mobile`
-// this is true so the mobile build stays testable in a plain browser. The Tauri-only
-// calls it gates (e.g. window.show()) reject harmlessly there.
+// No isTauri() guard: browser `dev:mobile` stays testable; Tauri-only calls no-op.
 export const isMobileApp = (): boolean => IS_MOBILE_BUILD;
 
 export const isDesktopApp = (): boolean => isTauri() && !IS_MOBILE_BUILD;

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -69,8 +69,7 @@ const safeRemoveItem = (key: string): void => {
   }
 };
 
-// Singleton promise — ensures only one Tauri store load is in flight at a time.
-// Cleared on failure so the next call retries rather than returning a stale rejection.
+// One Tauri store load in flight; cleared on failure so the next call retries.
 let desktopStorePromise: Promise<AuthStoreBackend | null> | null = null;
 
 async function getDesktopAuthStore(): Promise<AuthStoreBackend | null> {
@@ -137,10 +136,8 @@ function initTokenCacheFromLocalStorage(): void {
   tokenCacheInitialized = true;
 }
 
-// Dual-backend auth token storage: uses the Tauri secure store on desktop and
-// localStorage in the browser. An in-memory cache (`cachedToken`) avoids async
-// reads on the hot path (every API request reads the token synchronously via
-// `getToken()`). Writes propagate to the backing store asynchronously.
+// Tauri secure store on desktop, localStorage in browser. In-memory cache for
+// sync getToken() on the API hot path; writes go to the backing store async.
 export const authStorage = {
   hydrate: async (): Promise<void> => {
     if (tokenCacheInitialized) {
@@ -185,8 +182,7 @@ export const authStorage = {
     tokenCacheInitialized = true;
 
     if (isTauri()) {
-      // Awaited so refresh rotation can't complete before the new token hits
-      // disk — a quit mid-persist would strand the old (rotated-away) one.
+      // Await so refresh rotation can't finish before the new token hits disk.
       await persistDesktopAuthState();
       safeRemoveItem(AUTH_TOKEN_KEY);
       safeRemoveItem(REFRESH_TOKEN_KEY);
@@ -213,10 +209,7 @@ export const authStorage = {
   },
 };
 
-// Remote (VPS) auth: the desktop talks to a second AgentRove instance for
-// cloud-run chats. Only the long-lived refresh token is persisted (in the same
-// secure backing store as local auth, under a distinct key) — the short-lived
-// access token is kept in memory and re-minted via the VPS refresh endpoint.
+// VPS auth: only the refresh token is persisted; access token stays in memory.
 let cloudAccessToken: string | null = null;
 let cloudRefreshToken: string | null = null;
 let cloudCacheInitialized = false;
@@ -275,10 +268,8 @@ export const cloudAuthStorage = {
     cloudRefreshToken = refreshToken;
     cloudCacheInitialized = true;
 
-    // Unlike authStorage there's no stale-localStorage cleanup on the Tauri
-    // path — this key is new and only ever written to localStorage in browsers.
+    // No localStorage cleanup on Tauri — this key is only written in browsers.
     if (isTauri()) {
-      // Awaited for the same reason as authStorage.setTokens.
       await persistCloudRefreshToken();
       return;
     }
@@ -299,10 +290,8 @@ export const cloudAuthStorage = {
   },
 };
 
-// Cross-tab sync (browser only — the `storage` event fires in every tab except
-// the writer): another tab rotating or clearing tokens must update this tab's
-// in-memory cache, or its next refresh replays a rotated-away token and gets a
-// 401 once the backend's reuse grace window closes.
+// Cross-tab: another tab rotating tokens must update this tab's memory cache
+// or the next refresh replays a rotated-away token after the grace window.
 if (typeof window !== 'undefined' && !isTauri()) {
   window.addEventListener('storage', (event) => {
     if (event.key === AUTH_TOKEN_KEY) {
@@ -311,8 +300,7 @@ if (typeof window !== 'undefined' && !isTauri()) {
       cachedRefreshToken = event.newValue;
     } else if (event.key === CLOUD_REFRESH_TOKEN_KEY) {
       cloudRefreshToken = event.newValue;
-      // Disconnect in another tab must also drop this tab's memory-only access
-      // token — it has no localStorage key of its own to sync through.
+      // Access token is memory-only — drop it when another tab disconnects.
       if (event.newValue === null) {
         cloudAccessToken = null;
       }
@@ -320,10 +308,7 @@ if (typeof window !== 'undefined' && !isTauri()) {
   });
 }
 
-// Per-chat SSE cursor persistence: stores the last-seen seq number in
-// localStorage so stream reconnection can resume from the right point after
-// a page refresh. Entries are pruned to MAX_CHAT_EVENT_ID_ENTRIES (500) by
-// evicting the lowest seq values to prevent unbounded localStorage growth.
+// Per-chat SSE last-seq for resume after refresh; pruned to bound storage.
 export const chatStorage = {
   getEventId: (chatId: string): string | null =>
     safeGetItem(`${CHAT_EVENT_ID_PREFIX}${chatId}${CHAT_EVENT_ID_SUFFIX}`),

--- a/frontend/src/utils/stream.ts
+++ b/frontend/src/utils/stream.ts
@@ -13,9 +13,7 @@ interface ParseCacheEntry {
   events: AssistantStreamEvent[];
 }
 
-// LRU-style parse cache: avoids re-parsing the same content_text on every render.
-// Keyed by a length+prefix+suffix fingerprint for long strings to avoid Map
-// key bloat. Capped at 20 entries with FIFO eviction.
+// Avoid re-parsing content_text each render. Long keys fingerprint length+ends.
 const PARSE_CACHE_MAX_SIZE = 20;
 const parseCache = new Map<string, ParseCacheEntry>();
 
@@ -25,9 +23,7 @@ function getContentKey(content: string): string {
     : content;
 }
 
-// Content starting with "[" is treated as a JSON event array; anything else
-// is wrapped as a single assistant_text event (backward compat with plain-text
-// messages).
+// "[" → JSON event array; otherwise plain text (legacy) as one assistant_text.
 function parseEventLogUncached(content: string): AssistantStreamEvent[] {
   const trimmed = content.trim();
   if (!trimmed) {
@@ -87,10 +83,8 @@ export interface ContentRenderSnapshot {
   events?: AssistantStreamEvent[];
 }
 
-// Collects streaming events and text fragments as they arrive from the SSE
-// pipeline. Maintains a parallel textParts array so getContentText() is a
-// cheap join rather than a full events scan. Seeded from existing message
-// content on reconnection so resumed streams append rather than restart.
+// Parallel textParts so getContentText() is a join, not an events scan.
+// Seeded on reconnect so resumed streams append rather than restart.
 export class StreamContentBuffer {
   private events: AssistantStreamEvent[];
   private textParts: string[];

--- a/frontend/src/utils/terminal.ts
+++ b/frontend/src/utils/terminal.ts
@@ -3,9 +3,8 @@ import type { ISearchDecorationOptions } from '@xterm/addon-search';
 import type { Palette } from '@/types/ui.types';
 import { CUSTOM_PALETTE_TOKENS, DARK_PALETTES } from '@/utils/theme';
 
-// xterm paints its own canvas background, so it can't read the surface-secondary CSS
-// var. Custom palettes derive bg/fg from the shared tokens; light/dark are the base
-// shades (mirrored from globals.css).
+// xterm paints its own canvas, so it can't read surface-secondary CSS vars.
+// Light/dark shades mirrored from globals.css; custom palettes use shared tokens.
 const BASE_SURFACE = {
   light: { background: '#f9f9f9', foreground: '#27272a' },
   dark: { background: '#141414', foreground: '#e4e4e7' },
@@ -17,9 +16,8 @@ function paletteSurface(palette: Palette): { background: string; foreground: str
   return { background: t.surfaceSecondary, foreground: t.textPrimary };
 }
 
-// xterm's built-in ANSI 16 defaults assume a dark background — on a light canvas,
-// white/bright-white and yellow output (git, ls, prompts) is near-invisible. Light
-// palettes get VS Code Light+'s re-tuned set; dark palettes keep the built-ins.
+// Built-in ANSI 16 assumes dark bg — light canvas makes white/yellow near-invisible.
+// Light palettes use VS Code Light+; dark keeps xterm defaults.
 const LIGHT_ANSI = {
   black: '#000000',
   red: '#cd3131',
@@ -65,16 +63,12 @@ export const buildSearchDecorations = (palette: Palette): ISearchDecorationOptio
   };
 };
 
-// Terminal tab layouts live in their own localStorage entries outside the zustand
-// persist blob. The key scheme is owned here so the Container's writes and the
-// uiStore's delete-time sweeps can't silently drift apart. The scope is a chat id,
-// or a `landing-<sandboxId>` scope for pre-chat terminals (those are only swept by
-// the clear-all path).
+// Key scheme owned here so Container writes and uiStore delete sweeps can't drift.
+// Scope is a chat id, or `landing-<sandboxId>` for pre-chat terminals (clear-all only).
 export const terminalStorageKey = (scope: string, panelKey: string): string =>
   `terminal:${scope}:${panelKey}`;
 
 export function clearTerminalStorage(chatId?: string): void {
-  // Sweep one chat's entries, or every chat's when chatId is omitted.
   const prefix = chatId ? `terminal:${chatId}:` : 'terminal:';
   for (let i = localStorage.length - 1; i >= 0; i--) {
     const key = localStorage.key(i);

--- a/frontend/src/utils/theme.ts
+++ b/frontend/src/utils/theme.ts
@@ -35,7 +35,6 @@ import type { Palette, Theme } from '@/types/ui.types';
 import type { PaletteDef, PaletteKey } from '@/styles/palettes';
 import { PALETTES } from '@/styles/palettes';
 
-// Palettes that aren't the plain light/dark base — each re-skins the base surfaces.
 export type CustomPalette = Exclude<Palette, 'light' | 'dark'>;
 
 export interface ThemeMeta {
@@ -44,9 +43,7 @@ export interface ThemeMeta {
   icon: LucideIcon;
 }
 
-// Single source for theme presentation and cycle order. A custom palette's colors +
-// light/dark base live in src/styles/palettes.ts (see DARK_PALETTES). Themes are picked
-// from the command menu's theme sub-mode, not per-theme chords (see commandRegistry).
+// Theme presentation + cycle order. Palette colors live in src/styles/palettes.ts.
 export const THEMES: ThemeMeta[] = [
   { value: 'dark', label: 'Dark', icon: Moon },
   { value: 'light', label: 'Light', icon: Sun },
@@ -85,23 +82,16 @@ const THEME_BY_VALUE = Object.fromEntries(THEMES.map((t) => [t.value, t])) as Re
   ThemeMeta
 >;
 
-// Fall back to the default theme if a persisted value no longer matches a known
-// theme — callers read `.icon` straight off the result and would otherwise crash.
+// Stale persisted themes fall back so callers reading `.icon` don't crash.
 export const getThemeMeta = (theme: Theme): ThemeMeta =>
   THEME_BY_VALUE[theme] ?? THEME_BY_VALUE.dark;
 
-// Order the quick-toggle (header / profile menu) steps through.
 export const THEME_CYCLE: Theme[] = THEMES.map((t) => t.value);
 
-// palettes.ts declares PaletteKey locally (it must stay alias-free for the Node/vite
-// tsconfig), so guard it against the Theme-derived CustomPalette here, where both are in
-// scope. Typing the PaletteKey-derived keys as CustomPalette[] forces the two unions to
-// match: a stray palette key fails this assignment; a theme missing its palette data fails
-// the PALETTES[p] lookups below.
+// PaletteKey (alias-free for vite/node tsconfig) must match CustomPalette here.
 const CUSTOM_PALETTE_KEYS: CustomPalette[] = Object.keys(PALETTES) as PaletteKey[];
 
-// Palettes that ride the dark base (body `dark` class + the *-dark token vars). The
-// `dark` mode has no override block; every dark custom palette is read from PALETTES.
+// Dark base (body `dark` class + *-dark tokens). Custom darks come from PALETTES.
 export const DARK_PALETTES: ReadonlySet<Palette> = new Set<Palette>([
   'dark',
   ...CUSTOM_PALETTE_KEYS.filter((p) => PALETTES[p].base === 'dark'),
@@ -109,7 +99,7 @@ export const DARK_PALETTES: ReadonlySet<Palette> = new Set<Palette>([
 
 export interface PaletteTokens {
   surface: string; // deepest/page background
-  surfaceSecondary: string; // raised surface (editor + terminal canvas)
+  surfaceSecondary: string; // raised (editor + terminal canvas)
   surfaceTertiary: string;
   textPrimary: string;
   textSecondary: string;
@@ -125,9 +115,7 @@ const toTokens = (def: PaletteDef): PaletteTokens => ({
   textTertiary: def.textTertiary,
 });
 
-// The surface/text subset of PALETTES that Monaco, xterm, and the VisualWidget iframe
-// need as hex — they can't read the CSS vars. Same source as the generated CSS, so the
-// two can't drift.
+// Hex tokens for Monaco/xterm/VisualWidget (they can't read CSS vars).
 export const CUSTOM_PALETTE_TOKENS = Object.fromEntries(
   CUSTOM_PALETTE_KEYS.map((p) => [p, toTokens(PALETTES[p])]),
 ) as Record<CustomPalette, PaletteTokens>;

--- a/frontend/src/utils/tileHelpers.ts
+++ b/frontend/src/utils/tileHelpers.ts
@@ -9,8 +9,7 @@ export const VIEW_LABELS: Record<ViewType, string> = {
   terminal: 'Terminal',
 };
 
-// Canonical view → icon map; shared by the pane tabs and the view switcher so the
-// glyph for a kind (diff, terminal…) stays identical in both places.
+// Shared by pane tabs and the view switcher so glyphs stay identical.
 export const VIEW_ICONS: Record<ViewType, LucideIcon> = {
   agent: Bot,
   diff: GitBranch,
@@ -30,8 +29,7 @@ export function isSplitTile(tileId: TileId): tileId is SplitTileId {
   return splitSlotOfTile(tileId) !== null;
 }
 
-// A split pane is the action target only when it's both focused and bound to a
-// chat — otherwise everything resolves to the primary pane.
+// Action target is a split pane only when focused and bound to a chat.
 export function activeSplitSlot(
   activeAgentTile: AgentTileId,
   splitChatIds: string[],
@@ -40,29 +38,24 @@ export function activeSplitSlot(
   return slot && splitChatIds[slot - 1] ? slot : null;
 }
 
-// Maps a stored tile id back to its ViewType for label/render lookups.
-// Both pane suffixes ('agent:primary', '<view>:split-N') strip to the view.
+// Both 'agent:primary' and '<view>:split-N' strip to the view kind.
 export function tileIdToViewType(tileId: TileId): ViewType {
   const colon = tileId.indexOf(':');
   return (colon === -1 ? tileId : tileId.slice(0, colon)) as ViewType;
 }
 
-// Maps a ViewType to its canonical primary tile id. The agent slot is special:
-// "the agent view" always means agent:primary; split agents are only created
-// by the split-chat affordance.
+// Agent always means agent:primary; split agents come only from split-chat.
 function viewTypeToPrimaryTile(view: ViewType): TileId {
   return view === 'agent' ? 'agent:primary' : view;
 }
 
-// Maps a (view, pane) pair to its tile id. Agent always maps to the primary slot;
-// split agent tiles are created only by the split-chat affordance.
+// Agent always maps to the primary slot (split agents only via split-chat).
 export function viewTypeToTileId(view: ViewType, slot: SplitSlot | null): TileId {
   if (slot && view !== 'agent') return `${view}:split-${slot}`;
   return viewTypeToPrimaryTile(view);
 }
 
-// Deduped view kinds for a set of tiles, preserving order. Two agent panes
-// collapse to a single 'agent' entry.
+// Deduped view kinds, order-preserving (two agent panes → one 'agent').
 export function tileViewKinds(tiles: TileId[]): ViewType[] {
   return Array.from(new Set(tiles.map(tileIdToViewType)));
 }

--- a/mcp-server/client.py
+++ b/mcp-server/client.py
@@ -17,14 +17,13 @@ class AgentroveClient:
         self._http = httpx.AsyncClient(base_url=self._base_url, timeout=60.0)
         self._access_token: str | None = None
         self._refresh_token: str | None = None
-        # Cached model list so send_message doesn't re-fetch on every call
         self._models_cache: list[dict[str, Any]] | None = None
 
     async def aclose(self) -> None:
         await self._http.aclose()
 
     async def _login(self) -> None:
-        # fastapi-users JWT login expects OAuth2 form fields (username = email)
+        # fastapi-users JWT login: OAuth2 form (username = email).
         resp = await self._http.post(
             "/auth/jwt/login",
             data={"username": self._email, "password": self._password},
@@ -59,7 +58,7 @@ class AgentroveClient:
         if self._access_token is None:
             await self._login()
         resp = await self._send(method, path, **kwargs)
-        # Access tokens are short-lived (15 min) — on expiry, refresh or re-login and retry once
+        # Short-lived access token: on 401, refresh/re-login and retry once.
         if resp.status_code == 401:
             if not await self._refresh():
                 await self._login()
@@ -99,8 +98,7 @@ class AgentroveClient:
         return resp.json().get("personas") or []
 
     async def create_persona(self, name: str, content: str) -> dict[str, Any]:
-        # No per-persona endpoint: personas live as a list on user settings, so we
-        # read the current list, append, and PATCH the whole array back.
+        # No per-persona API — personas are a settings list; read-modify-PATCH.
         resp = await self.request("GET", "/settings/")
         personas = resp.json().get("personas") or []
         if any(p["name"] == name for p in personas):
@@ -133,8 +131,7 @@ class AgentroveClient:
         return resp.json()
 
     async def resolve_model(self, model_id: str | None) -> tuple[str, str]:
-        # Returns (model_id, agent_kind). agent_kind drives the per-agent permission
-        # mode, so it must come from the model registry, not be assumed.
+        # agent_kind must come from the registry (drives permission mode).
         if self._models_cache is None:
             resp = await self.request("GET", "/models/")
             self._models_cache = resp.json()
@@ -142,7 +139,6 @@ class AgentroveClient:
         if not models:
             raise AgentroveError("No models available.")
         if model_id is None:
-            # Default to a Claude model when present, otherwise the first listed
             chosen = next((m for m in models if m["agent_kind"] == "claude"), models[0])
         else:
             chosen = next((m for m in models if m["model_id"] == model_id), None)
@@ -162,7 +158,7 @@ class AgentroveClient:
             "model_id": model_id,
             "workspace_id": workspace_id,
         }
-        # Sub-thread: the backend overrides workspace_id with the parent's workspace
+        # Backend overrides workspace_id with the parent's for sub-threads.
         if parent_chat_id:
             body["parent_chat_id"] = parent_chat_id
         resp = await self.request("POST", "/chat/chats", json=body, expected=(201,))
@@ -179,8 +175,7 @@ class AgentroveClient:
         fast_mode: bool = False,
         persona: str | None = None,
     ) -> dict[str, Any]:
-        # Endpoint reads Form fields; no file upload here so urlencoded form is fine
-        # (httpx serializes bools to "true"/"false", which FastAPI parses back)
+        # Form endpoint (no files); httpx bools "true"/"false" parse in FastAPI.
         data: dict[str, Any] = {
             "prompt": prompt,
             "chat_id": chat_id,

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -7,11 +7,8 @@ from client import DEFAULT_API_URL, AgentroveClient, AgentroveError
 
 mcp = FastMCP("agentrove")
 
-# Each agent's unattended (no-prompt, full-execution) session mode. The backend
-# rejects modes that don't belong to the target agent (e.g. Codex only accepts
-# auto/read-only/full-access), so the mode must match the model's agent kind.
-# Canonical valid modes live in backend adapters.py (*_SESSION_MODES); this thin
-# HTTP client can't import them, so the unattended tier is mirrored here.
+# Unattended full-execution mode per agent. Backend rejects cross-agent modes;
+# mirrored here because this HTTP client can't import adapters.*_SESSION_MODES.
 PERMISSION_MODE_BY_AGENT = {
     "claude": "bypassPermissions",
     "codex": "full-access",
@@ -216,9 +213,7 @@ async def send_message(
     mode (e.g. bypassPermissions for Claude, full-access for Codex).
     """
     if chat_id is not None:
-        # Follow-up: default omitted settings to the chat's previous turn so a
-        # bare send_message(chat_id=...) continues with the same model/persona/
-        # effort instead of silently switching to the global defaults.
+        # Inherit last turn's model/persona/effort when omitted (not globals).
         chat = await client.get_chat(chat_id)
         model_id = model_id or chat.get("last_model_id")
         thinking_mode = thinking_mode or chat.get("last_thinking_mode")
@@ -261,7 +256,7 @@ async def get_messages(
     Use the returned next_cursor with a follow-up call to page through older messages.
     """
     page = await client.get_messages(chat_id, limit=limit, cursor=cursor)
-    # Backend returns newest-first; flip to chronological for readability
+    # Backend is newest-first; reverse for chronological readability.
     messages = [
         {
             "id": m["id"],


### PR DESCRIPTION
## Summary
- Condense multi-line "why" comments to single lines and drop ones that just restate the code, across backend (Python) and frontend (TS/TSX/JSX) files.
- No behavior changes — comment-only diff.

## Test plan
- [x] Pre-commit hooks (eslint, prettier, ruff) passed on all staged files.
- [ ] CI suite green