### PR TITLE
chore: add container debug tools, fix message trail width

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,9 @@ RUN apt-get update && \
     gosu docker-cli \
     build-essential \
     openssh-client \
-    gh ripgrep fd-find jq less tree unzip tmux && \
+    gh ripgrep fd-find jq less tree unzip tmux \
+    file vim nano wget procps psmisc lsof rsync patch \
+    iproute2 netcat-openbsd dnsutils && \
     ln -s "$(command -v fdfind)" /usr/local/bin/fd && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \

--- a/frontend/src/components/chat/chat-window/MessageTrail.module.scss
+++ b/frontend/src/components/chat/chat-window/MessageTrail.module.scss
@@ -20,7 +20,15 @@
 }
 
 .trail-rail {
+  pointer-events: auto;
   position: relative;
+  width: var(--space-6);
+
+  @include responsive.hover {
+    .tick--inactive-compact {
+      background-color: colors.theme-color('text-quaternary', 0.5);
+    }
+  }
 }
 
 .trail-item {
@@ -87,7 +95,7 @@
 
   &--inactive-compact {
     width: var(--space-1-5);
-    background-color: colors.theme-color('text-quaternary', 0.5);
+    background-color: colors.theme-color('text-quaternary', 0.25);
   }
 }
 

--- a/frontend/src/components/chat/chat-window/MessageTrail.tsx
+++ b/frontend/src/components/chat/chat-window/MessageTrail.tsx
@@ -8,8 +8,8 @@ import styles from './MessageTrail.module.scss';
 // Cap preview text so a huge message doesn't dump megabytes into the DOM
 const PREVIEW_MAX_CHARS = 200;
 const TICK_SPACING_PX = 12;
-// Width of the centered message column (lg:max-w-4xl = 56rem)
-const MESSAGE_COLUMN_MAX_PX = 896;
+// Width of the centered message column (Chat.module.scss .column max-width: 67.2rem)
+const MESSAGE_COLUMN_MAX_PX = 67.2 * 16;
 const MIN_GUTTER_PX = 40;
 const ACTIVE_VIEWPORT_FRACTION = 0.4;
 

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -20,6 +20,22 @@ RUN apt-get update && apt-get install -y \
     ripgrep \
     ca-certificates \
     gnupg \
+    file \
+    vim \
+    nano \
+    wget \
+    less \
+    tree \
+    fd-find \
+    procps \
+    psmisc \
+    lsof \
+    rsync \
+    patch \
+    iproute2 \
+    netcat-openbsd \
+    dnsutils \
+    && ln -sf "$(command -v fdfind)" /usr/local/bin/fd \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update \
     && apt-get install -y python3.12 python3.12-venv python3.12-dev \


### PR DESCRIPTION
## Summary
- Add common debugging/networking tools (vim, nano, wget, lsof, rsync, dnsutils, iproute2, etc.) to the backend and sandbox Docker images for easier in-container troubleshooting.
- Fix `MessageTrail`'s hardcoded column-width constant to match the actual chat column max-width (`Chat.module.scss` `.column`), preventing tick alignment drift.
- Widen the trail rail hit area and tune inactive-tick opacity for compact/hover states.

## Test plan
- [ ] Rebuild backend and sandbox Docker images and verify the new tools are installed
- [ ] Visually check message trail tick alignment against the chat column at various viewport widths