### PR TITLE
feat: notify only for background chats, badge unseen notifications

### DIFF
--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "core:window:allow-toggle-maximize",
     "core:window:allow-is-maximized",
     "core:window:allow-start-dragging",
+    "core:window:allow-set-badge-count",
     "core:webview:allow-set-webview-zoom",
     "store:default",
     "updater:default",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, Suspense } from 'react';
 import { lazyNamed } from '@/utils/lazyNamed';
 import { useMountEffect } from '@/hooks/useMountEffect';
 import { useDesktopZoom } from '@/hooks/useDesktopZoom';
+import { useAppBadge } from '@/hooks/useAppBadge';
 import { Layout } from '@/components/layout/Layout/Layout';
 import { Toaster } from 'react-hot-toast';
 import { useAuthStore } from '@/store/authStore';
@@ -24,6 +25,7 @@ import { isTauri, invoke } from '@tauri-apps/api/core';
 import { isDesktopApp, isMobileApp } from '@/utils/platform';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { authStorage, cloudAuthStorage } from '@/utils/storage';
+import { useNotificationPermissionPrompt } from '@/hooks/useNotificationPermissionPrompt';
 import { clearCloudOrigins } from '@/utils/chatOrigin';
 import { PALETTES } from '@/styles/palettes';
 import { checkDesktopUpdate } from '@/services/desktopUpdateService';
@@ -72,6 +74,7 @@ function AppContent() {
   useCloudStreamRestoration({ enabled: isSessionAuthenticated });
   useChatEvents({ enabled: isSessionAuthenticated });
   useCloudChatEvents({ enabled: isSessionAuthenticated });
+  useNotificationPermissionPrompt(isSessionAuthenticated);
 
   const showLoading = hasToken && isLoading;
 
@@ -248,6 +251,7 @@ export default function App() {
   });
 
   useDesktopZoom();
+  useAppBadge();
 
   // Tauri release builds disable Cmd/Ctrl+R reload by default.
   useMountEffect(() => {

--- a/frontend/src/components/layout/ChatTabs/ChatTabs.tsx
+++ b/frontend/src/components/layout/ChatTabs/ChatTabs.tsx
@@ -14,7 +14,7 @@ import { useChatAgentKind } from '@/hooks/useChatAgentKind';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import clsx from 'clsx';
 import { stripMarkdownTitle } from '@/utils/format';
-import { splitSlotOfTile } from '@/utils/tileHelpers';
+import { paintedChatIds } from '@/utils/tileHelpers';
 import { stateClasses } from '@/config/stateClasses';
 import styles from './ChatTabs.module.scss';
 
@@ -112,15 +112,10 @@ export function ChatTabs() {
   const pendingRequests = usePermissionStore((s) => s.pendingRequests);
 
   // From layout (not splitChatIds): a split chat under a full-screen primary is off-screen.
-  const visibleChatIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const tileId of visibleLayout.flat()) {
-      const slot = splitSlotOfTile(tileId);
-      const owner = slot ? splitChatIds[slot - 1] : routedChatId;
-      if (owner) ids.add(owner);
-    }
-    return ids;
-  }, [visibleLayout, routedChatId, splitChatIds]);
+  const visibleChatIds = useMemo(
+    () => paintedChatIds(visibleLayout.flat(), splitChatIds, routedChatId),
+    [visibleLayout, routedChatId, splitChatIds],
+  );
 
   const streamingChatIdSet = useMemo(
     () => new Set(activeStreamMetadata.map((meta) => meta.chatId)),

--- a/frontend/src/components/ui/SplitViewContainer/SplitViewContainer.tsx
+++ b/frontend/src/components/ui/SplitViewContainer/SplitViewContainer.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo, ReactNode } from 'react';
 import { useUIStore } from '@/store/uiStore';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { WorkspaceSplit } from '@/components/ui/WorkspaceSplit/WorkspaceSplit';
