### PR TITLE
fix: enforce Grok always-approve via launch flag

### DIFF
--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -63,11 +63,10 @@ COPILOT_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
 # Cursor CLI exposes three ACP session modes (see https://cursor.com/docs/cli/acp).
 CURSOR_SESSION_MODES = frozenset({"agent", "plan", "ask"})
 
-# Grok Build's ACP session modes (CLI >= 0.2.9x): `auto` is the default —
-# a classifier auto-approves routine tool calls and prompts via
-# session/request_permission for risky ones; `always-approve` skips all
-# prompts; `plan` blocks writes except the session plan file. The old `code`
-# mode was removed upstream (set_mode silently ignores unknown ids).
+# Current stable Grok advertises no ACP session modes and silently ignores
+# set_mode ids. `always-approve` uses the launch flag; `auto` keeps the CLI's
+# default classifier behavior (routine calls pass, risky ones prompt); `plan`
+# stays for the set_mode plan-hop and revives if ACP modes return.
 GROK_SESSION_MODES = frozenset({"auto", "always-approve", "plan"})
 # Only Grok 4.5 exposes the low/medium/high reasoning-effort dial; Composer
 # ignores it, so the effort launch flag is skipped for other models.
@@ -176,6 +175,7 @@ class AgentAdapter(ABC):
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
         reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
     ) -> LaunchConfig:
         raise NotImplementedError
 
@@ -212,6 +212,7 @@ class ClaudeAgentAdapter(AgentAdapter):
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
         reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
     ) -> LaunchConfig:
         # Config via env + session meta only (no CLI args).
         return LaunchConfig(binary="claude-agent-acp")
@@ -260,6 +261,7 @@ class CodexAgentAdapter(AgentAdapter):
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
         reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
     ) -> LaunchConfig:
         # codex-acp uses CODEX_CONFIG only; modes bundle approval/sandbox, effort is on the model ID.
         config: dict[str, Any] = {}
@@ -319,6 +321,7 @@ class CopilotCliAdapter(AgentAdapter):
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
         reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
     ) -> LaunchConfig:
         return LaunchConfig(binary="copilot", cli_args=["--acp", "--stdio"])
 
@@ -371,6 +374,7 @@ class CursorAgentAdapter(AgentAdapter):
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
         reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
     ) -> LaunchConfig:
         return LaunchConfig(binary="cursor-agent", cli_args=["acp"])
 
@@ -405,7 +409,7 @@ class CursorAgentAdapter(AgentAdapter):
 
 
 class GrokAgentAdapter(AgentAdapter):
-    # Effort is launch-only (`--reasoning-effort`); mid-session changes respawn via fingerprint.
+    # Effort and permission mode are launch-baked; changes respawn via fingerprint.
 
     def __init__(self) -> None:
         super().__init__(kind=AgentKind.GROK)
@@ -417,9 +421,15 @@ class GrokAgentAdapter(AgentAdapter):
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
         reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
     ) -> LaunchConfig:
         # Agent-level flags must precede the `stdio` subcommand.
         cli_args = ["agent"]
+        if (
+            permission_mode is not None
+            and self.map_session_mode(permission_mode) == "always-approve"
+        ):
+            cli_args.append("--always-approve")
         if reasoning_effort:
             cli_args.extend(["--reasoning-effort", reasoning_effort])
         cli_args.append("stdio")
@@ -482,6 +492,7 @@ class OpencodeAgentAdapter(AgentAdapter):
         system_prompt_is_full_replace: bool,
         instructions_file_path: str | None = None,
         reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
     ) -> LaunchConfig:
         return LaunchConfig(binary="opencode", cli_args=["acp"])
 

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -51,6 +51,7 @@ VALID_PERMISSION_MODES: set[str] = {
     "read-only",
     "full-access",
     "ask",
+    "always-approve",
 }
 
 # Human option labels → PermissionMode when option_id isn't already a literal.
@@ -65,6 +66,7 @@ PERMISSION_MODE_BY_OPTION_NAME: dict[str, PermissionMode] = {
     "auto": "auto",
     "read only": "read-only",
     "full access": "full-access",
+    "always approve": "always-approve",
 }
 
 # Grok delivers its ask_user_question tool as an ACP extension request

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -481,10 +481,8 @@ class AcpSession:
         session_id: str,
         mode_id: str,
     ) -> None:
-        # Grok silently ignores direct auto <-> always-approve switches (the
-        # TUI gates those behind a confirmation ACP can't answer) but accepts
-        # any transition out of plan, so hop through plan to make the target
-        # mode actually take effect. No turn runs between the two calls.
+        # Stable Grok ignores set_mode; always-approve is enforced at launch.
+        # Keep the plan hop in case ACP modes return; no turn runs between calls.
         if agent_kind == AgentKind.GROK and mode_id != "plan":
             await conn.set_session_mode(mode_id="plan", session_id=session_id)
         await conn.set_session_mode(mode_id=mode_id, session_id=session_id)
@@ -553,6 +551,7 @@ class AcpSession:
             system_prompt_is_full_replace=config.system_prompt_is_full_replace,
             instructions_file_path=config.codex_instructions_file_path,
             reasoning_effort=config.reasoning_effort,
