### PR TITLE
Fix automation dispatch: poison-pill, double-fire, DST repeats, orphaned rows

### DIFF
--- a/backend/app/models/schemas/automation.py
+++ b/backend/app/models/schemas/automation.py
@@ -10,6 +10,10 @@ from app.prompts.system_prompt import DEFAULT_PERSONA_NAME
 
 
 def validate_cron_expression(value: str) -> str:
+    # Syntax-only: whether the expression still has a future occurrence is
+    # timezone-dependent (calendar-constrained and year-bounded crons), so
+    # that check lives in AutomationService._compute_next_run_validated,
+    # where the automation's zone is known.
     if not croniter.is_valid(value):
         raise ValueError("Invalid cron expression")
     return value
@@ -62,6 +66,27 @@ class AutomationUpdate(BaseModel):
     worktree: bool | None = None
     selected_persona_name: str | None = Field(None, min_length=1, max_length=100)
     enabled: bool | None = None
+
+    @field_validator(
+        "name",
+        "prompt",
+        "model_id",
+        "workspace_id",
+        "cron_expression",
+        "timezone",
+        "permission_mode",
+        "worktree",
+        "selected_persona_name",
+        "enabled",
+        mode="before",
+    )
+    @classmethod
+    def reject_explicit_null(cls, value: object) -> object:
+        # None here can only mean an explicit JSON null (validators don't run
+        # for omitted fields): these columns are non-nullable, reject it.
+        if value is None:
+            raise ValueError("Field cannot be null")
+        return value
 
     @field_validator("cron_expression")
     @classmethod

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -51,6 +51,10 @@ COPILOT_SESSION_MODE_IDS: dict[str, str] = {
 CLAUDE_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "max"})
 CLAUDE_XHIGH_VALID_THINKING_MODES = CLAUDE_VALID_THINKING_MODES | {"xhigh"}
 CLAUDE_XHIGH_MODEL_IDS = frozenset({"claude-fable-5", "claude-opus-5"})
+# claude-agent-acp only advertises the "effort" config option for models that
+# report supportsEffort — Haiku doesn't, so set_config_option("effort") fails
+# with "Unknown config option: effort". Empty set = no effort dial for these.
+CLAUDE_NO_EFFORT_MODEL_IDS = frozenset({"haiku"})
 CODEX_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
 CODEX_MAX_VALID_THINKING_MODES = CODEX_VALID_THINKING_MODES | {"max"}
 CODEX_MAX_MODEL_IDS = frozenset({"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"})
@@ -99,6 +103,8 @@ THINKING_MODE_ORDER = ("low", "medium", "high", "xhigh", "max", "ultra")
 def valid_thinking_modes(agent_kind: AgentKind, model_id: str) -> frozenset[str]:
     # Accepted thinking tiers; empty = no effort dial (thinking_mode ignored).
     if agent_kind is AgentKind.CLAUDE:
+        if model_id in CLAUDE_NO_EFFORT_MODEL_IDS:
+            return frozenset()
         return (
             CLAUDE_XHIGH_VALID_THINKING_MODES
             if model_id in CLAUDE_XHIGH_MODEL_IDS
@@ -234,9 +240,11 @@ class ClaudeAgentAdapter(AgentAdapter):
 
         # Claude exposes thinking budget as the "effort" session config option,
         # applied post-handshake via set_config_option; the UI's named tiers
-        # are passed through directly as effort level IDs.
-        reasoning_effort = coerce_thinking_mode(
-            thinking_mode, valid_thinking_modes(AgentKind.CLAUDE, model_id)
+        # are passed through directly as effort level IDs. Models without the
+        # effort dial (Haiku) get None so that call is skipped entirely.
+        claude_modes = valid_thinking_modes(AgentKind.CLAUDE, model_id)
+        reasoning_effort = (
+            coerce_thinking_mode(thinking_mode, claude_modes) if claude_modes else None
         )
 
         return SessionConfig(

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -426,7 +426,9 @@ class AcpSession:
                         config.reasoning_effort,
                     )
                 except Exception:
-                    logger.warning("Failed to set initial model: %s", config.model)
+                    logger.warning(
+                        "Failed to set initial model: %s", config.model, exc_info=True
+                    )
 
             if config.permission_mode and config.permission_mode != "default":
                 try:
@@ -438,7 +440,9 @@ class AcpSession:
                     )
                 except Exception:
                     logger.warning(
-                        "Failed to set initial mode: %s", config.permission_mode
+                        "Failed to set initial mode: %s",
+                        config.permission_mode,
+                        exc_info=True,
                     )
 
             # Claude receives thinking budget via the "effort" session config
@@ -456,6 +460,7 @@ class AcpSession:
                     logger.warning(
                         "Failed to set initial effort: %s",
                         config.reasoning_effort,
+                        exc_info=True,
                     )
 
             # Fast mode is per-turn service tier state inside codex-acp; default

--- a/backend/app/services/automation.py
+++ b/backend/app/services/automation.py
@@ -4,8 +4,8 @@ from typing import Any, cast
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
-from croniter import croniter
-from sqlalchemy import select
+from croniter import CroniterError, croniter
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.constants import MODELS
@@ -18,7 +18,7 @@ from app.models.schemas.chat import ChatCreate, ChatRequest
 from app.models.types import PermissionMode
 from app.services.chat import ChatService
 from app.services.db import BaseDbService, SessionFactoryType
-from app.services.exceptions import AutomationException, ErrorCode
+from app.services.exceptions import AutomationException, ErrorCode, ServiceException
 
 logger = logging.getLogger(__name__)
 
@@ -36,13 +36,43 @@ class AutomationService(BaseDbService[Automation]):
         self._chat_service = chat_service
 
     @staticmethod
-    def compute_next_run(cron_expression: str, timezone_name: str) -> datetime:
+    def compute_next_run(
+        cron_expression: str, timezone_name: str, base: datetime | None = None
+    ) -> datetime:
         # Evaluate the cron in the automation's own zone so "daily at 9am"
         # follows the user's wall clock (incl. DST), then store UTC for the
         # dispatch comparison.
-        base = datetime.now(ZoneInfo(timezone_name))
-        next_local: datetime = croniter(cron_expression, base).get_next(datetime)
+        tz = ZoneInfo(timezone_name)
+        base = datetime.now(tz) if base is None else base.astimezone(tz)
+        it = croniter(cron_expression, base)
+        next_local: datetime = it.get_next(datetime)
+        # DST fall-back: during the repeated hour croniter can return a wall-clock
+        # time that already elapsed before `base` (naive local time moves backward
+        # while the UTC instant moves forward). Fire each wall-clock slot at most
+        # once: skip candidates whose naive local time is not after base's.
+        # Bounded: candidates advance monotonically in real time, so this scans
+        # at most one repeated hour (~82ms worst case for an every-second cron,
+        # once a year; 0.2ms for minute-level crons).
+        while next_local.replace(tzinfo=None) <= base.replace(tzinfo=None):
+            next_local = it.get_next(datetime)
         return next_local.astimezone(timezone.utc)
+
+    def _compute_next_run_validated(
+        self, cron_expression: str, timezone_name: str
+    ) -> datetime:
+        # The schema's croniter.is_valid check is syntax-only and timezone-blind:
+        # whether a calendar-constrained or year-bounded expression still has a
+        # future slot depends on the automation's own zone (a UTC-based probe
+        # mis-judges around year boundaries), so the authoritative check is here.
+        try:
+            return self.compute_next_run(cron_expression, timezone_name)
+        except CroniterError as e:
+            raise AutomationException(
+                "Cron expression has no future occurrence in its timezone",
+                error_code=ErrorCode.VALIDATION_ERROR,
+                details={"cron_expression": cron_expression},
+                status_code=400,
+            ) from e
 
     @staticmethod
     def _validate_model(model_id: str) -> None:
@@ -107,7 +137,9 @@ class AutomationService(BaseDbService[Automation]):
             automation = Automation(
                 user_id=user.id,
                 **data.model_dump(),
-                next_run_at=self.compute_next_run(data.cron_expression, data.timezone),
+                next_run_at=self._compute_next_run_validated(
+                    data.cron_expression, data.timezone
+                ),
             )
             db.add(automation)
             await db.commit()
@@ -127,7 +159,7 @@ class AutomationService(BaseDbService[Automation]):
             for field, value in changes.items():
                 setattr(automation, field, value)
             if SCHEDULE_FIELDS & changes.keys():
-                automation.next_run_at = self.compute_next_run(
+                automation.next_run_at = self._compute_next_run_validated(
                     automation.cron_expression, automation.timezone
                 )
             await db.commit()
@@ -153,6 +185,8 @@ class AutomationService(BaseDbService[Automation]):
         # Dispatch job entry point. Advances schedules before firing so a crash
         # mid-dispatch can't re-fire the same slot on the next poll.
         now = datetime.now(timezone.utc)
+        to_fire: list[Automation] = []
+        users: dict[UUID, User] = {}
         async with self.session_factory() as db:
             result = await db.execute(
                 select(Automation).filter(
@@ -161,28 +195,97 @@ class AutomationService(BaseDbService[Automation]):
                 )
             )
             due = list(result.scalars().all())
-            users: dict[UUID, User] = {}
             for automation in due:
-                automation.last_run_at = now
-                automation.next_run_at = self.compute_next_run(
-                    automation.cron_expression, automation.timezone
-                )
-                if automation.user_id not in users:
-                    users[automation.user_id] = await db.get_one(
-                        User, automation.user_id
+                # A row whose schedule can no longer be computed (exhausted
+                # year-bounded cron, timezone dropped from tzdata) must not
+                # abort the batch: disable it and move on.
+                try:
+                    next_run = self.compute_next_run(
+                        automation.cron_expression, automation.timezone
                     )
+                except Exception:
+                    logger.exception(
+                        "Automation %s (%s) schedule is uncomputable; disabling",
+                        automation.id,
+                        automation.name,
+                    )
+                    # Guarded like the claim below: a concurrent repair (PATCH
+                    # of a schedule field) recomputes next_run_at, so only the
+                    # still-broken row is disabled — never a just-fixed one.
+                    await db.execute(
+                        update(Automation)
+                        .where(
+                            Automation.id == automation.id,
+                            Automation.next_run_at == automation.next_run_at,
+                        )
+                        .values(enabled=False)
+                        .execution_options(synchronize_session=False)
+                    )
+                    continue
+                try:
+                    if automation.user_id not in users:
+                        users[automation.user_id] = await db.get_one(
+                            User, automation.user_id
+                        )
+                except Exception:
+                    # Likely transient; leave the row due and retry next tick.
+                    logger.exception(
+                        "Automation %s: could not load user %s; skipping tick",
+                        automation.id,
+                        automation.user_id,
+                    )
+                    continue
+                # Compare-and-swap claim: only the dispatcher that advances the
+                # row fires it, so a concurrent process can't double-fire a slot.
+                claim = await db.execute(
+                    update(Automation)
+                    .where(
+                        Automation.id == automation.id,
+                        Automation.next_run_at == automation.next_run_at,
+                    )
+                    .values(next_run_at=next_run, last_run_at=now)
+                    .execution_options(synchronize_session=False)
+                )
+                if claim.rowcount == 1:
+                    to_fire.append(automation)
             await db.commit()
 
-        for automation in due:
+        for automation in to_fire:
             try:
                 await self._fire(automation, users[automation.user_id])
+            except ServiceException as exc:
+                if exc.error_code == ErrorCode.WORKSPACE_NOT_FOUND:
+                    # Soft-deleted workspace: the run can never succeed again.
+                    await self._disable_for_missing_workspace(automation)
+                logger.exception(
+                    "Automation %s (%s) failed to start",
+                    automation.id,
+                    automation.name,
+                )
             except Exception:
-                # One broken automation (deleted workspace, retired model) must
-                # not block the rest of the batch.
                 logger.exception(
                     "Automation %s (%s) failed to start", automation.id, automation.name
                 )
         return {}
+
+    async def _disable_for_missing_workspace(self, automation: Automation) -> None:
+        async with self.session_factory() as db:
+            await db.execute(
+                update(Automation)
+                .where(
+                    Automation.id == automation.id,
+                    # Guard against a concurrent repair: only disable if the
+                    # row still points at the workspace that just failed.
+                    Automation.workspace_id == automation.workspace_id,
+                )
+                .values(enabled=False)
+            )
+            await db.commit()
+        logger.warning(
+            "Automation %s disabled: workspace %s deleted",
+            automation.id,
+            automation.workspace_id,
+        )
 
     async def _fire(self, automation: Automation, user: User) -> Chat:
         # Re-check the saved model before creating the chat — a model retired
@@ -199,16 +302,26 @@ class AutomationService(BaseDbService[Automation]):
                 workspace_id=automation.workspace_id,
             ),
         )
-        await self._chat_service.initiate_chat_completion(
-            ChatRequest(
-                prompt=automation.prompt,
-                chat_id=chat.id,
-                model_id=automation.model_id,
-                permission_mode=cast(PermissionMode, automation.permission_mode),
-                thinking_mode=automation.thinking_mode,
-                worktree=automation.worktree,
-                selected_persona_name=automation.selected_persona_name,
-            ),
-            user,
-        )
+        try:
+            await self._chat_service.initiate_chat_completion(
+                ChatRequest(
+                    prompt=automation.prompt,
+                    chat_id=chat.id,
+                    model_id=automation.model_id,
+                    permission_mode=cast(PermissionMode, automation.permission_mode),
+                    thinking_mode=automation.thinking_mode,
+                    worktree=automation.worktree,
+                    selected_persona_name=automation.selected_persona_name,
+                ),
+                user,
+            )
+        except Exception:
+            # Don't leave an empty orphan chat for a run that never started.
+            try:
+                await self._chat_service.delete_chat(chat.id, user)
+            except Exception:
+                logger.exception(
+                    "Failed to clean up chat %s after initiation failure", chat.id
+                )
+            raise
         return chat

--- a/backend/app/services/workspace.py
+++ b/backend/app/services/workspace.py
@@ -10,10 +10,11 @@ from pathlib import Path
 from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
-from sqlalchemy import func, select, update
+from sqlalchemy import delete, func, select, update
 
 from app.constants import BUILTIN_SLASH_COMMANDS
 from app.core.config import get_settings
+from app.models.db_models.automation import Automation
 from app.models.db_models.chat import Chat, Message
 from app.models.db_models.user import User
 from app.models.db_models.workspace import Workspace
@@ -315,6 +316,12 @@ class WorkspaceService(BaseDbService[Workspace]):
                     )
                     .values(deleted_at=now)
                 )