+import { paintedLayout } from '@/utils/tileHelpers';
 import type { TileId } from '@/types/ui.types';
 
 interface SplitViewContainerProps {
@@ -16,13 +17,11 @@ export const SplitViewContainer = memo(function SplitViewContainer({
   const focusedTile = useUIStore((state) => state.focusedTile);
   const isMobile = useIsMobile();
 
-  // Mobile paints one pane (focused, else first). Render-only — store layout stays intact.
-  const layout = useMemo(() => {
-    if (!isMobile) return visibleLayout;
-    const flat = visibleLayout.flat();
-    const tile = focusedTile && flat.includes(focusedTile) ? focusedTile : flat[0];
-    return [[tile]];
-  }, [isMobile, visibleLayout, focusedTile]);
+  // Render-only collapse — the store layout stays intact.
+  const layout = useMemo(
+    () => paintedLayout(visibleLayout, focusedTile, isMobile),
+    [isMobile, visibleLayout, focusedTile],
+  );
 
   return <WorkspaceSplit openTabs={openTabs} visibleLayout={layout} renderView={renderView} />;
 });

--- a/frontend/src/hooks/queries/useSettingsQueries.ts
+++ b/frontend/src/hooks/queries/useSettingsQueries.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import type { UseQueryOptions } from '@tanstack/react-query';
+import type { QueryClient, UseQueryOptions } from '@tanstack/react-query';
 import { settingsService } from '@/services/settingsService';
 import type { UserSettings, UserSettingsUpdate } from '@/types/user.types';
 import { createMutation } from './createMutation';
@@ -7,10 +7,14 @@ import { queryKeys } from './queryKeys';
 import { useCloudSettingsQuery } from './useCloudQueries';
 import { isCloudChat } from '@/utils/chatOrigin';
 
+const settingsQuery = () => ({
+  queryKey: [queryKeys.settings],
+  queryFn: () => settingsService.getSettings(),
+});
+
 export const useSettingsQuery = (options?: Partial<UseQueryOptions<UserSettings>>) => {
   return useQuery({
-    queryKey: [queryKeys.settings],
-    queryFn: () => settingsService.getSettings(),
+    ...settingsQuery(),
     ...options,
   });
 };
@@ -25,6 +29,18 @@ export const useSettingsForChatQuery = (chatId: string | undefined, enabled = tr
   const cloudQuery = useCloudSettingsQuery(enabled && chatIsCloud);
   return chatIsCloud ? cloudQuery : localQuery;
 };
+
+// Settings are never persisted to storage (they carry secrets), so a cold tab
+// must fetch before a saved opt-out can be honored.
+export async function fetchNotificationsEnabled(queryClient: QueryClient): Promise<boolean> {
+  try {
+    const settings = await queryClient.ensureQueryData(settingsQuery());
+    return settings.notifications_enabled;
+  } catch {
+    // Settings unreachable — assume the server default (enabled).
+    return true;
+  }
+}
 
 export const useUpdateSettingsMutation = createMutation<UserSettings, Error, UserSettingsUpdate>(
   (data) => settingsService.updateSettings(data),

--- a/frontend/src/hooks/useAppBadge.ts
+++ b/frontend/src/hooks/useAppBadge.ts
@@ -1,0 +1,16 @@
+import { useMountEffect } from '@/hooks/useMountEffect';
+import { resetAppBadge } from '@/utils/notifications';
+
+// Coming back to the app acknowledges the notifications useBackgroundNotify badged.
+export function useAppBadge(): void {
+  useMountEffect(() => {
+    const controller = new AbortController();
+    const clear = () => {
+      if (document.visibilityState === 'visible') void resetAppBadge();
+    };
+    const options = { signal: controller.signal };
+    window.addEventListener('focus', clear, options);
+    document.addEventListener('visibilitychange', clear, options);
+    return () => controller.abort();
+  });
+}

--- a/frontend/src/hooks/useBackgroundNotify.test.tsx
+++ b/frontend/src/hooks/useBackgroundNotify.test.tsx
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NotifyOptions } from '@/utils/notifications';
+
+const h = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  isMobile: { value: false },
+  fetchNotificationsEnabled: vi.fn(async () => true),
+  bumpAppBadge: vi.fn(async () => {}),
+}));
+
+// Partial mock: matchPath stays real so the live-route read is exercised.
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useNavigate: () => h.navigate,
+}));
+vi.mock('@/hooks/useIsMobile', () => ({ isMobileViewport: () => h.isMobile.value }));
+vi.mock('@/hooks/queries/useSettingsQueries', () => ({
+  fetchNotificationsEnabled: h.fetchNotificationsEnabled,
+}));
+vi.mock('@/utils/notifications', () => ({ bumpAppBadge: h.bumpAppBadge }));
+
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useBackgroundNotify } from './useBackgroundNotify';
+import { useUIStore } from '@/store/uiStore';
+import type { TileId } from '@/types/ui.types';
+
+const testQueryClient = new QueryClient();
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>
+);
+
+const notify = vi.fn<(options: NotifyOptions) => Promise<boolean>>(async () => true);
+
+// The notify handoff sits behind the async settings gate.
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function setRoute(path: string) {
+  window.history.replaceState({}, '', path);
+}
+
+function setLayout(over: {
+  visibleLayout?: TileId[][];
+  focusedTile?: TileId | null;
+  splitChatIds?: string[];
+}) {
+  useUIStore.setState({
+    visibleLayout: [['agent:primary']],
+    focusedTile: null,
+    splitChatIds: [],
+    ...over,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+  setRoute('/');
+  h.isMobile.value = false;
+  h.fetchNotificationsEnabled.mockResolvedValue(true);
+  notify.mockResolvedValue(true);
+  setLayout({});
+});
+
+describe('useBackgroundNotify', () => {
+  it('suppresses while the target chat is painted in a focused window', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setRoute('/chat/chat-1');
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-1', notify);
+    await flush();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('notifies when the window is unfocused', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    setRoute('/chat/chat-1');
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-1', notify);
+    await flush();
+    expect(notify).toHaveBeenCalledWith({ onClick: expect.any(Function) });
+  });
+
+  it('notifies for a chat in a hidden split tab even when focused', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setRoute('/chat/chat-1');
+    // chat-2 is bound to slot 1, but its tile is not in the visible layout.
+    setLayout({ visibleLayout: [['agent:primary']], splitChatIds: ['chat-2'] });
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-2', notify);
+    await flush();
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies from a route that mounts no tiles, whatever the persisted layout says', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setRoute('/settings');
+    setLayout({ visibleLayout: [['agent:primary', 'agent:split-1']], splitChatIds: ['chat-2'] });
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-2', notify);
+    await flush();
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses a split chat painted on the landing route', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setRoute('/');
+    setLayout({ visibleLayout: [['agent:primary', 'agent:split-1']], splitChatIds: ['chat-2'] });
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-2', notify);
+    await flush();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('suppresses a split chat that is painted on screen', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setRoute('/chat/chat-1');
+    setLayout({ visibleLayout: [['agent:primary', 'agent:split-1']], splitChatIds: ['chat-2'] });
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-2', notify);
+    await flush();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('on mobile only the focused tile counts as painted', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    h.isMobile.value = true;
+    setRoute('/chat/chat-1');
+    setLayout({
+      visibleLayout: [['agent:primary', 'agent:split-1']],
+      splitChatIds: ['chat-2'],
+      focusedTile: 'agent:primary',
+    });
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-2', notify);
+    await flush();
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses when the chat's non-agent tile is painted (full-screen diff)", async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setRoute('/chat/chat-1');
+    setLayout({ visibleLayout: [['diff']] });
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-1', notify);
+    await flush();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('notifies for sub-threads, which are never painted as tiles', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setRoute('/chat/chat-1');
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('sub-thread-1', notify);
+    await flush();
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when notifications are disabled in settings', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    h.fetchNotificationsEnabled.mockResolvedValue(false);
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-1', notify);
+    await flush();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('routes clicks to the chat and badges the delivered notification', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-2', notify);
+    await flush();
+    expect(h.bumpAppBadge).toHaveBeenCalledTimes(1);
+
+    notify.mock.calls[0][0].onClick?.();
+    expect(h.navigate).toHaveBeenCalledWith('/chat/chat-2');
+  });
+
+  it('does not badge when the user returns to the app mid-delivery', async () => {
+    // Unfocused at the gate, focused again by the time delivery resolves.
+    vi.spyOn(document, 'hasFocus').mockReturnValueOnce(false).mockReturnValue(true);
+    setRoute('/chat/chat-1');
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-1', notify);
+    await flush();
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(h.bumpAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('does not badge a notification the OS never showed', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    notify.mockResolvedValue(false);
+    const { result } = renderHook(() => useBackgroundNotify(), { wrapper });
+
+    result.current('chat-2', notify);
+    await flush();
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(h.bumpAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('reads the live route even from closures that outlived their pane', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setRoute('/chat/chat-1');
+    const { result, unmount } = renderHook(() => useBackgroundNotify(), { wrapper });
+    const staleNotifyBackground = result.current;
+    unmount();
+
+    // Pane gone, user navigated on; chat-1 is no longer painted anywhere.
+    setRoute('/chat/chat-2');
+    staleNotifyBackground('chat-1', notify);
+    await flush();
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('still suppresses from an outlived closure when the target is on screen', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    setRoute('/chat/chat-1');
+    const { result, unmount } = renderHook(() => useBackgroundNotify(), { wrapper });
+    const staleNotifyBackground = result.current;
+    unmount();
+
+    setRoute('/chat/chat-2');
+    staleNotifyBackground('chat-2', notify);
+    await flush();
+    expect(notify).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useBackgroundNotify.ts
+++ b/frontend/src/hooks/useBackgroundNotify.ts
@@ -1,0 +1,51 @@
+import { useCallback } from 'react';
+import { matchPath, useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { isMobileViewport } from '@/hooks/useIsMobile';
+import { useUIStore } from '@/store/uiStore';
+import { fetchNotificationsEnabled } from '@/hooks/queries/useSettingsQueries';
+import { paintedChatIds, paintedLayout } from '@/utils/tileHelpers';
+import { logger } from '@/utils/logger';
+import { bumpAppBadge, type NotifyOptions } from '@/utils/notifications';
+
+// Suppress only when the event's chat is painted on screen in a focused window.
+// Panes stay mounted while hidden, so mount state can't stand in for visibility.
+export function useBackgroundNotify(): (
+  targetChatId: string | undefined,
+  notify: (options: NotifyOptions) => Promise<boolean>,
+) => void {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    (targetChatId: string | undefined, notify: (options: NotifyOptions) => Promise<boolean>) => {
+      // Read live: stored stream callbacks can invoke this closure long after
+      // the pane that created it unmounted, freezing anything captured at render.
+      const pathname = window.location.pathname;
+      const routeChatId = matchPath('/chat/:chatId', pathname)?.params.chatId;
+      // Only the workspace routes mount tiles — elsewhere (settings, auth) the
+      // persisted layout paints nothing, so it can't suppress anything.
+      const paintsTiles = Boolean(routeChatId || matchPath('/', pathname));
+      if (paintsTiles && targetChatId && document.hasFocus()) {
+        const { visibleLayout, focusedTile, splitChatIds } = useUIStore.getState();
+        const painted = paintedChatIds(
+          paintedLayout(visibleLayout, focusedTile, isMobileViewport()).flat(),
+          splitChatIds,
+          routeChatId,
+        );
+        if (painted.has(targetChatId)) return;
+      }
+
+      void (async () => {
+        if (!(await fetchNotificationsEnabled(queryClient))) return;
+        const delivered = await notify({
+          onClick: targetChatId ? () => navigate(`/chat/${targetChatId}`) : undefined,
+        });
+        // Focus is re-read: the user can return during the awaits above, after
+        // useAppBadge's clear already ran on a zero count.
+        if (delivered && !document.hasFocus()) await bumpAppBadge();
+      })().catch((error) => logger.warn('Background notify failed', 'notifications', error));
+    },
+    [navigate, queryClient],
+  );
+}

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -2,14 +2,16 @@ import { useState } from 'react';
 import { MOBILE_BREAKPOINT } from '@/config/constants';
 import { useMountEffect } from '@/hooks/useMountEffect';
 
+// Point-in-time read for non-render code paths; useIsMobile is the reactive form.
+export const isMobileViewport = (): boolean =>
+  typeof window !== 'undefined' && window.innerWidth < MOBILE_BREAKPOINT;
+
 export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(
-    typeof window !== 'undefined' ? window.innerWidth < MOBILE_BREAKPOINT : false,
-  );
+  const [isMobile, setIsMobile] = useState(isMobileViewport());
 
   useMountEffect(() => {
     const handleResize = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(isMobileViewport());
     };
 
     window.addEventListener('resize', handleResize, { passive: true });

--- a/frontend/src/hooks/useNotificationPermissionPrompt.test.tsx
+++ b/frontend/src/hooks/useNotificationPermissionPrompt.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  isTauri: vi.fn(() => false),
+  settings: { data: undefined as { notifications_enabled: boolean } | undefined },
+  requestNotificationPermission: vi.fn(async () => {}),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ isTauri: h.isTauri }));
+vi.mock('@/hooks/queries/useSettingsQueries', () => ({ useSettingsQuery: () => h.settings }));
+vi.mock('@/utils/notifications', () => ({
+  requestNotificationPermission: h.requestNotificationPermission,
+}));
+
+import { useNotificationPermissionPrompt } from './useNotificationPermissionPrompt';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.isTauri.mockReturnValue(false);
+  h.settings.data = { notifications_enabled: true };
+  vi.stubGlobal('Notification', { permission: 'default' });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function gesture() {
+  window.dispatchEvent(new Event('pointerdown'));
+}
+
+describe('useNotificationPermissionPrompt', () => {
+  it('asks synchronously inside the first gesture, and only once', () => {
+    renderHook(() => useNotificationPermissionPrompt(true));
+
+    gesture();
+    // Synchronous assert — an await sneaking into the handler breaks this.
+    expect(h.requestNotificationPermission).toHaveBeenCalledTimes(1);
+
+    gesture();
+    expect(h.requestNotificationPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not arm until settings resolve, then arms once they land', () => {
+    h.settings.data = undefined;
+    const { rerender } = renderHook(() => useNotificationPermissionPrompt(true));
+
+    gesture();
+    expect(h.requestNotificationPermission).not.toHaveBeenCalled();
+
+    h.settings.data = { notifications_enabled: true };
+    rerender();
+    gesture();
+    expect(h.requestNotificationPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not arm while notifications are disabled', () => {
+    h.settings.data = { notifications_enabled: false };
+    renderHook(() => useNotificationPermissionPrompt(true));
+
+    gesture();
+    expect(h.requestNotificationPermission).not.toHaveBeenCalled();
+  });
+
+  it('does not arm once permission is decided', () => {
+    vi.stubGlobal('Notification', { permission: 'granted' });
+    renderHook(() => useNotificationPermissionPrompt(true));
+
+    gesture();
+    expect(h.requestNotificationPermission).not.toHaveBeenCalled();
+  });
+
+  it('does not arm in Tauri', () => {
+    h.isTauri.mockReturnValue(true);
+    renderHook(() => useNotificationPermissionPrompt(true));
+
+    gesture();
+    expect(h.requestNotificationPermission).not.toHaveBeenCalled();
+  });
+
+  it('disarms on unmount', () => {
+    const { unmount } = renderHook(() => useNotificationPermissionPrompt(true));
+    unmount();
+
+    gesture();
+    expect(h.requestNotificationPermission).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useNotificationPermissionPrompt.ts
+++ b/frontend/src/hooks/useNotificationPermissionPrompt.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { isTauri } from '@tauri-apps/api/core';
+import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
+import { requestNotificationPermission } from '@/utils/notifications';
+
+// Browsers only honor the permission prompt inside a user gesture, so arm a
+// one-shot listener for the first one after sign-in. Settings must resolve
+// before arming — a gesture-time fetch would outlive the activation window.
+export function useNotificationPermissionPrompt(enabled: boolean): void {
+  const { data } = useSettingsQuery({ enabled });
+  // undefined until loaded — don't arm until it is explicitly on.
+  const notificationsOn = data?.notifications_enabled;
+
+  useEffect(() => {
+    if (!enabled || isTauri() || !notificationsOn) return;
+    if (!('Notification' in window) || Notification.permission !== 'default') return;
+
+    const controller = new AbortController();
+    const ask = () => {
+      controller.abort();
+      void requestNotificationPermission();
+    };
+    const options = { signal: controller.signal };
+    window.addEventListener('pointerdown', ask, options);
+    window.addEventListener('keydown', ask, options);
+    return () => controller.abort();
+  }, [enabled, notificationsOn]);
+}

--- a/frontend/src/hooks/usePermissionRequest.test.tsx
+++ b/frontend/src/hooks/usePermissionRequest.test.tsx
@@ -12,7 +12,7 @@ const h = vi.hoisted(() => ({
   respondToPermission: vi.fn(() => Promise.resolve()),
   isPermissionResolved: vi.fn(() => false),
   notifyPermissionRequest: vi.fn(),
-  settings: { data: undefined as { notifications_enabled?: boolean } | undefined },
+  notifyBackground: vi.fn(),
   executePermissionResponse: vi.fn<
     (
       serviceFn: () => unknown,
@@ -33,7 +33,7 @@ vi.mock('@/store/permissionStore', () => ({
 }));
 vi.mock('@/utils/permissionStorage', () => ({ isPermissionResolved: h.isPermissionResolved }));
 vi.mock('@/utils/notifications', () => ({ notifyPermissionRequest: h.notifyPermissionRequest }));
-vi.mock('@/hooks/queries/useSettingsQueries', () => ({ useSettingsQuery: () => h.settings }));
+vi.mock('@/hooks/useBackgroundNotify', () => ({ useBackgroundNotify: () => h.notifyBackground }));
 vi.mock('@/utils/permissionResponse', () => ({
   executePermissionResponse: h.executePermissionResponse,
   clearPermissionRequest: h.clearPermissionRequest,
@@ -51,10 +51,10 @@ function makeRequest(overrides: Partial<PermissionRequest> = {}): PermissionRequ
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.restoreAllMocks();
   h.storeState.pendingRequests = new Map();
   h.storeState.enqueuePermissionRequest.mockReturnValue(true);
   h.isPermissionResolved.mockReturnValue(false);
-  h.settings.data = undefined;
 });
 
 describe('usePermissionRequest', () => {
@@ -71,12 +71,17 @@ describe('usePermissionRequest', () => {
     expect(result.current.pendingRequest).toBeNull();
   });
 
-  it('enqueues and notifies for a genuinely new request', () => {
+  it('enqueues and hands a genuinely new request to the background notifier', () => {
     const { result } = renderHook(() => usePermissionRequest('chat-1'));
     const req = makeRequest();
     act(() => result.current.handlePermissionRequest(req));
     expect(h.storeState.enqueuePermissionRequest).toHaveBeenCalledWith('chat-1', req);
-    expect(h.notifyPermissionRequest).toHaveBeenCalledWith(req);
+    expect(h.notifyBackground).toHaveBeenCalledWith('chat-1', expect.any(Function));
+
+    const [, notifyFn] = h.notifyBackground.mock.calls[0];
+    const onClick = vi.fn();
+    notifyFn({ onClick });
+    expect(h.notifyPermissionRequest).toHaveBeenCalledWith(req, { onClick });
   });
 
   it('drops requests the user already resolved (no enqueue, no notify)', () => {
@@ -84,22 +89,14 @@ describe('usePermissionRequest', () => {
     const { result } = renderHook(() => usePermissionRequest('chat-1'));
     act(() => result.current.handlePermissionRequest(makeRequest()));
     expect(h.storeState.enqueuePermissionRequest).not.toHaveBeenCalled();
-    expect(h.notifyPermissionRequest).not.toHaveBeenCalled();
+    expect(h.notifyBackground).not.toHaveBeenCalled();
   });
 
   it('does not notify when the store dedupes the request (added=false)', () => {
     h.storeState.enqueuePermissionRequest.mockReturnValue(false);
     const { result } = renderHook(() => usePermissionRequest('chat-1'));
     act(() => result.current.handlePermissionRequest(makeRequest()));
-    expect(h.notifyPermissionRequest).not.toHaveBeenCalled();
-  });
-
-  it('does not notify when notifications are disabled in settings', () => {
-    h.settings.data = { notifications_enabled: false };
-    const { result } = renderHook(() => usePermissionRequest('chat-1'));
-    act(() => result.current.handlePermissionRequest(makeRequest()));
-    expect(h.storeState.enqueuePermissionRequest).toHaveBeenCalled();
-    expect(h.notifyPermissionRequest).not.toHaveBeenCalled();
+    expect(h.notifyBackground).not.toHaveBeenCalled();
   });
 
   it('wires approve to the service and cleanup with the pending request ids', async () => {

--- a/frontend/src/hooks/usePermissionRequest.ts
+++ b/frontend/src/hooks/usePermissionRequest.ts
@@ -3,7 +3,7 @@ import { permissionService } from '@/services/permissionService';
 import { usePermissionStore } from '@/store/permissionStore';
 import { isPermissionResolved } from '@/utils/permissionStorage';
 import { notifyPermissionRequest } from '@/utils/notifications';
-import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
+import { useBackgroundNotify } from '@/hooks/useBackgroundNotify';
 import { executePermissionResponse, clearPermissionRequest } from '@/utils/permissionResponse';
 import type { PermissionRequest } from '@/types/chat.types';
 
@@ -20,7 +20,7 @@ interface UsePermissionRequestReturn {
 export function usePermissionRequest(chatId: string | undefined): UsePermissionRequestReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { data: settings } = useSettingsQuery();
+  const notifyBackground = useBackgroundNotify();
 
   // Select only this chat's queue so other chats' permission changes don't re-render us.
   const pendingRequest = usePermissionStore((state) => {
@@ -47,11 +47,11 @@ export function usePermissionRequest(chatId: string | undefined): UsePermissionR
       // queue; only notify when it was a genuinely new request, not a
       // duplicate envelope for one still awaiting a response.
       const added = usePermissionStore.getState().enqueuePermissionRequest(chatId, request);
-      if (added && (settings?.notifications_enabled ?? true)) {
-        void notifyPermissionRequest(request);
+      if (added) {
+        notifyBackground(chatId, (options) => notifyPermissionRequest(request, options));
       }
     },
-    [chatId, settings?.notifications_enabled],
+    [chatId, notifyBackground],
   );
 
   const handleApprove = useCallback(

--- a/frontend/src/hooks/useStreamCallbacks.ts
+++ b/frontend/src/hooks/useStreamCallbacks.ts
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useRef } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import { QueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
-import type { StreamContentBuffer } from '@/utils/stream';
+import { extractAssistantText, type StreamContentBuffer } from '@/utils/stream';
 import { notifyStreamComplete } from '@/utils/notifications';
 import { queryKeys } from '@/hooks/queries/queryKeys';
 import { markChatViewed } from '@/hooks/queries/useChatQueries';
 import { invalidateGitState } from '@/hooks/queries/useSandboxQueries';
-import { useSettingsQuery } from '@/hooks/queries/useSettingsQueries';
+import { useBackgroundNotify } from '@/hooks/useBackgroundNotify';
 import type {
   AssistantStreamEvent,
   Chat,
@@ -123,7 +123,7 @@ export function useStreamCallbacks({
     chatId,
     queryClient,
   });
-  const { data: settings } = useSettingsQuery();
+  const notifyBackground = useBackgroundNotify();
 
   // Live state only when on-screen; always can write cache so off-screen progress survives switches.
   const flushBufferedContent = useCallback(
@@ -351,6 +351,11 @@ export function useStreamCallbacks({
         flushBufferedContent(resolvedStreamId, { writeToCache: true });
       }
 
+      // Read before clearStreamSession drops the buffer holding it.
+      const assistantText = resolvedStreamId
+        ? extractAssistantText(getStreamBuffer(resolvedStreamId)?.getEvents() ?? [])
+        : '';
+
       clearStreamSession(resolvedStreamId);
 
       const targetChatId = sessionChatId ?? chatId;
@@ -406,6 +411,12 @@ export function useStreamCallbacks({
         void invalidateGitState(queryClient, targetSandboxId);
       }
 
+      if (!isCancelled) {
+        notifyBackground(targetChatId, (options) =>
+          notifyStreamComplete({ ...options, message: assistantText }),
+        );
+      }
+
       if (!isCurrentChat) return;
 
       // Re-stamp read so initiation's updated_at bump doesn't re-flag unread.
@@ -417,10 +428,6 @@ export function useStreamCallbacks({
       setPendingUserMessageId(null);
       setStreamState('idle');
       setCurrentMessageId(null);
-
-      if (!isCancelled && (settings?.notifications_enabled ?? true)) {
-        void notifyStreamComplete();
-      }
 
       timerIdsRef.current.forEach(clearTimeout);
       timerIdsRef.current = [];
@@ -443,12 +450,12 @@ export function useStreamCallbacks({
       chatId,
       currentChat?.sandbox_id,
       currentChat?.parent_chat_id,
+      notifyBackground,
       queryClient,
       setCurrentMessageId,
       setMessages,
       setPendingUserMessageId,
       setStreamState,
-      settings?.notifications_enabled,
     ],
   );
 

--- a/frontend/src/utils/notifications.test.ts
+++ b/frontend/src/utils/notifications.test.ts
@@ -1,17 +1,20 @@
+// @vitest-environment jsdom
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PermissionRequest } from '@/types/chat.types';
 
-const { isTauri, isPermissionGranted, requestPermission, sendNotification, debug } = vi.hoisted(
-  () => ({
+const { isTauri, isPermissionGranted, requestPermission, sendNotification, setBadgeCount, debug } =
+  vi.hoisted(() => ({
     isTauri: vi.fn(() => true),
     isPermissionGranted: vi.fn(async () => true),
     requestPermission: vi.fn(async () => 'granted'),
     sendNotification: vi.fn(),
+    setBadgeCount: vi.fn(async () => {}),
     debug: vi.fn(),
-  }),
-);
+  }));
 
 vi.mock('@tauri-apps/api/core', () => ({ isTauri }));
+vi.mock('@tauri-apps/api/window', () => ({ getCurrentWindow: () => ({ setBadgeCount }) }));
 vi.mock('@tauri-apps/plugin-notification', () => ({
   isPermissionGranted,
   requestPermission,
@@ -30,9 +33,13 @@ const request = (overrides: Partial<PermissionRequest> = {}): PermissionRequest 
 
 beforeEach(() => {
   isTauri.mockReturnValue(true);
+  isPermissionGranted.mockClear();
   isPermissionGranted.mockResolvedValue(true);
+  requestPermission.mockClear();
   requestPermission.mockResolvedValue('granted');
   sendNotification.mockClear();
+  setBadgeCount.mockClear();
+  setBadgeCount.mockResolvedValue(undefined);
   debug.mockClear();
 });
 
@@ -74,20 +81,110 @@ describe('notifyPermissionRequest', () => {
     expect(sendNotification).toHaveBeenCalledTimes(1);
   });
 
-  it('does not send when permission is denied', async () => {
+  it('does not send when permission is denied, and a replay after granting still notifies', async () => {
     isPermissionGranted.mockResolvedValueOnce(false);
     requestPermission.mockResolvedValueOnce('denied');
     const { notifyPermissionRequest } = await load();
     await notifyPermissionRequest(request());
-
     expect(sendNotification).not.toHaveBeenCalled();
+
+    // Nothing was shown, so the dedupe key must not be burned.
+    await notifyPermissionRequest(request());
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the dedupe key on the web permission-default path', async () => {
+    isTauri.mockReturnValue(false);
+    const instances: unknown[] = [];
+    class FakeNotification {
+      static permission = 'default';
+      onclick: (() => void) | null = null;
+      close = vi.fn();
+      constructor() {
+        instances.push(this);
+      }
+    }
+    vi.stubGlobal('Notification', FakeNotification);
+
+    try {
+      const { notifyPermissionRequest } = await load();
+      await notifyPermissionRequest(request({ request_id: 'pending' }));
+      expect(instances).toHaveLength(0);
+
+      // User granted via the first-gesture prompt; a replay must still notify…
+      FakeNotification.permission = 'granted';
+      await notifyPermissionRequest(request({ request_id: 'pending' }));
+      expect(instances).toHaveLength(1);
+
+      // …and only once.
+      await notifyPermissionRequest(request({ request_id: 'pending' }));
+      expect(instances).toHaveLength(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('swallows notification errors and logs them', async () => {
     isPermissionGranted.mockRejectedValueOnce(new Error('nope'));
     const { notifyPermissionRequest } = await load();
 
-    await expect(notifyPermissionRequest(request())).resolves.toBeUndefined();
+    await expect(notifyPermissionRequest(request())).resolves.toBe(false);
+    expect(debug).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('app badge', () => {
+  it('counts up with each delivered notification', async () => {
+    const { bumpAppBadge } = await load();
+    await bumpAppBadge();
+    await bumpAppBadge();
+
+    expect(setBadgeCount).toHaveBeenNthCalledWith(1, 1);
+    expect(setBadgeCount).toHaveBeenNthCalledWith(2, 2);
+  });
+
+  it('clears the badge on reset and starts over afterwards', async () => {
+    const { bumpAppBadge, resetAppBadge } = await load();
+    await bumpAppBadge();
+    await resetAppBadge();
+    expect(setBadgeCount).toHaveBeenLastCalledWith(undefined);
+
+    await bumpAppBadge();
+    expect(setBadgeCount).toHaveBeenLastCalledWith(1);
+  });
+
+  it('skips the reset round-trip when nothing is badged', async () => {
+    const { resetAppBadge } = await load();
+    await resetAppBadge();
+
+    expect(setBadgeCount).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the web Badging API outside Tauri', async () => {
+    isTauri.mockReturnValue(false);
+    const setAppBadge = vi.fn(async () => {});
+    const clearAppBadge = vi.fn(async () => {});
+    Object.assign(navigator, { setAppBadge, clearAppBadge });
+
+    try {
+      const { bumpAppBadge, resetAppBadge } = await load();
+      await bumpAppBadge();
+      expect(setAppBadge).toHaveBeenCalledWith(1);
+
+      await resetAppBadge();
+      expect(clearAppBadge).toHaveBeenCalledTimes(1);
+      expect(setBadgeCount).not.toHaveBeenCalled();
+    } finally {
+      delete (navigator as { setAppBadge?: unknown }).setAppBadge;
+      delete (navigator as { clearAppBadge?: unknown }).clearAppBadge;
+    }
+  });
+
+  it('swallows badge errors and logs them', async () => {
+    setBadgeCount.mockRejectedValueOnce(new Error('nope'));
+    const { bumpAppBadge } = await load();
+
+    await expect(bumpAppBadge()).resolves.toBeUndefined();
     expect(debug).toHaveBeenCalledTimes(1);
   });
 });
@@ -101,5 +198,95 @@ describe('notifyStreamComplete', () => {
       title: 'Task completed',
       body: 'The assistant has finished responding.',
     });
+  });
+
+  it("uses the assistant's reply as the body", async () => {
+    const { notifyStreamComplete } = await load();
+    await notifyStreamComplete({ message: '  Renamed the auth guard and updated its tests.  ' });
+
+    expect(sendNotification).toHaveBeenCalledWith({
+      title: 'Task completed',
+      body: 'Renamed the auth guard and updated its tests.',
+    });
+  });
+
+  it('truncates a long reply and falls back when the reply is empty', async () => {
+    const { notifyStreamComplete } = await load();
+    await notifyStreamComplete({ message: 'x'.repeat(250) });
+    expect(sendNotification).toHaveBeenLastCalledWith({
+      title: 'Task completed',
+      body: `${'x'.repeat(200)}…`,
+    });
+
+    await notifyStreamComplete({ message: '   ' });
+    expect(sendNotification).toHaveBeenLastCalledWith({
+      title: 'Task completed',
+      body: 'The assistant has finished responding.',
+    });
+  });
+
+  // Pins deliberate web behavior: OS-default auto-dismiss, click → focus + route + close.
+  it('sends a plain auto-dismissing web notification whose click focuses and routes', async () => {
+    isTauri.mockReturnValue(false);
+    const instances: FakeNotification[] = [];
+    class FakeNotification {
+      static permission = 'granted';
+      onclick: (() => void) | null = null;
+      close = vi.fn();
+      constructor(
+        public title: string,
+        public options?: { body?: string },
+      ) {
+        instances.push(this);
+      }
+    }
+    vi.stubGlobal('Notification', FakeNotification);
+    const focus = vi.spyOn(window, 'focus').mockImplementation(() => {});
+
+    try {
+      const { notifyStreamComplete } = await load();
+      const onClick = vi.fn();
+      await notifyStreamComplete({ message: 'Done.', onClick });
+
+      expect(instances).toHaveLength(1);
+      expect(instances[0].title).toBe('Task completed');
+      expect(instances[0].options).toEqual({ body: 'Done.' });
+
+      instances[0].onclick?.();
+      expect(focus).toHaveBeenCalledTimes(1);
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(instances[0].close).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+      focus.mockRestore();
+    }
+  });
+});
+
+describe('requestNotificationPermission', () => {
+  it('prompts the browser while permission is undecided', async () => {
+    const browserRequest = vi.fn(async () => 'granted');
+    vi.stubGlobal('Notification', { permission: 'default', requestPermission: browserRequest });
+
+    try {
+      const { requestNotificationPermission } = await load();
+      await requestNotificationPermission();
+      expect(browserRequest).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('does nothing once permission is decided', async () => {
+    const browserRequest = vi.fn(async () => 'granted');
+    vi.stubGlobal('Notification', { permission: 'denied', requestPermission: browserRequest });
+
+    try {
+      const { requestNotificationPermission } = await load();
+      await requestNotificationPermission();
+      expect(browserRequest).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/frontend/src/utils/notifications.ts
+++ b/frontend/src/utils/notifications.ts
@@ -1,4 +1,5 @@
 import { isTauri } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import {
   isPermissionGranted,
   requestPermission,
@@ -7,11 +8,24 @@ import {
 import type { PermissionRequest } from '@/types/chat.types';
 import { logger } from '@/utils/logger';
 
-const NOTIFICATION_DURATION_MS = 10_000;
 // Dedup OS notifications when SSE envelopes replay on reconnect.
 const NOTIFIED_PERMISSION_REQUESTS = new Set<string>();
 
-function buildPermissionNotification(request: PermissionRequest): { title: string; body: string } {
+// The OS clips long bodies anyway.
+const BODY_MAX_CHARS = 200;
+
+// Notify-or-not policy lives in useBackgroundNotify; this module formats and sends.
+export interface NotifyOptions {
+  // The assistant's reply — becomes the notification body.
+  message?: string;
+  // Web only: invoked after focusing the window. Tauri clicks activate the app natively.
+  onClick?: () => void;
+}
+
+function buildPermissionNotification(request: PermissionRequest): {
+  title: string;
+  body: string;
+} {
   switch (request.tool_name) {
     case 'ExitPlanMode':
       return {
@@ -26,66 +40,138 @@ function buildPermissionNotification(request: PermissionRequest): { title: strin
   }
 }
 
-async function sendWebNotification(title: string, body: string): Promise<void> {
+async function sendWebNotification(
+  title: string,
+  body: string,
+  onClick?: () => void,
+): Promise<boolean> {
   if (typeof window === 'undefined' || !('Notification' in window)) {
-    return;
+    return false;
   }
 
-  if (Notification.permission === 'default') {
-    await Notification.requestPermission();
+  // Prompting here would be ignored outside a user gesture — useNotificationPermissionPrompt asks.
+  if (Notification.permission !== 'granted') {
+    return false;
   }
 
-  if (Notification.permission === 'granted') {
-    const notification = new Notification(title, { body, requireInteraction: true });
-    notification.onclick = () => notification.close();
-    setTimeout(() => notification.close(), NOTIFICATION_DURATION_MS);
-  }
+  const notification = new Notification(title, { body });
+  notification.onclick = () => {
+    window.focus();
+    onClick?.();
+    notification.close();
+  };
+  return true;
 }
 
-async function sendTauriNotification(title: string, body: string): Promise<void> {
+async function sendTauriNotification(title: string, body: string): Promise<boolean> {
   let permissionGranted = await isPermissionGranted();
   if (!permissionGranted) {
     permissionGranted = (await requestPermission()) === 'granted';
   }
 
-  if (permissionGranted) {
-    sendNotification({ title, body });
+  if (!permissionGranted) {
+    return false;
+  }
+  sendNotification({ title, body });
+  return true;
+}
+
+// Resolves to whether a notification was actually shown.
+async function deliver(title: string, body: string, onClick?: () => void): Promise<boolean> {
+  if (isTauri()) {
+    return sendTauriNotification(title, body);
+  }
+
+  return sendWebNotification(title, body, onClick);
+}
+
+// Web only — call from a user gesture so the browser honors the prompt.
+export async function requestNotificationPermission(): Promise<void> {
+  try {
+    if (
+      typeof window !== 'undefined' &&
+      'Notification' in window &&
+      Notification.permission === 'default'
+    ) {
+      await Notification.requestPermission();
+    }
+  } catch (error) {
+    logger.debug('Failed to request notification permission', 'notifications', error);
   }
 }
 
-export async function notifyStreamComplete(): Promise<void> {
-  const title = 'Task completed';
-  const body = 'The assistant has finished responding.';
+// Notifications the user hasn't come back to yet.
+let unseenNotifications = 0;
 
+async function syncAppBadge(count: number): Promise<void> {
   try {
     if (isTauri()) {
-      await sendTauriNotification(title, body);
+      // App-wide dock/taskbar badge; undefined clears it.
+      await getCurrentWindow().setBadgeCount(count > 0 ? count : undefined);
       return;
     }
 
-    await sendWebNotification(title, body);
+    // Badging API only has an effect for installed PWAs.
+    if ('setAppBadge' in navigator) {
+      if (count > 0) {
+        await navigator.setAppBadge(count);
+      } else {
+        await navigator.clearAppBadge();
+      }
+    }
   } catch (error) {
-    logger.debug('Failed to send stream complete notification', 'notifications', error);
+    logger.debug('Failed to sync app badge', 'notifications', error);
   }
 }
 
-export async function notifyPermissionRequest(request: PermissionRequest): Promise<void> {
-  if (NOTIFIED_PERMISSION_REQUESTS.has(request.request_id)) {
-    return;
-  }
+export async function bumpAppBadge(): Promise<void> {
+  unseenNotifications += 1;
+  await syncAppBadge(unseenNotifications);
+}
 
+export async function resetAppBadge(): Promise<void> {
+  if (unseenNotifications === 0) return;
+  unseenNotifications = 0;
+  await syncAppBadge(0);
+}
+
+function assistantBody(message: string | undefined): string {
+  const text = message?.trim();
+  if (!text) return 'The assistant has finished responding.';
+  return text.length > BODY_MAX_CHARS ? `${text.slice(0, BODY_MAX_CHARS).trimEnd()}…` : text;
+}
+
+export async function notifyStreamComplete(options: NotifyOptions = {}): Promise<boolean> {
+  try {
+    return await deliver('Task completed', assistantBody(options.message), options.onClick);
+  } catch (error) {
+    logger.debug('Failed to send stream complete notification', 'notifications', error);
+    return false;
+  }
+}
+
+export async function notifyPermissionRequest(
+  request: PermissionRequest,
+  options: NotifyOptions = {},
+): Promise<boolean> {
+  // Claimed synchronously so concurrent replays can't double-notify, and
+  // released below if nothing was shown so a later replay can still notify.
+  if (NOTIFIED_PERMISSION_REQUESTS.has(request.request_id)) {
+    return false;
+  }
   NOTIFIED_PERMISSION_REQUESTS.add(request.request_id);
 
   const { title, body } = buildPermissionNotification(request);
 
   try {
-    if (isTauri()) {
-      await sendTauriNotification(title, body);
-      return;
+    const delivered = await deliver(title, body, options.onClick);
+    if (!delivered) {
+      NOTIFIED_PERMISSION_REQUESTS.delete(request.request_id);
     }
-
-    await sendWebNotification(title, body);
+    return delivered;
   } catch (error) {
+    NOTIFIED_PERMISSION_REQUESTS.delete(request.request_id);
     logger.debug('Failed to send permission notification', 'notifications', error);
+    return false;
   }
 }

--- a/frontend/src/utils/tileHelpers.ts
+++ b/frontend/src/utils/tileHelpers.ts
@@ -59,3 +59,30 @@ export function viewTypeToTileId(view: ViewType, slot: SplitSlot | null): TileId
 export function tileViewKinds(tiles: TileId[]): ViewType[] {
   return Array.from(new Set(tiles.map(tileIdToViewType)));
 }
+
+// Mobile paints one pane (focused, else first); desktop paints the whole layout.
+export function paintedLayout(
+  visibleLayout: TileId[][],
+  focusedTile: TileId | null,
+  isMobile: boolean,
+): TileId[][] {
+  if (!isMobile) return visibleLayout;
+  const flat = visibleLayout.flat();
+  const tile = focusedTile && flat.includes(focusedTile) ? focusedTile : flat[0];
+  return tile ? [[tile]] : [];
+}
+
+// Split tiles bind their slot's chat; every other tile binds the route chat.
+export function paintedChatIds(
+  tiles: TileId[],
+  splitChatIds: string[],
+  routeChatId: string | undefined,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const tile of tiles) {
+    const slot = splitSlotOfTile(tile);
+    const chatId = slot ? splitChatIds[slot - 1] : routeChatId;
+    if (chatId) ids.add(chatId);
+  }
+  return ids;
+}


### PR DESCRIPTION
## What

OS notifications fired on every stream completion and permission request regardless of whether the chat was on screen, each call site repeated its own `notifications_enabled` check, and the dock badge tracked the pending permission queue rather than anything the user had been told about.

## Changes

**Notify only what the user isn't watching.** `useBackgroundNotify` centralizes the policy: it reads visibility live at call time (store layout, route, `document.hasFocus()`) and suppresses only when the target chat is painted on screen in a focused window. Nothing is captured at render — stored stream callbacks can invoke the closure long after the pane that created it unmounted. Stream completions now notify for background chats at all, having moved above `onComplete`'s `isCurrentChat` early return.

**Bodies carry the assistant's reply.** Instead of `"Chat title" finished responding.`, the body is the turn's actual reply (capped at 200 chars), read off the stream buffer via `extractAssistantText` before `clearStreamSession` drops it. Falls back to the static sentence for tool-only turns.

**Badge mirrors notifications.** `useAppBadge` no longer subscribes to `permissionStore`. The senders report whether the OS actually showed the notification; `useBackgroundNotify` bumps the badge only on a real delivery and only while the user is still away, and returning to the app clears it.

**Web notification fixes.** Dropped `requireInteraction` and the 10s close timer in favor of OS-default auto-dismiss; clicking now focuses the window and routes to the chat. Permission prompts moved out of the send path — browsers ignore them outside a user gesture — into a one-shot listener armed on the first gesture after sign-in. A denied or undecided permission no longer burns a request's dedupe key, so a replay after granting still notifies.

**Shared visibility rule.** Extracted `paintedLayout`/`paintedChatIds` into `tileHelpers` so `ChatTabs`, `SplitViewContainer` and the notifier share one definition of what is on screen. Only the workspace routes (`/` and `/chat/:chatId`) mount tiles, so the persisted layout can't suppress anything from `/settings`.

Needed `core:window:allow-set-badge-count` in the Tauri capabilities.

## Testing

`npx tsc --noEmit`, `npx eslint`, and the full suite — 717 passing, including new specs for `useBackgroundNotify`, `useNotificationPermissionPrompt`, the badge lifecycle, dedupe-key release, and click-to-route.