### PR TITLE
fix: reliably scroll to the target line when opening search results

### DIFF
--- a/frontend/src/components/editor/code-view/CodeView.tsx
+++ b/frontend/src/components/editor/code-view/CodeView.tsx
@@ -135,8 +135,11 @@ export const CodeView = memo(function CodeView({
     // Respect a collapsed file tree — opening a file shouldn't reopen it;
     // handleFileTreeExpand re-reveals the selection if the user expands later.
     if (!fileTreePanelRef.current?.isCollapsed()) treeRef.current?.reveal(path);
-    if (pendingFileOpen.line != null) {
-      setTargetLine({ path, line: pendingFileOpen.line, nonce: pendingFileOpen.nonce });
+    const line = pendingFileOpen.line;
+    if (line != null) {
+      // Share handleOpenResult's counter — a second nonce sequence could
+      // collide in View's path:line:nonce dedupe and skip the jump.
+      setTargetLine((prev) => ({ path, line, nonce: (prev?.nonce ?? 0) + 1 }));
     }
     useUIStore.setState({ pendingFileOpen: null });
   }, [pendingFileOpen, chatId, onFileSelect, files.length]);

--- a/frontend/src/components/editor/editor-view/View.test.tsx
+++ b/frontend/src/components/editor/editor-view/View.test.tsx
@@ -1,0 +1,293 @@
+// @vitest-environment jsdom
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { FileStructure } from '@/types/file-system.types';
+import { View, type ViewProps } from './View';
+
+const h = vi.hoisted(() => ({
+  fileContent: undefined as { path: string; content: string } | undefined,
+  pendingRaf: null as (() => void) | null,
+  models: new Map<string, { content: string; reveals: number[] }>(),
+  // 0 simulates a jump into a display:none tile (re-centered on first layout).
+  layoutHeight: 300,
+  layoutChangeCb: null as ((info: { height: number }) => void) | null,
+}));
+
+function lines(n: number): string {
+  return Array.from({ length: n }, (_, i) => `line ${i + 1}`).join('\n');
+}
+
+// The jump effect reveals via requestAnimationFrame; capture the callback so
+// tests can fire it deterministically instead of driving real timers.
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  h.pendingRaf = null;
+  h.models.clear();
+  h.layoutHeight = 300;
+  h.layoutChangeCb = null;
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    h.pendingRaf = () => cb(performance.now());
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => {
+    h.pendingRaf = null;
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Fake @monaco-editor/react: registers a model per path, syncs `value` into it,
+// and hands onMount a minimal editor whose reveal calls are recorded per model.
+vi.mock('@monaco-editor/react', async () => {
+  const { useEffect } = await import('react');
+  function makeMonaco() {
+    return {
+      editor: {
+        registerEditorOpener: () => ({ dispose: () => {} }),
+        defineTheme: () => {},
+        setTheme: () => {},
+      },
+      languages: {
+        registerDefinitionProvider: () => ({ dispose: () => {} }),
+        registerReferenceProvider: () => ({ dispose: () => {} }),
+        typescript: {
+          typescriptDefaults: { setDiagnosticsOptions: () => {}, setCompilerOptions: () => {} },
+          javascriptDefaults: { setDiagnosticsOptions: () => {}, setCompilerOptions: () => {} },
+          ScriptTarget: {},
+          ModuleKind: {},
+          JsxEmit: {},
+          ModuleResolutionKind: {},
+        },
+      },
+      KeyMod: { CtrlCmd: 0 },
+      KeyCode: { KeyL: 0, KeyI: 0 },
+    };
+  }
+  function makeEditor(modelPath: string) {
+    return {
+      getModel: () => {
+        const model = h.models.get(modelPath);
+        return {
+          getLineCount: () => (model ? model.content.split('\n').length : 0),
+        };
+      },
+      revealLineInCenter: (line: number) => {
+        h.models.get(modelPath)?.reveals.push(line);
+      },
+      setPosition: () => {},
+      setSelection: () => {},
+      focus: () => {},
+      getLayoutInfo: () => ({ height: h.layoutHeight }),
+      onDidLayoutChange: (cb: (info: { height: number }) => void) => {
+        h.layoutChangeCb = cb;
+        return {
+          dispose: () => {
+            h.layoutChangeCb = null;
+          },
+        };
+      },
+      onDidFocusEditorText: () => ({ dispose: () => {} }),
+      onMouseMove: () => ({ dispose: () => {} }),
+      addAction: () => {},
+    };
+  }
+  function FakeEditor(props: {
+    value: string;
+    path: string;
+    onMount?: (editor: unknown, monaco: unknown) => void;
+  }) {
+    const { value, path, onMount } = props;
+    useEffect(() => {
+      if (!h.models.has(path)) h.models.set(path, { content: value, reveals: [] });
+      onMount?.(makeEditor(path), makeMonaco());
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    useEffect(() => {
+      const model = h.models.get(path);
+      if (model) model.content = value;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [value]);
+    return null;
+  }
+  return { default: FakeEditor };
+});
+
+vi.mock('@/hooks/queries/useSandboxQueries', () => ({
+  useFileContentQuery: () => ({ data: h.fileContent, isLoading: false, error: null }),
+  useUpdateFileMutation: () => ({ isPending: false, mutate: vi.fn() }),
+  useGitChangedPathsQuery: () => ({ data: { paths: [] } }),
+  useGitFileBaselineQuery: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock('@/hooks/useEditorTheme', () => ({
+  useEditorTheme: () => ({ currentTheme: 'custom-light', setupEditorTheme: vi.fn() }),
+}));
+vi.mock('@/hooks/useResolvedTheme', () => ({ useResolvedTheme: () => 'light' }));
+vi.mock('react-hot-toast', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@/components/editor/file-preview/FilePreview', () => ({ FilePreview: () => null }));
+
+async function renderView(overrides: Partial<ViewProps> = {}) {
+  const props: ViewProps = {
+    selectedFile: null,
+    fileStructure: [],
+    sandboxId: 'sbx',
+    chatId: undefined,
+    cwd: undefined,
+    targetLine: null,
+    openFiles: [],
+    onFileSelect: vi.fn(),
+    onCloseFile: vi.fn(),
+    ...overrides,
+  };
+  // The editor is loaded through React.lazy — await the async act so the
+  // Suspense fallback resolves before the jump effect runs.
+  let result!: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(<View {...props} />);
+  });
+  return result;
+}
+
+function viewProps(file: FileStructure, targetLine: ViewProps['targetLine']): ViewProps {
+  return {
+    selectedFile: file,
+    fileStructure: [file],
+    sandboxId: 'sbx',
+    chatId: undefined,
+    cwd: undefined,
+    targetLine,
+    openFiles: [file],
+    onFileSelect: vi.fn(),
+    onCloseFile: vi.fn(),
+  };
+}
+
+function modelPath(path: string): string {
+  return `sandbox://sbx/${path}`;
+}
+
+describe('View jump-to-line reveal', () => {
+  it('reveals the requested line when jumping to the open file', async () => {
+    const file: FileStructure = { path: 'src/b.ts', type: 'file', content: '' };
+    h.fileContent = { path: 'src/b.ts', content: lines(30) };
+    await renderView({
+      selectedFile: file,
+      fileStructure: [file],
+      openFiles: [file],
+      targetLine: { path: 'src/b.ts', line: 12, nonce: 1 },
+    });
+    await act(async () => {
+      h.pendingRaf?.();
+    });
+    expect(h.models.get(modelPath('src/b.ts'))?.reveals).toContain(12);
+  });
+
+  it('re-reveals the same path/line when the nonce bumps', async () => {
+    const file: FileStructure = { path: 'src/b.ts', type: 'file', content: '' };
+    h.fileContent = { path: 'src/b.ts', content: lines(30) };
+    const { rerender } = await renderView({
+      selectedFile: file,
+      fileStructure: [file],
+      openFiles: [file],
+      targetLine: { path: 'src/b.ts', line: 12, nonce: 1 },
+    });
+    await act(async () => {
+      h.pendingRaf?.();
+    });
+    const model = h.models.get(modelPath('src/b.ts'));
+    expect(model?.reveals).toEqual([12]);
+    // Re-clicking the same result bumps only the nonce — the reveal must re-fire.
+    await act(async () => {
+      rerender(<View {...viewProps(file, { path: 'src/b.ts', line: 12, nonce: 2 })} />);
+    });
+    await act(async () => {
+      h.pendingRaf?.();
+    });
+    expect(model?.reveals).toEqual([12, 12]);
+  });
+
+  it('reveals the target after jumping from preview back to code for the same file', async () => {
+    const file: FileStructure = { path: 'notes.md', type: 'file', content: '' };
+    h.fileContent = { path: 'notes.md', content: lines(10) };
+    const { rerender } = await renderView({
+      selectedFile: file,
+      fileStructure: [file],
+      openFiles: [file],
+    });
+    // notes.md defaults to preview; open in code, return to preview, then jump.
+    await act(async () => {
+      fireEvent.click(screen.getByText('Raw'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Preview'));
+    });
+    await act(async () => {
+      rerender(<View {...viewProps(file, { path: 'notes.md', line: 4, nonce: 1 })} />);
+    });
+    await act(async () => {
+      h.pendingRaf?.();
+    });
+    expect(h.models.get(modelPath('notes.md'))?.reveals).toContain(4);
+  });
+
+  it('re-reveals the true line after the buffer catches up to a clamped jump', async () => {
+    const file: FileStructure = { path: 'src/c.ts', type: 'file', content: '' };
+    h.fileContent = { path: 'src/c.ts', content: lines(50) };
+    const { rerender } = await renderView({
+      selectedFile: file,
+      fileStructure: [file],
+      openFiles: [file],
+      targetLine: { path: 'src/c.ts', line: 90, nonce: 1 },
+    });
+    await act(async () => {
+      h.pendingRaf?.();
+    });
+    const model = h.models.get(modelPath('src/c.ts'));
+    // Buffer (50 lines) is shorter than the requested line — clamped to its end.
+    expect(model?.reveals).toEqual([50]);
+    // Disk content catches up to the search hit; the jump should land for real.
+    h.fileContent = { path: 'src/c.ts', content: lines(100) };
+    await act(async () => {
+      rerender(<View {...viewProps(file, { path: 'src/c.ts', line: 90, nonce: 1 })} />);
+    });
+    await act(async () => {
+      h.pendingRaf?.();
+    });
+    expect(model?.reveals).toEqual([50, 90]);
+  });
+
+  it('re-centers on the first real layout when revealed at zero height', async () => {
+    const file: FileStructure = { path: 'src/d.ts', type: 'file', content: '' };
+    h.fileContent = { path: 'src/d.ts', content: lines(30) };
+    // Jump fires while the editor tile is still display:none (0-high layout).
+    h.layoutHeight = 0;
+    await renderView({
+      selectedFile: file,
+      fileStructure: [file],
+      openFiles: [file],
+      targetLine: { path: 'src/d.ts', line: 12, nonce: 1 },
+    });
+    await act(async () => {
+      h.pendingRaf?.();
+    });
+    const model = h.models.get(modelPath('src/d.ts'));
+    expect(model?.reveals).toEqual([12]);
+    // The tile becomes visible and Monaco lays out — the reveal re-centers once.
+    h.layoutHeight = 300;
+    await act(async () => {
+      h.layoutChangeCb?.({ height: 300 });
+    });
+    expect(model?.reveals).toEqual([12, 12]);
+    // Later layouts (resizes) must not keep yanking the viewport back.
+    await act(async () => {
+      h.layoutChangeCb?.({ height: 400 });
+    });
+    expect(model?.reveals).toEqual([12, 12]);
+  });
+});

--- a/frontend/src/components/editor/editor-view/View.tsx
+++ b/frontend/src/components/editor/editor-view/View.tsx
@@ -229,12 +229,14 @@ export const View = memo(function View({
     const editor = editorRef.current;
     if (!editor) return;
 
+    let layoutListener: monaco.IDisposable | null = null;
     const raf = requestAnimationFrame(() => {
       if (editorRef.current !== editor) return;
       const model = editor.getModel();
       if (!model) return;
-      let lineNumber = Math.max(1, targetLine.line);
-      if (model.getLineCount() < lineNumber) {
+      const targetLineNumber = Math.max(1, targetLine.line);
+      let lineNumber = targetLineNumber;
+      if (model.getLineCount() < targetLineNumber) {
         // The model is shorter than the requested line. If the loaded content
         // hasn't synced into Monaco's value prop yet, wait for the next run
         // (currentContent is in deps) instead of clamping a stale buffer.
@@ -245,7 +247,12 @@ export const View = memo(function View({
         if (!contentReady) return;
         lineNumber = model.getLineCount();
       }
-      lastAppliedTargetRef.current = key;
+      // Only an exact reveal (or a clamp onto an unsaved draft) consumes the
+      // target — a clamp onto non-draft content means the cache is behind the
+      // search hit, so leave it pending for the refetch to land the real line.
+      if (lineNumber === targetLineNumber || hasUnsavedChanges) {
+        lastAppliedTargetRef.current = key;
+      }
       editor.revealLineInCenter(lineNumber);
       editor.setPosition({ lineNumber, column: 1 });
       editor.setSelection({
@@ -255,8 +262,21 @@ export const View = memo(function View({
         endColumn: Number.MAX_SAFE_INTEGER,
       });
       editor.focus();
+      // A jump into a display:none tile reveals against a 0-high layout and
+      // nothing re-centers later — redo the reveal on the first real layout.
+      if (editor.getLayoutInfo().height === 0) {
+        layoutListener = editor.onDidLayoutChange((info) => {
+          if (info.height === 0) return;
+          layoutListener?.dispose();
+          layoutListener = null;
+          if (editorRef.current === editor) editor.revealLineInCenter(lineNumber);
+        });
+      }
     });
-    return () => cancelAnimationFrame(raf);
+    return () => {
+      cancelAnimationFrame(raf);
+      layoutListener?.dispose();
+    };
   }, [
     targetLine,
     selectedFile,
@@ -273,6 +293,12 @@ export const View = memo(function View({
   if (prevViewModeRef.current !== viewMode || prevFilePathRef.current !== selectedFile?.path) {
     const fileChanged = prevFilePathRef.current !== selectedFile?.path;
     const enteredDiff = prevViewModeRef.current !== 'diff' && viewMode === 'diff';
+    // Only an actual preview unmounts Content — 'preview' mode on a
+    // non-previewable file keeps the editor mounted.
+    const enteredPreview =
+      prevViewModeRef.current !== 'preview' &&
+      viewMode === 'preview' &&
+      isPreviewableFile(selectedFile);
     prevViewModeRef.current = viewMode;
     prevFilePathRef.current = selectedFile?.path;
     if (isPreviewFullscreen) {
@@ -283,9 +309,10 @@ export const View = memo(function View({
     if (fileChanged) {
       setViewMode(defaultViewMode(selectedFile));
     }
-    if (enteredDiff) {
-      // Content unmounts while the diff is shown; drop the disposed editor so
-      // the jump-to-line effect waits for the remount instead of touching it.
+    if (enteredDiff || enteredPreview) {
+      // Content unmounts while the diff/preview is shown; drop the disposed
+      // editor so the jump-to-line effect waits for the remount instead of
+      // touching it.
       editorRef.current = null;
       if (mountedEditorPath !== null) setMountedEditorPath(null);
     }

--- a/frontend/src/store/uiStore.test.ts
+++ b/frontend/src/store/uiStore.test.ts
@@ -29,6 +29,7 @@ beforeEach(() => {
     currentWorkspaceChatId: null,
     chatTabs: [],
     pendingFileOpen: null,
+    fileOpenNonce: 0,
     composerSelectionsByChat: {},
   });
 });
@@ -139,6 +140,15 @@ describe('openFileInEditor', () => {
     state().openFileInEditor('a.ts', 'c1', 12);
     // Same path/line re-opens must still register (nonce increments) so the
     // editor re-focuses after the user scrolled away.
+    expect(state().pendingFileOpen?.nonce).toBe(2);
+  });
+
+  it('keeps incrementing the nonce after a consumer clears pendingFileOpen', () => {
+    state().openFileInEditor('a.ts', 'c1', 12);
+    // Consumers null the pending open — a restarted nonce would repeat a
+    // path:line:nonce key and the editor would skip the jump as already applied.
+    useUIStore.setState({ pendingFileOpen: null });
+    state().openFileInEditor('a.ts', 'c1', 12);
     expect(state().pendingFileOpen?.nonce).toBe(2);
   });
 

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -81,6 +81,8 @@ type UIStoreState = ThemeState &
     setCreateCommitDialogOpen: (open: boolean) => void;
     // chatId binds the jump to one editor tile; undefined = landing editor.
     pendingFileOpen: PendingFileOpen | null;
+    // Monotonic — consumers null pendingFileOpen, so its nonce can't seed the next.
+    fileOpenNonce: number;
     openFileInEditor: (path: string, chatId: string | undefined, line?: number) => void;
     pendingChatMessage: { chatId: string; message: string } | null;
     setPendingChatMessage: (payload: { chatId: string; message: string } | null) => void;
@@ -309,16 +311,19 @@ export const useUIStore = create<UIStoreState>()(
       },
 
       pendingFileOpen: null,
+      fileOpenNonce: 0,
       openFileInEditor: (path, chatId, line) => {
         const state = get();
         const splitIndex = chatId ? state.splitChatIds.indexOf(chatId) : -1;
         const slot = splitIndex >= 0 ? splitSlotAt(splitIndex) : null;
         const tileId = viewTypeToTileId('editor', slot);
+        const nonce = state.fileOpenNonce + 1;
         set({
+          fileOpenNonce: nonce,
           pendingFileOpen: {
             path,
             chatId,
-            nonce: (state.pendingFileOpen?.nonce ?? 0) + 1,
+            nonce,
             ...(line != null ? { line } : {}),
           },
           openTabs: state.openTabs.includes(tileId) ? state.openTabs : [...state.openTabs, tileId],


### PR DESCRIPTION
## Problem
Clicking a result in the command-menu Grep tab (and other `openFileInEditor` callers) opens the file in the editor but sometimes doesn't scroll to the matched line.

## Root causes & fixes
1. **Nonce reset → dedupe skip** (primary): `openFileInEditor` derived each jump's nonce from `pendingFileOpen`, which consumers (`CodeView`, `ChatPage`, `clearJumpsFor*`) null after use — every jump carried `nonce: 1`, and `View`'s `path:line:nonce` dedupe silently skipped repeat jumps to the same spot. The store now keeps a dedicated monotonic `fileOpenNonce`, and `CodeView` routes consumed jumps through the same local counter as the sidebar search so the two nonce sequences can't collide.
2. **Preview left stale editor refs**: entering an active preview (md/csv/image/pdf) unmounts the Monaco `Content`, but only `diff` cleared `editorRef`/`mountedEditorPath` — later jumps ran against a disposed editor and the remount's same-value `setMountedEditorPath` couldn't re-trigger the reveal. Now cleared on `enteredDiff || enteredPreview`, guarded by `isPreviewableFile` so a 'preview' mode that keeps the editor mounted doesn't strand the jump.
3. **0-height reveal on hidden tiles**: a jump that activates a `display:none` editor tile revealed against a 0-high layout and never re-centered — the reveal now redoes itself once on the first real layout via a one-shot `onDidLayoutChange`.
4. **Clamp onto stale cache consumed the target**: when the cached content was shorter than the search hit, the clamped reveal marked the target applied, so the refetch that grew the file never re-jumped. A non-draft clamp now leaves the target pending until content catches up.

## Tests
- New `View.test.tsx` (fake Monaco + deterministic rAF): exact reveal, nonce-bump re-reveal, preview→code jump, clamped-jump catch-up, 0-height re-center (incl. no repeat yank on later resizes).
- `uiStore.test.ts`: nonce keeps incrementing after a consumer clears `pendingFileOpen`.
- Full frontend suite: 723 passing; tsc + eslint clean.