+
+            # Soft-delete never fires the FK CASCADE: remove this workspace's
+            # automations outright or they keep firing into a deleted workspace.
+            await db.execute(
+                delete(Automation).where(Automation.workspace_id == workspace_id)
+            )
 
             await db.commit()
 

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.constants import REDIS_KEY_USER_STREAMS_LIVE
 from app.core.config import get_settings
 from app.models.db_models.workspace import Workspace
-from app.services.acp.adapters import AgentKind, GrokAgentAdapter
+from app.services.acp.adapters import AgentKind, ClaudeAgentAdapter, GrokAgentAdapter
 from app.services.acp.session import AcpSessionConfig
 from app.services.sandbox_providers import SandboxProviderType
 from app.services.session_registry import session_registry
@@ -96,6 +96,36 @@ def test_grok_launch_args_apply_always_approve_flag(
     )
 
     assert launch.cli_args == expected_args
+
+
+@pytest.mark.parametrize(
+    "model_id,thinking_mode,expected_effort",
+    [
+        # Haiku has no effort dial in claude-agent-acp (supportsEffort false);
+        # sending "effort" would fail with "Unknown config option: effort".
+        ("haiku", None, None),
+        ("haiku", "medium", None),
+        ("haiku", "high", None),
+        ("sonnet", None, "medium"),
+        ("sonnet", "high", "high"),
+        ("sonnet", "xhigh", "medium"),  # xhigh is fable/opus-only; clamps
+        ("claude-opus-5", "xhigh", "xhigh"),
+    ],
+)
+def test_claude_session_config_gates_effort_by_model(
+    model_id: str,
+    thinking_mode: str | None,
+    expected_effort: str | None,
+) -> None:
+    session_config = ClaudeAgentAdapter().build_session_config(
+        system_prompt=None,
+        system_prompt_is_full_replace=False,
+        model_id=model_id,
+        thinking_mode=thinking_mode,
+        permission_mode="default",
+    )
+
+    assert session_config.reasoning_effort == expected_effort
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_automation_validation.py
+++ b/backend/tests/test_automation_validation.py
@@ -1,0 +1,236 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.db_models.automation import Automation
+from app.models.db_models.workspace import Workspace
+from app.services.sandbox_providers.base import SandboxProvider
+
+from tests.conftest import LoginClient, UserFactory
+from tests.helpers import FakeProviderFactory, create_authenticated_workspace
+from tests.test_automations import TEST_MODEL_ID, automation_payload
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def workspace_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(SandboxProvider, "create_provider", FakeProviderFactory())
+
+
+@pytest.mark.parametrize("cron_expression", ["0 0 30 2 *", "0 0 * * * 0 2020"])
+async def test_create_automation_rejects_cron_without_future_occurrence(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    cron_expression: str,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id, cron_expression=cron_expression),
+        headers=headers,
+    )
+
+    # 400 from the service, not 422 from the schema: "has a future occurrence"
+    # is timezone-dependent, so it is checked where the zone is known.
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("cron_expression", ["0 0 30 2 *", "0 0 * * * 0 2020"])
+async def test_update_automation_rejects_cron_without_future_occurrence(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    cron_expression: str,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id),
+        headers=headers,
+    )
+    automation_id = created.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/automations/{automation_id}",
+        json={"cron_expression": cron_expression},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    unchanged = await client.get("/api/v1/automations", headers=headers)
+    assert unchanged.json()[0]["cron_expression"] == "0 9 * * *"
+
+
+async def test_create_automation_accepts_ordinary_cron(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+
+    response = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id, cron_expression="0 9 * * *"),
+        headers=headers,
+    )
+
+    assert response.status_code == 201
+    assert response.json()["cron_expression"] == "0 9 * * *"
+
+
+@pytest.mark.parametrize("field", ["cron_expression", "timezone", "enabled"])
+async def test_update_automation_rejects_explicit_null(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    field: str,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id),
+        headers=headers,
+    )
+    automation_id = created.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/automations/{automation_id}",
+        json={field: None},
+        headers=headers,
+    )
+
+    assert response.status_code == 422
+
+
+async def test_update_automation_accepts_null_thinking_mode(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id, thinking_mode="think"),
+        headers=headers,
+    )
+    automation_id = created.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/automations/{automation_id}",
+        json={"thinking_mode": None},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["thinking_mode"] is None
+
+
+async def test_update_automation_accepts_empty_payload(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    headers, _user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    created = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(workspace.id),
+        headers=headers,
+    )
+    automation_id = created.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/automations/{automation_id}",
+        json={},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["cron_expression"] == "0 9 * * *"
+    assert response.json()["next_run_at"] == created.json()["next_run_at"]
+
+
+async def test_delete_workspace_removes_its_automations_only(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+    workspace_sandbox: None,
+) -> None:
+    headers, user, first_workspace = await create_authenticated_workspace(
+        db_session,
+        create_user,
+        login,
+        email="automation-delete@example.com",
+        username="automationdelete",
+    )
+    second_workspace = Workspace(
+        name="Second Workspace",
+        user_id=user.id,
+        sandbox_id="sandbox-automationdelete-2",
+        sandbox_provider="host",
+        workspace_path="/tmp/agentrove-test-automationdelete-2",
+        source_type="empty",
+        source_url=None,
+    )
+    db_session.add(second_workspace)
+    await db_session.commit()
+    await db_session.refresh(second_workspace)
+
+    enabled = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(first_workspace.id, name="Enabled"),
+        headers=headers,
+    )
+    disabled = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(first_workspace.id, name="Disabled"),
+        headers=headers,
+    )
+    survivor = await client.post(
+        "/api/v1/automations",
+        json=automation_payload(
+            second_workspace.id, name="Survivor", model_id=TEST_MODEL_ID
+        ),
+        headers=headers,
+    )
+    assert enabled.status_code == 201
+    assert survivor.status_code == 201
+    disable_response = await client.patch(
+        f"/api/v1/automations/{disabled.json()['id']}",
+        json={"enabled": False},
+        headers=headers,
+    )
+    assert disable_response.status_code == 200
+
+    response = await client.delete(
+        f"/api/v1/workspaces/{first_workspace.id}", headers=headers
+    )
+
+    assert response.status_code == 204
+    listed = await client.get("/api/v1/automations", headers=headers)
+    assert [item["name"] for item in listed.json()] == ["Survivor"]
+    remaining = await db_session.execute(select(Automation.workspace_id))
+    assert remaining.scalars().all() == [second_workspace.id]

