### PR TITLE
Fix streaming reliability: terminal events, one-turn gating, reconnect gaps

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -97,4 +97,4 @@ jobs:
           COVERAGE_CORE: sysmon
         run: |
           cd backend
-          pytest tests --faulthandler-timeout=8 --cov=app --cov-report=term-missing:skip-covered --cov-fail-under=85
+          pytest tests --cov=app --cov-report=term-missing:skip-covered --cov-fail-under=85

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -97,4 +97,4 @@ jobs:
           COVERAGE_CORE: sysmon
         run: |
           cd backend
-          pytest tests --cov=app --cov-report=term-missing:skip-covered --cov-fail-under=85
+          pytest tests --faulthandler-timeout=8 --cov=app --cov-report=term-missing:skip-covered --cov-fail-under=85

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -18,7 +18,7 @@ from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sse_starlette.sse import EventSourceResponse
+from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 
 from app.constants import (
     MODELS,
@@ -94,6 +94,9 @@ INACTIVE_TASK_RESPONSE = {
     "last_seq": 0,
 }
 
+# Bounds the HTTP hold for pathological unwinds.
+CANCEL_UNWIND_TIMEOUT_SECONDS = 10.0
+
 
 @router.post(
     "/chats",
@@ -167,9 +170,7 @@ async def send_message(
     except ValidationError as e:
         raise RequestValidationError(e.errors()) from e
     except ChatException as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
-        ) from e
+        raise HTTPException(status_code=e.status_code, detail=str(e)) from e
 
 
 @router.post("/enhance-prompt", response_model=EnhancePromptResponse)
@@ -337,6 +338,8 @@ async def stream_user_streams(
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",
         },
+        # Real events — EventSource can't see comment pings — so the client can detect stalls.
+        ping_message_factory=lambda: ServerSentEvent(event="ping", data=""),
     )
 
 
@@ -569,15 +572,10 @@ async def restore_message_checkpoint(
 async def cancel_stream(
     chat_id: UUID,
     _chat: Chat = Depends(ensure_chat_access),
-    chat_service: ChatService = Depends(get_chat_service),
 ) -> None:
-    if not ChatStreamRuntime.has_active_chat(
-        str(chat_id)
-    ) and not await chat_service.has_cancelable_pending_start(chat_id):
-        return
-
-    # Cancel may race the runtime task start; registry holds a pending flag.
-    await session_registry.cancel_generation(str(chat_id))
+    await ChatStreamRuntime.cancel_chat_turn(
+        str(chat_id), timeout=CANCEL_UNWIND_TIMEOUT_SECONDS
+    )
 
 
 @router.post(
@@ -744,8 +742,11 @@ async def send_now_queued_message(
             detail="Queued message not found",
         )
 
-    if ChatStreamRuntime.has_active_chat(str(chat_id)):
-        # Cancel so send-now is picked up without waiting for the current turn.
+    if ChatStreamRuntime.has_active_chat(
+        str(chat_id)
+    ) or ChatStreamRuntime.has_pending_start(str(chat_id)):
+        # Cancel so send-now is picked up without waiting for the current turn —
+        # a reserved start consumes the flag at bootstrap and interrupts the same way.
         await session_registry.cancel_generation(str(chat_id))
     else:
         try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -45,6 +45,7 @@ settings = get_settings()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    await ChatStreamRuntime.reconcile_orphaned_messages(SessionLocal)
     maintenance_service = MaintenanceService()
     await maintenance_service.start()
     try:

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -128,9 +128,19 @@ class AcpClientHandler:
             self._active_tools.clear()
         self._resolved_permissions.clear()
         self._permission_option_modes.clear()
+        # Unanswered permission prompts must not outlive the turn.
+        self.dismiss_pending_permissions()
         self.event_queue.put_nowait(_SENTINEL)
 
+    def dismiss_pending_permissions(self) -> None:
+        # Agent still alive: "" resolves as a proper DeniedOutcome("cancelled") RPC response.
+        for future in self._pending_permissions.values():
+            if not future.done():
+                future.set_result("")
+        self._pending_permissions.clear()
+
     def cancel_pending_permissions(self) -> None:
+        # Teardown/dead process: no response can be delivered, just unblock the waiters.
         for future in self._pending_permissions.values():
             if not future.done():
                 future.cancel()

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -113,6 +113,7 @@ class AcpSession:
         acp_session_id: str,
         agent_kind: AgentKind = AgentKind.CLAUDE,
         stderr_task: asyncio.Task[None] | None = None,
+        exit_watch_task: asyncio.Task[None] | None = None,
     ) -> None:
         self._handler = handler
         self._conn = conn
@@ -120,6 +121,7 @@ class AcpSession:
         self.acp_session_id = acp_session_id
         self._agent_kind = agent_kind
         self._stderr_task = stderr_task
+        self._exit_watch_task = exit_watch_task
 
     @property
     def handler(self) -> AcpClientHandler:
@@ -280,6 +282,7 @@ class AcpSession:
         # Orderly shutdown: cancel any pending permission prompts (so blocked
         # request_permission() calls unblock), close the ACP connection, then
         # terminate the agent process with a SIGTERM grace period before SIGKILL.
+        # The exit watcher is left running; it no-ops once the process is reaped.
         self._handler.cancel_pending_permissions()
         if self._stderr_task and not self._stderr_task.done():
             self._stderr_task.cancel()
@@ -299,6 +302,21 @@ class AcpSession:
                 await self._force_kill_group(self._process)
             except Exception:
                 logger.debug("Error killing ACP agent process", exc_info=True)
+
+    @staticmethod
+    async def _watch_process_exit(
+        process: asyncio.subprocess.Process,
+        conn: ClientSideConnection,
+        handler: AcpClientHandler,
+    ) -> None:
+        # The SDK treats a dead agent's EOF as a clean end and never rejects
+        # pending RPCs — close the connection so the turn fails instead of hanging.
+        await process.wait()
+        handler.cancel_pending_permissions()
+        try:
+            await conn.close()
+        except Exception:
+            logger.debug("Error closing ACP connection after agent exit", exc_info=True)
 
     @staticmethod
     async def _force_kill_group(process: asyncio.subprocess.Process) -> None:
@@ -352,6 +370,10 @@ class AcpSession:
         )
 
         stderr_task = asyncio.create_task(cls._read_stderr(process))
+        # Started before the handshake so a crash there also unblocks.
+        exit_watch_task = asyncio.create_task(
+            cls._watch_process_exit(process, conn, handler)
+        )
 
         try:
             await conn.initialize(protocol_version=ACP_PROTOCOL_VERSION)
@@ -445,6 +467,7 @@ class AcpSession:
                 except (asyncio.TimeoutError, Exception):
                     pass
             stderr_task.cancel()
+            exit_watch_task.cancel()
 
             error_data = getattr(exc, "data", None)
             error_code = getattr(exc, "code", None)
@@ -472,6 +495,7 @@ class AcpSession:
             acp_session_id=acp_session_id,
             agent_kind=config.agent_kind,
             stderr_task=stderr_task,
+            exit_watch_task=exit_watch_task,
         )
 
     @staticmethod

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -4,11 +4,10 @@ import logging
 import math
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
-from typing import Any, cast
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import exists, func, select, update
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import aliased, selectinload
 
 from app.constants import (
@@ -17,7 +16,7 @@ from app.constants import (
     REDIS_KEY_USER_STREAMS_LIVE,
 )
 from app.models.db_models.chat import Chat, ChatCheckpoint, Message
-from app.models.db_models.enums import MessageRole, MessageStreamStatus, StreamEventKind
+from app.models.db_models.enums import MessageRole, StreamEventKind
 from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
 from app.models.schemas.chat import Chat as ChatSchema
@@ -41,9 +40,8 @@ from app.models.schemas.pagination import (
 )
 from app.models.types import ChatCompletionResult, MessageAttachmentDict, PermissionMode
 from app.prompts.system_prompt import DEFAULT_PERSONA_NAME, build_system_prompt_for_chat
-from app.services.agent import AgentService
 from app.services.db import BaseDbService, SessionFactoryType
-from app.services.exceptions import ChatException, ErrorCode, SandboxException
+from app.services.exceptions import ChatException, ErrorCode
 from app.services.git import GitService
 from app.services.message import MessageService
 from app.services.sandbox import SandboxService
@@ -57,8 +55,6 @@ from app.services.user import UserService
 from app.utils.cache import CacheError, CachePubSub, cache_connection, cache_pubsub
 
 logger = logging.getLogger(__name__)
-
-TERMINAL_STREAM_EVENT_TYPES = frozenset({"cancelled", "complete", "error"})
 
 # Context chars kept before a search match in snippets.
 SEARCH_SNIPPET_CONTEXT_BEFORE = 30
@@ -735,54 +731,6 @@ class ChatService(BaseDbService[Chat]):
 
         return await self.message_service.get_chat_messages(chat_id, cursor, limit)
 
-    @staticmethod
-    async def create_checkpoint_for_message(
-        chat: Chat,
-        assistant_message_id: UUID,
-        session_factory: SessionFactoryType,
-        worktree: bool,
-        base_branch: str | None = None,
-    ) -> UUID | None:
-        # Best-effort: a non-git workspace must not block the agent run.
-        sandbox_id = chat.sandbox_id
-        if not sandbox_id:
-            return None
-
-        try:
-            # Resolve the same cwd the agent turn runs in, so the checkpoint's
-            # diff and restore target match where the agent actually edited.
-            cwd = await AgentService(session_factory=session_factory).resolve_cwd(
-                chat, worktree, base_branch
-            )
-            provider = SandboxProvider.create_provider(
-                chat.sandbox_provider, workspace_path=chat.workspace_path
-            )
-            checkpoint = await GitService(SandboxService(provider)).create_checkpoint(
-                sandbox_id, cwd
-            )
-            if checkpoint is None:
-                return None
-
-            async with session_factory() as db:
-                checkpoint_row = ChatCheckpoint(
-                    chat_id=chat.id,
-                    assistant_message_id=assistant_message_id,
-                    cwd=cwd,
-                    base_head=checkpoint.base_head,
-                    pre_run_diff=checkpoint.pre_run_diff,
-                )
-                db.add(checkpoint_row)
-                await db.commit()
-                await db.refresh(checkpoint_row)
-                return cast(UUID, checkpoint_row.id)
-        except (SandboxException, SQLAlchemyError, TimeoutError, ValueError) as exc:
-            logger.warning(
-                "Failed to create checkpoint for message %s: %s",
-                assistant_message_id,
-                exc,
-            )
-            return None
-
     async def restore_checkpoint_all(
         self,
         message_id: UUID,
@@ -829,7 +777,7 @@ class ChatService(BaseDbService[Chat]):
         chat_id: UUID,
         after_seq: int,
     ) -> AsyncIterator[dict[str, Any]]:
-        # SSE reconnection catch-up: page events after the client's last seq, then live pub/sub.
+        # Catch-up after the client's last seq; terminal pruning keeps volume O(turns).
         page_size = 5000
         cursor = after_seq
 
@@ -851,8 +799,6 @@ class ChatService(BaseDbService[Chat]):
                     kind=event.event_type,
                     payload=event.render_payload,
                 )
-                if event.event_type in TERMINAL_STREAM_EVENT_TYPES:
-                    return
 
             next_cursor = int(backlog[-1].seq)
             if next_cursor <= cursor:
@@ -891,10 +837,6 @@ class ChatService(BaseDbService[Chat]):
                 payload=payload,
             ),
         }
