### PR TITLE
Update MiniMax M3 context window to 1,000,000 tokens

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -279,7 +279,7 @@ MODELS: dict[str, ModelInfo] = {
         "MiniMax M2.7 (Opencode Go)", AgentKind.OPENCODE, 204_800
     ),
     "opencode:opencode-go/minimax-m3": ModelInfo(
-        "MiniMax M3 (Opencode Go)", AgentKind.OPENCODE, 512_000
+        "MiniMax M3 (Opencode Go)", AgentKind.OPENCODE, 1_000_000
     ),
     "opencode:opencode-go/qwen3.5-plus": ModelInfo(
         "Qwen3.5 Plus (Opencode Go)", AgentKind.OPENCODE, 262_144


### PR DESCRIPTION
Reason: Refresh MiniMax M3 context window parameter to match the upstream OpenCode Go model registry.

## Changes
- Update the `opencode:opencode-go/minimax-m3` model entry context window from 512,000 to 1,000,000 tokens in `backend/app/constants.py`.

## Rationale
The OpenCode Go model registry declares MiniMax M3 with a 1,000,000-token context window. The catalog entry previously recorded 512,000 tokens, which is inconsistent with the current upstream parameter. MiniMax M2.7 is already declared at 204,800 tokens and required no change.

## Verification
- `python3 -m py_compile backend/app/constants.py` passes.
