### PR TITLE
feat: add get_persona MCP tool

### DIFF
--- a/mcp-server/client.py
+++ b/mcp-server/client.py
@@ -105,6 +105,13 @@ class AgentroveClient:
         resp = await self.request("GET", "/settings/")
         return resp.json().get("personas") or []
 
+    async def get_persona(self, name: str) -> dict[str, Any]:
+        personas = await self.list_personas()
+        persona = next((p for p in personas if p["name"] == name), None)
+        if persona is None:
+            raise AgentroveError(f"No persona named {name!r} exists.")
+        return persona
+
     async def create_persona(self, name: str, content: str) -> dict[str, Any]:
         # No per-persona API — personas are a settings list; read-modify-PATCH.
         resp = await self.request("GET", "/settings/")

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -135,11 +135,25 @@ async def list_chats(
 async def list_personas() -> dict[str, Any]:
     """List custom personas available for send_message's `persona` argument.
 
-    Returns each persona's name. Pass one as `persona` to send_message; if none are
-    defined or `persona` is omitted, the standard "Default" persona is used.
+    Returns each persona's name and system prompt content. Pass a name as `persona` to
+    send_message; if none are defined or `persona` is omitted, the standard "Default"
+    persona is used.
     """
     personas = await client.list_personas()
-    return {"personas": [{"name": p["name"]} for p in personas]}
+    return {
+        "personas": [{"name": p["name"], "content": p["content"]} for p in personas]
+    }
+
+
+@mcp.tool()
+async def get_persona(name: str) -> dict[str, Any]:
+    """Get a persona's name and system prompt content.
+
+    `name` must match an existing persona (see list_personas). Returns name and content
+    so you can inspect or copy a persona before updating it or using it with send_message.
+    """
+    persona = await client.get_persona(name)
+    return {"persona": {"name": persona["name"], "content": persona["content"]}}
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary
- Add `get_persona` MCP tool and client method to fetch a persona by name (name + content)
- Include persona `content` in `list_personas` responses so agents can inspect system prompts without a second call

## Test plan
- [ ] Call `list_personas` and confirm each entry includes `name` and `content`
- [ ] Call `get_persona` with a known persona name and confirm name + content
- [ ] Call `get_persona` with an unknown name and confirm a clear error
- [ ] Smoke-test existing persona tools (`create_persona`, `update_persona`, `delete_persona`, `send_message` with `persona`) still work