### PR TITLE
feat: Coolify PR preview deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ VITE_WS_URL=/api/v1/ws
 # APP_URL=https://yourdomain.com
 # ALLOWED_ORIGINS=https://yourdomain.com
 # TRUSTED_PROXY_HOSTS=*
+# Optional: pin sandbox network (default: auto-detect compose sandbox network)
+# DOCKER_NETWORK=agentrove-sandbox-net
+# Coolify PR previews: leave APP_URL/ALLOWED_ORIGINS unset (or $SERVICE_URL_WEB)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ docker compose -f docker-compose-production.yml up -d --build
 
 ### Coolify / reverse proxy
 
-Point Coolify at the `web` service (port 80). Set:
+Point Coolify at the `web` service (port 80) using `docker-compose-production.yml`. Set:
 
 | Variable | Example |
 | --- | --- |
@@ -150,7 +150,22 @@ Point Coolify at the `web` service (port 80). Set:
 | `SECRET_KEY` | 32+ char secret |
 | `TRUSTED_PROXY_HOSTS` | `*` (default in production compose) |
 
+If `APP_URL` / `ALLOWED_ORIGINS` are unset, the compose file falls back to Coolify's `SERVICE_URL_WEB` (correct for production and PR previews).
+
 If `/admin` loads as plain unstyled HTML (blue links, no layout), the API is generating `http://` URLs for SQLAdmin CSS/JS while the page is `https://`. Rebuild with the production compose above so nginx forwards Coolify's `X-Forwarded-Proto` and the API trusts the proxy.
+
+### Coolify preview deployments (per PR)
+
+1. **Advanced** → enable **Preview Deployments** (and **Allow Public PR Deployments** if the repo is public / accepts fork PRs).
+2. **Preview Deployments** → set the URL template, e.g. `pr-{{pr_id}}.yourdomain.com`.
+3. Point a DNS wildcard (`*.yourdomain.com` or `pr-*.yourdomain.com`) at the Coolify server and let Coolify issue certificates.
+4. In **Environment Variables** → **Preview Deployments**, set:
+   - `AGENTROVE_STORAGE_SOURCE=agentrove_storage` (named volume; do not share production's host path)
+   - `APP_URL` / `ALLOWED_ORIGINS` empty or `$SERVICE_URL_WEB` (so each preview gets its own origin)
+   - copy `SECRET_KEY` and other secrets from production
+5. Open a PR (or **Load Pull Requests** and deploy manually). Coolify spins up an isolated compose stack at the preview URL.
+
+The sandbox Docker network is per compose project (no fixed name), so preview sandboxes do not join production's network.
 
 ## Stack
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,12 +1,32 @@
 #!/bin/sh
 
 ensure_docker_network() {
-    if [ -S /var/run/docker.sock ]; then
-        NETWORK_NAME="${DOCKER_NETWORK:-agentrove-sandbox-net}"
-        if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
-            echo "Creating Docker network: $NETWORK_NAME"
-            docker network create "$NETWORK_NAME" 2>/dev/null || true
-        fi
+    if [ ! -S /var/run/docker.sock ]; then
+        return
+    fi
+
+    NETWORK_NAME="${DOCKER_NETWORK:-}"
+    if [ -z "$NETWORK_NAME" ]; then
+        # Prefer the compose "sandbox" network this container is already on so
+        # production and Coolify PR previews stay isolated without a fixed name.
+        CONTAINER_ID="$(hostname)"
+        NETWORK_NAME="$(
+            docker inspect -f '{{range $k, $v := .NetworkSettings.Networks}}{{println $k}}{{end}}' "$CONTAINER_ID" 2>/dev/null \
+                | grep -E 'sandbox' \
+                | head -n 1 \
+                || true
+        )"
+    fi
+    if [ -z "$NETWORK_NAME" ]; then
+        NETWORK_NAME="agentrove-sandbox-net"
+    fi
+
+    export DOCKER_NETWORK="$NETWORK_NAME"
+    if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+        echo "Creating Docker network: $NETWORK_NAME"
+        docker network create "$NETWORK_NAME" 2>/dev/null || true
+    else
+        echo "Using Docker network: $NETWORK_NAME"
     fi
 }
 

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -38,7 +38,11 @@ services:
       sandbox-setup:
         condition: service_completed_successfully
     volumes:
