### PR TITLE
feat: steer live ACP turns on send-now instead of cancelling

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -718,7 +718,7 @@ async def send_now_queued_message(
 
     chat_id_str = str(chat_id)
     active_at_entry = ChatStreamRuntime.has_active_chat(chat_id_str)
-    logger.info(
+    logger.warning(
         "Send-now for chat %s message %s: active_chat=%s",
         chat_id_str,
         message_id,
@@ -742,14 +742,14 @@ async def send_now_queued_message(
 
     if ChatStreamRuntime.has_active_chat(chat_id_str):
         # Cancel so send-now is picked up without waiting for the current turn.
-        logger.info("Send-now for chat %s: cancelling active generation", chat_id_str)
+        logger.warning("Send-now for chat %s: cancelling active generation", chat_id_str)
         await session_registry.cancel_generation(chat_id_str)
     else:
         try:
             processed = await ChatStreamRuntime.process_send_now_idle(
                 chat_id_str, chat_service.session_factory
             )
-            logger.info(
+            logger.warning(
                 "Send-now for chat %s: idle path processed=%s", chat_id_str, processed
             )
         except asyncio.CancelledError:

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -716,13 +716,30 @@ async def send_now_queued_message(
             detail="Queued message not found",
         )
 
-    if ChatStreamRuntime.has_active_chat(str(chat_id)):
+    chat_id_str = str(chat_id)
+    if ChatStreamRuntime.has_active_chat(chat_id_str):
+        try:
+            if await ChatStreamRuntime.try_steer_send_now(
+                chat_id=chat_id_str,
+                queued_message_id=str(message_id),
+                queue_service=queue_service,
+                session_factory=chat_service.session_factory,
+            ):
+                return
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Failed to coordinate ACP steering for chat %s", chat_id, exc_info=True
+            )
+
+    if ChatStreamRuntime.has_active_chat(chat_id_str):
         # Cancel so send-now is picked up without waiting for the current turn.
-        await session_registry.cancel_generation(str(chat_id))
+        await session_registry.cancel_generation(chat_id_str)
     else:
         try:
             await ChatStreamRuntime.process_send_now_idle(
-                str(chat_id), chat_service.session_factory
+                chat_id_str, chat_service.session_factory
             )
         except asyncio.CancelledError:
             raise

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -717,7 +717,14 @@ async def send_now_queued_message(
         )
 
     chat_id_str = str(chat_id)
-    if ChatStreamRuntime.has_active_chat(chat_id_str):
+    active_at_entry = ChatStreamRuntime.has_active_chat(chat_id_str)
+    logger.info(
+        "Send-now for chat %s message %s: active_chat=%s",
+        chat_id_str,
+        message_id,
+        active_at_entry,
+    )
+    if active_at_entry:
         try:
             if await ChatStreamRuntime.try_steer_send_now(
                 chat_id=chat_id_str,
@@ -735,11 +742,15 @@ async def send_now_queued_message(
 
     if ChatStreamRuntime.has_active_chat(chat_id_str):
         # Cancel so send-now is picked up without waiting for the current turn.
+        logger.info("Send-now for chat %s: cancelling active generation", chat_id_str)
         await session_registry.cancel_generation(chat_id_str)
     else:
         try:
-            await ChatStreamRuntime.process_send_now_idle(
+            processed = await ChatStreamRuntime.process_send_now_idle(
                 chat_id_str, chat_service.session_factory
+            )
+            logger.info(
+                "Send-now for chat %s: idle path processed=%s", chat_id_str, processed
             )
         except asyncio.CancelledError:
             raise

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 from acp.schema import (
     AgentMessageChunk,
@@ -31,7 +31,7 @@ from acp.schema import (
 from app.models.types import PermissionMode
 from app.models.db_models.enums import ToolStatus
 from app.services.acp.adapters import AgentKind
-from app.services.streaming.types import StreamEvent, StreamEventType, ToolPayload
+from app.services.streaming.types import StreamEvent, ToolPayload
 
 logger = logging.getLogger(__name__)
 
@@ -88,10 +88,12 @@ class AcpClientHandler:
         self._resolved_permissions: dict[str, PermissionMode | None] = {}
         # request_id → option_id → permission_mode (filled in request_permission).
         self._permission_option_modes: dict[str, dict[str, PermissionMode | None]] = {}
+        self._rotated_tool_ids: set[str] = set()
         self.total_cost_usd: float = 0.0
         self.usage: dict[str, int] | None = None
         # Suppress replayed history events during load_session.
         self.muted: bool = False
+        self.prompt_active: bool = False
 
     def on_connect(self, conn: Any) -> None:
         pass
@@ -104,31 +106,54 @@ class AcpClientHandler:
                 self.event_queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
+        self._rotated_tool_ids.clear()
+        self.prompt_active = True
 
     def finish(self, *, prompt_completed: bool) -> None:
+        self.prompt_active = False
         if self._active_tools:
             if prompt_completed:
-                terminal_status: Literal["completed", "failed"] = (
-                    ToolStatus.COMPLETED.value
-                )
-                terminal_event_type: StreamEventType = "tool_completed"
+                for payload in self._active_tools.values():
+                    payload["status"] = ToolStatus.COMPLETED.value
+                    self.event_queue.put_nowait(
+                        StreamEvent(type="tool_completed", tool=payload)
+                    )
+                self._active_tools.clear()
             else:
-                terminal_status = ToolStatus.FAILED.value
-                terminal_event_type = "tool_failed"
-            for payload in self._active_tools.values():
-                payload["status"] = terminal_status
-                if not prompt_completed and "error" not in payload:
-                    # Codex occasionally ends the turn without a terminal tool
-                    # progress update. Mark the tool as interrupted so the UI
-                    # does not leave it stuck in a perpetual loading state.
-                    payload["error"] = "Tool ended before a terminal ACP update arrived"
-                self.event_queue.put_nowait(
-                    StreamEvent(type=terminal_event_type, tool=payload)
-                )
-            self._active_tools.clear()
+                for event in self.rotate_active_tools():
+                    self.event_queue.put_nowait(event)
+        self._rotated_tool_ids.clear()
         self._resolved_permissions.clear()
         self._permission_option_modes.clear()
         self.event_queue.put_nowait(_SENTINEL)
+
+    @property
+    def has_pending_permissions(self) -> bool:
+        return bool(self._pending_permissions)
+
+    def rotate_active_tools(self) -> list[StreamEvent]:
+        events: list[StreamEvent] = []
+        for tool_call_id, payload in self._active_tools.items():
+            payload["status"] = ToolStatus.FAILED.value
+            if "error" not in payload:
+                # Match a legacy interrupted prompt so old tool cards terminate.
+                payload["error"] = "Tool ended before a terminal ACP update arrived"
+            events.append(StreamEvent(type="tool_failed", tool=payload))
+            self._rotated_tool_ids.add(tool_call_id)
+            self._resolved_permissions.pop(tool_call_id, None)
+        self._active_tools.clear()
+        return events
+
+    def enqueue_steer_rotation(self, queued_msg: dict[str, Any]) -> bool:
+        if not self.prompt_active:
+            return False
+        self.event_queue.put_nowait(
+            StreamEvent(
+                type="_steer_rotation",
+                data={"queued_msg": queued_msg},
+            )
+        )
+        return True
 
     def cancel_pending_permissions(self) -> None:
         for future in self._pending_permissions.values():
@@ -385,7 +410,9 @@ class AcpClientHandler:
             return StreamEvent(type="user_text", text=chunk.content.text)
         return None
 
-    def _map_tool_call_start(self, tc: ToolCallStart) -> StreamEvent:
+    def _map_tool_call_start(self, tc: ToolCallStart) -> StreamEvent | None:
+        if tc.tool_call_id in self._rotated_tool_ids:
+            return None
         payload = ToolPayload(
             id=tc.tool_call_id,
             name=self._extract_tool_name(tc),
@@ -406,6 +433,10 @@ class AcpClientHandler:
     def _map_tool_call_progress(self, tc: ToolCallProgress) -> StreamEvent | None:
         # Multiple progress events per tool possible; re-emit only when title/input changes.
         status = tc.status
+        if tc.tool_call_id in self._rotated_tool_ids:
+            if status in ("completed", "failed"):
+                self._rotated_tool_ids.discard(tc.tool_call_id)
+            return None
 
         existing = self._active_tools.get(tc.tool_call_id)
         if existing is None and status is None:

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -113,6 +113,7 @@ class AcpSession:
         acp_session_id: str,
         agent_kind: AgentKind = AgentKind.CLAUDE,
         stderr_task: asyncio.Task[None] | None = None,
+        steering_supported: bool = False,
     ) -> None:
         self._handler = handler
         self._conn = conn
@@ -120,6 +121,7 @@ class AcpSession:
         self.acp_session_id = acp_session_id
         self._agent_kind = agent_kind
         self._stderr_task = stderr_task
+        self.steering_supported = steering_supported
 
     @property
     def handler(self) -> AcpClientHandler:
@@ -136,18 +138,7 @@ class AcpSession:
     ) -> None:
         self._handler.prepare_for_prompt()
 
-        prompt_blocks: list[
-            TextContentBlock | ImageContentBlock | EmbeddedResourceContentBlock
-        ] = [
-            TextContentBlock(type="text", text=content),
-        ]
-        if attachments:
-            attachment_note = self._build_attachment_note(attachments, agent_kind)
-            if attachment_note:
-                prompt_blocks.append(
-                    TextContentBlock(type="text", text=attachment_note)
-                )
-            prompt_blocks.extend(self._build_attachment_blocks(attachments, agent_kind))
+        prompt_blocks = self._build_prompt_blocks(content, attachments, agent_kind)
 
         try:
             await self._conn.prompt(
@@ -160,6 +151,47 @@ class AcpSession:
             raise
         finally:
             self._handler.finish(prompt_completed=prompt_completed)
+
+    async def steer(
+        self,
+        content: str,
+        attachments: list[dict[str, Any]] | None = None,
+        agent_kind: AgentKind = AgentKind.CLAUDE,
+    ) -> str:
+        prompt_blocks = self._build_prompt_blocks(content, attachments, agent_kind)
+        # The original prompt task owns the live handler queue and its end sentinel;
+        # preparing or finishing here would discard events or terminate that turn.
+        result = await self._conn.ext_method(
+            "_session/steering",
+            {
+                "sessionId": self.acp_session_id,
+                "prompt": [
+                    block.model_dump(by_alias=True, exclude_none=True)
+                    for block in prompt_blocks
+                ],
+            },
+        )
+        outcome = (result or {}).get("outcome", "failed")
+        return outcome if isinstance(outcome, str) else "failed"
+
+    @classmethod
+    def _build_prompt_blocks(
+        cls,
+        content: str,
+        attachments: list[dict[str, Any]] | None,
+        agent_kind: AgentKind,
+    ) -> list[TextContentBlock | ImageContentBlock | EmbeddedResourceContentBlock]:
+        prompt_blocks: list[
+            TextContentBlock | ImageContentBlock | EmbeddedResourceContentBlock
+        ] = [TextContentBlock(type="text", text=content)]
+        if attachments:
+            attachment_note = cls._build_attachment_note(attachments, agent_kind)
+            if attachment_note:
+                prompt_blocks.append(
+                    TextContentBlock(type="text", text=attachment_note)
+                )
+            prompt_blocks.extend(cls._build_attachment_blocks(attachments, agent_kind))
+        return prompt_blocks
 
     @staticmethod
     def _build_attachment_note(
@@ -354,7 +386,13 @@ class AcpSession:
         stderr_task = asyncio.create_task(cls._read_stderr(process))
 
         try:
-            await conn.initialize(protocol_version=ACP_PROTOCOL_VERSION)
+            init_resp = await conn.initialize(protocol_version=ACP_PROTOCOL_VERSION)
+            meta = getattr(init_resp, "field_meta", None) or {}
+            steering_supported = bool(
+                isinstance(meta, dict)
+                and isinstance(meta.get("steering"), dict)
+                and meta["steering"].get("supported") is True
+            )
 
             mcp_servers = cls._build_mcp_servers(config.mcp_servers)
             session_meta = config.session_meta
@@ -472,6 +510,7 @@ class AcpSession:
             acp_session_id=acp_session_id,
             agent_kind=config.agent_kind,
             stderr_task=stderr_task,
+            steering_supported=steering_supported,
         )
 
     @staticmethod

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -161,8 +161,11 @@ class AcpSession:
         prompt_blocks = self._build_prompt_blocks(content, attachments, agent_kind)
         # The original prompt task owns the live handler queue and its end sentinel;
         # preparing or finishing here would discard events or terminate that turn.
+        # The SDK's ext_method prepends the `_` extension prefix, so pass the
+        # unprefixed name — the wire method is `_session/steering`. (Passing the
+        # prefixed name yields `__session/steering` → "Method not found".)
         result = await self._conn.ext_method(
-            "_session/steering",
+            "session/steering",
             {
                 "sessionId": self.acp_session_id,
                 "prompt": [

--- a/backend/app/services/queue.py
+++ b/backend/app/services/queue.py
@@ -91,6 +91,12 @@ class QueueService:
         queue = await self._read_queue(key)
         return [self._to_queued_message(item) for item in queue]
 
+    async def get_message_by_id(
+        self, chat_id: str, message_id: str
+    ) -> dict[str, Any] | None:
+        queue = await self._read_queue(self._queue_key(chat_id))
+        return next((item for item in queue if item["id"] == message_id), None)
+
     async def update_message(
         self, chat_id: str, message_id: str, content: str
     ) -> QueuedMessage | None:
@@ -167,12 +173,35 @@ class QueueService:
         await self._write_queue(key, remaining)
         return target
 
+    async def pop_message_by_id(
+        self, chat_id: str, message_id: str
+    ) -> dict[str, Any] | None:
+        key = self._queue_key(chat_id)
+        queue = await self._read_queue(key)
+        target = next((item for item in queue if item["id"] == message_id), None)
+        if target is None:
+            return None
+
+        await self._write_queue(
+            key, [item for item in queue if item["id"] != message_id]
+        )
+        send_now_key = REDIS_KEY_CHAT_QUEUE_SEND_NOW.format(chat_id=chat_id)
+        if await self.cache.get(send_now_key) == message_id:
+            await self.cache.delete(send_now_key)
+        return target
+
     async def requeue_message(self, chat_id: str, message_data: dict[str, Any]) -> None:
         # Front of queue so a failed process is retried next.
         key = self._queue_key(chat_id)
         queue = await self._read_queue(key)
         queue.insert(0, message_data)
         await self._write_queue(key, queue)
+
+    async def restore_send_now(
+        self, chat_id: str, message_data: dict[str, Any]
+    ) -> None:
+        await self.requeue_message(chat_id, message_data)
+        await self.mark_send_now(chat_id, message_data["id"])
 
     async def clear_send_now(self, chat_id: str) -> None:
         send_now_key = REDIS_KEY_CHAT_QUEUE_SEND_NOW.format(chat_id=chat_id)

--- a/backend/app/services/session_registry.py
+++ b/backend/app/services/session_registry.py
@@ -49,7 +49,7 @@ class SessionRegistry:
         config: AcpSessionConfig,
     ) -> tuple[ChatSession, bool]:
         session = self._sessions.get(chat_id)
-        fingerprint = self._compute_fingerprint(config)
+        fingerprint = self.compute_fingerprint(config)
 
         if session is not None and not session.acp_session.is_alive():
             await self._close_session(session)
@@ -124,6 +124,9 @@ class SessionRegistry:
             return_exceptions=True,
         )
 
+    def get(self, chat_id: str) -> ChatSession | None:
+        return self._sessions.get(chat_id)
+
     async def close_idle_sessions(self, ttl_seconds: float) -> None:
         now = time.monotonic()
         expired: list[str] = []
@@ -144,7 +147,7 @@ class SessionRegistry:
             logger.info("Closed %d idle chat session(s)", len(expired))
 
     @staticmethod
-    def _compute_fingerprint(config: AcpSessionConfig) -> str:
+    def compute_fingerprint(config: AcpSessionConfig) -> str:
         # cwd is stable per chat (workspace root or the chat's worktree, never
         # agent-reported paths), so including it respawns the agent process in
         # the worktree when worktree mode is enabled mid-chat — otherwise the

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -254,7 +254,7 @@ class ChatStreamRuntime:
             checkpoint_id=checkpoint_id,
             prior_duration_ms=duration_ms,
         )
-        logger.info(
+        logger.warning(
             "Rotated live stream for steered message %s on chat %s "
             "(old assistant %s interrupted, continuing into %s)",
             queued_msg.get("id"),
@@ -874,11 +874,11 @@ class ChatStreamRuntime:
         session_factory: SessionFactoryType,
     ) -> bool:
         if chat_id in cls._steering_chats:
-            logger.info("Steering already in flight for chat %s", chat_id)
+            logger.warning("Steering already in flight for chat %s", chat_id)
             return True
         cls._steering_chats.add(chat_id)
         try:
-            logger.info(
+            logger.warning(
                 "Steer attempt for chat %s (send-now message %s)",
                 chat_id,
                 queued_message_id,
@@ -899,7 +899,7 @@ class ChatStreamRuntime:
             elif session.acp_session.handler.has_pending_permissions:
                 skip_reason = "a permission prompt is pending"
             if skip_reason is not None:
-                logger.info(
+                logger.warning(
                     "Steering skipped for chat %s: %s — using legacy send-now",
                     chat_id,
                     skip_reason,
@@ -910,14 +910,14 @@ class ChatStreamRuntime:
                 chat_id, queued_message_id
             )
             if not queued_msg:
-                logger.info(
+                logger.warning(
                     "Send-now message %s for chat %s was already claimed or deleted",
                     queued_message_id,
                     chat_id,
                 )
                 return True
             if queued_msg["model_id"] != runtime.model_id:
-                logger.info(
+                logger.warning(
                     "Steering skipped for chat %s: queued model %s != running model %s"
                     " — using legacy send-now",
                     chat_id,
@@ -958,7 +958,7 @@ class ChatStreamRuntime:
                 or config.permission_mode != session.current_mode
                 or config.fast_mode != session.current_fast_mode
             ):
-                logger.info(
+                logger.warning(
                     "Steering skipped for chat %s: settings differ from running turn "
                     "(fingerprint_match=%s, mode %r vs %r, fast_mode %s vs %s, "
                     "model %s, effort %r) — using legacy send-now",
@@ -977,7 +977,7 @@ class ChatStreamRuntime:
                 chat_id, queued_message_id
             )
             if claimed_msg is None:
-                logger.info(
+                logger.warning(
                     "Send-now message %s for chat %s was concurrently claimed or deleted",
                     queued_message_id,
                     chat_id,
@@ -1014,7 +1014,7 @@ class ChatStreamRuntime:
                     and session.acp_session.handler.enqueue_steer_rotation(claimed_msg)
                 )
                 if delivered:
-                    logger.info(
+                    logger.warning(
                         "Steered send-now message %s into live ACP turn for chat %s",
                         queued_message_id,
                         chat_id,

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -254,6 +254,14 @@ class ChatStreamRuntime:
             checkpoint_id=checkpoint_id,
             prior_duration_ms=duration_ms,
         )
+        logger.info(
+            "Rotated live stream for steered message %s on chat %s "
+            "(old assistant %s interrupted, continuing into %s)",
+            queued_msg.get("id"),
+            self.chat_id,
+            self.assistant_message_id,
+            assistant_message.id,
+        )
         await self._start_rotated_stream(
             assistant_message_id=str(assistant_message.id),
             model_id=queued_msg["model_id"],
@@ -967,6 +975,11 @@ class ChatStreamRuntime:
                     and session.acp_session.handler.enqueue_steer_rotation(claimed_msg)
                 )
                 if delivered:
+                    logger.info(
+                        "Steered send-now message %s into live ACP turn for chat %s",
+                        queued_message_id,
+                        chat_id,
+                    )
                     return True
                 logger.warning(
                     "ACP steer rotation could not be delivered for chat %s", chat_id

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -21,11 +21,11 @@ from app.constants import (
 )
 from app.core.config import get_settings
 from app.db.session import SessionLocal
-from app.models.db_models.chat import Chat
+from app.models.db_models.chat import Chat, Message
 from app.models.db_models.enums import MessageRole, MessageStreamStatus
 from app.models.db_models.user import User, UserSettings
 from app.prompts.system_prompt import build_system_prompt_for_chat
-from app.services.acp.session import AcpSessionConfig
+from app.services.acp.session import AcpSession, AcpSessionConfig
 from app.services.agent import (
     AgentService,
     StreamResult,
@@ -53,6 +53,12 @@ TRANSPORT_FATAL_TYPES = (
     OSError,
 )
 
+# Steering acceptance is a fast control-plane call (adapters reply on acceptance,
+# not on LLM completion). Bound it so a hung adapter can't hold the send-now claim
+# and the per-chat steering guard forever; on timeout the generic failure path
+# restores the claim and falls back to the legacy cancel flow.
+STEER_ACCEPT_TIMEOUT_SECONDS = 15.0
+
 # Snapshot-contributing events (text/tools/etc.) — batched; control events persist immediately.
 SNAPSHOT_EVENT_KINDS = frozenset(
     {
@@ -71,6 +77,9 @@ SNAPSHOT_EVENT_KINDS = frozenset(
 class ChatStreamRuntime:
     # Background stream tasks by asyncio.Task — track chats, await shutdown, block duplicates.
     _background_task_chat_ids: dict[asyncio.Task[str], str] = {}
+    _active_runtimes: dict[str, ChatStreamRuntime] = {}
+    # Per-process like the runtime/session registries it protects.
+    _steering_chats: set[str] = set()
 
     def __init__(
         self,
@@ -105,6 +114,9 @@ class ChatStreamRuntime:
         self._last_emitted_tokens: int = 0
         self._last_emitted_context_window: int = 0
         self._stream: AsyncIterator[StreamEvent] | None = None
+        self._stream_result: StreamResult = StreamResult()
+        self._start_seq = 0
+        self._acp_session: AcpSession | None = None
 
     async def run(
         self,
@@ -112,6 +124,7 @@ class ChatStreamRuntime:
         stream: AsyncIterator[StreamEvent],
     ) -> str:
         self._stream = stream
+        self._stream_result = stream_result
         # Titling only needs the user's prompt, so it starts alongside the turn
         # instead of after it — the sidebar shows a real title while streaming.
         title_task = asyncio.create_task(self._generate_title())
@@ -119,52 +132,36 @@ class ChatStreamRuntime:
         title_task.add_done_callback(self._bg_tasks.discard)
         title_task.add_done_callback(ChatStreamRuntime._on_title_task_done)
         try:
-            start_seq = await self.emit_event(
-                "stream_started",
-                {"status": "started"},
-                apply_snapshot=False,
-            )
-            if self.assistant_message_id:
-                await self.message_service.update_message_snapshot(
-                    UUID(self.assistant_message_id),
-                    content_text="",
-                    content_render=self.snapshot.to_render(),
-                    last_seq=start_seq,
-                    active_stream_id=self.stream_id,
+            await self._start_message_stream()
+            await self._consume_stream(stream)
+            if self._acp_session is not None:
+                self._stream_result.total_cost_usd = (
+                    self._acp_session.handler.total_cost_usd
                 )
-            # Emit worktree_cwd up front so the frontend can patch the chat
-            # cache mid-turn; without this, branch/diff/editor actions during
-            # the turn would target the workspace root until end-of-stream
-            # invalidation refetches the chat.
-            if self.chat.worktree_cwd:
-                await self.emit_event(
-                    "system",
-                    {"data": {"worktree_cwd": self.chat.worktree_cwd}},
-                )
-            await self._consume_stream(stream_result, stream)
+                self._stream_result.usage = self._acp_session.handler.usage
             await self._emit_prompt_suggestions()
 
             if self._cancelled:
                 return await self._complete_stream(
-                    stream_result, MessageStreamStatus.INTERRUPTED
+                    self._stream_result, MessageStreamStatus.INTERRUPTED
                 )
 
             # Buffered events may not have flushed yet (debounce) — a fast turn
             # can finish with last_seq still at start_seq, so check the buffer
             # too before declaring the stream empty.
-            if self.last_seq <= start_seq and not self._event_buffer:
+            if self.last_seq <= self._start_seq and not self._event_buffer:
                 # Cancel/send-now may have arrived after the last event was
                 # consumed but before _consume_stream returned — the stream
                 # ended naturally (via StopAsyncIteration) so CancelledError
                 # never fired. Treat as interrupted rather than erroring.
                 if self._cancel_event and self._cancel_event.is_set():
                     return await self._complete_stream(
-                        stream_result, MessageStreamStatus.INTERRUPTED
+                        self._stream_result, MessageStreamStatus.INTERRUPTED
                     )
                 raise AgentException("Stream completed without any events")
 
             return await self._complete_stream(
-                stream_result, MessageStreamStatus.COMPLETED
+                self._stream_result, MessageStreamStatus.COMPLETED
             )
 
         except Exception as exc:
@@ -174,12 +171,13 @@ class ChatStreamRuntime:
                 {"error": str(exc)},
                 apply_snapshot=False,
             )
-            await self._save_final_snapshot(stream_result, MessageStreamStatus.FAILED)
+            await self._save_final_snapshot(
+                self._stream_result, MessageStreamStatus.FAILED
+            )
             raise
 
     async def _consume_stream(
         self,
-        stream_result: StreamResult,
         stream: AsyncIterator[StreamEvent],
     ) -> None:
         stream_iter = aiter(stream)
@@ -195,6 +193,15 @@ class ChatStreamRuntime:
                     k: v for k, v in event_dict.items() if k != "type"
                 }
 
+                if kind == "_steer_rotation":
+                    data = payload.get("data")
+                    queued_msg = (
+                        data.get("queued_msg") if isinstance(data, dict) else None
+                    )
+                    if isinstance(queued_msg, dict):
+                        await self._rotate_for_steer(queued_msg)
+                    continue
+
                 if kind == "system":
                     session_data: dict[str, Any] = payload.get("data") or {}
                     if session_data.get("session_id"):
@@ -207,10 +214,10 @@ class ChatStreamRuntime:
 
                 if kind == "usage":
                     usage_data = payload.get("data")
-                    stream_result.usage = (
+                    self._stream_result.usage = (
                         usage_data if isinstance(usage_data, dict) else None
                     )
-                    await self._emit_context_usage(stream_result)
+                    await self._emit_context_usage(self._stream_result)
                 else:
                     await self.emit_event(kind, payload)
                     await self._flush_snapshot(force=False)
@@ -218,6 +225,39 @@ class ChatStreamRuntime:
             if not (self._cancel_event and self._cancel_event.is_set()):
                 raise
             self._cancelled = True
+
+    async def _rotate_for_steer(self, queued_msg: dict[str, Any]) -> None:
+        materialized = await self._create_queued_handoff(queued_msg)
+        if materialized is None:
+            await self._requeue_next_message(queued_msg, mark_send_now=True)
+            await session_registry.cancel_generation(self.chat_id)
+            return
+        user_message, assistant_message, checkpoint_id = materialized
+
+        assert self._acp_session is not None
+        handler = self._acp_session.handler
+        if handler.has_pending_permissions:
+            handler.cancel_pending_permissions()
+        for event in handler.rotate_active_tools():
+            event_dict = dict(event)
+            kind = str(event_dict.pop("type", "tool_failed"))
+            await self.emit_event(kind, event_dict)
+            await self._flush_snapshot(force=False)
+
+        duration_ms = await self._save_final_snapshot(
+            self._stream_result, MessageStreamStatus.INTERRUPTED
+        )
+        await self._emit_queue_processing(
+            queued_msg=queued_msg,
+            user_message=user_message,
+            assistant_message=assistant_message,
+            checkpoint_id=checkpoint_id,
+            prior_duration_ms=duration_ms,
+        )
+        await self._start_rotated_stream(
+            assistant_message_id=str(assistant_message.id),
+            model_id=queued_msg["model_id"],
+        )
 
     async def _emit_prompt_suggestions(self) -> None:
         raw = "".join(self.snapshot.text_parts)
@@ -488,7 +528,10 @@ class ChatStreamRuntime:
             logger.error("Session update task failed: %s", exc)
 
     async def _process_next_queued(
-        self, *, send_now_only: bool = False, prior_duration_ms: int | None = None
+        self,
+        *,
+        send_now_only: bool = False,
+        prior_duration_ms: int | None = None,
     ) -> bool:
         next_msg: dict[str, Any] | None = None
         try:
@@ -506,49 +549,20 @@ class ChatStreamRuntime:
         if not next_msg:
             return False
 
+        materialized = await self._create_queued_handoff(next_msg)
+        if materialized is None:
+            await self._requeue_next_message(next_msg)
+            return False
+        user_message, assistant_message, checkpoint_id = materialized
+
         try:
-            user_message = await self.message_service.create_message(
-                UUID(self.chat_id),
-                next_msg["content"],
-                MessageRole.USER,
-                attachments=next_msg.get("attachments"),
+            await self._emit_queue_processing(
+                queued_msg=next_msg,
+                user_message=user_message,
+                assistant_message=assistant_message,
+                checkpoint_id=checkpoint_id,
+                prior_duration_ms=prior_duration_ms,
             )
-            assistant_message = await self.message_service.create_message(
-                UUID(self.chat_id),
-                "",
-                MessageRole.ASSISTANT,
-                model_id=next_msg["model_id"],
-                stream_status=MessageStreamStatus.IN_PROGRESS,
-            )
-            # Avoid circular import with chat.py.
-            from app.services.chat import ChatService
-
-            checkpoint_id = await ChatService.create_checkpoint_for_message(
-                self.chat,
-                assistant_message.id,
-                self.session_factory,
-                next_msg["worktree"],
-            )
-
-            await self.emit_event(
-                "queue_processing",
-                {
-                    "queued_message_id": next_msg["id"],
-                    "user_message_id": str(user_message.id),
-                    "assistant_message_id": str(assistant_message.id),
-                    "checkpoint_id": str(checkpoint_id) if checkpoint_id else None,
-                    "content": next_msg["content"],
-                    "model_id": next_msg["model_id"],
-                    "attachments": MessageService.serialize_attachments(
-                        next_msg, user_message
-                    ),
-                    # The prior turn's terminal event is suppressed during a queue
-                    # handoff, so ship its persisted duration here for the rollup.
-                    "prior_duration_ms": prior_duration_ms,
-                },
-                apply_snapshot=False,
-            )
-
             user_service = UserService(session_factory=self.session_factory)
             user_settings = await user_service.get_user_settings(
                 self.chat.user_id, db=None
@@ -574,11 +588,115 @@ class ChatStreamRuntime:
         )
         return True
 
-    async def _requeue_next_message(self, queued_msg: dict[str, Any]) -> None:
+    async def _create_queued_handoff(
+        self,
+        queued_msg: dict[str, Any],
+    ) -> tuple[Message, Message, UUID | None] | None:
+        try:
+            user_message = await self.message_service.create_message(
+                UUID(self.chat_id),
+                queued_msg["content"],
+                MessageRole.USER,
+                attachments=queued_msg.get("attachments"),
+            )
+            assistant_message = await self.message_service.create_message(
+                UUID(self.chat_id),
+                "",
+                MessageRole.ASSISTANT,
+                model_id=queued_msg["model_id"],
+                stream_status=MessageStreamStatus.IN_PROGRESS,
+            )
+            # Avoid circular import with chat.py.
+            from app.services.chat import ChatService
+
+            checkpoint_id = await ChatService.create_checkpoint_for_message(
+                self.chat,
+                assistant_message.id,
+                self.session_factory,
+                queued_msg["worktree"],
+            )
+            return user_message, assistant_message, checkpoint_id
+        except Exception as exc:
+            logger.error("Failed to materialize queued message: %s", exc)
+            return None
+
+    async def _emit_queue_processing(
+        self,
+        *,
+        queued_msg: dict[str, Any],
+        user_message: Message,
+        assistant_message: Message,
+        checkpoint_id: UUID | None,
+        prior_duration_ms: int | None,
+    ) -> None:
+        await self.emit_event(
+            "queue_processing",
+            {
+                "queued_message_id": queued_msg["id"],
+                "user_message_id": str(user_message.id),
+                "assistant_message_id": str(assistant_message.id),
+                "checkpoint_id": str(checkpoint_id) if checkpoint_id else None,
+                "content": queued_msg["content"],
+                "model_id": queued_msg["model_id"],
+                "attachments": MessageService.serialize_attachments(
+                    queued_msg, user_message
+                ),
+                # The prior turn's terminal event is suppressed during a queue
+                # handoff, so ship its persisted duration here for the rollup.
+                "prior_duration_ms": prior_duration_ms,
+            },
+            apply_snapshot=False,
+        )
+
+    async def _start_message_stream(self) -> None:
+        self._start_seq = await self.emit_event(
+            "stream_started",
+            {"status": "started"},
+            apply_snapshot=False,
+        )
+        if self.assistant_message_id:
+            await self.message_service.update_message_snapshot(
+                UUID(self.assistant_message_id),
+                content_text="",
+                content_render=self.snapshot.to_render(),
+                last_seq=self._start_seq,
+                active_stream_id=self.stream_id,
+            )
+        # Emit worktree_cwd up front so mid-turn actions target the worktree.
+        if self.chat.worktree_cwd:
+            await self.emit_event(
+                "system",
+                {"data": {"worktree_cwd": self.chat.worktree_cwd}},
+            )
+
+    async def _start_rotated_stream(
+        self, *, assistant_message_id: str, model_id: str
+    ) -> None:
+        self.assistant_message_id = assistant_message_id
+        self.model_id = model_id
+        self.context_window = MODELS[model_id].context_window
+        self.stream_id = uuid4()
+        self.snapshot = StreamSnapshotAccumulator()
+        self.last_seq = 0
+        self.pending_since_flush = 0
+        self.last_flush_at = time.monotonic()
+        self._event_buffer = []
+        self._stream_result = StreamResult()
+        self._last_emitted_tokens = 0
+        self._last_emitted_context_window = 0
+
+        await self._start_message_stream()
+
+    async def _requeue_next_message(
+        self, queued_msg: dict[str, Any], *, mark_send_now: bool = False
+    ) -> None:
         try:
             async with cache_connection() as cache:
                 queue_service = QueueService(cache)
-                await queue_service.requeue_message(self.chat_id, queued_msg)
+                if mark_send_now:
+                    await queue_service.restore_send_now(self.chat_id, queued_msg)
+                else:
+                    await queue_service.requeue_message(self.chat_id, queued_msg)
         except Exception as requeue_exc:
             logger.error("Failed to re-queue message: %s", requeue_exc)
 
@@ -737,6 +855,140 @@ class ChatStreamRuntime:
     def has_active_chat(cls, chat_id: str) -> bool:
         cls._prune_done_tasks()
         return chat_id in cls._background_task_chat_ids.values()
+
+    @classmethod
+    async def try_steer_send_now(
+        cls,
+        *,
+        chat_id: str,
+        queued_message_id: str,
+        queue_service: QueueService,
+        session_factory: SessionFactoryType,
+    ) -> bool:
+        if chat_id in cls._steering_chats:
+            logger.info("Steering already in flight for chat %s", chat_id)
+            return True
+        cls._steering_chats.add(chat_id)
+        try:
+            runtime = cls._active_runtimes.get(chat_id)
+            session = session_registry.get(chat_id)
+            if (
+                runtime is None
+                or session is None
+                or runtime._acp_session is not session.acp_session
+                or not session.acp_session.is_alive()
+                or not session.acp_session.steering_supported
+                or session.acp_session.handler.has_pending_permissions
+            ):
+                return False
+
+            queued_msg = await queue_service.get_message_by_id(
+                chat_id, queued_message_id
+            )
+            if not queued_msg:
+                logger.info(
+                    "Send-now message %s for chat %s was already claimed or deleted",
+                    queued_message_id,
+                    chat_id,
+                )
+                return True
+            if queued_msg["model_id"] != runtime.model_id:
+                return False
+
+            user_service = UserService(session_factory=session_factory)
+            user_settings = await user_service.get_user_settings(
+                runtime.chat.user_id, db=None
+            )
+            queued_request = cls._build_queued_stream_request(
+                chat=runtime.chat,
+                queued_msg=queued_msg,
+                user_settings=user_settings,
+                assistant_message_id="",
+                session_id_override=runtime.session_id,
+            )
+            ai_service = AgentService(session_factory=session_factory)
+            config = await ai_service.build_session_config(
+                user=User(id=runtime.chat.user_id),
+                chat=runtime.chat,
+                model_id=queued_request.model_id,
+                permission_mode=queued_request.permission_mode,
+                session_id=queued_request.session_id,
+                thinking_mode=queued_request.thinking_mode,
+                system_prompt=queued_request.system_prompt,
+                worktree=queued_request.worktree,
+                selected_persona_name=queued_request.selected_persona_name,
+                fast_mode=queued_request.fast_mode,
+            )
+            if (
+                session_registry.compute_fingerprint(config) != session.fingerprint
+                or config.permission_mode != session.current_mode
+                or config.fast_mode != session.current_fast_mode
+            ):
+                return False
+
+            claimed_msg = await queue_service.pop_message_by_id(
+                chat_id, queued_message_id
+            )
+            if claimed_msg is None:
+                logger.info(
+                    "Send-now message %s for chat %s was concurrently claimed or deleted",
+                    queued_message_id,
+                    chat_id,
+                )
+                return True
+
+            content = AgentService.prepare_user_prompt(
+                claimed_msg["content"], queued_request.custom_instructions
+            )
+            try:
+                async with asyncio.timeout(STEER_ACCEPT_TIMEOUT_SECONDS):
+                    outcome = await session.acp_session.steer(
+                        content,
+                        attachments=claimed_msg.get("attachments"),
+                        agent_kind=config.agent_kind,
+                    )
+            except asyncio.CancelledError:
+                await queue_service.restore_send_now(chat_id, claimed_msg)
+                raise
+            except Exception:
+                logger.warning(
+                    "ACP steering failed for chat %s", chat_id, exc_info=True
+                )
+                await queue_service.restore_send_now(chat_id, claimed_msg)
+                return False
+
+            if outcome == "injected":
+                current_runtime = cls._active_runtimes.get(chat_id)
+                # Events already queued stay old. The response precedes steered output
+                # on the wire, leaving only one task-switch window for pre-steer tail
+                # output; ACP provides no stronger boundary marker.
+                delivered = (
+                    current_runtime is runtime
+                    and session.acp_session.handler.enqueue_steer_rotation(claimed_msg)
+                )
+                if delivered:
+                    return True
+                logger.warning(
+                    "ACP steer rotation could not be delivered for chat %s", chat_id
+                )
+                await queue_service.restore_send_now(chat_id, claimed_msg)
+                await session.acp_session.cancel()
+                return False
+
+            if outcome == "startedNewTurn":
+                await queue_service.restore_send_now(chat_id, claimed_msg)
+                await session.acp_session.cancel()
+                return False
+
+            logger.warning(
+                "ACP steering returned %s for chat %s; using cancel fallback",
+                outcome,
+                chat_id,
+            )
+            await queue_service.restore_send_now(chat_id, claimed_msg)
+            return False
+        finally:
+            cls._steering_chats.discard(chat_id)
 
     @classmethod
     def active_chat_ids(cls) -> set[str]:
@@ -1059,6 +1311,8 @@ class ChatStreamRuntime:
             if session_registry.consume_pending_cancel(runtime.chat_id):
                 session.cancel_event.set()
             runtime._cancel_event = session.cancel_event
+            runtime._acp_session = session.acp_session
+            cls._active_runtimes[runtime.chat_id] = runtime
             session.active_generation_task = asyncio.current_task()
             stream: AsyncIterator[StreamEvent] | None = None
             try:
@@ -1111,6 +1365,8 @@ class ChatStreamRuntime:
                 await session_registry.terminate(runtime.chat_id)
                 raise
             finally:
+                if cls._active_runtimes.get(runtime.chat_id) is runtime:
+                    cls._active_runtimes.pop(runtime.chat_id, None)
                 await runtime._close_stream()
                 session.active_generation_task = None
                 session.last_used_at = time.monotonic()

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -878,16 +878,32 @@ class ChatStreamRuntime:
             return True
         cls._steering_chats.add(chat_id)
         try:
+            logger.info(
+                "Steer attempt for chat %s (send-now message %s)",
+                chat_id,
+                queued_message_id,
+            )
             runtime = cls._active_runtimes.get(chat_id)
             session = session_registry.get(chat_id)
-            if (
-                runtime is None
-                or session is None
-                or runtime._acp_session is not session.acp_session
-                or not session.acp_session.is_alive()
-                or not session.acp_session.steering_supported
-                or session.acp_session.handler.has_pending_permissions
-            ):
+            skip_reason: str | None = None
+            if runtime is None:
+                skip_reason = "no active runtime in this process"
+            elif session is None:
+                skip_reason = "no registered ACP session"
+            elif runtime._acp_session is not session.acp_session:
+                skip_reason = "runtime is bound to a different ACP session"
+            elif not session.acp_session.is_alive():
+                skip_reason = "ACP agent process is not alive"
+            elif not session.acp_session.steering_supported:
+                skip_reason = "adapter did not advertise steering support"
+            elif session.acp_session.handler.has_pending_permissions:
+                skip_reason = "a permission prompt is pending"
+            if skip_reason is not None:
+                logger.info(
+                    "Steering skipped for chat %s: %s — using legacy send-now",
+                    chat_id,
+                    skip_reason,
+                )
                 return False
 
             queued_msg = await queue_service.get_message_by_id(
@@ -901,6 +917,13 @@ class ChatStreamRuntime:
                 )
                 return True
             if queued_msg["model_id"] != runtime.model_id:
+                logger.info(
+                    "Steering skipped for chat %s: queued model %s != running model %s"
+                    " — using legacy send-now",
+                    chat_id,
+                    queued_msg["model_id"],
+                    runtime.model_id,
+                )
                 return False
 
             user_service = UserService(session_factory=session_factory)
@@ -927,11 +950,27 @@ class ChatStreamRuntime:
                 selected_persona_name=queued_request.selected_persona_name,
                 fast_mode=queued_request.fast_mode,
             )
+            fingerprint_matches = (
+                session_registry.compute_fingerprint(config) == session.fingerprint
+            )
             if (
-                session_registry.compute_fingerprint(config) != session.fingerprint
+                not fingerprint_matches
                 or config.permission_mode != session.current_mode
                 or config.fast_mode != session.current_fast_mode
             ):
+                logger.info(
+                    "Steering skipped for chat %s: settings differ from running turn "
+                    "(fingerprint_match=%s, mode %r vs %r, fast_mode %s vs %s, "
+                    "model %s, effort %r) — using legacy send-now",
+                    chat_id,
+                    fingerprint_matches,
+                    config.permission_mode,
+                    session.current_mode,
+                    config.fast_mode,
+                    session.current_fast_mode,
+                    config.model,
+                    config.reasoning_effort,
+                )
                 return False
 
             claimed_msg = await queue_service.pop_message_by_id(

--- a/backend/app/services/streaming/types.py
+++ b/backend/app/services/streaming/types.py
@@ -12,6 +12,8 @@ from app.prompts.system_prompt import DEFAULT_PERSONA_NAME
 
 
 StreamEventType = Literal[
+    # Internal in-band control signal; intercepted by the runtime, never sent to SSE.
+    "_steer_rotation",
     "assistant_text",
     "assistant_thinking",
     "tool_started",

--- a/backend/tests/fake_acp_agent.py
+++ b/backend/tests/fake_acp_agent.py
@@ -70,6 +70,7 @@ MARKER_TOOL_EMPTY_RESULT = "MARKER_TOOL_EMPTY_RESULT"
 MARKER_TOOL_START_DIFF = "MARKER_TOOL_START_DIFF"
 MARKER_TOOL_UNKNOWN_DICT_ERROR = "MARKER_TOOL_UNKNOWN_DICT_ERROR"
 MARKER_ENTER_PLAN_MODE = "MARKER_ENTER_PLAN_MODE"
+MARKER_STEERING = "MARKER_STEERING"
 # 1x1 transparent PNG, reused wherever the protocol needs inline image bytes.
 TINY_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
 
@@ -91,6 +92,7 @@ class FakeAgent:
     def __init__(self) -> None:
         self._client: AgentSideConnection | None = None
         self._cancel_events: dict[str, asyncio.Event] = {}
+        self._steering_events: dict[str, asyncio.Event] = {}
 
     def on_connect(self, conn: AgentSideConnection) -> None:
         self._client = conn
@@ -107,6 +109,9 @@ class FakeAgent:
         return InitializeResponse(
             protocol_version=protocol_version,
             agent_capabilities=AgentCapabilities(load_session=True),
+            field_meta=(
+                None if SCENARIO == "no_steering" else {"steering": {"supported": True}}
+            ),
         )
 
     async def new_session(
@@ -212,7 +217,37 @@ class FakeAgent:
         self._cancel_events.setdefault(session_id, asyncio.Event()).set()
 
     async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if method == "_session/steering":
+            session_id = params["sessionId"]
+            prompt = params.get("prompt") or []
+            text = "".join(
+                block.get("text", "") for block in prompt if block.get("type") == "text"
+            )
+            outcome = os.environ.get("FAKE_ACP_STEERING_OUTCOME", "injected")
+            log_event(
+                {
+                    "event": "steering",
+                    "session_id": session_id,
+                    "text": text,
+                    "outcome": outcome,
+                }
+            )
+            if outcome == "injected" and self._client is not None:
+                asyncio.create_task(self._emit_steered_response(session_id))
+            return {"outcome": outcome}
         return {}
+
+    async def _emit_steered_response(self, session_id: str) -> None:
+        assert self._client is not None
+        await asyncio.sleep(0.01)
+        await self._client.session_update(
+            session_id=session_id,
+            update=AgentMessageChunk(
+                session_update="agent_message_chunk",
+                content=text_block("Steered response"),
+            ),
+        )
+        self._steering_events.setdefault(session_id, asyncio.Event()).set()
 
     async def ext_notification(self, method: str, params: dict[str, Any]) -> None:
         return None
@@ -252,6 +287,17 @@ class FakeAgent:
             await self._call_fs_terminal_stubs(session_id)
         if MARKER_ENTER_PLAN_MODE in text:
             return await self._run_enter_plan_mode_turn(session_id)
+        if MARKER_STEERING in text:
+            await self._client.session_update(
+                session_id=session_id,
+                update=AgentMessageChunk(
+                    session_update="agent_message_chunk",
+                    content=text_block("Before steering"),
+                ),
+            )
+            await self._steering_events.setdefault(session_id, asyncio.Event()).wait()
+            self._steering_events.pop(session_id, None)
+            return PromptResponse(stop_reason="end_turn")
 
         return await self._run_default_turn(session_id, text)
 

--- a/backend/tests/fake_acp_agent.py
+++ b/backend/tests/fake_acp_agent.py
@@ -217,7 +217,9 @@ class FakeAgent:
         self._cancel_events.setdefault(session_id, asyncio.Event()).set()
 
     async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
-        if method == "_session/steering":
+        # The agent-side router strips the leading `_` from the wire method
+        # (`_session/steering`) before dispatching here.
+        if method == "session/steering":
             session_id = params["sessionId"]
             prompt = params.get("prompt") or []
             text = "".join(

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import get_settings
 from app.models.db_models.workspace import Workspace
 from app.services.acp.adapters import AgentKind, GrokAgentAdapter
-from app.services.acp.session import AcpSessionConfig
+from app.services.acp.session import AcpSession, AcpSessionConfig
 from app.services.sandbox_providers import SandboxProviderType
 from app.services.session_registry import session_registry
 from tests.conftest import LoginClient, UserFactory
@@ -63,6 +63,42 @@ DEFAULT_TURN_TEXT = "Hello from the fake agent."
 # content_type, not on parsing the file itself.
 PNG_BYTES = bytes.fromhex("89504e470d0a1a0a0000000d49484452")
 PDF_BYTES = b"%PDF-1.4\n%fake\n"
+
+
+@pytest.mark.parametrize(
+    "scenario,expected_supported",
+    [("normal", True), ("no_steering", False)],
+)
+async def test_acp_session_captures_steering_capability(
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: "FakeAgentHandle",
+    monkeypatch: pytest.MonkeyPatch,
+    scenario: str,
+    expected_supported: bool,
+) -> None:
+    _headers, workspace = auth_workspace
+    monkeypatch.setenv("FAKE_ACP_SCENARIO", scenario)
+    session = await AcpSession.create(
+        AcpSessionConfig(
+            sandbox_id=workspace.sandbox_id,
+            sandbox_provider=SandboxProviderType.HOST,
+            cwd="",
+            user_id=str(workspace.user_id),
+            workspace_path=workspace.workspace_path,
+            agent_kind=AgentKind.CLAUDE,
+        )
+    )
+    try:
+        assert session.steering_supported is expected_supported
+        if expected_supported:
+            outcome = await session.steer("wire prompt")
+            assert outcome == "injected"
+            await asyncio.sleep(0.05)
+            [steering] = fake_agent.events_of("steering")
+            assert steering["text"] == "wire prompt"
+            assert steering["session_id"] == NEW_SESSION_ID
+    finally:
+        await session.close()
 
 
 @pytest.mark.parametrize(
@@ -113,9 +149,9 @@ def test_permission_mode_only_changes_grok_session_fingerprint(
     )
     always_approve = replace(auto, permission_mode="always-approve")
 
-    fingerprints_equal = session_registry._compute_fingerprint(
+    fingerprints_equal = session_registry.compute_fingerprint(
         auto
-    ) == session_registry._compute_fingerprint(always_approve)
+    ) == session_registry.compute_fingerprint(always_approve)
     assert fingerprints_equal is expect_equal
 
 

--- a/backend/tests/test_streaming.py
+++ b/backend/tests/test_streaming.py
@@ -10,7 +10,12 @@ import httpx
 import pytest
 import pytest_asyncio
 import uvicorn
-from acp.schema import PermissionOption, ToolCallUpdate
+from acp.schema import (
+    PermissionOption,
+    ToolCallProgress,
+    ToolCallStart,
+    ToolCallUpdate,
+)
 from fastapi import FastAPI
 from httpx import AsyncClient
 from sqlalchemy import event as sa_event
@@ -18,7 +23,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.endpoints import chat as chat_endpoint
 from app.core import deps
-from app.constants import MODELS, REDIS_KEY_USER_STREAMS_LIVE
+from app.constants import (
+    MODELS,
+    REDIS_KEY_USER_STREAMS_LIVE,
+)
 from app.db.session import engine
 from app.models.db_models.chat import Chat
 from app.models.db_models.enums import MessageStreamStatus
@@ -26,6 +34,7 @@ from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
 from app.services.acp.client import AcpClientHandler
 from app.services.acp.session import AcpSession, AcpSessionConfig
+from app.services.queue import QueueService
 from app.services.session_registry import session_registry
 from app.services import chat as chat_service_module
 from app.services.sandbox_providers.base import SandboxProvider
@@ -49,6 +58,7 @@ pytestmark = pytest.mark.anyio
 # Sentinel script step: makes the fake ACP session block forever on this
 # prompt (until the runtime cancels it), simulating a long-running turn.
 BLOCK_FOREVER = object()
+END_TURN = object()
 
 
 class ConnectionCounter:
@@ -73,6 +83,12 @@ class PermissionStep:
     on_response: dict[str, list[StreamEvent]]
 
 
+@dataclass
+class DelayedAcpUpdate:
+    delay: float
+    update: ToolCallProgress
+
+
 class FakeAcpSession:
     # Duck-types AcpSession so AgentService/SessionRegistry run without spawn.
     def __init__(
@@ -82,6 +98,10 @@ class FakeAcpSession:
         usage: dict[str, int] | None = None,
         total_cost_usd: float = 0.0,
         session_id: str = "acp-session-1",
+        steering_supported: bool = False,
+        steering_outcomes: list[str] | None = None,
+        steering_scripts: list[list[Any]] | None = None,
+        steer_gate: asyncio.Event | None = None,
     ) -> None:
         self.handler: AcpClientHandler | None = None
         self.configs: list[AcpSessionConfig] = []
@@ -96,6 +116,12 @@ class FakeAcpSession:
         self.set_model_calls: list[tuple[str, str | None]] = []
         self.close_calls = 0
         self.prompt_calls: list[str] = []
+        self.steering_supported = steering_supported
+        self.steering_outcomes = steering_outcomes or []
+        self.steering_scripts = steering_scripts or []
+        self.steer_calls: list[str] = []
+        self.steer_gate = steer_gate
+        self._turn_done = asyncio.Event()
 
     def is_alive(self) -> bool:
         return self.alive
@@ -116,8 +142,10 @@ class FakeAcpSession:
             for step in script:
                 if isinstance(step, PermissionStep):
                     await self._run_permission_step(step)
+                elif isinstance(step, (ToolCallStart, ToolCallProgress)):
+                    await self.handler.session_update(self.acp_session_id, step)
                 elif step is BLOCK_FOREVER:
-                    await asyncio.Event().wait()
+                    await self._turn_done.wait()
                 elif isinstance(step, BaseException):
                     raise step
                 else:
@@ -128,6 +156,35 @@ class FakeAcpSession:
                 self.handler.usage = self.usage
             self.handler.total_cost_usd = self.total_cost_usd
             self.handler.finish(prompt_completed=prompt_completed)
+
+    async def steer(
+        self,
+        content: str,
+        attachments: list[dict[str, Any]] | None = None,
+        agent_kind: Any = None,
+    ) -> str:
+        assert self.handler is not None
+        self.steer_calls.append(content)
+        if self.steer_gate is not None:
+            await self.steer_gate.wait()
+        outcome = self.steering_outcomes.pop(0)
+        if outcome == "injected":
+            script = self.steering_scripts.pop(0)
+            asyncio.get_running_loop().call_soon(
+                asyncio.create_task, self._emit_steer_script(script)
+            )
+        return outcome
+
+    async def _emit_steer_script(self, script: list[Any]) -> None:
+        assert self.handler is not None
+        for step in script:
+            if step is END_TURN:
+                self._turn_done.set()
+            elif isinstance(step, DelayedAcpUpdate):
+                await asyncio.sleep(step.delay)
+                await self.handler.session_update(self.acp_session_id, step.update)
+            else:
+                self.handler.event_queue.put_nowait(step)
 
     async def _run_permission_step(self, step: PermissionStep) -> None:
         assert self.handler is not None
@@ -183,10 +240,14 @@ def streaming_runtime_state_reset() -> Iterator[None]:
     # Both registries are process-wide singletons/class state — reset around
     # every test so a task or session left by one test can't leak into the next.
     ChatStreamRuntime._background_task_chat_ids.clear()
+    ChatStreamRuntime._active_runtimes.clear()
+    ChatStreamRuntime._steering_chats.clear()
     session_registry._sessions.clear()
     session_registry._pending_cancels.clear()
     yield
     ChatStreamRuntime._background_task_chat_ids.clear()
+    ChatStreamRuntime._active_runtimes.clear()
+    ChatStreamRuntime._steering_chats.clear()
     session_registry._sessions.clear()
     session_registry._pending_cancels.clear()
 
@@ -747,9 +808,8 @@ async def test_send_now_cancels_active_generation_and_starts_queued_message(
 
     first_script = [StreamEvent(type="assistant_text", text="Working"), BLOCK_FOREVER]
     second_script = [StreamEvent(type="assistant_text", text="Send-now turn done")]
-    acp_factory.queue(
-        FakeAcpSession([first_script, second_script], session_id="resumed-7")
-    )
+    acp_session = FakeAcpSession([first_script, second_script], session_id="resumed-7")
+    acp_factory.queue(acp_session)
 
     queue_response = await client.post(
         f"/api/v1/chat/chats/{chat.id}/queue",
@@ -793,6 +853,730 @@ async def test_send_now_cancels_active_generation_and_starts_queued_message(
         f"/api/v1/chat/chats/{chat.id}/queue", headers=headers
     )
     assert queue_list_response.json() == []
+    assert acp_session.cancel_calls == 1
+
+
+async def test_send_now_steers_and_rotates_the_live_stream(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="steer-1")
+    acp_session = FakeAcpSession(
+        [[StreamEvent(type="assistant_text", text="Working"), BLOCK_FOREVER]],
+        session_id="steer-1",
+        steering_supported=True,
+        steering_outcomes=["injected"],
+        steering_scripts=[
+            [StreamEvent(type="assistant_text", text="Steered answer"), END_TURN]
+        ],
+    )
+    acp_factory.queue(acp_session)
+
+    queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Urgent follow-up", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    queued_id = queued.json()["id"]
+    first = await send_message(client, headers, chat, prompt="First prompt")
+    await wait_for_message_event_type(
+        client, headers, first["message_id"], "stream_started"
+    )
+    await asyncio.sleep(0.05)
+
+    response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued_id}/send-now", headers=headers
+    )
+    assert response.status_code == 204
+    await run_background_task(chat.id)
+
+    messages = (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/messages", headers=headers)
+    ).json()["items"]
+    first_assistant = next(
+        item for item in messages if item["id"] == first["message_id"]
+    )
+    second_assistant = next(
+        item
+        for item in messages
+        if item["role"] == "assistant" and item["id"] != first["message_id"]
+    )
+    users = [item for item in messages if item["role"] == "user"]
+    assert first_assistant["stream_status"] == MessageStreamStatus.INTERRUPTED.value
+    assert first_assistant["duration_ms"] is not None
+    assert second_assistant["stream_status"] == MessageStreamStatus.COMPLETED.value
+    assert second_assistant["content_text"] == "Steered answer"
+    assert [item["content_text"] for item in users].count("Urgent follow-up") == 1
+
+    handoff = await wait_for_message_event_type(
+        client, headers, first["message_id"], "queue_processing"
+    )
+    payload = handoff["render_payload"]
+    assert payload["queued_message_id"] == queued_id
+    assert payload["assistant_message_id"] == second_assistant["id"]
+    assert payload["user_message_id"] == next(
+        item["id"] for item in users if item["content_text"] == "Urgent follow-up"
+    )
+    assert payload["prior_duration_ms"] == first_assistant["duration_ms"]
+    assert acp_session.cancel_calls == 0
+    assert len(acp_session.prompt_calls) == 1
+    assert len(acp_session.steer_calls) == 1
+    assert (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/queue", headers=headers)
+    ).json() == []
+
+
+async def test_send_now_model_mismatch_uses_legacy_cancel(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="steer-2")
+    acp_session = FakeAcpSession(
+        [
+            [StreamEvent(type="assistant_text", text="Working"), BLOCK_FOREVER],
+            [StreamEvent(type="assistant_text", text="Legacy answer")],
+        ],
+        session_id="steer-2",
+        steering_supported=True,
+    )
+    acp_factory.queue(acp_session)
+    other_model = "opencode:google-vertex-anthropic/claude-opus-4@20250514"
+    queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Different model", "model_id": other_model},
+        headers=headers,
+    )
+    first = await send_message(client, headers, chat)
+    await wait_for_message_event_type(
+        client, headers, first["message_id"], "stream_started"
+    )
+    await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued.json()['id']}/send-now",
+        headers=headers,
+    )
+    await run_background_task(chat.id)
+    await asyncio.sleep(0)
+    await run_background_task(chat.id)
+    assert acp_session.steer_calls == []
+    assert acp_session.cancel_calls == 1
+    assert len(acp_session.prompt_calls) == 2
+
+
+@pytest.mark.parametrize("outcome", ["failed", "startedNewTurn"])
+async def test_send_now_steering_outcome_falls_back_once(
+    outcome: str,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(
+        db_session, user, workspace, session_id="steer-fallback"
+    )
+    acp_session = FakeAcpSession(
+        [
+            [StreamEvent(type="assistant_text", text="Working"), BLOCK_FOREVER],
+            [StreamEvent(type="assistant_text", text="Fallback answer")],
+        ],
+        session_id="steer-fallback",
+        steering_supported=True,
+        steering_outcomes=[outcome],
+    )
+    acp_factory.queue(acp_session)
+    queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Fallback prompt", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    first = await send_message(client, headers, chat)
+    await wait_for_message_event_type(
+        client, headers, first["message_id"], "stream_started"
+    )
+    await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued.json()['id']}/send-now",
+        headers=headers,
+    )
+    await run_background_task(chat.id)
+    await asyncio.sleep(0)
+    await run_background_task(chat.id)
+
+    messages = (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/messages", headers=headers)
+    ).json()["items"]
+    assert [item["content_text"] for item in messages if item["role"] == "user"].count(
+        "Fallback prompt"
+    ) == 1
+    assert len(acp_session.prompt_calls) == 2
+    assert len(acp_session.steer_calls) == 1
+    assert acp_session.cancel_calls == (2 if outcome == "startedNewTurn" else 1)
+    assert (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/queue", headers=headers)
+    ).json() == []
+
+
+async def test_send_now_steer_timeout_falls_back_to_legacy_cancel(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A hung _session/steering RPC must not hold the send-now claim (or the
+    # per-chat steering guard) forever — the acceptance timeout routes it
+    # through the generic failure path into the legacy cancel flow.
+    monkeypatch.setattr(runtime_module, "STEER_ACCEPT_TIMEOUT_SECONDS", 0.05)
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(
+        db_session, user, workspace, session_id="steer-timeout"
+    )
+    acp_session = FakeAcpSession(
+        [
+            [StreamEvent(type="assistant_text", text="Working"), BLOCK_FOREVER],
+            [StreamEvent(type="assistant_text", text="Fallback answer")],
+        ],
+        session_id="steer-timeout",
+        steering_supported=True,
+        steering_outcomes=["injected"],
+        steer_gate=asyncio.Event(),  # never set — steer hangs until cancelled
+    )
+    acp_factory.queue(acp_session)
+    queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Timeout prompt", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    first = await send_message(client, headers, chat)
+    await wait_for_message_event_type(
+        client, headers, first["message_id"], "stream_started"
+    )
+    await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued.json()['id']}/send-now",
+        headers=headers,
+    )
+    await run_background_task(chat.id)
+    await asyncio.sleep(0)
+    await run_background_task(chat.id)
+
+    messages = (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/messages", headers=headers)
+    ).json()["items"]
+    assert [item["content_text"] for item in messages if item["role"] == "user"].count(
+        "Timeout prompt"
+    ) == 1
+    assert len(acp_session.steer_calls) == 1
+    assert len(acp_session.prompt_calls) == 2
+    assert acp_session.cancel_calls == 1
+    assert ChatStreamRuntime._steering_chats == set()
+    assert (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/queue", headers=headers)
+    ).json() == []
+
+
+async def test_send_now_can_steer_twice_in_one_acp_turn(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="steer-double")
+    acp_session = FakeAcpSession(
+        [[StreamEvent(type="assistant_text", text="First"), BLOCK_FOREVER]],
+        session_id="steer-double",
+        steering_supported=True,
+        steering_outcomes=["injected", "injected"],
+        steering_scripts=[
+            [StreamEvent(type="assistant_text", text="Second")],
+            [StreamEvent(type="assistant_text", text="Third"), END_TURN],
+        ],
+    )
+    acp_factory.queue(acp_session)
+    first = await send_message(client, headers, chat)
+    await wait_for_message_event_type(
+        client, headers, first["message_id"], "stream_started"
+    )
+    await asyncio.sleep(0.05)
+
+    first_queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Steer one", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{first_queued.json()['id']}/send-now",
+        headers=headers,
+    )
+    first_handoff = await wait_for_message_event_type(
+        client, headers, first["message_id"], "queue_processing"
+    )
+    second_assistant_id = first_handoff["render_payload"]["assistant_message_id"]
+    await wait_for_message_event_type(
+        client, headers, second_assistant_id, "stream_started"
+    )
+    await asyncio.sleep(0.05)
+
+    second_queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Steer two", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{second_queued.json()['id']}/send-now",
+        headers=headers,
+    )
+    await run_background_task(chat.id)
+
+    messages = (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/messages", headers=headers)
+    ).json()["items"]
+    assistants = [item for item in messages if item["role"] == "assistant"]
+    assert len(assistants) == 3
+    by_content = {item["content_text"]: item for item in assistants}
+    assert by_content["First"]["stream_status"] == MessageStreamStatus.INTERRUPTED.value
+    assert (
+        by_content["Second"]["stream_status"] == MessageStreamStatus.INTERRUPTED.value
+    )
+    assert by_content["Third"]["stream_status"] == MessageStreamStatus.COMPLETED.value
+    assert len(acp_session.prompt_calls) == 1
+    assert len(acp_session.steer_calls) == 2
+
+
+async def test_send_now_steer_terminates_active_tool_and_drops_late_update(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="steer-tool")
+    tool_id = "tool-active-during-steer"
+    acp_session = FakeAcpSession(
+        [
+            [
+                ToolCallStart(
+                    session_update="tool_call",
+                    tool_call_id=tool_id,
+                    title="Long-running tool",
+                ),
+                StreamEvent(type="assistant_text", text="Before"),
+                BLOCK_FOREVER,
+            ]
+        ],
+        session_id="steer-tool",
+        steering_supported=True,
+        steering_outcomes=["injected"],
+        steering_scripts=[
+            [
+                StreamEvent(type="assistant_text", text="After"),
+                DelayedAcpUpdate(
+                    0.2,
+                    ToolCallProgress(
+                        session_update="tool_call_update",
+                        tool_call_id=tool_id,
+                        status="completed",
+                        raw_output="late result",
+                    ),
+                ),
+                END_TURN,
+            ]
+        ],
+    )
+    acp_factory.queue(acp_session)
+    first = await send_message(client, headers, chat)
+    await wait_for_message_event_type(
+        client, headers, first["message_id"], "stream_started"
+    )
+    await asyncio.sleep(0.05)
+    queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Rotate with tool", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued.json()['id']}/send-now",
+        headers=headers,
+    )
+    await run_background_task(chat.id)
+
+    messages = (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/messages", headers=headers)
+    ).json()["items"]
+    old = next(item for item in messages if item["id"] == first["message_id"])
+    new = next(
+        item
+        for item in messages
+        if item["role"] == "assistant" and item["id"] != first["message_id"]
+    )
+    old_tools = [
+        event
+        for event in old["content_render"]["events"]
+        if event["type"].startswith("tool_")
+    ]
+    assert old["stream_status"] == MessageStreamStatus.INTERRUPTED.value
+    assert old_tools[-1]["type"] == "tool_failed"
+    assert old_tools[-1]["tool"]["id"] == tool_id
+    assert (
+        old_tools[-1]["tool"]["error"]
+        == "Tool ended before a terminal ACP update arrived"
+    )
+    assert new["content_text"] == "After"
+    assert not any(
+        event["type"].startswith("tool_") for event in new["content_render"]["events"]
+    )
+
+
+async def test_send_now_refuses_steering_while_permission_is_pending(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(
+        db_session, user, workspace, session_id="steer-permission"
+    )
+    permission = PermissionStep(
+        options=[("allow_once", "Allow", "allow")],
+        tool_call_id="permission-tool",
+        on_response={},
+    )
+    acp_session = FakeAcpSession(
+        [
+            [permission],
+            [StreamEvent(type="assistant_text", text="Legacy after permission")],
+        ],
+        session_id="steer-permission",
+        steering_supported=True,
+    )
+    acp_factory.queue(acp_session)
+    queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Do not steer", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    first = await send_message(client, headers, chat)
+    await wait_for_message_event_type(
+        client, headers, first["message_id"], "permission_request"
+    )
+    await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued.json()['id']}/send-now",
+        headers=headers,
+    )
+    await run_background_task(chat.id)
+    await asyncio.sleep(0)
+    await run_background_task(chat.id)
+    assert acp_session.steer_calls == []
+    assert acp_session.cancel_calls == 1
+
+
+async def test_concurrent_send_now_claims_once_and_second_attempt_is_noop(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="steer-race")
+    acp_session = FakeAcpSession(
+        [[StreamEvent(type="assistant_text", text="Before"), BLOCK_FOREVER]],
+        session_id="steer-race",
+        steering_supported=True,
+        steering_outcomes=["injected"],
+        steering_scripts=[
+            [StreamEvent(type="assistant_text", text="Claimed once"), END_TURN]
+        ],
+    )
+    acp_factory.queue(acp_session)
+    first = await send_message(client, headers, chat)
+    await wait_for_message_event_type(
+        client, headers, first["message_id"], "stream_started"
+    )
+    await asyncio.sleep(0.05)
+    queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Race prompt", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    queued_id = queued.json()["id"]
+    queue_service = QueueService(streaming_cache.store)
+    assert await queue_service.mark_send_now(str(chat.id), queued_id)
+    assert await queue_service.mark_send_now(str(chat.id), queued_id)
+
+    results = await asyncio.gather(
+        *[
+            ChatStreamRuntime.try_steer_send_now(
+                chat_id=str(chat.id),
+                queued_message_id=queued_id,
+                queue_service=queue_service,
+                session_factory=runtime_module.SessionLocal,
+            )
+            for _ in range(2)
+        ]
+    )
+    assert results == [True, True]
+    await run_background_task(chat.id)
+
+    messages = (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/messages", headers=headers)
+    ).json()["items"]
+    assert len(acp_session.steer_calls) == 1
+    assert [item["content_text"] for item in messages if item["role"] == "user"].count(
+        "Race prompt"
+    ) == 1
+    assert (
+        sum(
+            item["stream_status"] == MessageStreamStatus.INTERRUPTED.value
+            for item in messages
+            if item["role"] == "assistant"
+        )
+        == 1
+    )
+
+
+async def test_in_flight_steering_guard_allows_only_one_driver(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="steer-guard")
+    steer_gate = asyncio.Event()
+    acp_session = FakeAcpSession(
+        [[StreamEvent(type="assistant_text", text="Before"), BLOCK_FOREVER]],
+        session_id="steer-guard",
+        steering_supported=True,
+        steering_outcomes=["injected"],
+        steering_scripts=[
+            [StreamEvent(type="assistant_text", text="Guarded"), END_TURN]
+        ],
+        steer_gate=steer_gate,
+    )
+    acp_factory.queue(acp_session)
+    first = await send_message(client, headers, chat)
+    await wait_for_message_event_type(
+        client, headers, first["message_id"], "stream_started"
+    )
+    await asyncio.sleep(0.05)
+    queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Guard prompt", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    queued_id = queued.json()["id"]
+    queue_service = QueueService(streaming_cache.store)
+    assert await queue_service.mark_send_now(str(chat.id), queued_id)
+
+    first_attempt = asyncio.create_task(
+        ChatStreamRuntime.try_steer_send_now(
+            chat_id=str(chat.id),
+            queued_message_id=queued_id,
+            queue_service=queue_service,
+            session_factory=runtime_module.SessionLocal,
+        )
+    )
+    deadline = time.monotonic() + 2.0
+    while not acp_session.steer_calls and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    assert len(acp_session.steer_calls) == 1
+
+    second_result = await ChatStreamRuntime.try_steer_send_now(
+        chat_id=str(chat.id),
+        queued_message_id=queued_id,
+        queue_service=queue_service,
+        session_factory=runtime_module.SessionLocal,
+    )
+    assert second_result is True
+    assert len(acp_session.steer_calls) == 1
+
+    steer_gate.set()
+    assert await first_attempt is True
+    await run_background_task(chat.id)
+    messages = (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/messages", headers=headers)
+    ).json()["items"]
+    assert [item["content_text"] for item in messages if item["role"] == "user"].count(
+        "Guard prompt"
+    ) == 1
+
+
+async def test_deleted_send_now_claim_is_noop_without_interrupting_live_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="steer-delete")
+    acp_session = FakeAcpSession(
+        [[StreamEvent(type="assistant_text", text="Keeps streaming"), BLOCK_FOREVER]],
+        session_id="steer-delete",
+        steering_supported=True,
+    )
+    acp_factory.queue(acp_session)
+    first = await send_message(client, headers, chat)
+    await wait_for_message_event_type(
+        client, headers, first["message_id"], "stream_started"
+    )
+    await asyncio.sleep(0.05)
+    queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Deleted prompt", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    queued_id = queued.json()["id"]
+    queue_service = QueueService(streaming_cache.store)
+    assert await queue_service.mark_send_now(str(chat.id), queued_id)
+
+    async def delete_before_claim(chat_id: str, message_id: str) -> None:
+        assert await queue_service.delete_message(chat_id, message_id)
+        return None
+
+    monkeypatch.setattr(queue_service, "pop_message_by_id", delete_before_claim)
+
+    handled = await ChatStreamRuntime.try_steer_send_now(
+        chat_id=str(chat.id),
+        queued_message_id=queued_id,
+        queue_service=queue_service,
+        session_factory=runtime_module.SessionLocal,
+    )
+    assert handled is True
+    assert acp_session.steer_calls == []
+    acp_session._turn_done.set()
+    await run_background_task(chat.id)
+    messages = (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/messages", headers=headers)
+    ).json()["items"]
+    old = next(item for item in messages if item["id"] == first["message_id"])
+    assert old["stream_status"] == MessageStreamStatus.COMPLETED.value
+    assert old["content_text"] == "Keeps streaming"
+
+
+async def test_steer_materialize_failure_cancels_and_redelivers_once(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(
+        db_session, user, workspace, session_id="steer-materialize"
+    )
+    acp_session = FakeAcpSession(
+        [
+            [StreamEvent(type="assistant_text", text="Still live"), BLOCK_FOREVER],
+            [StreamEvent(type="assistant_text", text="Retried")],
+        ],
+        session_id="steer-materialize",
+        steering_supported=True,
+        steering_outcomes=["injected"],
+        steering_scripts=[[StreamEvent(type="assistant_text", text="Continues")]],
+    )
+    acp_factory.queue(acp_session)
+    first = await send_message(client, headers, chat)
+    await wait_for_message_event_type(
+        client, headers, first["message_id"], "stream_started"
+    )
+    await asyncio.sleep(0.05)
+    runtime = ChatStreamRuntime._active_runtimes[str(chat.id)]
+    original_create_message = runtime.message_service.create_message
+    fail_next_create = True
+
+    async def fail_create_message(*args: Any, **kwargs: Any) -> Any:
+        nonlocal fail_next_create
+        if fail_next_create:
+            fail_next_create = False
+            raise RuntimeError("materialize failed")
+        return await original_create_message(*args, **kwargs)
+
+    monkeypatch.setattr(runtime.message_service, "create_message", fail_create_message)
+    queued = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={"content": "Retry me", "model_id": TEST_MODEL_ID},
+        headers=headers,
+    )
+    queued_id = queued.json()["id"]
+    await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued_id}/send-now",
+        headers=headers,
+    )
+    await run_background_task(chat.id)
+    await asyncio.sleep(0)
+    await run_background_task(chat.id)
+
+    messages = (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/messages", headers=headers)
+    ).json()["items"]
+    old = next(item for item in messages if item["id"] == first["message_id"])
+    retried = next(
+        item
+        for item in messages
+        if item["role"] == "assistant" and item["id"] != first["message_id"]
+    )
+    assert old["stream_status"] == MessageStreamStatus.INTERRUPTED.value
+    assert retried["stream_status"] == MessageStreamStatus.COMPLETED.value
+    assert retried["content_text"] == "Retried"
+    assert [item["content_text"] for item in messages if item["role"] == "user"].count(
+        "Retry me"
+    ) == 1
+    assert len(acp_session.steer_calls) == 1
+    assert len(acp_session.prompt_calls) == 2
+    assert (
+        await client.get(f"/api/v1/chat/chats/{chat.id}/queue", headers=headers)
+    ).json() == []
 
 
 async def test_send_now_starts_immediately_when_chat_is_idle(


### PR DESCRIPTION
## What

`claude-agent-acp` 0.61.0 ([980ac8d](https://github.com/agentclientprotocol/claude-agent-acp/commit/980ac8dc56e671cbcdb607171f290dfcc024c696)) and `codex-acp` 1.1.6 ([2524dfb](https://github.com/agentclientprotocol/codex-acp/commit/2524dfb8568eeac659353ca9705e73501bb403c8)) added a **steering** extension — JSON-RPC request `_session/steering` (`{sessionId, prompt}` → `{outcome: "injected" | "startedNewTurn" | "failed"}`), advertised at `_meta.steering.supported` on the `initialize` response. Both versions are already pinned (#896).

This PR makes **Send now** on a queued message *steer* the running turn — inject the prompt into the live turn without cancelling — whenever the adapter supports it. The DB/SSE outcome is byte-identical to the legacy send-now/queue handoff, so the frontend is untouched:

- old assistant message → `interrupted` (duration recorded, active tools terminal-marked exactly like a legacy interrupt)
- new USER + ASSISTANT(`in_progress`) pair + `queue_processing` event (same payload)
- the same ACP turn keeps streaming into the new message → `completed`

Everything else falls back to today's cancel+re-prompt unchanged: non-steering agents (Grok/Copilot/Cursor), model/persona/permission-mode/fast-mode mismatch with the running session, pending permission prompt, or any steering failure.

## How

- **`AcpSession`** — capture `_meta.steering.supported` from `initialize` (response was previously discarded); `steer()` via the SDK's `ext_method`; prompt-block building shared with `send_prompt`.
- **`ChatStreamRuntime.try_steer_send_now`** — eligibility (live runtime+session, capability, session-fingerprint/mode/fast-mode match, no pending permission) → **claim-before-steer** (`pop_message_by_id`) → `_session/steering` bounded by a 15s acceptance timeout → on `injected`, an in-band `_steer_rotation` sentinel (carrying the claimed payload, so rotation never re-reads Redis) rotates the runtime in place. A per-chat in-flight guard closes the concurrent-send-now claim race.
- **Rotation** (`_rotate_for_steer`) — materialize the new rows/checkpoint *first* (failure → restore claim + cancel the turn, so an already-injected prompt is never double-delivered), cancel slipped-in permission prompts, apply `rotate_active_tools()` failures to the old snapshot, save `interrupted`, emit `queue_processing`, rebind stream state via the shared start helper.
- **`AcpClientHandler`** — `prompt_active` tracking, `rotate_active_tools()` mirroring `finish(prompt_completed=False)`, and rotated-id drop guards so late tool updates from the pre-steer turn can't create phantom cards on the new message.
- **Failure recovery** — every non-injected outcome (`startedNewTurn` → cancel orphan turn, `failed`, exception, timeout, undeliverable sentinel) restores the claim via `QueueService.restore_send_now` and falls through to the existing legacy branches. A queued message is never lost and never delivered twice.

## Review

Implemented and hardened through 3 adversarial review rounds; all confirmed findings fixed (rotation-ordering corruption, tool/permission state leakage across rotation, non-atomic claim race, post-injection double-delivery, unbounded steer RPC). Known accepted limitation (documented in code): event attribution across the rotation boundary has a sub-task-switch race window — ACP provides no protocol-level turn-boundary marker; in practice steered output cannot precede the steer response on the wire.

## Testing

- 340 backend tests passing (14 new: capability capture, steer wire payload, rotation happy path, double steer, tool-active steer + late-update drop, permission-pending refusal, concurrent claim, deleted claim, materialize-failure redelivery, steer timeout, legacy fallbacks per outcome, fingerprint mismatch)
- `ruff check` clean
- Legacy paths (plain queue drain, stop/cancel, non-steering agents) covered by the existing suite, unchanged