### PR TITLE
feat: add theme-aware brand mark to auth pages

### DIFF
--- a/frontend/src/components/auth/AuthPageLayout/AuthPageLayout.module.scss
+++ b/frontend/src/components/auth/AuthPageLayout/AuthPageLayout.module.scss
@@ -38,6 +38,30 @@
   }
 }
 
+.logo {
+  height: var(--space-7);
+  width: var(--space-7);
+  margin: 0 auto var(--space-3);
+
+  // Two variants swap by theme — the dark glyph shows on light surfaces and
+  // vice versa, same convention as the landing greeting and message avatars.
+  &--on-light {
+    display: block;
+
+    :global([data-theme='dark']) & {
+      display: none;
+    }
+  }
+
+  &--on-dark {
+    display: none;
+
+    :global([data-theme='dark']) & {
+      display: block;
+    }
+  }
+}
+
 .title {
   @include type.type-page-title;
   @include anim.fade-in;

--- a/frontend/src/components/auth/AuthPageLayout/AuthPageLayout.tsx
+++ b/frontend/src/components/auth/AuthPageLayout/AuthPageLayout.tsx
@@ -1,5 +1,8 @@
 import { memo, type ReactNode } from 'react';
+import clsx from 'clsx';
 import { Layout } from '@/components/layout/Layout/Layout';
+import iconDark from '/assets/images/icon-dark.svg';
+import iconLight from '/assets/images/icon-white.svg';
 import styles from './AuthPageLayout.module.scss';
 
 interface AuthPageLayoutProps {
@@ -19,6 +22,18 @@ export const AuthPageLayout = memo(function AuthPageLayout({
         <div className={styles.container}>
           <div className={styles.content}>
             <div className={styles.header}>
+              {/* Theme-aware brand mark — dark glyph on light surfaces and vice versa,
+                  matching the landing greeting and message avatars. */}
+              <img
+                src={iconDark}
+                alt="Agentrove"
+                className={clsx(styles.logo, styles['logo--on-light'])}
+              />
+              <img
+                src={iconLight}
+                alt="Agentrove"
+                className={clsx(styles.logo, styles['logo--on-dark'])}
+              />
               <h2 className={styles.title}>{title}</h2>
               <p className={styles.subtitle}>{subtitle}</p>
             </div>


### PR DESCRIPTION
## Summary

The auth pages were already token-compliant (no hardcoded colors, consistent `--theme-*` / `--space-*` / type mixins), but they were missing the one element that anchors the app's design schema everywhere else: the **theme-aware Agentrove brand mark**. The `LandingPage` greeting and chat message avatars both lead with the logo, swapping `icon-dark.svg` on light surfaces for `icon-white.svg` on dark. The auth pages led with only a bare text title.

This adds the brand mark to the shared **`AuthPageLayout`**, which covers all four form pages in one place: **Login, Signup, Forgot Password, and Reset Password**.

## Changes

- **`AuthPageLayout.tsx`** — renders both logo variants above the title using the same `clsx` + dual-`<img>` pattern as `LandingPage`, with `alt="Agentrove"`.
- **`AuthPageLayout.module.scss`** — adds `.logo` (sized to `--space-7`, centered) with `--on-light` / `--on-dark` variants that swap on `[data-theme='dark']`, matching the landing/avatar convention.

## Notes

- **`AuthSuccessScreen`** and **`VerificationStatus`** are intentionally left unchanged — they lead with a status icon (check / alert / mail), a deliberate distinct pattern where a brand logo would compete rather than reinforce.
- Reuses existing tokens and assets only; nothing new added to the design system.

## Testing

Change is a verbatim reuse of the logo-swap pattern from `LandingPage.tsx`. Local `tsc`/`eslint` could not be run in this environment (no `node_modules` installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)