-      - /data/agentrove/storage:/data/agentrove/storage
+      # Absolute path → host bind (default keeps production data at
+      # /data/agentrove/storage). Non-path name → named volume (set
+      # AGENTROVE_STORAGE_SOURCE=agentrove_storage in Coolify preview env
+      # so each PR gets isolated SQLite/storage).
+      - ${AGENTROVE_STORAGE_SOURCE:-/data/agentrove/storage}:/data/agentrove/storage
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       ENVIRONMENT: production
@@ -48,12 +52,16 @@ services:
       SESSION_SECRET_KEY: ${SESSION_SECRET_KEY:-}
       STORAGE_PATH: /data/agentrove/storage
       DOCKER_IMAGE: ${DOCKER_IMAGE:-ghcr.io/mng-dev-ai/agentrove-sandbox:latest}
-      DOCKER_NETWORK: agentrove-sandbox-net
+      # Empty → entrypoint joins/creates the compose sandbox network for this stack
+      # (required for PR previews; a fixed name collides with production).
+      DOCKER_NETWORK: ${DOCKER_NETWORK:-}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       PYTHONUNBUFFERED: "1"
-      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost,http://127.0.0.1}
-      BASE_URL: ${APP_URL:-http://localhost}
-      FRONTEND_URL: ${APP_URL:-http://localhost}
+      # Prefer Coolify SERVICE_URL_WEB so PR previews get the right origin without
+      # hardcoding production APP_URL into preview env.
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-${SERVICE_URL_WEB:-http://localhost,http://127.0.0.1}}
+      BASE_URL: ${APP_URL:-${SERVICE_URL_WEB:-http://localhost}}
+      FRONTEND_URL: ${APP_URL:-${SERVICE_URL_WEB:-http://localhost}}
       # Coolify/Traefik (and the web nginx container) sit in front of the API.
       # Without this, ProxyHeadersMiddleware ignores X-Forwarded-Proto and
       # SQLAdmin emits http:// asset URLs on an https:// page (unstyled admin).
@@ -78,6 +86,7 @@ services:
         condition: service_healthy
     environment:
       - SERVICE_FQDN_WEB_80
+      - SERVICE_URL_WEB
     expose:
       - "80"
     healthcheck:
@@ -87,8 +96,11 @@ services:
       retries: 12
 
 networks:
+  # No fixed `name:` — Coolify / compose project isolation gives each deploy
+  # (production + every PR preview) its own sandbox network.
   sandbox:
-    name: agentrove-sandbox-net
 
 volumes:
   redis_data:
+  # Used when AGENTROVE_STORAGE_SOURCE=agentrove_storage (preview deploys).
+  agentrove_storage:


### PR DESCRIPTION
## Summary
- Make production compose safe for Coolify PR previews: configurable storage bind vs named volume, no fixed sandbox network name, `APP_URL`/`ALLOWED_ORIGINS` fall back to `SERVICE_URL_WEB`.
- Auto-detect the compose sandbox network in the API entrypoint so previews don't join production's Docker network.
- Document Coolify preview setup (URL template, wildcard DNS, preview env vars) in README and `.env.example`.

Coolify UI already has previews enabled (`pr-{{pr_id}}.agentrove.app`); Cloudflare wildcard DNS is in place.

## Test plan
- [ ] Merge and redeploy production on Coolify
- [ ] Open a PR (or Load Pull Requests → Deploy) and confirm `https://pr-<id>.agentrove.app` comes up
- [ ] Confirm production still uses `/data/agentrove/storage` and is unaffected by the preview