-
-    async def has_cancelable_pending_start(self, chat_id: UUID) -> bool:
-        message = await self.message_service.get_in_progress_assistant_message(chat_id)
-        return bool(message and message.active_stream_id is None)
 
     async def filter_owned_chat_ids(
         self, user_id: UUID, chat_ids: list[UUID]
@@ -1032,6 +974,21 @@ class ChatService(BaseDbService[Chat]):
         request: ChatRequest,
         current_user: User,
     ) -> ChatCompletionResult:
+        async with ChatStreamRuntime.chat_start_slot(str(request.chat_id)) as reserved:
+            if not reserved:
+                raise ChatException(
+                    "A response is already streaming for this chat. "
+                    "Wait for it to finish or queue the message instead.",
+                    error_code=ErrorCode.VALIDATION_ERROR,
+                    status_code=409,
+                )
+            return await self._initiate_chat_completion_reserved(request, current_user)
+
+    async def _initiate_chat_completion_reserved(
+        self,
+        request: ChatRequest,
+        current_user: User,
+    ) -> ChatCompletionResult:
         user_settings = await self._user_service.get_user_settings(current_user.id)
         chat = await self.get_chat(request.chat_id, current_user)
 
@@ -1096,36 +1053,24 @@ class ChatService(BaseDbService[Chat]):
                 )
             )
 
-        await self.message_service.create_message(
-            chat_id,
-            request.prompt,
-            MessageRole.USER,
-            attachments=attachments,
-        )
-
-        assistant_message = await self.message_service.create_message(
-            chat.id,
-            "",
-            MessageRole.ASSISTANT,
-            model_id=request.model_id,
-            stream_status=MessageStreamStatus.IN_PROGRESS,
-        )
-
-        checkpoint_id = await self.create_checkpoint_for_message(
-            chat,
-            assistant_message.id,
-            self._session_factory,
-            request.worktree,
-            request.base_branch,
-        )
-
+        # Validate before the scaffold writes any rows.
         model = MODELS[request.model_id]
         system_prompt = build_system_prompt_for_chat(
             user_settings,
             agent_kind=model.agent_kind,
             selected_persona_name=request.selected_persona_name,
         )
-        try:
+
+        async with ChatStreamRuntime.turn_scaffold(
+            self.message_service,
+            chat,
+            prompt=request.prompt,
+            model_id=request.model_id,
+            attachments=attachments,
+            worktree=request.worktree,
+            base_branch=request.base_branch,
+            session_factory=self._session_factory,
+        ) as (_, assistant_message, checkpoint_id):
             await self._enqueue_chat_task(
                 prompt=request.prompt,
                 system_prompt=system_prompt,
@@ -1143,10 +1088,6 @@ class ChatService(BaseDbService[Chat]):
                 context_window=model.context_window,
                 selected_persona_name=request.selected_persona_name,
             )
-        except Exception as e:
-            logger.error("Failed to enqueue chat task: %s", e)
-            await self.message_service.soft_delete_message(assistant_message.id)
-            raise
 
         # Lets open sessions mark this chat "running" even when the turn was
         # started out-of-band (e.g. via the MCP server) with no client stream.

--- a/backend/app/services/message.py
+++ b/backend/app/services/message.py
@@ -134,6 +134,7 @@ class MessageService(BaseDbService[Message]):
         active_stream_id: UUID | None,
         stream_status: MessageStreamStatus | None = None,
         total_cost_usd: float | None = None,
+        record_activity: bool = True,
     ) -> Message | None:
         # Periodic snapshot write so reconnecting clients can hydrate without
         # replaying every event. Returns None if the row was soft-deleted mid-stream.
@@ -156,7 +157,7 @@ class MessageService(BaseDbService[Message]):
                 # Record total run time once, at the terminal snapshot. created_at
                 # marks run start — the empty assistant row is inserted before
                 # streaming begins.
-                if stream_status != MessageStreamStatus.IN_PROGRESS:
+                if record_activity and stream_status != MessageStreamStatus.IN_PROGRESS:
                     created_at = await db.scalar(
                         select(Message.created_at).where(Message.id == message_id)
                     )
@@ -200,14 +201,19 @@ class MessageService(BaseDbService[Message]):
         event_type: str,
         render_payload: dict[str, Any],
         audit_payload: dict[str, Any] | None,
+        record_activity: bool = True,
     ) -> int:
         # Allocate a gapless chat-scoped seq atomically via UPDATE...RETURNING;
         # clients use it as the SSE id for catch-up on reconnect.
+        values: dict[str, Any] = {"last_event_seq": Chat.last_event_seq + 1}
+        if not record_activity:
+            # Self-assign to suppress the onupdate bump.
+            values["updated_at"] = Chat.updated_at
         async with self.session_factory() as db:
             seq_result = await db.execute(
                 update(Chat)
                 .where(Chat.id == chat_id)
-                .values(last_event_seq=Chat.last_event_seq + 1)
+                .values(**values)
                 .returning(Chat.last_event_seq)
             )
             next_seq = seq_result.scalar_one_or_none()
@@ -406,6 +412,13 @@ class MessageService(BaseDbService[Message]):
             .where(MessageAttachment.id == attachment_id)
         )
         return cast(MessageAttachment | None, result.scalar_one_or_none())
+
+    async def discard_message_quietly(self, message_id: UUID) -> None:
+        # Must not mask the original startup error.
+        try:
+            await self.soft_delete_message(message_id)
+        except Exception:
+            logger.exception("Failed to discard message %s", message_id)
 
     async def soft_delete_message(self, message_id: UUID) -> bool:
         async with self.session_factory() as db:

--- a/backend/app/services/queue.py
+++ b/backend/app/services/queue.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from datetime import datetime, timezone
 from typing import Any, cast
@@ -15,8 +16,15 @@ from app.utils.cache import CacheStore
 
 
 class QueueService:
+    # Serializes per-chat read-modify-write; single uvicorn worker only
+    # (entrypoint.sh). Locks are retained for the process lifetime.
+    _locks: dict[str, asyncio.Lock] = {}
+
     def __init__(self, cache: CacheStore):
         self.cache = cache
+
+    def _lock(self, chat_id: str) -> asyncio.Lock:
+        return self._locks.setdefault(chat_id, asyncio.Lock())
 
     def _queue_key(self, chat_id: str) -> str:
         return REDIS_KEY_CHAT_QUEUE.format(chat_id=chat_id)
@@ -46,29 +54,30 @@ class QueueService:
         selected_persona_name: str = DEFAULT_PERSONA_NAME,
         attachments: list[dict[str, Any]] | None = None,
     ) -> QueueAddResponse:
-        key = self._queue_key(chat_id)
-        queue = await self._read_queue(key)
+        async with self._lock(chat_id):
+            key = self._queue_key(chat_id)
+            queue = await self._read_queue(key)
 
-        message_id = uuid4()
-        queued_at = datetime.now(timezone.utc)
-        message_data: dict[str, Any] = {
-            "id": str(message_id),
-            "content": content,
-            "model_id": model_id,
-            "permission_mode": permission_mode,
-            "thinking_mode": thinking_mode,
-            "worktree": worktree,
-            "base_branch": base_branch,
-            "fast_mode": fast_mode,
-            "selected_persona_name": selected_persona_name,
-            "queued_at": queued_at.isoformat(),
-            "attachments": attachments,
-        }
+            message_id = uuid4()
+            queued_at = datetime.now(timezone.utc)
+            message_data: dict[str, Any] = {
+                "id": str(message_id),
+                "content": content,
+                "model_id": model_id,
+                "permission_mode": permission_mode,
+                "thinking_mode": thinking_mode,
+                "worktree": worktree,
+                "base_branch": base_branch,
+                "fast_mode": fast_mode,
+                "selected_persona_name": selected_persona_name,
+                "queued_at": queued_at.isoformat(),
+                "attachments": attachments,
+            }
 
-        queue.append(message_data)
-        await self._write_queue(key, queue)
+            queue.append(message_data)
+            await self._write_queue(key, queue)
 
-        return QueueAddResponse(id=message_id, queued_at=queued_at)
+            return QueueAddResponse(id=message_id, queued_at=queued_at)
 
     @staticmethod
     def _to_queued_message(item: dict[str, Any]) -> QueuedMessage:
@@ -97,86 +106,90 @@ class QueueService:
     async def update_message(
         self, chat_id: str, message_id: str, content: str
     ) -> QueuedMessage | None:
-        key = self._queue_key(chat_id)
-        queue = await self._read_queue(key)
+        async with self._lock(chat_id):
+            key = self._queue_key(chat_id)
+            queue = await self._read_queue(key)
 
-        for item in queue:
-            if item["id"] == message_id:
-                item["content"] = content
-                await self._write_queue(key, queue)
-                return self._to_queued_message(item)
+            for item in queue:
+                if item["id"] == message_id:
+                    item["content"] = content
+                    await self._write_queue(key, queue)
+                    return self._to_queued_message(item)
 
-        return None
-
-    async def delete_message(self, chat_id: str, message_id: str) -> bool:
-        key = self._queue_key(chat_id)
-        queue = await self._read_queue(key)
-        original_len = len(queue)
-        queue = [item for item in queue if item["id"] != message_id]
-
-        if len(queue) == original_len:
-            return False
-
-        await self._write_queue(key, queue)
-        return True
-
-    async def clear_queue(self, chat_id: str) -> None:
-        key = self._queue_key(chat_id)
-        await self.cache.delete(key)
-
-    async def pop_next_message(self, chat_id: str) -> dict[str, Any] | None:
-        key = self._queue_key(chat_id)
-        queue = await self._read_queue(key)
-
-        if not queue:
             return None
 
-        next_msg = queue[0]
-        await self._write_queue(key, queue[1:])
-        return next_msg
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        async with self._lock(chat_id):
+            key = self._queue_key(chat_id)
+            queue = await self._read_queue(key)
+            original_len = len(queue)
+            queue = [item for item in queue if item["id"] != message_id]
+
+            if len(queue) == original_len:
+                return False
+
+            await self._write_queue(key, queue)
+            return True
+
+    async def clear_queue(self, chat_id: str) -> None:
+        # Locked so a concurrent pop's _write_queue can't resurrect the key.
+        async with self._lock(chat_id):
+            key = self._queue_key(chat_id)
+            await self.cache.delete(key)
+
+    async def pop_next_message(self, chat_id: str) -> dict[str, Any] | None:
+        async with self._lock(chat_id):
+            key = self._queue_key(chat_id)
+            queue = await self._read_queue(key)
+
+            if not queue:
+                return None
+
+            next_msg = queue[0]
+            await self._write_queue(key, queue[1:])
+            return next_msg
 
     async def mark_send_now(self, chat_id: str, message_id: str) -> bool:
         # Runtime checks this key to skip normal queue order.
-        key = self._queue_key(chat_id)
-        queue = await self._read_queue(key)
-        if not any(item["id"] == message_id for item in queue):
-            return False
+        async with self._lock(chat_id):
+            key = self._queue_key(chat_id)
+            queue = await self._read_queue(key)
+            if not any(item["id"] == message_id for item in queue):
+                return False
 
-        send_now_key = REDIS_KEY_CHAT_QUEUE_SEND_NOW.format(chat_id=chat_id)
-        await self.cache.set(send_now_key, message_id, ex=QUEUE_MESSAGE_TTL_SECONDS)
-        return True
+            send_now_key = REDIS_KEY_CHAT_QUEUE_SEND_NOW.format(chat_id=chat_id)
+            await self.cache.set(send_now_key, message_id, ex=QUEUE_MESSAGE_TTL_SECONDS)
+            return True
 
     async def pop_send_now_message(self, chat_id: str) -> dict[str, Any] | None:
-        send_now_key = REDIS_KEY_CHAT_QUEUE_SEND_NOW.format(chat_id=chat_id)
-        message_id = await self.cache.get(send_now_key)
-        if not message_id:
-            return None
+        async with self._lock(chat_id):
+            send_now_key = REDIS_KEY_CHAT_QUEUE_SEND_NOW.format(chat_id=chat_id)
+            message_id = await self.cache.get(send_now_key)
+            if not message_id:
+                return None
 
-        await self.cache.delete(send_now_key)
+            await self.cache.delete(send_now_key)
 
-        key = self._queue_key(chat_id)
-        queue = await self._read_queue(key)
-        target = None
-        remaining = []
-        for item in queue:
-            if item["id"] == message_id and target is None:
-                target = item
-            else:
-                remaining.append(item)
+            key = self._queue_key(chat_id)
+            queue = await self._read_queue(key)
+            target = None
+            remaining = []
+            for item in queue:
+                if item["id"] == message_id and target is None:
+                    target = item
+                else:
+                    remaining.append(item)
 
-        if target is None:
-            return None
+            if target is None:
+                return None
 
-        await self._write_queue(key, remaining)
-        return target
+            await self._write_queue(key, remaining)
+            return target
 
     async def requeue_message(self, chat_id: str, message_data: dict[str, Any]) -> None:
         # Front of queue so a failed process is retried next.
-        key = self._queue_key(chat_id)
-        queue = await self._read_queue(key)
-        queue.insert(0, message_data)
-        await self._write_queue(key, queue)
-
-    async def clear_send_now(self, chat_id: str) -> None:
-        send_now_key = REDIS_KEY_CHAT_QUEUE_SEND_NOW.format(chat_id=chat_id)
-        await self.cache.delete(send_now_key)
+        async with self._lock(chat_id):
+            key = self._queue_key(chat_id)
+            queue = await self._read_queue(key)
+            queue.insert(0, message_data)
+            await self._write_queue(key, queue)

--- a/backend/app/services/session_registry.py
+++ b/backend/app/services/session_registry.py
@@ -86,6 +86,8 @@ class SessionRegistry:
         if session is None:
             return
         session.cancel_event.set()