--- a/backend/tests/test_automations.py
+++ b/backend/tests/test_automations.py
@@ -1,17 +1,21 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
 
 import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_automation_service
+from app.db.session import SessionLocal
+from app.models.db_models.automation import Automation
 from app.models.db_models.chat import Chat
 from app.models.db_models.user import User
 from app.models.schemas.chat import ChatCreate, ChatRequest
 from app.services.automation import AutomationService
-from app.services.exceptions import ChatException
+from app.services.exceptions import ChatException, ErrorCode
 
 from tests.conftest import LoginClient, UserFactory
 from tests.helpers import create_authenticated_workspace
@@ -26,13 +30,20 @@ TEST_MODEL_ID = "opencode:google-vertex-anthropic/claude-sonnet-4-5@20250929"
 class FakeChatService:
     def __init__(self) -> None:
         self.created_chats: list[ChatCreate] = []
+        self.created_chat_ids: list[UUID] = []
         self.completions: list[tuple[ChatRequest, User]] = []
+        self.deleted_chats: list[UUID] = []
+        self.create_error: ChatException | None = None
         self.completion_error: ChatException | None = None
 
     async def create_chat(self, user: User, chat_data: ChatCreate) -> Chat:
+        if self.create_error:
+            raise self.create_error
         self.created_chats.append(chat_data)
