### PR TITLE
Add branded tool UI for all agentrove MCP tools

### DIFF
--- a/frontend/src/components/chat/tools/agentrove/AgentRoveTool.module.scss
+++ b/frontend/src/components/chat/tools/agentrove/AgentRoveTool.module.scss
@@ -1,0 +1,72 @@
+@use '@/styles/globals/typography' as type;
+@use '@/styles/globals/responsive' as responsive;
+
+.icon {
+  height: var(--space-3-5);
+  width: var(--space-3-5);
+
+  &--on-light {
+    display: block;
+
+    :global([data-theme='dark']) & {
+      display: none;
+    }
+  }
+
+  &--on-dark {
+    display: none;
+
+    :global([data-theme='dark']) & {
+      display: block;
+    }
+  }
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.field-label {
+  @include type.type-meta;
+  color: var(--theme-text-quaternary);
+}
+
+.field-text {
+  @include type.type-meta;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  color: var(--theme-text-tertiary);
+}
+
+.summary {
+  @include type.type-meta(500);
+  color: var(--theme-text-secondary);
+}
+
+.chat-link {
+  @include type.type-meta(500);
+  align-self: flex-start;
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-2);
+  color: var(--theme-text-secondary);
+  // subtle inset surface — black overlay on light, white overlay on dark
+  background-color: rgb(0 0 0 / 0.05);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-tertiary);
+    background-color: rgb(255 255 255 / 0.05);
+  }
+
+  @include responsive.hover {
+    background-color: var(--theme-surface-hover);
+    color: var(--theme-text-primary);
+  }
+}

