### PR TITLE
feat: add Claude Opus 5 and bump claude-agent-acp to 0.62.0

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.61.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.36
+RUN npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.62.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to /root/.local/bin) — used for the Cursor
 # ACP server (`cursor-agent acp`). The install script downloads the binary for

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -135,9 +135,9 @@ SANDBOX_BASHRC_PATH: Final[str] = "/home/user/.bashrc"
 
 MODELS: dict[str, ModelInfo] = {
     "sonnet": ModelInfo("Sonnet", AgentKind.CLAUDE, 1_000_000),
-    "opus": ModelInfo("Opus", AgentKind.CLAUDE, 1_000_000),
     "haiku": ModelInfo("Haiku", AgentKind.CLAUDE, 200_000),
     "claude-fable-5": ModelInfo("Fable 5", AgentKind.CLAUDE, 1_000_000),
+    "claude-opus-5": ModelInfo("Opus 5", AgentKind.CLAUDE, 1_000_000),
     # 1M via model_context_window in ~/.codex/config.toml (registry default 372k).
     # Live-reported window still wins over these fallbacks.
     "gpt-5.6-sol": ModelInfo("GPT 5.6 Sol", AgentKind.CODEX, 1_050_000),

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -50,7 +50,7 @@ COPILOT_SESSION_MODE_IDS: dict[str, str] = {
 
 CLAUDE_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "max"})
 CLAUDE_XHIGH_VALID_THINKING_MODES = CLAUDE_VALID_THINKING_MODES | {"xhigh"}
-CLAUDE_XHIGH_MODEL_IDS = frozenset({"opus", "claude-fable-5"})
+CLAUDE_XHIGH_MODEL_IDS = frozenset({"claude-fable-5", "claude-opus-5"})
 CODEX_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
 CODEX_MAX_VALID_THINKING_MODES = CODEX_VALID_THINKING_MODES | {"max"}
 CODEX_MAX_MODEL_IDS = frozenset({"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"})

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -355,7 +355,7 @@ def last_tool(message: dict[str, Any], tool_id: str) -> dict[str, Any]:
     "model_id",
     [
         "sonnet",
-        "opus",
+        "claude-opus-5",
         "gpt-5.6-sol",
         "gpt-5.6-luna",
         "gpt-5.4",
@@ -448,7 +448,9 @@ async def test_enhance_prompt_survives_config_option_failures(
     )
     monkeypatch.setenv("FAKE_ACP_SCENARIO", "config_error")
 
-    response = await enhance_prompt(client, headers, prompt="hi", model_id="opus")
+    response = await enhance_prompt(
+        client, headers, prompt="hi", model_id="claude-opus-5"
+    )
 
     assert response.status_code == 200, response.text
     assert response.json() == {"enhanced_prompt": DEFAULT_TURN_TEXT}

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -46,6 +46,13 @@ async def test_list_models_returns_registered_models(
         "xhigh",
         "max",
     ]
+    assert by_id["claude-opus-5"]["thinking_modes"] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
     assert by_id["grok:grok-4.5"]["thinking_modes"] == ["low", "medium", "high"]
     assert by_id["cursor:auto"]["thinking_modes"] == []
 

--- a/desktop/run_build.mjs
+++ b/desktop/run_build.mjs
@@ -22,7 +22,7 @@ const PYTHON_VERSION = '3.12.12';
 const NODE_VERSION = '22.12.0';
 const RELEASE_TAG = '20260211';
 const RIPGREP_VERSION = '14.1.1';
-const CLAUDE_AGENT_ACP_VERSION = '0.61.0';
+const CLAUDE_AGENT_ACP_VERSION = '0.62.0';
 const CODEX_ACP_VERSION = '1.1.7';
 const GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py';
 

--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -18,7 +18,7 @@ const CLAUDE_XHIGH_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'xhigh', label: 'XHigh' },
   { value: 'max', label: 'Max' },
 ];
-const CLAUDE_XHIGH_MODEL_IDS = new Set(['opus', 'claude-fable-5']);
+const CLAUDE_XHIGH_MODEL_IDS = new Set(['claude-fable-5', 'claude-opus-5']);
 
 const CODEX_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'low', label: 'Low' },

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.61.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.36
+    npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.62.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.36
 
 # Cursor CLI (installs `cursor-agent` to ~/.local/bin, which is already on PATH).
 RUN curl -fsS https://cursor.com/install | bash


### PR DESCRIPTION
## Summary
- Bump `@agentclientprotocol/claude-agent-acp` from 0.61.0 → 0.62.0 (backend/sandbox Dockerfiles + desktop sidecar build)
- Add `claude-opus-5` (Opus 5, 1M context) to the Claude model registry
- Enable `xhigh` thinking mode for `claude-fable-5` and `claude-opus-5` only
- Remove the short `opus` alias so Claude models use explicit IDs

## Test plan
- [x] `pytest tests/test_models.py` passes
- [ ] Select Claude Opus 5 in the model picker and confirm it appears as "Opus 5"
- [ ] Confirm Opus 5 and Fable 5 show Low/Medium/High/XHigh/Max effort tiers
- [ ] Confirm Sonnet/Haiku still show Low/Medium/High/Max (no XHigh)
- [ ] Smoke a short Claude turn on Opus 5 after rebuilding images/sidecar with the new ACP pin