+            permission_mode=config.permission_mode,
         )
 
     @staticmethod

--- a/backend/app/services/session_registry.py
+++ b/backend/app/services/session_registry.py
@@ -8,6 +8,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from app.services.acp.adapters import AgentKind
 from app.services.acp.session import AcpSession, AcpSessionConfig
 
 logger = logging.getLogger(__name__)
@@ -156,6 +157,12 @@ class SessionRegistry:
             "mcp_servers": config.mcp_servers,
             "system_prompt": config.system_prompt,
             "reasoning_effort": config.reasoning_effort,
+            # Grok bakes approval into launch, so mode changes must respawn;
+            # resume_session_id preserves context. Other agents switch live,
+            # so fingerprinting their mode would respawn needlessly.
+            "permission_mode": (
+                config.permission_mode if config.agent_kind is AgentKind.GROK else None
+            ),
         }
         data = json.dumps(fingerprint_dict, sort_keys=True, default=str)
         return hashlib.sha256(data.encode()).hexdigest()

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 from collections.abc import Iterator
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import get_settings
 from app.models.db_models.workspace import Workspace
+from app.services.acp.adapters import AgentKind, GrokAgentAdapter
+from app.services.acp.session import AcpSessionConfig
+from app.services.sandbox_providers import SandboxProviderType
 from app.services.session_registry import session_registry
 from tests.conftest import LoginClient, UserFactory
 from tests.fake_acp_agent import (
@@ -59,6 +63,60 @@ DEFAULT_TURN_TEXT = "Hello from the fake agent."
 # content_type, not on parsing the file itself.
 PNG_BYTES = bytes.fromhex("89504e470d0a1a0a0000000d49484452")
 PDF_BYTES = b"%PDF-1.4\n%fake\n"
+
+
+@pytest.mark.parametrize(
+    "permission_mode,reasoning_effort,expected_args",
+    [
+        ("always-approve", None, ["agent", "--always-approve", "stdio"]),
+        (
+            "always-approve",
+            "low",
+            ["agent", "--always-approve", "--reasoning-effort", "low", "stdio"],
+        ),
+        ("auto", None, ["agent", "stdio"]),
+        ("plan", None, ["agent", "stdio"]),
+        (None, None, ["agent", "stdio"]),
+        ("bypassPermissions", None, ["agent", "--always-approve", "stdio"]),
+    ],
+)
+def test_grok_launch_args_apply_always_approve_flag(
+    permission_mode: str | None,
+    reasoning_effort: str | None,
+    expected_args: list[str],
+) -> None:
+    launch = GrokAgentAdapter().build_launch_config(
+        system_prompt=None,
+        system_prompt_is_full_replace=False,
+        reasoning_effort=reasoning_effort,
+        permission_mode=permission_mode,
+    )
+
+    assert launch.cli_args == expected_args
+
+
+@pytest.mark.parametrize(
+    "agent_kind,expect_equal",
+    [(AgentKind.GROK, False), (AgentKind.CLAUDE, True)],
+)
+def test_permission_mode_only_changes_grok_session_fingerprint(
+    agent_kind: AgentKind,
+    expect_equal: bool,
+) -> None:
+    auto = AcpSessionConfig(
+        sandbox_id="sandbox",
+        sandbox_provider=SandboxProviderType.HOST,
+        cwd="/workspace",
+        user_id="user",
+        agent_kind=agent_kind,
+        permission_mode="auto",
+    )
+    always_approve = replace(auto, permission_mode="always-approve")
+
+    fingerprints_equal = session_registry._compute_fingerprint(
+        auto
+    ) == session_registry._compute_fingerprint(always_approve)
+    assert fingerprints_equal is expect_equal
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
- Grok chats in `always-approve` permission mode still showed permission prompts. Root cause: the current stable Grok CLI (`0.1.220-alpha.4`, ACP agentVersion `0.2.0-dev`) dropped ACP session modes — `session/new` advertises no modes and `session/set_mode` returns success-shaped `{}` while silently ignoring any id — so the mode we set over ACP never took effect. Upstream moved auto-approve to the `grok agent --always-approve` launch flag.
- Thread `permission_mode` into `build_launch_config` (keyword param on all adapters; only Grok uses it) and pass `--always-approve` when the mapped mode is always-approve, including the legacy-string fallback via `map_session_mode`.
- Include `permission_mode` in the session fingerprint **for Grok only**: the mode is launch-baked (like reasoning effort), so mid-chat mode flips respawn the process (`resume_session_id` preserves context). Other agents keep switching modes live — fingerprinting their mode would respawn needlessly.
- Keep the `set_mode`/plan-hop plumbing: harmless no-op on the current CLI, still correct for older CLIs (<= 0.2.99) that honor ACP modes.
- Complete the missing `always-approve` entries in `client.py`'s permission-mode mapping tables.
- Tests: parametrized coverage for Grok launch args (flag present/absent per mode, ordering with `--reasoning-effort`) and fingerprint scoping (Grok differs on mode, Claude does not).