--- a/frontend/src/components/chat/tools/agentrove/AgentRoveTool.tsx
+++ b/frontend/src/components/chat/tools/agentrove/AgentRoveTool.tsx
@@ -1,0 +1,61 @@
+import { memo } from 'react';
+import { Link } from 'react-router-dom';
+import clsx from 'clsx';
+import type { ToolAggregate } from '@/types/tools.types';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import {
+  buildInputSummary,
+  collectLongInputFields,
+  extractChatId,
+  getDescriptor,
+  parseAgentRoveResult,
+  summarizeResultData,
+} from './agentRoveDescriptors';
+import toolText from '../common/toolText.module.scss';
+import iconDark from '/assets/images/icon-dark.svg';
+import iconLight from '/assets/images/icon-white.svg';
+import styles from './AgentRoveTool.module.scss';
+
+export const AgentRoveTool = memo(function AgentRoveTool({ tool }: { tool: ToolAggregate }) {
+  const { label } = getDescriptor(tool.name);
+  const summary = buildInputSummary(tool.name, tool.input);
+  const longFields = collectLongInputFields(tool.name, tool.input);
+  const result = parseAgentRoveResult(tool.result);
+  const resultSummary = summarizeResultData(result.data);
+  const chatId = extractChatId(result.data);
+  const hasDetails = longFields.length > 0 || Boolean(result.text);
+
+  return (
+    <ToolCard
+      icon={
+        <>
+          <img src={iconDark} alt="" className={clsx(styles.icon, styles['icon--on-light'])} />
+          <img src={iconLight} alt="" className={clsx(styles.icon, styles['icon--on-dark'])} />
+        </>
+      }
+      status={tool.status}
+      title={`AgentRove · ${label}`}
+      statusDetail={summary}
+      loadingContent="Calling AgentRove…"
+      error={tool.error}
+    >
+      {hasDetails ? (
+        <div className={styles.details}>
+          {longFields.map((field) => (
+            <div key={field.key} className={styles.field}>
+              <span className={styles['field-label']}>{field.key}</span>
+              <p className={styles['field-text']}>{field.text}</p>
+            </div>
+          ))}
+          {resultSummary && <p className={styles.summary}>{resultSummary}</p>}
+          {chatId && (
+            <Link to={`/chat/${chatId}`} className={styles['chat-link']}>
+              Open chat
+            </Link>
+          )}
+          {result.text && <pre className={toolText['output-pre']}>{result.text}</pre>}
+        </div>
+      ) : null}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/agentrove/agentRoveDescriptors.ts
+++ b/frontend/src/components/chat/tools/agentrove/agentRoveDescriptors.ts
@@ -1,0 +1,159 @@
+import { extractResultText } from '@/utils/agentTool';
+import { formatResult } from '@/utils/format';
+
+const PREFIX = 'mcp__agentrove__';
+
+type ToolInput = Record<string, unknown>;
+
+interface AgentRoveDescriptor {
+  label: string;
+  summary?: (input: ToolInput) => string | null;
+  longFields?: string[];
+}
+
+export interface ParsedAgentRoveResult {
+  data: ToolInput | null;
+  text: string;
+}
+
+const isRecord = (value: unknown): value is ToolInput =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const value = (input: ToolInput, key: string): string | null => {
+  const raw = input[key];
+  if (typeof raw === 'string') return raw.trim() || null;
+  if (typeof raw === 'number') return String(raw);
+  return null;
+};
+
+const labeled = (input: ToolInput, key: string, label: string): string | null => {
+  const resolved = value(input, key);
+  return resolved ? `${label} ${resolved}` : null;
+};
+
+const flag = (input: ToolInput, key: string): string | null => (input[key] === true ? key : null);
+
+const join = (...parts: (string | null)[]): string | null =>
+  parts.filter(Boolean).join(' · ') || null;
+
+const DESCRIPTORS: Record<string, AgentRoveDescriptor> = {
+  list_workspaces: { label: 'List Workspaces' },
+  list_models: { label: 'List Models', summary: (i) => value(i, 'agent_kind') },
+  get_current_chat: { label: 'Get Current Chat' },
+  list_chats: { label: 'List Chats', summary: (i) => labeled(i, 'workspace_id', 'workspace') },
+  list_personas: { label: 'List Personas' },
+  get_persona: { label: 'Get Persona', summary: (i) => value(i, 'name') },
+  create_persona: {
+    label: 'Create Persona',
+    summary: (i) => value(i, 'name'),
+    longFields: ['content'],
+  },
+  update_persona: {
+    label: 'Update Persona',
+    summary: (i) => value(i, 'name'),
+    longFields: ['content'],
+  },
+  delete_persona: { label: 'Delete Persona', summary: (i) => value(i, 'name') },
+  send_message: {
+    label: 'Send Message',
+    summary: (i) =>
+      join(
+        value(i, 'model_id'),
+        labeled(i, 'persona', 'persona'),
+        labeled(i, 'thinking_mode', 'thinking'),
+        flag(i, 'worktree'),
+        flag(i, 'fast_mode'),
+      ),
+    longFields: ['prompt'],
+  },
+  get_messages: { label: 'Get Messages', summary: (i) => labeled(i, 'chat_id', 'chat') },
+  list_automations: { label: 'List Automations' },
+  create_automation: {
+    label: 'Create Automation',
+    summary: (i) => join(value(i, 'name'), value(i, 'cron_expression')),
+    longFields: ['prompt'],
+  },
+  update_automation: {
+    label: 'Update Automation',
+    summary: (i) =>
+      join(
+        value(i, 'name') ?? labeled(i, 'automation_id', 'automation'),
+        value(i, 'cron_expression'),
+      ),
+    longFields: ['prompt'],
+  },
+  delete_automation: {
+    label: 'Delete Automation',
+    summary: (i) => labeled(i, 'automation_id', 'automation'),
+  },
+  run_automation: {
+    label: 'Run Automation',
+    summary: (i) => labeled(i, 'automation_id', 'automation'),
+  },
+};
+
+export const stripAgentRovePrefix = (toolName: string): string =>
+  toolName.startsWith(PREFIX) ? toolName.slice(PREFIX.length) : toolName;
+
+export const humanizeToolName = (name: string): string =>
+  name
+    .split('_')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+export const getDescriptor = (toolName: string): AgentRoveDescriptor => {
+  const name = stripAgentRovePrefix(toolName);
+  return DESCRIPTORS[name] ?? { label: humanizeToolName(name) || name };
+};
+
+export const buildInputSummary = (
+  toolName: string,
+  input: ToolInput | null | undefined,
+): string | null => {
+  const { summary } = getDescriptor(toolName);
+  if (!summary || !input) return null;
+  return summary(input);
+};
+
+export const collectLongInputFields = (
+  toolName: string,
+  input: ToolInput | null | undefined,
+): { key: string; text: string }[] => {
+  const { longFields } = getDescriptor(toolName);
+  if (!longFields || !input) return [];
+  return longFields.flatMap((key) => {
+    // Trim only to detect blanks — keep the raw string, whitespace matters in prompts.
+    const raw = input[key];
+    if (typeof raw !== 'string' || !raw.trim()) return [];
+    return [{ key, text: raw }];
+  });
+};
+
+// Results arrive as [{type:'text', text}] blocks holding JSON, a plain object,
+// or a bare string — never throw, always keep the text for the raw fallback.
+export const parseAgentRoveResult = (result: unknown): ParsedAgentRoveResult => {
+  if (result === null || result === undefined) return { data: null, text: '' };
+  if (isRecord(result)) return { data: result, text: formatResult(result) };
+  const text = extractResultText(result) ?? formatResult(result);
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return { data: isRecord(parsed) ? parsed : null, text };
+  } catch {
+    return { data: null, text };
+  }
+};
+
+export const summarizeResultData = (data: ToolInput | null): string | null => {
+  if (!data) return null;
+  if (data.deleted === true) return 'deleted ✓';
+  return (
+    Object.entries(data)
+      .filter(([, entry]) => Array.isArray(entry))
+      .map(([key, entry]) => `${(entry as unknown[]).length} ${key}`)
+      .join(' · ') || null
+  );
+};
+
+export const extractChatId = (data: ToolInput | null): string | null =>
+  data && typeof data.chat_id === 'string' && data.chat_id ? data.chat_id : null;

--- a/frontend/src/components/chat/tools/registry.tsx
+++ b/frontend/src/components/chat/tools/registry.tsx
@@ -105,6 +105,8 @@ const mcpLoader: ToolModuleLoader = () =>
   import('./claude/MCPTool').then((m) => ({ default: m.MCPTool }));
 const webSearchLoader: ToolModuleLoader = () =>
   import('./claude/WebSearch').then((m) => ({ default: m.WebSearch }));
+const agentRoveLoader: ToolModuleLoader = () =>
+  import('./agentrove/AgentRoveTool').then((m) => ({ default: m.AgentRoveTool }));
 
 const lazyToolComponents = new Map<string, ToolComponent>();
 
@@ -147,6 +149,11 @@ export const getToolComponent = (toolName: string, agentKind?: AgentKind): ToolC
     toolName.startsWith('mcp__web_search_prime__')
   ) {
     return getOrCreateLazy(toolName, webSearchLoader);
+  }
+
+  if (toolName.startsWith('mcp__agentrove__')) {
+    // The prefix is a collision-proof cache key — any tool name equal to it routes here.
+    return getOrCreateLazy('mcp__agentrove__', agentRoveLoader);
   }
 
   return getOrCreateLazy(toolName, mcpLoader);


### PR DESCRIPTION
## What

One custom tool-call card for the whole `mcp__agentrove__*` family — a single `AgentRoveTool` component instead of the generic `MCPTool` fallback (and instead of one component per tool).

- **Registry**: `mcp__agentrove__` prefix branch in `getToolComponent`, ahead of the generic MCP fallback, lazy-loaded like every other tool component (cache key = the prefix itself, which is collision-proof).
- **One rendering path, descriptor-driven**: a declarative map covers all 16 server tools with per-tool labels and input summaries (`send_message` → `model · persona persona · thinking tier · worktree`); unknown/future tools fall back to a humanized title, so a newer MCP server never breaks the card.
- **Defensive result parsing**: content-block JSON → plain object → bare string → malformed, never throws; parsed payloads get compact summaries (`10 personas`, `deleted ✓`) with the raw `<pre>` always available.
- **Open chat link** when a result carries a `chat_id` (`send_message`, `run_automation`, `get_current_chat`) → `/chat/:chatId`.
- **Brand mark** in the header — `icon-dark.svg`/`icon-white.svg` with the same theme swap as `BotAvatar`; loading/error states delegate to the shared `ToolCard`.

## Verification

- `tsc --noEmit`, eslint, and `npm run build` clean; lazy chunk emits correctly.
- Cross-reviewed (Bugbot); both findings fixed: cache-key collision, whitespace trimmed from long fields.
- Exercised live against the real MCP server: list counts, 102KB `list_models` payload through the raw fallback, failed `get_persona` error card, `send_message` chips + prompt + Open-chat link into a real sub-thread, both themes.

No tests by repo convention (tool components are untested); note `parseAgentRoveResult` is the one logic-bearing piece if that ever changes.