### PR TITLE
chore: bump claude-agent-acp and codex-acp to latest

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.59.0 @agentclientprotocol/codex-acp@1.1.4 @openai/codex@0.144.1 @github/copilot@1.0.36
+RUN npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.61.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to /root/.local/bin) — used for the Cursor
 # ACP server (`cursor-agent acp`). The install script downloads the binary for

--- a/desktop/run_build.mjs
+++ b/desktop/run_build.mjs
@@ -22,8 +22,8 @@ const PYTHON_VERSION = '3.12.12';
 const NODE_VERSION = '22.12.0';
 const RELEASE_TAG = '20260211';
 const RIPGREP_VERSION = '14.1.1';
-const CLAUDE_AGENT_ACP_VERSION = '0.59.0';
-const CODEX_ACP_VERSION = '1.1.4';
+const CLAUDE_AGENT_ACP_VERSION = '0.61.0';
+const CODEX_ACP_VERSION = '1.1.7';
 const GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py';
 
 const platform = process.platform;

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.59.0 @agentclientprotocol/codex-acp@1.1.4 @openai/codex@0.144.1 @github/copilot@1.0.36
+    npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.61.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to ~/.local/bin, which is already on PATH).
 RUN curl -fsS https://cursor.com/install | bash


### PR DESCRIPTION
## Summary
- Bump `@agentclientprotocol/claude-agent-acp` from `0.59.0` → `0.61.0`
- Bump `@agentclientprotocol/codex-acp` from `1.1.4` → `1.1.7`
- Keep pins aligned across backend Dockerfile, sandbox Dockerfile, and desktop `run_build.mjs`

## Test plan
- [ ] Backend image builds and agents launch (`claude-agent-acp`, `codex-acp`)
- [ ] Sandbox image builds with the new global npm packages
- [ ] Desktop sidecar rebuild installs the new ACP versions (stamp invalidates)