+        chat_id = uuid4()
+        self.created_chat_ids.append(chat_id)
         return Chat(
-            id=uuid4(),
+            id=chat_id,
             title=chat_data.title,
             user_id=user.id,
             workspace_id=chat_data.workspace_id,
@@ -42,6 +53,9 @@ class FakeChatService:
         if self.completion_error:
             raise self.completion_error
         self.completions.append((request, user))
+
+    async def delete_chat(self, chat_id: UUID, user: User) -> None:
+        self.deleted_chats.append(chat_id)
 
 
 class AutomationServiceOverride:
@@ -571,3 +585,247 @@ async def test_run_automation_translates_chat_completion_error(
 
     assert response.status_code == 503
     assert response.json()["detail"] == "Provider unavailable"
+
+
+async def test_due_automation_isolates_uncomputable_schedule(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    _headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    poison = Automation(
+        user_id=user.id,
+        workspace_id=workspace.id,
+        name="Exhausted schedule",
+        prompt="Never runs",
+        model_id=TEST_MODEL_ID,
+        cron_expression="0 0 * * * 0 2020",
+        timezone="UTC",
+        next_run_at=datetime.now(timezone.utc) - timedelta(minutes=2),
+    )
+    healthy = Automation(
+        user_id=user.id,
+        workspace_id=workspace.id,
+        name="Healthy schedule",
+        prompt="Runs once",
+        model_id=TEST_MODEL_ID,
+        cron_expression="0 9 * * *",
+        timezone="UTC",
+        next_run_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+    )
+    db_session.add_all([poison, healthy])
+    await db_session.commit()
+    fake_chat_service = FakeChatService()
+
+    await AutomationService(fake_chat_service).run_due_automations()
+
+    await db_session.refresh(poison)
+    assert poison.enabled is False
+    assert len(fake_chat_service.completions) == 1
+    assert fake_chat_service.completions[0][0].prompt == "Runs once"
+
+
+async def test_due_automation_slot_fires_only_once(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    _headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    automation = Automation(
+        user_id=user.id,
+        workspace_id=workspace.id,
+        name="Due once",
+        prompt="Run once",
+        model_id=TEST_MODEL_ID,
+        cron_expression="0 9 * * *",
+        timezone="UTC",
+        next_run_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+    )
+    db_session.add(automation)
+    await db_session.commit()
+    fake_chat_service = FakeChatService()
+    service = AutomationService(fake_chat_service)
+
+    await service.run_due_automations()
+    await service.run_due_automations()
+
+    assert len(fake_chat_service.completions) == 1
+
+
+async def test_due_automation_advanced_by_other_session_is_not_fired(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    _headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    automation = Automation(
+        user_id=user.id,
+        workspace_id=workspace.id,
+        name="Already claimed",
+        prompt="Do not run",
+        model_id=TEST_MODEL_ID,
+        cron_expression="0 9 * * *",
+        timezone="UTC",
+        next_run_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+    )
+    db_session.add(automation)
+    await db_session.commit()
+    async with SessionLocal() as second_session:
+        loaded = await second_session.get_one(Automation, automation.id)
+        loaded.next_run_at = datetime.now(timezone.utc) + timedelta(days=1)
+        await second_session.commit()
+    fake_chat_service = FakeChatService()
+
+    await AutomationService(fake_chat_service).run_due_automations()
+
+    assert fake_chat_service.completions == []
+
+
+async def test_automation_claim_compare_and_swap_rejects_wrong_expected_time(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    _headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    due_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    automation = Automation(
+        user_id=user.id,
+        workspace_id=workspace.id,
+        name="CAS target",
+        prompt="Do not claim",
+        model_id=TEST_MODEL_ID,
+        cron_expression="0 9 * * *",
+        timezone="UTC",
+        next_run_at=due_at,
+    )
+    db_session.add(automation)
+    await db_session.commit()
+    await db_session.refresh(automation)
+
+    claim = await db_session.execute(
+        update(Automation)
+        .where(
+            Automation.id == automation.id,
+            Automation.next_run_at == due_at - timedelta(seconds=1),
+        )
+        .values(next_run_at=datetime.now(timezone.utc) + timedelta(days=1))
+        .execution_options(synchronize_session=False)
+    )
+    await db_session.commit()
+
+    assert claim.rowcount == 0
+    stored = await db_session.scalar(
+        select(Automation).where(Automation.id == automation.id)
+    )
+    assert stored is not None
+    assert stored.next_run_at == due_at
+
+
+def test_compute_next_run_skips_repeated_fall_back_slot() -> None:
+    next_run = AutomationService.compute_next_run(
+        "30 1 * * *",
+        "America/New_York",
+        base=datetime(2026, 11, 1, 1, 35, tzinfo=ZoneInfo("America/New_York")),
+    )
+
+    assert next_run == datetime(2026, 11, 2, 6, 30, tzinfo=timezone.utc)
+
+
+def test_compute_next_run_normal_day() -> None:
+    next_run = AutomationService.compute_next_run(
+        "30 1 * * *",
+        "America/New_York",
+        base=datetime(2026, 6, 1, 0, 0, tzinfo=ZoneInfo("America/New_York")),
+    )
+
+    assert next_run == datetime(2026, 6, 1, 5, 30, tzinfo=timezone.utc)
+
+
+def test_compute_next_run_skips_repeated_hour_for_sub_hourly_cron() -> None:
+    next_run = AutomationService.compute_next_run(
+        "* * * * *",
+        "America/New_York",
+        base=datetime(2026, 11, 1, 1, 59, 30, tzinfo=ZoneInfo("America/New_York")),
+    )
+
+    assert next_run == datetime(2026, 11, 1, 7, 0, tzinfo=timezone.utc)
+
+
+async def test_due_automation_disables_when_workspace_is_gone(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    _headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    automation = Automation(
+        user_id=user.id,
+        workspace_id=workspace.id,
+        name="Deleted workspace",
+        prompt="Cannot run",
+        model_id=TEST_MODEL_ID,
+        cron_expression="0 9 * * *",
+        timezone="UTC",
+        next_run_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+    )
+    db_session.add(automation)
+    await db_session.commit()
+    fake_chat_service = FakeChatService()
+    fake_chat_service.create_error = ChatException(
+        "Workspace not found",
+        error_code=ErrorCode.WORKSPACE_NOT_FOUND,
+        status_code=404,
+    )
+
+    await AutomationService(fake_chat_service).run_due_automations()
+
+    await db_session.refresh(automation)
+    assert automation.enabled is False
+
+
+async def test_initiation_failure_cleans_up_manual_and_due_chats(
+    db_session: AsyncSession,
+    create_user: UserFactory,
+    login: LoginClient,
+) -> None:
+    _headers, user, workspace = await create_authenticated_workspace(
+        db_session, create_user, login
+    )
+    automation = Automation(
+        user_id=user.id,
+        workspace_id=workspace.id,
+        name="Failed initiation",
+        prompt="Cannot start",
+        model_id=TEST_MODEL_ID,
+        cron_expression="0 9 * * *",
+        timezone="UTC",
+        next_run_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+    )
+    db_session.add(automation)
+    await db_session.commit()
+    await db_session.refresh(automation)
+    fake_chat_service = FakeChatService()
+    fake_chat_service.completion_error = ChatException(
+        "Provider unavailable", status_code=503
+    )
+    service = AutomationService(fake_chat_service)
+
+    with pytest.raises(ChatException, match="Provider unavailable"):
+        await service.run_automation(automation.id, user)
+
+    assert fake_chat_service.deleted_chats == [fake_chat_service.created_chat_ids[0]]
+    manual_deleted_chat = fake_chat_service.deleted_chats[0]
+    await service.run_due_automations()
+
+    assert len(fake_chat_service.deleted_chats) == 2
+    assert fake_chat_service.deleted_chats[0] == manual_deleted_chat
+    assert fake_chat_service.deleted_chats[1] != manual_deleted_chat

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -36,9 +36,11 @@ async def test_list_models_returns_registered_models(
         "name": MODELS["haiku"].display_name,
         "agent_kind": MODELS["haiku"].agent_kind.value,
         "context_window": MODELS["haiku"].context_window,
-        "thinking_modes": ["low", "medium", "high", "max"],
+        # Haiku has no effort dial in claude-agent-acp (supportsEffort false).
+        "thinking_modes": [],
     } in body
     by_id = {item["model_id"]: item for item in body}
+    assert by_id["sonnet"]["thinking_modes"] == ["low", "medium", "high", "max"]
     assert by_id["claude-fable-5"]["thinking_modes"] == [
         "low",
         "medium",

--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -19,6 +19,10 @@ const CLAUDE_XHIGH_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'max', label: 'Max' },
 ];
 const CLAUDE_XHIGH_MODEL_IDS = new Set(['claude-fable-5', 'claude-opus-5']);
+// claude-agent-acp only exposes the effort dial for models that report
+// supportsEffort — Haiku doesn't, so hide the selector. Mirrors
+// CLAUDE_NO_EFFORT_MODEL_IDS in backend app/services/acp/adapters.py.
+const CLAUDE_NO_EFFORT_MODEL_IDS = new Set(['haiku']);
 
 const CODEX_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'low', label: 'Low' },
@@ -78,7 +82,11 @@ export function getThinkingModesForAgent(
   agentKind: AgentKind,
   modelId?: string,
 ): ThinkingModeOption[] {
-  // Claude only exposes `xhigh` on selected high-capability models.
+  // Claude gates the effort dial per model: none at all on Haiku, and
+  // `xhigh` only on selected high-capability models.
+  if (agentKind === 'claude' && modelId && CLAUDE_NO_EFFORT_MODEL_IDS.has(modelId)) {
+    return EMPTY_THINKING_MODES;
+  }
   if (agentKind === 'claude' && modelId && CLAUDE_XHIGH_MODEL_IDS.has(modelId)) {
     return CLAUDE_XHIGH_THINKING_MODES;
   }


### PR DESCRIPTION
## Summary

Review of `backend/app/services/automation.py` surfaced 7 verified bugs (1 critical). This PR fixes all of them, each with regression tests. All claims below were reproduced empirically before fixing.

### Critical
- **One bad cron could permanently kill dispatch for every user.** `croniter.is_valid` accepts year-bounded expressions (`0 0 * * * 0 2026`); once exhausted, `compute_next_run` raised inside the pre-commit dispatch loop → rollback → row stays due → every 60s tick crashes forever. Now: per-row isolation, the broken row is disabled (guarded on `next_run_at` so a concurrently repaired automation is never wrongly disabled), and the batch continues.

### High
- **Workspace soft-delete orphaned automations.** Soft-delete never fires the FK CASCADE, so automations kept firing into a deleted workspace (silent per-slot failure, forever). Now: `delete_workspace` hard-deletes its automations, and the dispatcher additionally auto-disables on `WORKSPACE_NOT_FOUND` (guarded on `workspace_id`).
- **Latent multi-process double-fire.** The dispatcher starts per FastAPI lifespan with no row claim; `--workers 2` would double-fire every slot. Now: compare-and-swap claim (`WHERE id AND next_run_at = <selected value>`); only `rowcount == 1` fires.

### Medium
- **`PATCH {"cron_expression": null}` → 500.** Explicit JSON nulls on non-nullable fields are now rejected with 422 (`thinking_mode` stays nullable; omitted fields unaffected).
- **Calendar-impossible crons → 500.** `0 0 30 2 *` passed `is_valid` but blew up on compute. The authoritative "has a future occurrence" check now lives in the service, evaluated in the automation's own timezone → clean 400. (A schema-level UTC probe was considered and rejected: it mis-judges year-bounded crons near year boundaries.)
- **Orphan empty chat on failed initiation.** `_fire` now deletes the just-created chat and re-raises.

### Low
- **DST fall-back double-fire.** Crons in the repeated 1–2am hour fired twice on fall-back day (verified: `30 1 * * *` America/New_York → 05:30Z and 06:30Z). `compute_next_run` now skips wall-clock repeats (once-per-wall-clock semantics; bounded scan, worst case ~82ms once a year for every-second crons; verified against Lord Howe 30-min DST, spring-forward, and exhaustion-during-fold).

### Design invariants preserved
- At-most-once: schedules advance and commit **before** firing; crashes lose a run, never repeat one.
- Missed slots coalesce (advance from `now`) — unchanged, intentional.
- Manual "Run now" still stacks with the scheduled slot — documented intent, untouched.

## Also included (separate commit)
**Gate Claude effort dial per model (a16d7077):** claude-agent-acp rejects the `effort` config option for models without `supportsEffort` — Haiku sessions failed with "Unknown config option: effort" on every start. Backend now returns no thinking modes for Haiku and skips the effort call; frontend hides the selector to match; ACP warning logs gain `exc_info`; parametrized effort-gating tests added.

## Test plan
- 13 new automation regression tests (poison isolation, CAS claim semantics, slot idempotence, DST fold ×3 zones/cases, workspace-gone auto-disable, orphan cleanup, explicit-null 422s, impossible-cron 400s on create+update, workspace-delete cleanup) + parametrized ACP effort-gating tests.
- Full backend suite: **385 passed** (run with both commits' changes in the tree). Ruff clean; frontend `tsc --noEmit` clean.