+        # Not every agent unblocks request_permission on session/cancel.
+        session.acp_session.handler.dismiss_pending_permissions()
         await session.acp_session.cancel()
 
     def resolve_permission(

--- a/backend/app/services/streaming/runtime.py
+++ b/backend/app/services/streaming/runtime.py
@@ -4,10 +4,11 @@ import asyncio
 import json
 import logging
 import time
+from contextlib import asynccontextmanager, suppress
 from copy import deepcopy
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from functools import partial
-from typing import Any
+from typing import Any, cast
 from uuid import UUID, uuid4
 
 from sqlalchemy import select, update
@@ -21,9 +22,10 @@ from app.constants import (
 )
 from app.core.config import get_settings
 from app.db.session import SessionLocal
-from app.models.db_models.chat import Chat
+from app.models.db_models.chat import Chat, ChatCheckpoint, Message
 from app.models.db_models.enums import MessageRole, MessageStreamStatus
 from app.models.db_models.user import User, UserSettings
+from app.models.types import MessageAttachmentDict
 from app.prompts.system_prompt import build_system_prompt_for_chat
 from app.services.acp.session import AcpSessionConfig
 from app.services.agent import (
@@ -32,9 +34,12 @@ from app.services.agent import (
 )
 from app.services.session_registry import session_registry
 from app.services.db import SessionFactoryType
-from app.services.exceptions import AgentException
+from app.services.exceptions import AgentException, SandboxException
+from app.services.git import GitService
 from app.services.message import MessageService
 from app.services.queue import QueueService
+from app.services.sandbox import SandboxService
+from app.services.sandbox_providers.base import SandboxProvider
 from app.services.streaming.types import (
     PROMPT_SUGGESTIONS_RE,
     ChatStreamRequest,
@@ -69,8 +74,28 @@ SNAPSHOT_EVENT_KINDS = frozenset(
 
 
 class ChatStreamRuntime:
-    # Background stream tasks by asyncio.Task — track chats, await shutdown, block duplicates.
+    # Single-process state: turn gating and reconcile assume the one uvicorn
+    # worker in entrypoint.sh. Scaling out needs Redis-side gating first.
     _background_task_chat_ids: dict[asyncio.Task[str], str] = {}
+    # Reserved before the background task registers — closes the double-send
+    # window. The event fires when the reservation is released.
+    _starting_chat_ids: dict[str, asyncio.Event] = {}
+
+    @classmethod
+    @asynccontextmanager
+    async def chat_start_slot(cls, chat_id: str) -> AsyncIterator[bool]:
+        # One turn per chat — concurrent turns would share and corrupt the ACP
+        # session. No awaits before the yield, so check-and-reserve is atomic.
+        reserved = chat_id not in cls._starting_chat_ids and not cls.has_active_chat(
+            chat_id
+        )
+        if reserved:
+            cls._starting_chat_ids[chat_id] = asyncio.Event()
+        try:
+            yield reserved
+        finally:
+            if reserved:
+                cls._starting_chat_ids.pop(chat_id).set()
 
     def __init__(
         self,
@@ -169,12 +194,15 @@ class ChatStreamRuntime:
 
         except Exception as exc:
             logger.error("Error in stream processing: %s", exc)
+            # Snapshot first — it prunes the event log — then the terminal
+            # event so it survives replay.
+            self.snapshot.add_error(str(exc))
+            await self._save_final_snapshot(stream_result, MessageStreamStatus.FAILED)
             await self.emit_event(
                 "error",
                 {"error": str(exc)},
                 apply_snapshot=False,
             )
-            await self._save_final_snapshot(stream_result, MessageStreamStatus.FAILED)
             raise
 
     async def _consume_stream(
@@ -507,65 +535,19 @@ class ChatStreamRuntime:
             return False
 
         try:
-            user_message = await self.message_service.create_message(
-                UUID(self.chat_id),
-                next_msg["content"],
-                MessageRole.USER,
-                attachments=next_msg.get("attachments"),
-            )
-            assistant_message = await self.message_service.create_message(
-                UUID(self.chat_id),
-                "",
-                MessageRole.ASSISTANT,
-                model_id=next_msg["model_id"],
-                stream_status=MessageStreamStatus.IN_PROGRESS,
-            )
-            # Avoid circular import with chat.py.
-            from app.services.chat import ChatService
-
-            checkpoint_id = await ChatService.create_checkpoint_for_message(
-                self.chat,
-                assistant_message.id,
-                self.session_factory,
-                next_msg["worktree"],
-                next_msg.get("base_branch"),
-            )
-
-            await self.emit_event(
-                "queue_processing",
-                {
-                    "queued_message_id": next_msg["id"],
-                    "user_message_id": str(user_message.id),
-                    "assistant_message_id": str(assistant_message.id),
-                    "checkpoint_id": str(checkpoint_id) if checkpoint_id else None,
-                    "content": next_msg["content"],
-                    "model_id": next_msg["model_id"],
-                    "attachments": MessageService.serialize_attachments(
-                        next_msg, user_message
-                    ),
-                    # The prior turn's terminal event is suppressed during a queue
-                    # handoff, so ship its persisted duration here for the rollup.
-                    "prior_duration_ms": prior_duration_ms,
-                },
-                apply_snapshot=False,
-            )
-
-            user_service = UserService(session_factory=self.session_factory)
-            user_settings = await user_service.get_user_settings(
-                self.chat.user_id, db=None
-            )
-            ChatStreamRuntime.start_background_chat(
-                self._build_queued_stream_request(
-                    chat=self.chat,
-                    queued_msg=next_msg,
-                    user_settings=user_settings,
-                    assistant_message_id=str(assistant_message.id),
-                    session_id_override=self.session_id,
-                )
+            await self._start_queued_turn(
+                chat=self.chat,
+                queued_msg=next_msg,
+                message_service=self.message_service,
+                session_factory=self.session_factory,
+                session_id_override=self.session_id,
+                before_handoff=partial(
+                    self._emit_queue_processing, next_msg, prior_duration_ms
+                ),
             )
         except Exception as exc:
             logger.error("Failed to process queued message: %s", exc)
-            await self._requeue_next_message(next_msg)
+            await self._requeue_message_quietly(self.chat_id, next_msg)
             return False
 
         logger.info(
@@ -575,13 +557,178 @@ class ChatStreamRuntime:
         )
         return True
 
-    async def _requeue_next_message(self, queued_msg: dict[str, Any]) -> None:
+    async def _emit_queue_processing(
+        self,
+        queued_msg: dict[str, Any],
+        prior_duration_ms: int | None,
+        user_message: Message,
+        assistant_message: Message,
+        checkpoint_id: UUID | None,
+    ) -> None:
+        await self.emit_event(
+            "queue_processing",
+            {
+                "queued_message_id": queued_msg["id"],
+                "user_message_id": str(user_message.id),
+                "assistant_message_id": str(assistant_message.id),
+                "checkpoint_id": str(checkpoint_id) if checkpoint_id else None,
+                "content": queued_msg["content"],
+                "model_id": queued_msg["model_id"],
+                "attachments": MessageService.serialize_attachments(
+                    queued_msg, user_message
+                ),
+                # The terminal is suppressed during handoff — ship the duration here.
+                "prior_duration_ms": prior_duration_ms,
+            },
+            apply_snapshot=False,
+        )
+
+    @staticmethod
+    async def create_checkpoint_for_message(
+        chat: Chat,
+        assistant_message_id: UUID,
+        session_factory: SessionFactoryType,
+        worktree: bool,
+        base_branch: str | None = None,
+    ) -> UUID | None:
+        # Best-effort: a non-git workspace must not block the agent run.
+        sandbox_id = chat.sandbox_id
+        if not sandbox_id:
+            return None
+
+        try:
+            # Resolve the same cwd the agent turn runs in, so the checkpoint's
+            # diff and restore target match where the agent actually edited.
+            cwd = await AgentService(session_factory=session_factory).resolve_cwd(
+                chat, worktree, base_branch
+            )
+            provider = SandboxProvider.create_provider(
+                chat.sandbox_provider, workspace_path=chat.workspace_path
+            )
+            checkpoint = await GitService(SandboxService(provider)).create_checkpoint(
+                sandbox_id, cwd
+            )
+            if checkpoint is None:
+                return None
+
+            async with session_factory() as db:
+                checkpoint_row = ChatCheckpoint(
+                    chat_id=chat.id,
+                    assistant_message_id=assistant_message_id,
+                    cwd=cwd,
+                    base_head=checkpoint.base_head,
+                    pre_run_diff=checkpoint.pre_run_diff,
+                )
+                db.add(checkpoint_row)
+                await db.commit()
+                await db.refresh(checkpoint_row)
+                return cast(UUID, checkpoint_row.id)
+        except (SandboxException, SQLAlchemyError, TimeoutError, ValueError) as exc:
+            logger.warning(
+                "Failed to create checkpoint for message %s: %s",
+                assistant_message_id,
+                exc,
+            )
+            return None
+
+    @classmethod
+    @asynccontextmanager
+    async def turn_scaffold(
+        cls,
+        message_service: MessageService,
+        chat: Chat,
+        *,
+        prompt: str,
+        model_id: str,
+        attachments: list[MessageAttachmentDict] | None,
+        worktree: bool,
+        base_branch: str | None,
+        session_factory: SessionFactoryType,
+    ) -> AsyncIterator[tuple[Message, Message, UUID | None]]:
+        # A turn that fails to start leaves no rows behind.
+        user_message = None
+        assistant_message = None
+        try:
+            chat_uuid = UUID(str(chat.id))
+            user_message = await message_service.create_message(
+                chat_uuid,
+                prompt,
+                MessageRole.USER,
+                attachments=attachments,
+            )
+            assistant_message = await message_service.create_message(
+                chat_uuid,
+                "",
+                MessageRole.ASSISTANT,
+                model_id=model_id,
+                stream_status=MessageStreamStatus.IN_PROGRESS,
+            )
+            checkpoint_id = await cls.create_checkpoint_for_message(
+                chat,
+                assistant_message.id,
+                session_factory,
+                worktree,
+                base_branch,
+            )
+            yield user_message, assistant_message, checkpoint_id
+        except Exception as exc:
+            logger.error("Turn failed to start for chat %s: %s", chat.id, exc)
+            for message in (assistant_message, user_message):
+                if message is not None:
+                    await message_service.discard_message_quietly(message.id)
+            raise
+
+    @classmethod
+    async def _start_queued_turn(
+        cls,
+        *,
+        chat: Chat,
+        queued_msg: dict[str, Any],
+        message_service: MessageService,
+        session_factory: SessionFactoryType,
+        session_id_override: str | None = None,
+        before_handoff: Callable[[Message, Message, UUID | None], Awaitable[None]]
+        | None = None,
+    ) -> None:
+        if queued_msg["model_id"] not in MODELS:
+            raise AgentException(
+                f"Queued message has unknown model {queued_msg['model_id']}"
+            )
+        user_settings = await UserService(
+            session_factory=session_factory
+        ).get_user_settings(chat.user_id, db=None)
+        async with cls.turn_scaffold(
+            message_service,
+            chat,
+            prompt=queued_msg["content"],
+            model_id=queued_msg["model_id"],
+            attachments=queued_msg.get("attachments"),
+            worktree=queued_msg["worktree"],
+            base_branch=queued_msg.get("base_branch"),
+            session_factory=session_factory,
+        ) as (user_message, assistant_message, checkpoint_id):
+            request = cls._build_queued_stream_request(
+                chat=chat,
+                queued_msg=queued_msg,
+                user_settings=user_settings,
+                assistant_message_id=str(assistant_message.id),
+                session_id_override=session_id_override,
+            )
+            # The client repoints on this event — nothing fallible may follow it.
+            if before_handoff is not None:
+                await before_handoff(user_message, assistant_message, checkpoint_id)
+            cls.start_background_chat(request)
+
+    @staticmethod
+    async def _requeue_message_quietly(
+        chat_id: str, queued_msg: dict[str, Any]
+    ) -> None:
         try:
             async with cache_connection() as cache:
-                queue_service = QueueService(cache)
-                await queue_service.requeue_message(self.chat_id, queued_msg)
-        except Exception as requeue_exc:
-            logger.error("Failed to re-queue message: %s", requeue_exc)
+                await QueueService(cache).requeue_message(chat_id, queued_msg)
+                logger.info("Re-queued message %s after failed start", queued_msg["id"])
+        except Exception as exc:
+            logger.error("Failed to re-queue message: %s", exc)
 
     async def _emit_context_usage(self, stream_result: StreamResult) -> None:
         usage = stream_result.usage
@@ -681,6 +828,37 @@ class ChatStreamRuntime:
             logger.error("Background title generation failed: %s", exc)
 
     @classmethod
+    async def reconcile_orphaned_messages(
+        cls, session_factory: SessionFactoryType
+    ) -> None:
+        # In-progress messages from a previous process can never complete.
+        try:
+            async with session_factory() as db:
+                result = await db.execute(
+                    select(Message.id).where(
+                        Message.stream_status == MessageStreamStatus.IN_PROGRESS,
+                        Message.deleted_at.is_(None),
+                    )
+                )
+                orphan_ids = list(result.scalars().all())
+        except SQLAlchemyError:
+            logger.exception("Failed to scan for orphaned in-progress messages")
+            return
+
+        for message_id in orphan_ids:
+            await cls.finalize_dead_stream(
+                assistant_message_id=str(message_id),
+                session_factory=session_factory,
+                stream_status=MessageStreamStatus.INTERRUPTED,
+                record_activity=False,
+            )
+        if orphan_ids:
+            logger.info(
+                "Reconciled %d orphaned in-progress message(s) from previous run",
+                len(orphan_ids),
+            )
+
+    @classmethod
     async def stop_background_chats(cls) -> None:
         if not cls._background_task_chat_ids:
             return
@@ -738,6 +916,39 @@ class ChatStreamRuntime:
     def has_active_chat(cls, chat_id: str) -> bool:
         cls._prune_done_tasks()
         return chat_id in cls._background_task_chat_ids.values()
+
+    @classmethod
+    def has_pending_start(cls, chat_id: str) -> bool:
+        return chat_id in cls._starting_chat_ids
+
+    @classmethod
+    def _chat_tasks(cls, chat_id: str) -> set[asyncio.Task[str]]:
+        return {
+            task
+            for task, task_chat_id in cls._background_task_chat_ids.items()
+            if task_chat_id == chat_id and not task.done()
+        }
+
+    @classmethod
+    async def cancel_chat_turn(cls, chat_id: str, timeout: float) -> None:
+        # Hold the response until the cancelled turn unwinds (a resend would 409).
+        # Capture first — the unwind can start a successor we must not wait on.
+        reservation = cls._starting_chat_ids.get(chat_id)
+        tasks = cls._chat_tasks(chat_id)
+        # Idle chats must not cancel — a stray pending-cancel flag could kill the next turn.
+        if reservation is None and not tasks:
+            return
+        await session_registry.cancel_generation(chat_id)
+        if reservation is not None:
+            # The reserved turn's task registers before the reservation frees.
+            with suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(reservation.wait(), timeout)
+            tasks |= cls._chat_tasks(chat_id)
+        tasks = {task for task in tasks if not task.done()}
+        if not tasks:
+            return
+        # asyncio.wait leaves the tasks running on timeout.
+        await asyncio.wait(tasks, timeout=timeout)
 
     @classmethod
     def active_chat_ids(cls) -> set[str]:
@@ -839,93 +1050,57 @@ class ChatStreamRuntime:
         chat_id: str,
         session_factory: SessionFactoryType,
     ) -> bool:
-        if cls.has_active_chat(chat_id):
-            return False
-
-        async with cache_connection() as cache:
-            queue_service = QueueService(cache)
-            queued_msg = await queue_service.pop_send_now_message(chat_id)
-            if not queued_msg:
+        async with cls.chat_start_slot(chat_id) as reserved:
+            if not reserved:
                 return False
 
-        try:
-            message_service = MessageService(session_factory=session_factory)
-            await message_service.create_message(
-                UUID(chat_id),
-                queued_msg["content"],
-                MessageRole.USER,
-                attachments=queued_msg.get("attachments"),
-            )
-            assistant_message = await message_service.create_message(
-                UUID(chat_id),
-                "",
-                MessageRole.ASSISTANT,
-                model_id=queued_msg["model_id"],
-                stream_status=MessageStreamStatus.IN_PROGRESS,
-            )
-
-            async with session_factory() as db:
-                result = await db.execute(
-                    select(Chat)
-                    .options(selectinload(Chat.workspace))
-                    .filter(Chat.id == UUID(chat_id))
-                )
-                chat = result.scalar_one_or_none()
-                if not chat:
-                    raise AgentException(f"Chat {chat_id} not found for idle send-now")
-
-            # Avoid circular import with chat.py.
-            from app.services.chat import ChatService
-
-            await ChatService.create_checkpoint_for_message(
-                chat,
-                assistant_message.id,
-                session_factory,
-                queued_msg["worktree"],
-                queued_msg.get("base_branch"),
-            )
-
-            user_service = UserService(session_factory=session_factory)
-            user_settings = await user_service.get_user_settings(chat.user_id, db=None)
-            cls.start_background_chat(
-                cls._build_queued_stream_request(
-                    chat=chat,
-                    queued_msg=queued_msg,
-                    user_settings=user_settings,
-                    assistant_message_id=str(assistant_message.id),
-                )
-            )
-
-            logger.info(
-                "Idle send-now: message %s started for chat %s",
-                queued_msg["id"],
-                chat_id,
-            )
-            return True
-
-        except Exception:
-            await cls._requeue_idle_message(chat_id=chat_id, queued_msg=queued_msg)
-            raise
-
-    @staticmethod
-    async def _requeue_idle_message(chat_id: str, queued_msg: dict[str, Any]) -> None:
-        try:
             async with cache_connection() as cache:
                 queue_service = QueueService(cache)
-                await queue_service.requeue_message(chat_id, queued_msg)
-                logger.info(
-                    "Re-queued message %s after idle send-now failure",
-                    queued_msg["id"],
+                queued_msg = await queue_service.pop_send_now_message(chat_id)
+                if not queued_msg:
+                    return False
+
+            try:
+                async with session_factory() as db:
+                    result = await db.execute(
+                        select(Chat)
+                        .options(selectinload(Chat.workspace))
+                        .filter(Chat.id == UUID(chat_id))
+                    )
+                    chat = result.scalar_one_or_none()
+                    if not chat:
+                        raise AgentException(
+                            f"Chat {chat_id} not found for idle send-now"
+                        )
+
+                await cls._start_queued_turn(
+                    chat=chat,
+                    queued_msg=queued_msg,
+                    message_service=MessageService(session_factory=session_factory),
+                    session_factory=session_factory,
                 )
-        except Exception as requeue_exc:
-            logger.error("Failed to re-queue message: %s", requeue_exc)
+
+                logger.info(
+                    "Idle send-now: message %s started for chat %s",
+                    queued_msg["id"],
+                    chat_id,
+                )
+                return True
+
+            except Exception:
+                await cls._requeue_message_quietly(chat_id, queued_msg)
+                raise
 
     @staticmethod
-    async def mark_message_failed(
+    async def finalize_dead_stream(
         *,
         assistant_message_id: str | None,
         session_factory: SessionFactoryType,
         stream_status: MessageStreamStatus,
+        user_id: str | None = None,
+        error_message: str | None = None,
+        # False for reconciliation: cleanup is not duration or unseen activity.
+        record_activity: bool = True,
     ) -> None:
         if not assistant_message_id:
             return
@@ -940,84 +1115,94 @@ class ChatStreamRuntime:
             message = await message_service.get_message(message_uuid)
             if not message or message.stream_status != MessageStreamStatus.IN_PROGRESS:
                 return
-            await message_service.update_message_snapshot(
+            content_text = message.content_text
+            content_render = message.content_render
+            if error_message is not None:
+                render_events = list(content_render.get("events", []))
+                render_events.append(
+                    StreamSnapshotAccumulator.error_event(error_message)
+                )
+                content_render = {**content_render, "events": render_events}
+                if not content_text:
+                    content_text = error_message
+            updated = await message_service.update_message_snapshot(
                 message_uuid,
-                content_text=message.content_text,
-                content_render=message.content_render,
+                content_text=content_text,
+                content_render=content_render,
                 last_seq=message.last_seq,
                 active_stream_id=None,
                 stream_status=stream_status,
+                record_activity=record_activity,
+            )
+            # After the snapshot prune, so the terminal event survives for clients.
+            await ChatStreamRuntime._emit_terminal_for_dead_stream(
+                message_service=message_service,
+                chat_id=message.chat_id,
+                message_id=message_uuid,
+                stream_id=message.active_stream_id or uuid4(),
+                stream_status=stream_status,
+                duration_ms=updated.duration_ms if updated else None,
+                user_id=user_id,
+                error_message=error_message,
+                record_activity=record_activity,
             )
         except Exception:
             logger.exception(
-                "Failed to update assistant message %s to %s after bootstrap failure",
+                "Failed to finalize assistant message %s as %s",
                 assistant_message_id,
                 stream_status.value,
             )
 
     @staticmethod
-    async def emit_bootstrap_error(
+    async def _emit_terminal_for_dead_stream(
         *,
-        chat_id: str,
-        user_id: str,
-        assistant_message_id: str | None,
-        session_factory: SessionFactoryType,
-        error_message: str,
+        message_service: MessageService,
+        chat_id: UUID,
+        message_id: UUID,
+        stream_id: UUID,
+        stream_status: MessageStreamStatus,
+        duration_ms: int | None,
+        user_id: str | None,
+        error_message: str | None = None,
+        record_activity: bool = True,
     ) -> None:
-        if not assistant_message_id:
+        if stream_status == MessageStreamStatus.INTERRUPTED:
+            kind = "cancelled"
+            payload: dict[str, Any] = {
+                "status": stream_status.value,
+                "duration_ms": duration_ms,
+            }
+        else:
+            kind = "error"
+            payload = {"error": error_message or "Stream ended unexpectedly"}
+        seq = await message_service.append_event_with_next_seq(
+            chat_id=chat_id,
+            message_id=message_id,
+            stream_id=stream_id,
+            event_type=kind,
+            render_payload=payload,
+            audit_payload={"payload": payload},
+            record_activity=record_activity,
+        )
+        if not user_id:
             return
         try:
-            message_service = MessageService(session_factory=session_factory)
-            message = await message_service.get_message(UUID(assistant_message_id))
-            if not message:
-                return
-            stream_id = uuid4()
-            payload = {"error": error_message}
-            error_seq = await message_service.append_event_with_next_seq(
-                chat_id=UUID(chat_id),
-                message_id=UUID(assistant_message_id),
-                stream_id=stream_id,
-                event_type="error",
-                render_payload=payload,
-                audit_payload={"payload": payload},
-            )
             async with cache_connection() as cache:
                 channel = REDIS_KEY_USER_STREAMS_LIVE.format(user_id=user_id)
-                envelope = StreamEnvelope.serialize(
-                    chat_id=UUID(chat_id),
-                    message_id=UUID(assistant_message_id),
-                    stream_id=stream_id,
-                    seq=error_seq,
-                    kind="error",
-                    payload=payload,
+                await cache.publish(
+                    channel,
+                    StreamEnvelope.serialize(
+                        chat_id=chat_id,
+                        message_id=message_id,
+                        stream_id=stream_id,
+                        seq=seq,
+                        kind=kind,
+                        payload=payload,
+                    ),
                 )
-                await cache.publish(channel, envelope)
-            existing_render = message.content_render
-            render_events = list(existing_render.get("events", []))
-            render_events.append(
-                {"type": "assistant_text", "text": f"\n\nError: {error_message}"}
-            )
-            content_text = message.content_text
-            if not content_text:
-                content_text = error_message
-            await message_service.update_message_snapshot(
-                UUID(assistant_message_id),
-                content_text=content_text,
-                content_render={**existing_render, "events": render_events},
-                last_seq=error_seq,
-                active_stream_id=None,
-                stream_status=MessageStreamStatus.FAILED,
-            )
-        except Exception as inner_exc:
-            logger.error(
-                "Failed to emit bootstrap error for chat %s: %s",
-                chat_id,
-                inner_exc,
-            )
-            await ChatStreamRuntime.mark_message_failed(
-                assistant_message_id=assistant_message_id,
-                session_factory=session_factory,
-                stream_status=MessageStreamStatus.FAILED,
+        except CacheError as exc:
+            logger.warning(
+                "Failed to publish terminal event for chat %s: %s", chat_id, exc
             )
 
     @classmethod
@@ -1133,10 +1318,11 @@ class ChatStreamRuntime:
                 session_factory=session_factory,
             )
         except asyncio.CancelledError:
-            await cls.mark_message_failed(
+            await cls.finalize_dead_stream(
                 assistant_message_id=request.assistant_message_id,
                 session_factory=session_factory,
                 stream_status=MessageStreamStatus.INTERRUPTED,
+                user_id=str(request.chat_data["user_id"]),
             )
             raise
         except Exception as exc:
@@ -1150,11 +1336,11 @@ class ChatStreamRuntime:
                 error_data,
                 exc_info=True,
             )
-            await cls.emit_bootstrap_error(
-                chat_id=chat_id,
-                user_id=str(request.chat_data["user_id"]),
+            await cls.finalize_dead_stream(
                 assistant_message_id=request.assistant_message_id,
                 session_factory=session_factory,
+                stream_status=MessageStreamStatus.FAILED,
+                user_id=str(request.chat_data["user_id"]),
                 error_message=str(exc),
             )
             raise

--- a/backend/app/services/streaming/types.py
+++ b/backend/app/services/streaming/types.py
@@ -98,6 +98,16 @@ class StreamSnapshotAccumulator:
 
         self.events.append({"type": kind, **payload})
 
+    def add_error(self, message: str) -> None:
+        self.add_event("assistant_text", {"text": f"\n\nError: {message}"})
+
+    @classmethod
+    def error_event(cls, message: str) -> dict[str, Any]:
+        # Keeps dead-stream finalization on the same error shape as live streams.
+        accumulator = cls()
+        accumulator.add_error(message)
+        return accumulator.events[0]
+
     def to_render(self) -> dict[str, Any]:
         return {"events": self.events}
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -114,8 +114,3 @@ DEP002 = [
     # spawns at runtime — not imported by backend source, so deptry can't see it.
     "mcp",
 ]
-
-[tool.pytest.ini_options]
-# TEMPORARY DIAGNOSTIC: dump all thread stacks for any test exceeding 8s, to
-# locate the CI-only SSE stall. Remove once diagnosed.
-faulthandler_timeout = 8

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -114,3 +114,8 @@ DEP002 = [
     # spawns at runtime — not imported by backend source, so deptry can't see it.
     "mcp",
 ]
+
+[tool.pytest.ini_options]
+# TEMPORARY DIAGNOSTIC: dump all thread stacks for any test exceeding 8s, to
+# locate the CI-only SSE stall. Remove once diagnosed.
+faulthandler_timeout = 8

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import AsyncIterator
 from uuid import UUID, uuid4
 
@@ -1941,7 +1942,7 @@ async def test_restore_message_checkpoint_translates_sandbox_and_value_errors(
     assert sandbox_error_response.json()["detail"] == "disk full"
 
 
-async def test_cancel_stream_endpoint_only_cancels_when_active_or_pending(
+async def test_cancel_stream_endpoint_only_cancels_when_turn_alive(
     client: AsyncClient,
     db_session: AsyncSession,
     create_user: UserFactory,
@@ -1953,21 +1954,15 @@ async def test_cancel_stream_endpoint_only_cancels_when_active_or_pending(
     )
     idle_chat = await create_chat_row(db_session, user, workspace, title="Idle")
     pending_chat = await create_chat_row(db_session, user, workspace, title="Pending")
-    await create_message_row(
-        db_session,
-        pending_chat,
-        content="",
-        role=MessageRole.ASSISTANT,
-        stream_status=MessageStreamStatus.IN_PROGRESS,
-    )
-    active_chat = await create_chat_row(db_session, user, workspace, title="Active")
 
     capture = CancelGenerationCapture()
     monkeypatch.setattr(chat_endpoint.session_registry, "cancel_generation", capture)
-    monkeypatch.setattr(
-        ChatStreamRuntime,
-        "has_active_chat",
-        lambda chat_id: chat_id == str(active_chat.id),
+    released_reservation = asyncio.Event()
+    released_reservation.set()
+    monkeypatch.setitem(
+        ChatStreamRuntime._starting_chat_ids,
+        str(pending_chat.id),
+        released_reservation,
     )
 
     idle_response = await client.delete(
@@ -1976,16 +1971,12 @@ async def test_cancel_stream_endpoint_only_cancels_when_active_or_pending(
     pending_response = await client.delete(
         f"/api/v1/chat/chats/{pending_chat.id}/stream", headers=headers
     )
-    active_response = await client.delete(
-        f"/api/v1/chat/chats/{active_chat.id}/stream", headers=headers
-    )
 
     assert idle_response.status_code == 204
     assert pending_response.status_code == 204
-    assert active_response.status_code == 204
-    # Idle+no-pending-start must not cancel; pending-start and active-runtime
-    # chats both should, even though only one has an active runtime task.
-    assert capture.chat_ids == [str(pending_chat.id), str(active_chat.id)]
+    # Idle must not cancel (a stray pending-cancel flag could kill the next
+    # turn); a reserved start should, even with no task registered yet.
+    assert capture.chat_ids == [str(pending_chat.id)]
 
 
 async def test_queue_message_with_attachments_saves_to_sandbox(
@@ -2232,3 +2223,57 @@ async def test_context_usage_for_chat_without_assistant_message(
         "context_window": 0,
         "percentage": 0.0,
     }
+
+
+async def test_send_now_during_reserved_start_cancels_current_turn(
+    app: FastAPI,
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_override = QueueServiceOverride()
+    send_now_capture = SendNowCapture()
+    cancel_capture = CancelGenerationCapture()
+
+    app.dependency_overrides[get_queue_service] = queue_override
+    monkeypatch.setattr(
+        ChatStreamRuntime,
+        "process_send_now_idle",
+        staticmethod(send_now_capture.process_send_now_idle),
+    )
+    monkeypatch.setattr(
+        chat_endpoint.session_registry, "cancel_generation", cancel_capture
+    )
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+    monkeypatch.setitem(
+        ChatStreamRuntime._starting_chat_ids, str(chat.id), asyncio.Event()
+    )
+
+    create_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue",
+        data={
+            "content": "Queued during reserved start",
+            "model_id": TEST_MODEL_ID,
+            "permission_mode": "bypassPermissions",
+            "selected_persona_name": "Default",
+        },
+        headers=headers,
+    )
+    assert create_response.status_code == 201
+    queued_id = create_response.json()["id"]
+
+    send_now_response = await client.post(
+        f"/api/v1/chat/chats/{chat.id}/queue/{queued_id}/send-now", headers=headers
+    )
+
+    assert send_now_response.status_code == 204
+    # A reserved start must take the cancel branch: the flag interrupts the
+    # starting turn, whose INTERRUPTED path picks the message up. The idle
+    # path would lose the reservation race and strand the send-now flag.
+    assert cancel_capture.chat_ids == [str(chat.id)]
+    assert send_now_capture.chat_ids == []

--- a/backend/tests/test_streaming.py
+++ b/backend/tests/test_streaming.py
@@ -20,14 +20,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.endpoints import chat as chat_endpoint
 from app.core import deps
 from app.constants import MODELS, REDIS_KEY_USER_STREAMS_LIVE
-from app.db.session import engine
-from app.models.db_models.chat import Chat
-from app.models.db_models.enums import MessageStreamStatus
+from app.db.session import SessionLocal, engine
+from app.models.db_models.chat import Chat, Message
+from app.models.db_models.enums import MessageRole, MessageStreamStatus
 from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
 from app.services.acp.client import AcpClientHandler
 from app.services.acp.session import AcpSession, AcpSessionConfig
 from app.services.git import GitService
+from app.services.exceptions import ChatException
+from app.services.queue import QueueService
 from app.services.session_registry import session_registry
 from app.services import chat as chat_service_module
 from app.services.sandbox_providers.base import SandboxProvider
@@ -182,13 +184,17 @@ class FakeAcpSessionFactory:
 
 @pytest.fixture(autouse=True)
 def streaming_runtime_state_reset() -> Iterator[None]:
-    # Both registries are process-wide singletons/class state — reset around
-    # every test so a task or session left by one test can't leak into the next.
+    # All process-wide class state — reset around every test so a task,
+    # reservation, lock, or session left by one test can't leak into the next.
     ChatStreamRuntime._background_task_chat_ids.clear()
+    ChatStreamRuntime._starting_chat_ids.clear()
+    QueueService._locks.clear()
     session_registry._sessions.clear()
     session_registry._pending_cancels.clear()
     yield
     ChatStreamRuntime._background_task_chat_ids.clear()
+    ChatStreamRuntime._starting_chat_ids.clear()
+    QueueService._locks.clear()
     session_registry._sessions.clear()
     session_registry._pending_cancels.clear()
 
@@ -582,12 +588,12 @@ async def test_cancel_stream_marks_message_interrupted(
 
     await wait_for_message_event_type(client, headers, message_id, "stream_started")
 
+    # DELETE holds its response until the turn unwinds, so the background
+    # task is already finished and the terminal state persisted.
     cancel_response = await client.delete(
         f"/api/v1/chat/chats/{chat.id}/stream", headers=headers
     )
     assert cancel_response.status_code == 204
-
-    await run_background_task(chat.id)
 
     messages_response = await client.get(
         f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
@@ -653,11 +659,12 @@ async def test_stream_failure_marks_message_failed_and_emits_bootstrap_error(
     assert events[-1]["type"] == "assistant_text"
     assert "Error: boom" in events[-1]["text"]
 
-    # Terminal snapshot deletes the error MessageEvent; only content_render remains.
+    # The error terminal event is appended after the snapshot prune so it
+    # survives — reconnecting clients need it to leave streaming mode.
     error_events_response = await client.get(
         f"/api/v1/chat/messages/{message_id}/events", headers=headers
     )
-    assert error_events_response.json() == []
+    assert [e["event_type"] for e in error_events_response.json()] == ["error"]
 
 
 async def test_queued_message_is_processed_automatically_after_stream_completes(
@@ -901,14 +908,13 @@ async def test_active_streams_and_status_reflect_running_background_task(
     assert status_body["has_active_task"] is True
     assert status_body["message_id"] == message_id
 
-    # Clean up the still-running background task so it doesn't leak past
-    # this test (the reset fixture only clears the registry, not live tasks).
+    # Clean up the still-running background task so it doesn't leak past this
+    # test — DELETE holds its response until the turn unwinds.
     await wait_for_message_event_type(client, headers, message_id, "stream_started")
     cancel_response = await client.delete(
         f"/api/v1/chat/chats/{chat.id}/stream", headers=headers
     )
     assert cancel_response.status_code == 204
-    await run_background_task(chat.id)
 
 
 async def test_active_streams_is_empty_when_user_has_no_running_chats(
@@ -1217,3 +1223,154 @@ async def test_sse_endpoints_release_db_connection_while_streaming(
         # into other tests.
         sa_event.remove(engine.sync_engine, "checkout", counter.on_checkout)
         sa_event.remove(engine.sync_engine, "checkin", counter.on_checkin)
+
+
+async def test_second_send_while_streaming_is_rejected_with_409(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    acp_factory: FakeAcpSessionFactory,
+    streaming_cache: EndpointCache,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace, session_id="resumed-409")
+
+    script = [StreamEvent(type="assistant_text", text="Working..."), BLOCK_FOREVER]
+    acp_factory.queue(FakeAcpSession([script], session_id="resumed-409"))
+
+    result = await send_message(client, headers, chat)
+    message_id = result["message_id"]
+
+    second_response = await client.post(
+        "/api/v1/chat/chat",
+        data={
+            "prompt": "Second prompt while streaming",
+            "chat_id": str(chat.id),
+            "model_id": TEST_MODEL_ID,
+            "permission_mode": "bypassPermissions",
+        },
+        headers=headers,
+    )
+    assert second_response.status_code == 409
+
+    # Clean up the blocked turn; DELETE holds until the task unwinds.
+    await wait_for_message_event_type(client, headers, message_id, "stream_started")
+    cancel_response = await client.delete(
+        f"/api/v1/chat/chats/{chat.id}/stream", headers=headers
+    )
+    assert cancel_response.status_code == 204
+
+
+async def test_reconcile_orphaned_messages_finalizes_without_flagging_chats(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+    orphan = Message(
+        chat_id=chat.id,
+        content_text="partial output",
+        content_render={
+            "events": [{"type": "assistant_text", "text": "partial output"}]
+        },
+        last_seq=3,
+        active_stream_id=None,
+        role=MessageRole.ASSISTANT,
+        model_id=TEST_MODEL_ID,
+        stream_status=MessageStreamStatus.IN_PROGRESS,
+    )
+    db_session.add(orphan)
+    await db_session.commit()
+    await db_session.refresh(orphan)
+    await db_session.refresh(chat)
+    updated_at_before = chat.updated_at
+
+    await ChatStreamRuntime.reconcile_orphaned_messages(SessionLocal)
+
+    messages_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+    item = next(
+        i for i in messages_response.json()["items"] if i["id"] == str(orphan.id)
+    )
+    assert item["stream_status"] == MessageStreamStatus.INTERRUPTED.value
+    # A dead turn's wall time is not a real duration.
+    assert item["duration_ms"] is None
+
+    # The terminal event survives so reconnecting clients leave streaming mode.
+    events_response = await client.get(
+        f"/api/v1/chat/messages/{orphan.id}/events", headers=headers
+    )
+    assert [e["event_type"] for e in events_response.json()] == ["cancelled"]
+
+    # Cleanup is bookkeeping — it must not flag the chat unread or reorder it.
+    await db_session.refresh(chat)
+    assert chat.updated_at == updated_at_before
+
+
+async def test_cancel_chat_turn_covers_reserved_but_unstarted_turn() -> None:
+    chat_id = str(uuid4())
+    reservation_held = asyncio.Event()
+
+    async def hold_reservation() -> None:
+        async with ChatStreamRuntime.chat_start_slot(chat_id) as reserved:
+            assert reserved
+            reservation_held.set()
+            # Simulates the pre-task window (checkpoint provisioning etc.).
+            await asyncio.sleep(0.15)
+
+    holder = asyncio.create_task(hold_reservation())
+    await reservation_held.wait()
+
+    await ChatStreamRuntime.cancel_chat_turn(chat_id, timeout=2.0)
+
+    # Cancel returning means an immediate resend must win the reservation.
+    async with ChatStreamRuntime.chat_start_slot(chat_id) as reserved:
+        assert reserved
+    await holder
+
+
+async def test_failed_turn_start_discards_both_messages(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    chat = await create_chat_row(db_session, user, workspace)
+
+    async def failing_checkpoint(*args: Any, **kwargs: Any) -> None:
+        raise ChatException("checkpoint provisioning failed")
+
+    monkeypatch.setattr(
+        ChatStreamRuntime, "create_checkpoint_for_message", failing_checkpoint
+    )
+
+    response = await client.post(
+        "/api/v1/chat/chat",
+        data={
+            "prompt": "Prompt whose turn fails to start",
+            "chat_id": str(chat.id),
+            "model_id": TEST_MODEL_ID,
+            "permission_mode": "bypassPermissions",
+        },
+        headers=headers,
+    )
+    assert response.status_code == 400
+
+    # A failed start leaves nothing behind: no orphaned user prompt and no
+    # in-progress assistant row for startup reconciliation to mop up.
+    messages_response = await client.get(
+        f"/api/v1/chat/chats/{chat.id}/messages", headers=headers
+    )
+    assert messages_response.json()["items"] == []

--- a/backend/tests/test_streaming.py
+++ b/backend/tests/test_streaming.py
@@ -9,7 +9,6 @@ from uuid import UUID, uuid4
 
 import httpx
 import pytest
-import pytest_asyncio
 import uvicorn
 from acp.schema import PermissionOption, ToolCallUpdate
 from fastapi import FastAPI
@@ -1093,9 +1092,11 @@ async def test_send_message_with_worktree_persists_cwd_and_emits_system_event(
     assert detail_response.json()["worktree_cwd"] == response.json()["worktree_cwd"]
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def live_server_url(app: FastAPI) -> AsyncIterator[str]:
     # ASGITransport buffers whole body — live SSE needs a real socket server.
+    # Plain (anyio-run) fixture: pytest-asyncio would start uvicorn on its own
+    # loop, which stops running during the anyio test — requests then hang.
     config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error")
     server = uvicorn.Server(config)
     serve_task = asyncio.create_task(server.serve())

--- a/frontend/src/hooks/queries/useAuthQueries.ts
+++ b/frontend/src/hooks/queries/useAuthQueries.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import type { UseMutationOptions, UseQueryOptions } from '@tanstack/react-query';
 import { authService } from '@/services/authService';
 import type { AuthResponse, User } from '@/types/user.types';
+import { clearAllStreamState } from '@/hooks/stream/streamRegistry';
 import { createMutation } from './createMutation';
 import { queryKeys } from './queryKeys';
 
@@ -102,5 +103,7 @@ export const useLogoutMutation = createMutation<void, Error, void>(
   async (queryClient) => {
     await queryClient.cancelQueries();
     queryClient.clear();
+    // SPA logout doesn't reload — the next session must not inherit buffers.
+    clearAllStreamState();
   },
 );

--- a/frontend/src/hooks/stream/streamRegistry.ts
+++ b/frontend/src/hooks/stream/streamRegistry.ts
@@ -1,0 +1,84 @@
+import { StreamContentBuffer } from '@/utils/stream';
+import type { AssistantStreamEvent } from '@/types/chat.types';
+import type { StreamEnvelope } from '@/types/stream.types';
+import type { StreamSessionState } from '@/hooks/stream/messageUpdates';
+
+// Module-level so chat-switch remounts don't destroy live stream state; these
+// functions are the only writers, keeping a stream's buffer and session paired.
+const streamBuffers = new Map<string, StreamContentBuffer>();
+const streamSessions = new Map<string, StreamSessionState>();
+const pendingStopEnvelopesByMessage = new Map<string, StreamEnvelope[]>();
+
+export function getStreamSession(streamId: string | undefined): StreamSessionState | undefined {
+  return streamId ? streamSessions.get(streamId) : undefined;
+}
+
+export function getStreamBuffer(streamId: string): StreamContentBuffer | undefined {
+  return streamBuffers.get(streamId);
+}
+
+export function findStreamIdByMessage(messageId?: string): string | undefined {
+  if (!messageId) return undefined;
+  for (const [streamId, session] of streamSessions.entries()) {
+    if (session.messageId === messageId) {
+      return streamId;
+    }
+  }
+  return undefined;
+}
+
+export function streamSessionsForChat(chatId: string): Array<[string, StreamSessionState]> {
+  return Array.from(streamSessions.entries()).filter(([, session]) => session.chatId === chatId);
+}
+
+// Update-if-present; a missing buffer tells the caller to seed one.
+export function advanceStreamSession(
+  streamId: string,
+  messageId: string,
+  seq: number,
+  chatId: string,
+): StreamContentBuffer | undefined {
+  const buffer = streamBuffers.get(streamId);
+  const session = streamSessions.get(streamId);
+  if (!buffer || !session) return undefined;
+  session.lastSeq = Math.max(session.lastSeq, seq);
+  session.messageId = messageId;
+  session.chatId = chatId;
+  return buffer;
+}
+
+export function createStreamSession(
+  streamId: string,
+  session: StreamSessionState,
+  seedEvents: AssistantStreamEvent[],
+  seedText: string,
+): StreamContentBuffer {
+  const buffer = new StreamContentBuffer(seedEvents, seedText);
+  streamBuffers.set(streamId, buffer);
+  streamSessions.set(streamId, session);
+  return buffer;
+}
+
+export function stashPendingStopEnvelope(messageId: string, envelope: StreamEnvelope): void {
+  const envelopes = pendingStopEnvelopesByMessage.get(messageId) ?? [];
+  envelopes.push(envelope);
+  pendingStopEnvelopesByMessage.set(messageId, envelopes);
+}
+
+export function takePendingStopEnvelopes(messageId: string): StreamEnvelope[] {
+  const envelopes = pendingStopEnvelopesByMessage.get(messageId) ?? [];
+  pendingStopEnvelopesByMessage.delete(messageId);
+  return envelopes;
+}
+
+export function clearStreamSession(streamId: string | undefined): void {
+  if (!streamId) return;
+  streamBuffers.delete(streamId);
+  streamSessions.delete(streamId);
+}
+
+export function clearAllStreamState(): void {
+  streamBuffers.clear();
+  streamSessions.clear();
+  pendingStopEnvelopesByMessage.clear();
+}

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import { QueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
-import { StreamContentBuffer } from '@/utils/stream';
+import type { StreamContentBuffer } from '@/utils/stream';
 import { notifyStreamComplete } from '@/utils/notifications';
 import { queryKeys } from '@/hooks/queries/queryKeys';
 import { markChatViewed } from '@/hooks/queries/useChatQueries';
@@ -32,9 +32,19 @@ import {
   buildFailedMessageUpdate,
   createEmptyRenderSnapshot,
   getStreamErrorMessage,
-  type StreamSessionState,
 } from '@/hooks/stream/messageUpdates';
 import { envelopeToRenderEvent, extractPayloadData } from '@/hooks/stream/envelopeTranslation';
+import {
+  advanceStreamSession,
+  clearStreamSession,
+  createStreamSession,
+  findStreamIdByMessage,
+  getStreamBuffer,
+  getStreamSession,
+  stashPendingStopEnvelope,
+  streamSessionsForChat,
+  takePendingStopEnvelopes,
+} from '@/hooks/stream/streamRegistry';
 
 // Token envelopes arrive ~10-50ms apart; 50ms batching (~20/s) avoids thrashing React/cache.
 const STREAM_FLUSH_INTERVAL_MS = 50;
@@ -105,10 +115,7 @@ export function useStreamCallbacks({
   const messagesRef = useRef<Message[]>(messages);
   messagesRef.current = messages;
   const timerIdsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
-  const buffersRef = useRef<Map<string, StreamContentBuffer>>(new Map());
   const flushTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
-  const streamSessionsRef = useRef<Map<string, StreamSessionState>>(new Map());
-  const pendingStopEnvelopesRef = useRef<Map<string, StreamEnvelope[]>>(new Map());
   const chatIdRef = useRef(chatId);
   chatIdRef.current = chatId;
 
@@ -118,42 +125,11 @@ export function useStreamCallbacks({
   });
   const { data: settings } = useSettingsQuery();
 
-  const clearStreamSession = useCallback((streamId: string | undefined) => {
-    if (!streamId) return;
-
-    const flushTimer = flushTimersRef.current.get(streamId);
-    if (flushTimer) {
-      clearTimeout(flushTimer);
-      flushTimersRef.current.delete(streamId);
-    }
-
-    buffersRef.current.delete(streamId);
-    streamSessionsRef.current.delete(streamId);
-  }, []);
-
-  const findStreamIdByMessage = useCallback((messageId?: string): string | undefined => {
-    if (!messageId) return undefined;
-
-    for (const [streamId, session] of streamSessionsRef.current.entries()) {
-      if (session.messageId === messageId) {
-        return streamId;
-      }
-    }
-
-    return undefined;
-  }, []);
-
-  const replayPendingStopEnvelopes = useCallback((messageId: string) => {
-    const envelopes = pendingStopEnvelopesRef.current.get(messageId);
-    pendingStopEnvelopesRef.current.delete(messageId);
-    return envelopes ?? [];
-  }, []);
-
   // Live state only when on-screen; always can write cache so off-screen progress survives switches.
   const flushBufferedContent = useCallback(
     (streamId: string, { writeToCache }: { writeToCache: boolean }) => {
-      const buffer = buffersRef.current.get(streamId);
-      const session = streamSessionsRef.current.get(streamId);
+      const buffer = getStreamBuffer(streamId);
+      const session = getStreamSession(streamId);
       if (!buffer || !session) return;
 
       const update = buildContentFlushUpdate(streamId, buffer, session);
@@ -171,19 +147,18 @@ export function useStreamCallbacks({
     [setMessages, queryClient],
   );
 
-  // One pending flush timer per stream.
+  // Per-pane timers — each pane flushes into its own messages state.
   const scheduleContentFlush = useCallback(
     (streamId: string) => {
-      if (flushTimersRef.current.has(streamId)) {
+      const timers = flushTimersRef.current;
+      if (timers.has(streamId)) {
         return;
       }
-
       const timer = setTimeout(() => {
-        flushTimersRef.current.delete(streamId);
+        timers.delete(streamId);
         flushBufferedContent(streamId, { writeToCache: true });
       }, STREAM_FLUSH_INTERVAL_MS);
-
-      flushTimersRef.current.set(streamId, timer);
+      timers.set(streamId, timer);
     },
     [flushBufferedContent],
   );
@@ -196,14 +171,8 @@ export function useStreamCallbacks({
       seq: number,
       streamChatId: string,
     ): StreamContentBuffer => {
-      const existing = buffersRef.current.get(streamId);
+      const existing = advanceStreamSession(streamId, messageId, seq, streamChatId);
       if (existing) {
-        const existingSession = streamSessionsRef.current.get(streamId);
-        if (existingSession) {
-          existingSession.lastSeq = Math.max(existingSession.lastSeq, seq);
-          existingSession.messageId = messageId;
-          existingSession.chatId = streamChatId;
-        }
         return existing;
       }
 
@@ -220,48 +189,35 @@ export function useStreamCallbacks({
         seedText = existingMessage.content_text ?? '';
       }
 
-      const buffer = new StreamContentBuffer(seedEvents, seedText);
-      buffersRef.current.set(streamId, buffer);
-      streamSessionsRef.current.set(streamId, {
-        messageId,
-        lastSeq: seq,
-        chatId: streamChatId,
-        // Resolve now while chat query is warm — completion-time resolve can miss after gc.
-        sandboxId: queryClient.getQueryData<Chat>(queryKeys.chat(streamChatId))?.sandbox_id,
-      });
-
-      return buffer;
+      return createStreamSession(
+        streamId,
+        {
+          messageId,
+          lastSeq: seq,
+          chatId: streamChatId,
+          // Resolve now while chat query is warm — completion-time resolve can miss after gc.
+          sandboxId: queryClient.getQueryData<Chat>(queryKeys.chat(streamChatId))?.sandbox_id,
+        },
+        seedEvents,
+        seedText,
+      );
     },
     [queryClient],
   );
 
   useEffect(() => {
     const flushTimers = flushTimersRef.current;
-    const buffers = buffersRef.current;
-    const streamSessions = streamSessionsRef.current;
-    const pendingStopEnvelopes = pendingStopEnvelopesRef.current;
-
     return () => {
       timerIdsRef.current.forEach(clearTimeout);
       timerIdsRef.current = [];
-
-      // Flush pending content so cursor-acked progress isn't lost on unmount.
-      for (const [streamId, timer] of flushTimers.entries()) {
+      // Persist the buffered tail — the next envelope can be minutes away.
+      for (const [streamId, timer] of flushTimers) {
         clearTimeout(timer);
-        const buffer = buffers.get(streamId);
-        const session = streamSessions.get(streamId);
-        if (buffer && session) {
-          const update = buildContentFlushUpdate(streamId, buffer, session);
-          updateMessageInCacheForChat(queryClient, session.chatId, session.messageId, update);
-        }
+        flushBufferedContent(streamId, { writeToCache: true });
       }
       flushTimers.clear();
-
-      buffers.clear();
-      streamSessions.clear();
-      pendingStopEnvelopes.clear();
     };
-  }, [queryClient]);
+  }, [flushBufferedContent]);
 
   const setPendingUserMessageId = useCallback(
     (id: string | null) => {
@@ -275,9 +231,7 @@ export function useStreamCallbacks({
   const onEnvelope = useCallback(
     (envelope: StreamEnvelope) => {
       if (pendingStopRef.current.has(envelope.messageId)) {
-        const envelopes = pendingStopEnvelopesRef.current.get(envelope.messageId) ?? [];
-        envelopes.push(envelope);
-        pendingStopEnvelopesRef.current.set(envelope.messageId, envelopes);
+        stashPendingStopEnvelope(envelope.messageId, envelope);
         return;
       }
 
@@ -364,13 +318,6 @@ export function useStreamCallbacks({
         envelope.chatId,
       );
       buffer.push(renderEvent);
-
-      const session = streamSessionsRef.current.get(envelope.streamId);
-      if (session) {
-        session.lastSeq = Math.max(session.lastSeq, envelope.seq);
-        session.messageId = envelope.messageId;
-      }
-
       scheduleContentFlush(envelope.streamId);
     },
     [
@@ -396,9 +343,7 @@ export function useStreamCallbacks({
       const resolvedStreamId = streamId ?? findStreamIdByMessage(messageId);
       const isCancelled = terminalKind === 'cancelled';
       const isCurrentChat = chatId === chatIdRef.current;
-      const session = resolvedStreamId
-        ? streamSessionsRef.current.get(resolvedStreamId)
-        : undefined;
+      const session = getStreamSession(resolvedStreamId);
       const sessionChatId = session?.chatId;
       const sessionSandboxId = session?.sandboxId;
 
@@ -413,7 +358,7 @@ export function useStreamCallbacks({
       // Finalize cache even off-screen so return within staleTime isn't stuck.
       if (messageId) {
         pendingStopRef.current.delete(messageId);
-        pendingStopEnvelopesRef.current.delete(messageId);
+        takePendingStopEnvelopes(messageId);
         const finalizeMessage = (message: Message): Message => ({
           ...message,
           active_stream_id: null,
@@ -437,6 +382,11 @@ export function useStreamCallbacks({
       // Server mutates title/updated_at/context during the turn — refresh even if off-screen.
       if (targetChatId) {
         queryClient.invalidateQueries({ queryKey: queryKeys.chat(targetChatId), exact: true });
+        // Server terminals only — an optimistic Stop races the unwind and
+        // would refetch pre-terminal state over the local patch.
+        if (streamId) {
+          queryClient.invalidateQueries({ queryKey: queryKeys.messages(targetChatId) });
+        }
       }
 
       // Refresh sandbox caches even off-screen (incl. cancelled — real file/branch effects).
@@ -491,11 +441,9 @@ export function useStreamCallbacks({
     [
       flushBufferedContent,
       chatId,
-      clearStreamSession,
       currentChat?.sandbox_id,
       currentChat?.parent_chat_id,
       queryClient,
-      findStreamIdByMessage,
       setCurrentMessageId,
       setMessages,
       setPendingUserMessageId,
@@ -508,9 +456,7 @@ export function useStreamCallbacks({
     (streamError: Error, assistantMessageId?: string, streamId?: string) => {
       const resolvedStreamId = streamId ?? findStreamIdByMessage(assistantMessageId);
       const isCurrentChat = chatId === chatIdRef.current;
-      const sessionChatId = resolvedStreamId
-        ? streamSessionsRef.current.get(resolvedStreamId)?.chatId
-        : undefined;
+      const sessionChatId = getStreamSession(resolvedStreamId)?.chatId;
 
       if (resolvedStreamId) {
         flushBufferedContent(resolvedStreamId, { writeToCache: true });
@@ -521,6 +467,9 @@ export function useStreamCallbacks({
 
       // Don't remove — already persisted; mirror backend snapshot so live UI matches refresh.
       if (assistantMessageId) {
+        // Same drain as onComplete — a stop ending in error must not keep stashing.
+        pendingStopRef.current.delete(assistantMessageId);
+        takePendingStopEnvelopes(assistantMessageId);
         const markFailed = buildFailedMessageUpdate(streamError);
         if (targetChatId) {
           updateMessageInCacheForChat(queryClient, targetChatId, assistantMessageId, markFailed);
@@ -530,6 +479,11 @@ export function useStreamCallbacks({
             prev.map((msg) => (msg.id === assistantMessageId ? markFailed(msg) : msg)),
           );
         }
+      }
+
+      // Same gate as onComplete — a connection-failure error has no streamId.
+      if (targetChatId && streamId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.messages(targetChatId) });
       }
 
       if (!isCurrentChat) return;
@@ -549,9 +503,8 @@ export function useStreamCallbacks({
     [
       flushBufferedContent,
       chatId,
-      clearStreamSession,
+      pendingStopRef,
       queryClient,
-      findStreamIdByMessage,
       setCurrentMessageId,
       setMessages,
       setPendingUserMessageId,
@@ -567,8 +520,8 @@ export function useStreamCallbacks({
 
       // Queue continuation starts a new stream/message pair without terminal events
       // on the prior stream, so flush and drop stale per-stream session state.
-      for (const [streamId, session] of Array.from(streamSessionsRef.current.entries())) {
-        if (session.chatId !== chatId || session.messageId === data.assistantMessageId) {
+      for (const [streamId, session] of streamSessionsForChat(chatId)) {
+        if (session.messageId === data.assistantMessageId) {
           continue;
         }
         flushBufferedContent(streamId, { writeToCache: true });
@@ -655,7 +608,6 @@ export function useStreamCallbacks({
     [
       flushBufferedContent,
       chatId,
-      clearStreamSession,
       queryClient,
       setMessages,
       setCurrentMessageId,
@@ -726,13 +678,13 @@ export function useStreamCallbacks({
         }
       } catch (error) {
         pendingStopRef.current.delete(messageId);
-        for (const envelope of replayPendingStopEnvelopes(messageId)) {
+        for (const envelope of takePendingStopEnvelopes(messageId)) {
           onEnvelope(envelope);
         }
         throw error;
       }
     },
-    [chatId, onComplete, onEnvelope, pendingStopRef, replayPendingStopEnvelopes],
+    [chatId, onComplete, onEnvelope, pendingStopRef],
   );
 
   return {

--- a/frontend/src/hooks/useStreamReconnect.ts
+++ b/frontend/src/hooks/useStreamReconnect.ts
@@ -23,7 +23,7 @@ interface UseStreamReconnectParams {
   replayStream: (messageId: string, afterSeq?: number) => Promise<string>;
 }
 
-// On chat entry: poll active task, resume SSE from max(server/local/message seq).
+// On chat entry: poll active task, resume SSE from the message's snapshot seq.
 export function useStreamReconnect({
   chatId,
   fetchedMessages,
@@ -81,16 +81,9 @@ export function useStreamReconnect({
         const existingMessage = messages.find((msg) => msg.id === targetMessageId);
         const messageExists = existingMessage != null;
 
-        // Resume from max(server, local storage, message cursor) to avoid duplicates.
-        const reconnectSeq = status.last_seq ?? existingMessage?.last_seq ?? 0;
-        const storedSeqRaw = chatStorage.getEventId(chatId);
-        const storedSeq = storedSeqRaw ? Number(storedSeqRaw) : Number.NaN;
-        const normalizedStoredSeq = Number.isFinite(storedSeq) && storedSeq > 0 ? storedSeq : 0;
-        const normalizedReconnectSeq = reconnectSeq > 0 ? reconnectSeq : 0;
-        // Missing local message → replay from 0 (truncated cursor would drop content).
-        const replayAfterSeq = messageExists
-          ? Math.max(normalizedStoredSeq, normalizedReconnectSeq)
-          : 0;
+        // Replay from the message's own last_seq — stored cursors can be ahead and would skip events.
+        const snapshotSeq = Number(existingMessage?.last_seq);
+        const replayAfterSeq = Number.isFinite(snapshotSeq) && snapshotSeq > 0 ? snapshotSeq : 0;
         if (replayAfterSeq > 0) {
           chatStorage.setEventId(chatId, String(replayAfterSeq));
         } else {

--- a/frontend/src/services/streamConnection.ts
+++ b/frontend/src/services/streamConnection.ts
@@ -17,6 +17,8 @@ interface ManagedConnection {
   retryAttempts: number;
   retryTimer: ReturnType<typeof setTimeout> | null;
   stableTimer: ReturnType<typeof setTimeout> | null;
+  stallTimer: ReturnType<typeof setInterval> | null;
+  lastActivityAt: number;
   // Bumped on (re)open/teardown so in-flight async opens self-cancel.
   generation: number;
 }
@@ -26,6 +28,9 @@ const RECONNECT_BASE_DELAY_MS = 1000;
 const RECONNECT_MAX_DELAY_MS = 15000;
 // Stay open this long before resetting retry budget (avoids open→die loops).
 const CONNECTION_STABLE_MS = 15000;
+// A half-open socket fires no error; silence past 3 server pings means dead.
+const STALL_CHECK_INTERVAL_MS = 15000;
+const STALL_TIMEOUT_MS = 45000;
 
 // One multiplexed SSE per API host (browsers cap ~6 HTTP/1.1 sockets per origin).
 // Opens when streamStore has active streams; closes when the last is removed.
@@ -104,6 +109,8 @@ class StreamConnectionManager {
       retryAttempts: 0,
       retryTimer: null,
       stableTimer: null,
+      stallTimer: null,
+      lastActivityAt: Date.now(),
       generation: 0,
     };
     this.connections.set(client, connection);
@@ -150,12 +157,19 @@ class StreamConnectionManager {
     params.append('cursors', JSON.stringify(cursors));
     const source = new EventSource(`${client.getBaseUrl()}/chat/chats/streams?${params}`);
     connection.source = source;
+    connection.lastActivityAt = Date.now();
+    this.startStallWatchdog(client, connection);
 
     source.addEventListener('stream', (event: Event) => {
+      connection.lastActivityAt = Date.now();
       const data = (event as MessageEvent).data;
       if (data) this.handlers?.onEnvelopeData(data);
     });
+    source.addEventListener('ping', () => {
+      connection.lastActivityAt = Date.now();
+    });
     source.onopen = () => {
+      connection.lastActivityAt = Date.now();
       if (connection.source !== source || connection.stableTimer) return;
       connection.stableTimer = setTimeout(() => {
         connection.stableTimer = null;
@@ -173,6 +187,16 @@ class StreamConnectionManager {
       connection.source = null;
       this.scheduleReconnect(client, connection);
     };
+  }
+
+  private startStallWatchdog(client: StreamApiClient, connection: ManagedConnection): void {
+    if (connection.stallTimer) return;
+    connection.stallTimer = setInterval(() => {
+      if (this.connections.get(client) !== connection || !connection.source) return;
+      if (Date.now() - connection.lastActivityAt <= STALL_TIMEOUT_MS) return;
+      logger.warn('Stream connection stalled; reopening', 'streamConnection');
+      this.open(client);
+    }, STALL_CHECK_INTERVAL_MS);
   }
 
   private scheduleReconnect(client: StreamApiClient, connection: ManagedConnection): void {
@@ -221,6 +245,10 @@ class StreamConnectionManager {
     if (connection.stableTimer) {
       clearTimeout(connection.stableTimer);
       connection.stableTimer = null;
+    }
+    if (connection.stallTimer) {
+      clearInterval(connection.stallTimer);
+      connection.stallTimer = null;
     }
     connection.source?.close();
     connection.source = null;

--- a/frontend/src/services/streamService.ts
+++ b/frontend/src/services/streamService.ts
@@ -139,6 +139,9 @@ class StreamService {
     const stream = useStreamStore.getState().getStreamByChat(chatId);
     if (!stream) return;
 
+    // A replayed handoff from an older turn must not repoint the stream backwards.
+    if (envelope.messageId !== stream.messageId) return;
+
     if (payload.assistant_message_id !== stream.messageId) {
       useStreamStore
         .getState()
@@ -291,9 +294,10 @@ class StreamService {
   }
 
   async stopStreamByMessage(chatId: string, messageId: string): Promise<boolean> {
-    const stream = useStreamStore.getState().getStreamByChatAndMessage(chatId, messageId);
     await chatService.stopStream(chatId);
 
+    // Read after the blocking DELETE — a pre-await handle would finalize twice.
+    const stream = useStreamStore.getState().getStreamByChatAndMessage(chatId, messageId);
     if (stream) {
       this.finalizeStreamAsCancelled(stream);
       return true;


### PR DESCRIPTION
## Summary

Fixes the critical streaming issues where turns died silently, events dropped until refresh, and concurrent streams corrupted each other — plus the regressions found across twelve review rounds while hardening the fixes.

### Backend

- **Terminal events survive replay**: the final snapshot prunes the message's event log, so terminal events (`complete`/`cancelled`/`error`) are now appended *after* the snapshot — reconnecting clients always see the turn end instead of spinning forever
- **One turn per chat**: `chat_start_slot` reserves the chat before any rows exist; a concurrent send gets a 409 with guidance to queue instead of sharing (and corrupting) the ACP session
- **Blocking cancel**: `DELETE /stream` holds until the cancelled turn actually unwinds — captured task set + reservation event, so an immediate resend isn't rejected and a queued successor isn't waited on
- **Startup reconciliation**: orphaned `in_progress` messages from a dead process are finalized as `interrupted` without flagging chats unread, reordering the sidebar, or fabricating `duration_ms` (`record_activity=False`)
- **Turn scaffold**: send and queue paths share one create-and-compensate sequence — a turn that fails to start (checkpoint, enqueue, anything) discards both message rows instead of leaving an orphaned prompt
- **Dead agent detection**: a process-exit watcher fails the turn when the agent dies mid-stream (the ACP SDK treats EOF as a clean end); pending permission prompts are dismissed on stop and cancelled on teardown so nothing hangs
- **Send-now during a reserved start** interrupts the starting turn via the pending-cancel flag instead of silently degrading to "after this turn finishes"
- **Queue safety**: per-chat process-local lock serializes queue read-modify-write

### Frontend

- **Stream state survives chat switches**: buffers/sessions moved to a module registry (cleared on logout); switching chats mid-stream no longer drops events
- **Reconnect heals gaps**: replay starts from the message's own snapshot seq, not stored cursors that may have run ahead of persisted content
- **Stall watchdog**: reopens the SSE feed after 45s of silence (server sends real `ping` events — EventSource can't see comment pings)
- **Stop is race-free**: waits for the server terminal; stale stream handles no longer double-finalize or overwrite the persisted duration
- **Pane lifecycle**: buffered content flushes on unmount; flush timers are per-pane so split panes both render live tokens
- **Handoff guard**: replayed `queue_processing` events from old turns can't repoint a live stream backwards

## Test plan

- Backend: `pytest` — **348 passed** (includes new tests for the 409 guard, orphan reconciliation, cancel-during-pending-start, failed-start compensation, and send-now-during-reserved-start)
- Frontend: `tsc` clean, `vitest` — **686 passed**, eslint at pre-existing baseline
- Manually exercised on the desktop app: multi-stream switching, stop/resend, restart with in-flight turns (unread/ordering preserved)