### PR TITLE
fix: name untracked tool updates from adapter meta, drop unrenderable ones

### DIFF
--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -403,6 +403,20 @@ class AcpClientHandler:
         self._active_tools[tc.tool_call_id] = payload
         return StreamEvent(type="tool_started", tool=payload)
 
+    @staticmethod
+    def _extract_meta_tool_name(tc: ToolCallProgress) -> str | None:
+        # claude-agent-acp stamps the real tool name on tool_progress updates
+        # at _meta.claudeCode.toolName (SDK >= 0.3.214 emits these for
+        # subagent-internal tools that never get a top-level tool_call start).
+        meta = getattr(tc, "field_meta", None)
+        if not isinstance(meta, dict):
+            return None
+        claude_meta = meta.get("claudeCode")
+        if not isinstance(claude_meta, dict):
+            return None
+        tool_name = claude_meta.get("toolName")
+        return tool_name if isinstance(tool_name, str) and tool_name else None
+
     def _map_tool_call_progress(self, tc: ToolCallProgress) -> StreamEvent | None:
         # Multiple progress events per tool possible; re-emit only when title/input changes.
         status = tc.status
@@ -411,11 +425,30 @@ class AcpClientHandler:
         if existing is None and status is None:
             return None
 
+        materialized = existing is None
         if existing is None:
+            # Update for a tool we never saw start. Use the real name from the
+            # adapter's _meta when present (subagent-internal tools report
+            # progress without a tool_call start); drop updates that carry no
+            # renderable identity at all instead of minting "Unknown tool"
+            # cards that finish() later stamps completed.
+            meta_tool_name = self._extract_meta_tool_name(tc)
+            if (
+                not tc.title
+                and tc.raw_input is None
+                and meta_tool_name is None
+                and self._extract_tool_result(tc) is None
+            ):
+                logger.debug(
+                    "Dropping update for untracked tool %s (status=%s)",
+                    tc.tool_call_id,
+                    status,
+                )
+                return None
             existing = ToolPayload(
                 id=tc.tool_call_id,
-                name="unknown",
-                title="Unknown tool",
+                name=meta_tool_name or "unknown",
+                title=meta_tool_name or "Unknown tool",
                 status=ToolStatus.STARTED.value,
                 parent_id=self._extract_parent_tool_id(tc),
                 input=None,
@@ -453,9 +486,10 @@ class AcpClientHandler:
             return StreamEvent(type="tool_failed", tool=existing)
 
         self._active_tools[tc.tool_call_id] = existing
-        # Re-emit tool_started so the frontend can update the loading title
-        # when input arrives or title changes.
-        if changed:
+        # Emit tool_started for a newly materialized card (first appearance),
+        # and re-emit when input arrives or the title changes so the frontend
+        # can update the loading title.
+        if materialized or changed:
             return StreamEvent(type="tool_started", tool=existing)
         return None
 

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -1138,3 +1138,65 @@ async def test_chat_attachments_and_mcp_servers_reach_the_agent(
     last_prompt = prompts[-1]
     assert "image" in last_prompt["block_types"]
     assert "doc.pdf is available at" in last_prompt["text"]
+
+
+def test_untracked_tool_updates_use_meta_name_or_are_dropped() -> None:
+    from acp.schema import ToolCallProgress
+
+    from app.services.acp.client import AcpClientHandler
+
+    handler = AcpClientHandler(agent_kind=AgentKind.CLAUDE)
+
+    # Bare progress for a tool that never had a tool_call start: no title, no
+    # input, no meta name — must be dropped, not minted as "Unknown tool".
+    bare = ToolCallProgress(
+        toolCallId="sub-tool-1", sessionUpdate="tool_call_update", status="in_progress"
+    )
+    assert handler._map_tool_call_progress(bare) is None
+    assert "sub-tool-1" not in handler._active_tools
+
+    # A later terminal update for the same untracked id is also dropped.
+    done = ToolCallProgress(
+        toolCallId="sub-tool-1", sessionUpdate="tool_call_update", status="completed"
+    )
+    assert handler._map_tool_call_progress(done) is None
+
+    # claude-agent-acp stamps the real tool name at _meta.claudeCode.toolName
+    # on subagent tool_progress updates — render the real name.
+    named = ToolCallProgress.model_validate(
+        {
+            "toolCallId": "sub-tool-2",
+            "sessionUpdate": "tool_call_update",
+            "status": "in_progress",
+            "_meta": {"claudeCode": {"toolName": "Bash"}},
+        }
+    )
+    event = handler._map_tool_call_progress(named)
+    assert event is not None
+    assert event["tool"]["name"] == "Bash"
+    assert event["tool"]["title"] == "Bash"
+    assert "sub-tool-2" in handler._active_tools
+
+    # Terminal update for the now-tracked tool completes the same card.
+    named_done = ToolCallProgress.model_validate(
+        {
+            "toolCallId": "sub-tool-2",
+            "sessionUpdate": "tool_call_update",
+            "status": "completed",
+        }
+    )
+    completed = handler._map_tool_call_progress(named_done)
+    assert completed is not None
+    assert completed["tool"]["name"] == "Bash"
+    assert completed["tool"]["status"] == "completed"
+
+    # Updates carrying a title still materialize a card (update-first adapters).
+    titled = ToolCallProgress(
+        toolCallId="sub-tool-3",
+        sessionUpdate="tool_call_update",
+        status="in_progress",
+        title="Reading config",
+    )
+    titled_event = handler._map_tool_call_progress(titled)
+    assert titled_event is not None
+    assert titled_event["tool"]["title"] == "Reading config"


### PR DESCRIPTION
## Problem

After bumping `claude-agent-acp` 0.59.0 → 0.61.0 (#896), chats with subagent-heavy turns end with a long column of **Unknown tool ✓** cards.

Root cause (verified against the upstream v0.59.0…v0.61.0 diff): no adapter change emits results without starts — but the bundled Claude Code SDK ≥ 0.3.214 now emits `tool_progress` updates for **subagent-internal tools** (with `subagent_type`/`subagent_retry` meta) that never get a top-level `tool_call` start, and the adapter has always forwarded these unconditionally as `tool_call_update`. Our handler fabricated an **"Unknown tool"** card for each unseen id, kept it in `_active_tools`, and `finish()` stamped them all completed at turn end — the flood.

## Fix

In `AcpClientHandler._map_tool_call_progress`, for updates whose tool id was never started:
- **Use the real tool name** the adapter stamps at `_meta.claudeCode.toolName` (e.g. `Bash`, `Read`) instead of "Unknown tool"
- **Drop** updates with no renderable identity at all (no title, no input, no meta name, no result) with a debug log
- Preserve the existing contract that **result-bearing** updates for unstarted tools synthesize a card (covered by the pre-existing `MARKER_TOOL_PROGRESS_NEW` test)
- Newly materialized cards emit `tool_started` on first appearance instead of registering silently and only surfacing on a later change

## Testing
- New unit test `test_untracked_tool_updates_use_meta_name_or_are_dropped` covering: bare updates dropped (in_progress and terminal), meta-named updates render the real name and complete correctly, titled updates still materialize
- Full backend suite: 327 passed; ruff clean

Independent of #897 (steering); touches the same file — whichever merges second takes a trivial conflict resolution.