### PR TITLE
fix: nginx API host for Coolify PR previews

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -95,8 +95,10 @@ services:
       api:
         condition: service_healthy
     environment:
-      - SERVICE_FQDN_WEB_80
-      - SERVICE_URL_WEB
+      # Coolify renames api → api-pr-N; nginx proxies to this hostname.
+      API_HOST: ${SERVICE_NAME_API:-api}
+      SERVICE_FQDN_WEB_80: ${SERVICE_FQDN_WEB_80:-}
+      SERVICE_URL_WEB: ${SERVICE_URL_WEB:-}
     expose:
       - "80"
     healthcheck:

--- a/frontend/Dockerfile.production
+++ b/frontend/Dockerfile.production
@@ -14,7 +14,9 @@ RUN npm run build
 
 FROM nginx:1.27-alpine
 
-COPY nginx-production.conf /etc/nginx/conf.d/default.conf
+# Official nginx image runs envsubst on templates/*.template at start.
+ENV API_HOST=api
+COPY nginx-production.conf /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
 
 EXPOSE 80

--- a/frontend/nginx-production.conf
+++ b/frontend/nginx-production.conf
@@ -7,6 +7,10 @@ map $http_x_forwarded_proto $forwarded_proto {
   ""      $scheme;
 }
 
+# Docker embedded DNS. Variable proxy_pass defers resolve so Coolify PR
+# previews work when the API service is named api-pr-N (not plain "api").
+resolver 127.0.0.11 valid=10s ipv6=off;
+
 server {
   listen 80;
   server_name _;
@@ -17,7 +21,8 @@ server {
   client_max_body_size 10m;
 
   location /api/ {
-    proxy_pass http://api:8080;
+    set $api_upstream ${API_HOST};
+    proxy_pass http://$api_upstream:8080;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -30,7 +35,8 @@ server {
   }
 
   location /admin {
-    proxy_pass http://api:8080;
+    set $api_upstream ${API_HOST};
+    proxy_pass http://$api_upstream:8080;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -39,7 +45,8 @@ server {
   }
 
   location /health {
-    proxy_pass http://api:8080/health;
+    set $api_upstream ${API_HOST};
+    proxy_pass http://$api_upstream:8080/health;
   }
 
   # Vite content-hashes everything under /assets/, so cache those forever and


### PR DESCRIPTION
## Summary
- Root cause of \`pr-*.agentrove.app\` Traefik 503: web container stuck restarting because nginx cannot resolve hostname \`api\` (Coolify renames it to \`api-pr-N\` on the shared project network).
- Proxy via \`API_HOST\` (\`SERVICE_NAME_API\` on Coolify, default \`api\`) with Docker embedded DNS.

## Test plan
- [ ] Redeploy PR preview; web container stays healthy (not Restarting)
- [ ] \`https://pr-<id>.agentrove.app\` serves the app
- [ ] Production still proxies /api and /admin correctly