### PR TITLE
fix: point MCP server at a reachable API URL for host-provider agents

### DIFF
--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
+import os
 import sys
 from collections.abc import AsyncIterator
 from pathlib import Path
+from urllib.parse import urlparse
 from typing import Any, cast
 from uuid import UUID
 
@@ -445,15 +447,27 @@ class AgentService:
         return env
 
     @staticmethod
-    def _build_mcp_server_configs(chat_id: str | None) -> list[dict[str, Any]]:
+    def _build_mcp_server_configs(
+        chat_id: str | None, sandbox_provider: SandboxProviderType
+    ) -> list[dict[str, Any]]:
         # Opt-in: hand the agent Agentrove's own chat tools over a stdio MCP server.
         # Skipped unless enabled with credentials — the server logs into this backend.
         if not settings.AGENTROVE_MCP_ENABLED:
             return []
         if not (settings.AGENTROVE_MCP_EMAIL and settings.AGENTROVE_MCP_PASSWORD):
             return []
+        if sandbox_provider is SandboxProviderType.HOST:
+            # Host-provider agents share this process's network namespace, but the
+            # public BASE_URL is often unreachable from inside the deployment
+            # (hairpin NAT), so point the MCP server at the local uvicorn instead.
+            # Web mode listens on ${PORT:-8080}; desktop derives its port from a
+            # loopback BASE_URL (desktop/entry.py).
+            port = os.environ.get("PORT") or urlparse(settings.BASE_URL).port or 8080
+            api_base = f"http://127.0.0.1:{port}"
+        else:
+            api_base = settings.BASE_URL
         env = {
-            "AGENTROVE_API_URL": f"{settings.BASE_URL}{settings.API_V1_STR}",
+            "AGENTROVE_API_URL": f"{api_base}{settings.API_V1_STR}",
             "AGENTROVE_EMAIL": settings.AGENTROVE_MCP_EMAIL,
             "AGENTROVE_PASSWORD": settings.AGENTROVE_MCP_PASSWORD,
         }
@@ -527,7 +541,7 @@ class AgentService:
             user_id=user_id,
             agent_kind=agent_kind,
             env=env,
-            mcp_servers=self._build_mcp_server_configs(chat_id),
+            mcp_servers=self._build_mcp_server_configs(chat_id, sandbox_provider),
             model=model_id,
             permission_mode=session_config.permission.session_mode,
             resume_session_id=session_id,

--- a/mcp-server/client.py
+++ b/mcp-server/client.py
@@ -55,14 +55,22 @@ class AgentroveClient:
     async def request(
         self, method: str, path: str, *, expected: tuple[int, ...] = (200,), **kwargs: Any
     ) -> httpx.Response:
-        if self._access_token is None:
-            await self._login()
-        resp = await self._send(method, path, **kwargs)
-        # Short-lived access token: on 401, refresh/re-login and retry once.
-        if resp.status_code == 401:
-            if not await self._refresh():
+        try:
+            if self._access_token is None:
                 await self._login()
             resp = await self._send(method, path, **kwargs)
+            # Short-lived access token: on 401, refresh/re-login and retry once.
+            if resp.status_code == 401:
+                if not await self._refresh():
+                    await self._login()
+                resp = await self._send(method, path, **kwargs)
+        except httpx.HTTPError as e:
+            # Transport errors (e.g. ConnectTimeout) often str() to "" — name the
+            # exception class and target URL so tool errors stay diagnosable.
+            raise AgentroveError(
+                f"Cannot reach the AgentRove API at {self._base_url}: "
+                f"{type(e).__name__}: {e}"
+            ) from e
         if resp.status_code not in expected:
             raise AgentroveError(f"{method} {path} -> {resp.status_code}: {resp.text}")
         return resp


### PR DESCRIPTION
## Problem

Every `agentrove` MCP tool call (`list_models`, `list_workspaces`, …) failed with a blank error:

```
Error executing tool list_models:
```

Root cause: the backend spawns the MCP server with `AGENTROVE_API_URL` derived from the public `BASE_URL` (e.g. `https://agentrove.app/api/v1`). Host-provider agents run **inside the api container**, and the deployment's own public URL is typically unreachable from there (hairpin NAT) — the connection times out. Since `httpx.ConnectTimeout` stringifies to an empty string, the tool error carried no message at all.

## Fix

- **`backend/app/services/agent.py`** — `_build_mcp_server_configs` now takes the sandbox provider and derives the URL accordingly:
  - **Host provider** (agent shares the backend's network namespace): `http://127.0.0.1:{PORT or BASE_URL port or 8080}` — talks to the local uvicorn directly. Covers web mode (`${PORT:-8080}`, see `backend/entrypoint.sh`) and desktop mode (loopback `BASE_URL`, see `desktop/entry.py`).
  - **Docker provider**: keeps `BASE_URL` (the sandbox container doesn't share the backend's loopback).
- **`mcp-server/client.py`** — wraps `httpx.HTTPError` into `AgentroveError` naming the exception class and target URL, so transport failures are diagnosable instead of blank:
  ```
  Cannot reach the AgentRove API at https://agentrove.app/api/v1: ConnectTimeout:
  ```

## Verification

- Exercised the client end-to-end from inside a production api container: `list_models` and `list_workspaces` succeed against `http://127.0.0.1:8080/api/v1`; the old public URL now raises the descriptive error above.
- `_build_mcp_server_configs` sanity-checked for both providers: `host → http://127.0.0.1:8080/api/v1`, `docker → <BASE_URL>/api/v1`.
- `pytest tests/test_acp.py -k mcp` passes.

## Note

Docker-sandbox MCP support has a separate pre-existing gap: the sandbox image ships neither `mcp-server/` nor the backend's Python, so the stdio server (spawned via `sys.executable` + `/app/mcp-server/server.py`) can't start there regardless of URL. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)