### PR TITLE
Fix duplicate Coolify preview domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For a single-host Docker deployment:
 
 ```bash
 SECRET_KEY=$(openssl rand -hex 32) \
-SERVICE_FQDN_WEB_80=https://yourdomain.com \
+SERVICE_URL_WEB_80=https://yourdomain.com \
 APP_URL=https://yourdomain.com \
 ALLOWED_ORIGINS=https://yourdomain.com \
 docker compose -f docker-compose-production.yml up -d --build
@@ -150,7 +150,7 @@ Point Coolify at the `web` service (port 80) using `docker-compose-production.ym
 | `SECRET_KEY` | 32+ char secret |
 | `TRUSTED_PROXY_HOSTS` | `*` (default in production compose) |
 
-If `APP_URL` / `ALLOWED_ORIGINS` are unset, the compose file falls back to Coolify's `SERVICE_URL_WEB` (correct for production and PR previews).
+If `APP_URL` / `ALLOWED_ORIGINS` are unset, the compose file falls back to Coolify's `SERVICE_URL_WEB_80` (correct for production and PR previews).
 
 If `/admin` loads as plain unstyled HTML (blue links, no layout), the API is generating `http://` URLs for SQLAdmin CSS/JS while the page is `https://`. Rebuild with the production compose above so nginx forwards Coolify's `X-Forwarded-Proto` and the API trusts the proxy.
 
@@ -161,7 +161,7 @@ If `/admin` loads as plain unstyled HTML (blue links, no layout), the API is gen
 3. Point a DNS wildcard (`*.yourdomain.com` or `pr-*.yourdomain.com`) at the Coolify server and let Coolify issue certificates.
 4. In **Environment Variables** → **Preview Deployments**, set:
    - `AGENTROVE_STORAGE_SOURCE=agentrove_storage` (named volume; do not share production's host path)
-   - `APP_URL` / `ALLOWED_ORIGINS` empty or `$SERVICE_URL_WEB` (so each preview gets its own origin)
+   - `APP_URL` / `ALLOWED_ORIGINS` empty or `$SERVICE_URL_WEB_80` (so each preview gets its own origin)
    - copy `SECRET_KEY` and other secrets from production
 5. Open a PR (or **Load Pull Requests** and deploy manually). Coolify spins up an isolated compose stack at the preview URL.
 

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -63,11 +63,11 @@ services:
       DOCKER_NETWORK: ${DOCKER_NETWORK:-}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       PYTHONUNBUFFERED: "1"
-      # Prefer Coolify SERVICE_URL_WEB so PR previews get the right origin without
+      # Prefer Coolify SERVICE_URL_WEB_80 so PR previews get the right origin without
       # hardcoding production APP_URL into preview env.
-      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-${SERVICE_URL_WEB:-http://localhost,http://127.0.0.1}}
-      BASE_URL: ${APP_URL:-${SERVICE_URL_WEB:-http://localhost}}
-      FRONTEND_URL: ${APP_URL:-${SERVICE_URL_WEB:-http://localhost}}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-${SERVICE_URL_WEB_80:-http://localhost,http://127.0.0.1}}
+      BASE_URL: ${APP_URL:-${SERVICE_URL_WEB_80:-http://localhost}}
+      FRONTEND_URL: ${APP_URL:-${SERVICE_URL_WEB_80:-http://localhost}}
       # Coolify/Traefik (and the web nginx container) sit in front of the API.
       # Without this, ProxyHeadersMiddleware ignores X-Forwarded-Proto and
       # SQLAdmin emits http:// asset URLs on an https:// page (unstyled admin).
@@ -97,8 +97,7 @@ services:
     environment:
       # Coolify renames api → api-pr-N; nginx proxies to this hostname.
       API_HOST: ${SERVICE_NAME_API:-api}
-      SERVICE_FQDN_WEB_80: ${SERVICE_FQDN_WEB_80:-}
-      SERVICE_URL_WEB: ${SERVICE_URL_WEB:-}
+      SERVICE_URL_WEB_80: ${SERVICE_URL_WEB_80:-}
     expose:
       - "80"
     healthcheck:


### PR DESCRIPTION
## Summary
- use one port-specific Coolify URL magic variable for the web service
- reuse that URL for API origins and public base URLs
- update production and preview deployment documentation

## Testing
- `docker compose -f docker-compose-production.yml config --format json`
- verified the resolved API URLs use `SERVICE_URL_WEB_80`
- verified conflicting `SERVICE_FQDN_WEB_80` and `SERVICE_URL_WEB` entries are absent