### PR TITLE
fix: drop Claude tool heartbeat updates instead of rendering them

### DIFF
--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 from typing import Any, Literal, cast
 
 from acp.schema import (
@@ -37,6 +38,12 @@ logger = logging.getLogger(__name__)
 
 # Sentinel on event_queue when the ACP prompt finishes (success or error).
 _SENTINEL = object()
+
+# The Claude CLI pings every 30s while a tool runs, under a synthetic
+# "<realToolId>-heartbeat-<n>" id. claude-agent-acp (<= 0.62.0) forwards those
+# pings as tool_call_updates keyed by that id and drops the SDK's `heartbeat`
+# flag, so the id shape is the only signal left to recognize them by.
+_HEARTBEAT_TOOL_ID_RE = re.compile(r"-heartbeat-\d+$")
 
 # Valid ACP option_ids that match our PermissionMode literals directly.
 VALID_PERMISSION_MODES: set[str] = {
@@ -415,9 +422,8 @@ class AcpClientHandler:
 
     @staticmethod
     def _extract_meta_tool_name(tc: ToolCallProgress) -> str | None:
-        # claude-agent-acp stamps the real tool name on tool_progress updates
-        # at _meta.claudeCode.toolName (SDK >= 0.3.214 emits these for
-        # subagent-internal tools that never get a top-level tool_call start).
+        # claude-agent-acp stamps the real tool name at _meta.claudeCode.toolName
+        # on updates that carry no title of their own.
         meta = getattr(tc, "field_meta", None)
         if not isinstance(meta, dict):
             return None
@@ -431,6 +437,11 @@ class AcpClientHandler:
         # Multiple progress events per tool possible; re-emit only when title/input changes.
         status = tc.status
 
+        # Heartbeat ids never get a terminal update, so materializing one would
+        # leave a card spinning until finish() sweeps it completed.
+        if _HEARTBEAT_TOOL_ID_RE.search(tc.tool_call_id):
+            return None
+
         existing = self._active_tools.get(tc.tool_call_id)
         if existing is None and status is None:
             return None
@@ -438,8 +449,7 @@ class AcpClientHandler:
         materialized = existing is None
         if existing is None:
             # Update for a tool we never saw start. Use the real name from the
-            # adapter's _meta when present (subagent-internal tools report
-            # progress without a tool_call start); drop updates that carry no
+            # adapter's _meta when present; drop updates that carry no
             # renderable identity at all instead of minting "Unknown tool"
             # cards that finish() later stamps completed.
             meta_tool_name = self._extract_meta_tool_name(tc)

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -1202,3 +1202,43 @@ def test_untracked_tool_updates_use_meta_name_or_are_dropped() -> None:
     titled_event = handler._map_tool_call_progress(titled)
     assert titled_event is not None
     assert titled_event["tool"]["title"] == "Reading config"
+
+
+def test_tool_heartbeat_updates_never_materialize_cards() -> None:
+    from acp.schema import ToolCallProgress, ToolCallStart
+
+    from app.services.acp.client import AcpClientHandler
+
+    handler = AcpClientHandler(agent_kind=AgentKind.CLAUDE)
+    handler._map_tool_call_start(
+        ToolCallStart.model_validate(
+            {
+                "toolCallId": "toolu_abc",
+                "sessionUpdate": "tool_call",
+                "title": "npm test",
+                "rawInput": {"command": "npm test"},
+                "_meta": {"claudeCode": {"toolName": "Bash"}},
+            }
+        )
+    )
+
+    # The CLI pings every 30s under "<realId>-heartbeat-<n>"; each ping names the
+    # real tool and carries an elapsed-time payload, so it passes the
+    # renderable-identity guard and would otherwise mint a card per 30s.
+    for beat in range(3):
+        heartbeat = ToolCallProgress.model_validate(
+            {
+                "toolCallId": f"toolu_abc-heartbeat-{beat}",
+                "sessionUpdate": "tool_call_update",
+                "status": "in_progress",
+                "_meta": {
+                    "claudeCode": {
+                        "toolName": "Bash",
+                        "toolResponse": {"elapsedTimeSeconds": 30 * (beat + 1)},
+                    }
+                },
+            }
+        )
+        assert handler._map_tool_call_progress(heartbeat) is None
+
+    assert list(handler._active_tools) == ["toolu_abc"]


### PR DESCRIPTION
## Problem

Long-running Bash calls left a stack of empty, permanently-spinning "Run command" cards in the chat:

```
{'type': 'tool_started', 'tool': {'id': 'toolu_01HscNsLdEiXPKePaUzurAd3-heartbeat-0',
 'name': 'Bash', 'title': 'Bash', 'status': 'started', 'parent_id': None, 'input': None}}
```

## Root cause

Three layers:

1. **Claude CLI** pings every 30s while a tool runs, emitting a progress event under a synthetic `<realToolId>-heartbeat-<n>` id (`toolUseID: \`${t}-heartbeat-${s++}\``, `setInterval(…, 30000)`). Deliberate — changelog: *"Added a periodic progress heartbeat for long-running tool calls that previously went silent."*
2. **claude-agent-sdk** converts it to `SDKToolProgressMessage` with **`heartbeat: true`** and the real id in `parent_tool_use_id` (`sdk.d.ts:4562`).
3. **claude-agent-acp ≤ 0.62.0** (`dist/acp-agent.js:2726-2754`) forwards it as a plain `tool_call_update` keyed by the *synthetic* id and drops both `heartbeat` and `parent_tool_use_id`. An ACP update for a `toolCallId` the client never saw start is a phantom by definition. Worth filing upstream — the older v0.31.0 adapter no-op'd `tool_progress`, which is why this is new.

Our `_map_tool_call_progress` then materialized a card per beat. The identity guard passed **twice over**: the adapter stamps `_meta.claudeCode.toolName` (`"Bash"`) *and* a `toolResponse` of `{elapsedTimeSeconds}`. No terminal update ever arrives for a heartbeat id, so each card spun until `finish()` swept it completed.

Measured in a local db — **297 phantom cards across 30 messages**, all `Bash`, since only Bash routinely outlives the 30s interval (`Agent`/`Task` is exempt upstream):

```
('Bash','started')     297
('Bash','completed')   297
('unknown','completed') 11   ← same bug, pre-03a528e3 flavor
```

This is also what 03a528e3 misdiagnosed as *"subagent-internal tools that never get a top-level tool_call start"* — it renamed the flood from `Unknown tool ✓` to `Run command ✓` rather than dropping it. That comment is corrected here.

## Fix

Drop heartbeat updates by id shape at the top of `_map_tool_call_progress`. Once the adapter discards `heartbeat: true` and `parent_tool_use_id`, the id shape is the only signal left on the wire — the comment says so, so it doesn't get "simplified" away later.

## Tests

`test_tool_heartbeat_updates_never_materialize_cards` starts a real `Bash` call, feeds three heartbeat updates shaped exactly as the adapter sends them (the `toolName` + `toolResponse` combination that defeated the old guard), asserts each maps to `None`, and asserts `_active_tools` still holds only the real id. Verified it fails without the guard. Full `test_acp.py` green (56 passed), ruff clean.

## Notes

- Only stops *new* phantoms; cards already persisted in `content_render` still render. Separate cleanup if wanted.
- Left the `_meta`-name materialization branch in place: it's near-dead on Claude post-guard, but still live for Codex/Cursor/Grok via `title` and result presence.