### PR TITLE
Chat mentions in the composer (@chat:<id>, resolved via agentrove MCP)

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -244,12 +244,17 @@ async def ask_about_code(
 async def get_chats(
     workspace_id: UUID | None = None,
     pinned: bool | None = None,
+    include_sub_threads: bool = False,
     pagination: PaginationParams = Depends(),
     current_user: User = Depends(get_current_user),
     chat_service: ChatService = Depends(get_chat_service),
 ) -> PaginatedResponse[ChatSchema]:
     return await chat_service.get_user_chats(
-        current_user, pagination, workspace_id=workspace_id, pinned=pinned
+        current_user,
+        pagination,
+        workspace_id=workspace_id,
+        pinned=pinned,
+        include_sub_threads=include_sub_threads,
     )
 
 

--- a/backend/app/prompts/system_prompt.py
+++ b/backend/app/prompts/system_prompt.py
@@ -25,6 +25,17 @@ Guidelines for suggestions:
 """
 
 
+CHAT_MENTIONS_INSTRUCTIONS = """
+<chat_mentions_instructions>
+User messages may contain @chat:<chat_id> tokens referencing other AgentRove chats.
+The referenced chat's content is NOT included in the prompt. To read it, call the
+agentrove MCP get_messages tool with that chat_id: the first call returns the most
+recent messages, and passing next_cursor pages back through older ones (repeat while
+has_more is true to read the full history).
+</chat_mentions_instructions>
+"""
+
+
 DEFAULT_PERSONA_NAME = "Default"
 
 
@@ -51,4 +62,4 @@ def build_system_prompt_for_chat(
         if persona:
             persona_content = f"\n{persona['content']}\n"
 
-    return f"{persona_content}\n{PROMPT_SUGGESTIONS_INSTRUCTIONS}"
+    return f"{persona_content}\n{CHAT_MENTIONS_INSTRUCTIONS}\n{PROMPT_SUGGESTIONS_INSTRUCTIONS}"

--- a/backend/app/services/chat.py
+++ b/backend/app/services/chat.py
@@ -87,8 +87,10 @@ class ChatService(BaseDbService[Chat]):
         pagination: PaginationParams | None = None,
         workspace_id: UUID | None = None,
         pinned: bool | None = None,
+        include_sub_threads: bool = False,
     ) -> PaginatedResponse[ChatSchema]:
-        # Top-level chats only; pinned first, then recency. Optional workspace/pinned filters.
+        # Top-level chats by default (include_sub_threads=True adds sub-threads,
+        # e.g. for composer @chat mentions); pinned first, then recency.
         if pagination is None:
             pagination = PaginationParams()
 
@@ -96,8 +98,9 @@ class ChatService(BaseDbService[Chat]):
             base_filters = [
                 Chat.user_id == user.id,
                 Chat.deleted_at.is_(None),
-                Chat.parent_chat_id.is_(None),
             ]
+            if not include_sub_threads:
+                base_filters.append(Chat.parent_chat_id.is_(None))
             if workspace_id is not None:
                 base_filters.append(Chat.workspace_id == workspace_id)
             if pinned is True:

--- a/frontend/src/components/chat/message-input/Input.test.tsx
+++ b/frontend/src/components/chat/message-input/Input.test.tsx
@@ -32,6 +32,10 @@ vi.mock('@/hooks/queries/useModelQueries', () => ({
   useModelMap: () => new Map(),
 }));
 
+vi.mock('@/hooks/queries/useChatQueries', () => ({
+  useRecentChatsQuery: () => ({ data: undefined }),
+}));
+
 const uiState = { composerSelectionsByChat: {} as Record<string, unknown[]> };
 vi.mock('@/store/uiStore', () => {
   const useUIStore = (selector: (s: typeof uiState) => unknown) => selector(uiState);
@@ -89,6 +93,7 @@ vi.mock('@/hooks/useInputSuggestions', () => ({
     selectSlashCommand: vi.fn(),
     handleSlashCommandKeyDown: () => false,
     filteredFiles: [],
+    filteredChats: [],
     highlightedMentionIndex: -1,
     selectMention: vi.fn(),
     handleMentionKeyDown: () => false,

--- a/frontend/src/components/chat/message-input/InputContext.ts
+++ b/frontend/src/components/chat/message-input/InputContext.ts
@@ -34,6 +34,7 @@ export interface InputState {
   slashCommandSuggestions: SlashCommand[];
   highlightedSlashCommandIndex: number;
   filteredFiles: MentionItem[];
+  filteredChats: MentionItem[];
   highlightedMentionIndex: number;
 }
 

--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useMemo, type ReactNode } from 'react';
 import { useAuthStore } from '@/store/authStore';
 import { useUIStore, type ComposerSelection } from '@/store/uiStore';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
+import { useRecentChatsQuery } from '@/hooks/queries/useChatQueries';
 import { useChatContext } from '@/hooks/useChatContext';
 import { useInputAttachments } from '@/hooks/useInputAttachments';
 import { useInputEnhance } from '@/hooks/useInputEnhance';
@@ -17,7 +18,7 @@ import {
   type InputContextValue,
 } from './InputContext';
 import type { InputProps } from './Input';
-import { getAgentKindForModelId, type AgentKind } from '@/types/chat.types';
+import { getAgentKindForModelId, type AgentKind, type Chat } from '@/types/chat.types';
 
 // Agents whose ACP servers don't emit UsageUpdate notifications — the context
 // window indicator stays at 0 for these, so we hide it entirely.
@@ -30,6 +31,7 @@ const AGENTS_WITHOUT_USAGE_UPDATE: ReadonlySet<AgentKind> = new Set([
 
 // Stable fallback so chat-less composers (landing page) don't churn the selector.
 const NO_SELECTIONS: ComposerSelection[] = [];
+const NO_CHATS: Chat[] = [];
 
 export function InputProvider({
   message,
@@ -58,6 +60,7 @@ export function InputProvider({
   // `/models/` is auth-protected; gate so the public landing composer doesn't 401.
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const modelMap = useModelMap(isAuthenticated);
+  const { data: recentChats } = useRecentChatsQuery(isAuthenticated);
   const agentKind =
     modelMap.get(selectedModelId)?.agent_kind ?? getAgentKindForModelId(selectedModelId);
   // Hide the context-usage indicator for agents whose ACP servers never emit
@@ -120,6 +123,7 @@ export function InputProvider({
     selectSlashCommand,
     handleSlashCommandKeyDown,
     filteredFiles,
+    filteredChats,
     highlightedMentionIndex,
     selectMention,
     handleMentionKeyDown,
@@ -132,6 +136,8 @@ export function InputProvider({
     messageRef,
     textareaRef,
     fileStructure,
+    mentionChats: recentChats?.items ?? NO_CHATS,
+    chatId,
     customSkills,
     builtinSlashCommands,
     agentKind,
@@ -195,6 +201,7 @@ export function InputProvider({
       slashCommandSuggestions,
       highlightedSlashCommandIndex,
       filteredFiles,
+      filteredChats,
       highlightedMentionIndex,
     }),
     [
@@ -228,6 +235,7 @@ export function InputProvider({
       slashCommandSuggestions,
       highlightedSlashCommandIndex,
       filteredFiles,
+      filteredChats,
       highlightedMentionIndex,
     ],
   );

--- a/frontend/src/components/chat/message-input/InputSuggestionsPanel.tsx
+++ b/frontend/src/components/chat/message-input/InputSuggestionsPanel.tsx
@@ -11,6 +11,7 @@ export const InputSuggestionsPanel = memo(function InputSuggestionsPanel() {
     return (
       <MentionSuggestionsPanel
         files={state.filteredFiles}
+        chats={state.filteredChats}
         highlightedIndex={state.highlightedMentionIndex}
         onSelect={actions.selectMention}
       />

--- a/frontend/src/components/chat/message-input/MentionSuggestionsPanel.module.scss
+++ b/frontend/src/components/chat/message-input/MentionSuggestionsPanel.module.scss
@@ -1,6 +1,6 @@
 @use '@/styles/globals/typography' as type;
 
-.file-row {
+.item-row {
   display: flex;
   min-width: 0;
   flex: 1;
@@ -8,13 +8,14 @@
   gap: var(--space-0-5);
 }
 
-.file-icon {
+.item-icon {
   height: var(--space-4);
   width: var(--space-4);
 }
 
-.file-name {
+.item-name {
   @include type.type-mono(0.9rem, 1.25);
+  @include type.type-overflow;
   color: var(--theme-text-secondary);
 
   &--active {
@@ -22,7 +23,7 @@
   }
 }
 
-.file-path {
+.item-path {
   @include type.type-meta;
   @include type.type-overflow;
   color: var(--theme-text-tertiary);

--- a/frontend/src/components/chat/message-input/MentionSuggestionsPanel.tsx
+++ b/frontend/src/components/chat/message-input/MentionSuggestionsPanel.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo } from 'react';
 import clsx from 'clsx';
+import { MessageSquare } from 'lucide-react';
 import { SuggestionPanel } from './SuggestionPanel';
 import { MentionIcon } from './MentionIcon';
 import type { MentionItem } from '@/types/ui.types';
@@ -7,6 +8,7 @@ import styles from './MentionSuggestionsPanel.module.scss';
 
 interface MentionSuggestionsPanelProps {
   files: MentionItem[];
+  chats: MentionItem[];
   highlightedIndex: number;
   onSelect: (item: MentionItem) => void;
 }
@@ -14,21 +16,35 @@ interface MentionSuggestionsPanelProps {
 function renderFile(file: MentionItem, isActive: boolean) {
   return (
     <>
-      <MentionIcon name={file.name} className={styles['file-icon']} />
-      <div className={styles['file-row']}>
-        <span className={clsx(styles['file-name'], isActive && styles['file-name--active'])}>
+      <MentionIcon name={file.name} className={styles['item-icon']} />
+      <div className={styles['item-row']}>
+        <span className={clsx(styles['item-name'], isActive && styles['item-name--active'])}>
           {file.name}
         </span>
-        <span className={styles['file-path']}>{file.path}</span>
+        <span className={styles['item-path']}>{file.path}</span>
       </div>
     </>
   );
 }
 
-const fileItemKey = (item: MentionItem) => item.path;
+function renderChat(chat: MentionItem, isActive: boolean) {
+  return (
+    <>
+      <MessageSquare className={styles['item-icon']} />
+      <div className={styles['item-row']}>
+        <span className={clsx(styles['item-name'], isActive && styles['item-name--active'])}>
+          {chat.name}
+        </span>
+      </div>
+    </>
+  );
+}
+
+const mentionItemKey = (item: MentionItem) => item.path;
 
 export const MentionSuggestionsPanel = memo(function MentionSuggestionsPanel({
   files,
+  chats,
   highlightedIndex,
   onSelect,
 }: MentionSuggestionsPanelProps) {
@@ -37,11 +53,17 @@ export const MentionSuggestionsPanel = memo(function MentionSuggestionsPanel({
       {
         label: 'Files',
         items: files,
-        itemKey: fileItemKey,
+        itemKey: mentionItemKey,
         renderItem: renderFile,
       },
+      {
+        label: 'Chats',
+        items: chats,
+        itemKey: mentionItemKey,
+        renderItem: renderChat,
+      },
     ],
-    [files],
+    [files, chats],
   );
 
   return (

--- a/frontend/src/hooks/queries/queryKeys.ts
+++ b/frontend/src/hooks/queries/queryKeys.ts
@@ -4,6 +4,7 @@ export const queryKeys = {
   chats: 'chats',
   chatsSearch: (query: string) => ['chats', 'search', query] as const,
   chatsSearchAll: ['chats', 'search'] as const,
+  chatsRecent: ['chats', 'recent'] as const,
   chat: (chatId?: string) => ['chat', chatId] as const,
   messages: (chatId?: string) => ['messages', chatId] as const,
   contextUsage: (chatId?: string) => ['chat', chatId, 'context-usage'] as const,

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -80,9 +80,8 @@ export const useInfiniteChatsQuery = (options?: {
   });
 };
 
-// Flat, most-recent-first list backing the composer's `@` chat mentions.
-// Fetched once per staleTime window — filtering is client-side, like files.
-// Sub-threads are valid mention targets, so they're included (the sidebar list isn't affected).
+// Backs the composer's `@` chat mentions: one fetch per staleTime window, filtered
+// client-side like files. Includes sub-threads (the top-level-only sidebar doesn't).
 export const useRecentChatsQuery = (enabled: boolean) => {
   return useQuery({
     queryKey: queryKeys.chatsRecent,
@@ -157,7 +156,6 @@ export const useContextUsageQuery = (
 // for local creates; second-pass invalidations are intentional (don't suppress).
 export async function applyCreatedChat(queryClient: QueryClient, newChat: Chat): Promise<void> {
   queryClient.setQueryData(queryKeys.chat(newChat.id), newChat);
-  // Composer `@` chat mentions should offer new chats without waiting out staleTime.
   queryClient.invalidateQueries({ queryKey: queryKeys.chatsRecent });
 
   if (newChat.parent_chat_id) {
@@ -214,7 +212,6 @@ export function patchChatInCache(
       };
     },
   );
-  // Keep composer `@` chat-mention titles in sync (e.g. mid-stream title backfill).
   queryClient.setQueryData<PaginatedChats>(queryKeys.chatsRecent, (oldData) => {
     if (!oldData) return oldData;
     return {
@@ -273,9 +270,8 @@ export const useUpdateChatMutation = createMutation<
       },
     );
 
-    // Keep composer `@` chat-mention titles in sync with renames. The map handles
-    // cached entries instantly; the invalidation re-fetches membership/order, since
-    // renaming bumps updated_at and can pull an uncached chat into the recent page.
+    // Patch + invalidate, not either alone: the patch renames cached entries instantly,
+    // the refetch fixes membership — updated_at bumps can pull in an uncached chat.
     queryClient.setQueryData<PaginatedChats>(queryKeys.chatsRecent, (oldData) => {
       if (!oldData) return oldData;
       return {
@@ -358,7 +354,6 @@ export const useDeleteChatMutation = createMutation<void, Error, string>(
     queryClient.removeQueries({ queryKey: queryKeys.contextUsage(chatId) });
     queryClient.removeQueries({ queryKey: queryKeys.subThreads(chatId) });
     queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
-    // Evict from `@` chat mentions — a mention token pointing at a deleted chat is dead.
     queryClient.invalidateQueries({ queryKey: queryKeys.chatsRecent });
     queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
     queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });

--- a/frontend/src/hooks/queries/useChatQueries.ts
+++ b/frontend/src/hooks/queries/useChatQueries.ts
@@ -25,6 +25,7 @@ import { createMutation } from './createMutation';
 import { queryKeys } from './queryKeys';
 
 const CHATS_PER_PAGE = 25;
+const RECENT_CHATS_PER_PAGE = 100;
 const GLOBAL_WORKSPACE_SENTINEL = 'all';
 
 // Global infinite chats: key[3]=GLOBAL_WORKSPACE_SENTINEL, key[4]=null (unpinned).
@@ -76,6 +77,23 @@ export const useInfiniteChatsQuery = (options?: {
     gcTime: 1000 * 60 * 1,
     // Snapshot hydrates first paint; always refetch so out-of-band creates surface.
     refetchOnMount: 'always',
+  });
+};
+
+// Flat, most-recent-first list backing the composer's `@` chat mentions.
+// Fetched once per staleTime window — filtering is client-side, like files.
+// Sub-threads are valid mention targets, so they're included (the sidebar list isn't affected).
+export const useRecentChatsQuery = (enabled: boolean) => {
+  return useQuery({
+    queryKey: queryKeys.chatsRecent,
+    queryFn: () =>
+      chatService.listChats({
+        page: 1,
+        per_page: RECENT_CHATS_PER_PAGE,
+        include_sub_threads: true,
+      }),
+    enabled,
+    staleTime: 1000 * 60 * 5,
   });
 };
 
@@ -139,6 +157,8 @@ export const useContextUsageQuery = (
 // for local creates; second-pass invalidations are intentional (don't suppress).
 export async function applyCreatedChat(queryClient: QueryClient, newChat: Chat): Promise<void> {
   queryClient.setQueryData(queryKeys.chat(newChat.id), newChat);
+  // Composer `@` chat mentions should offer new chats without waiting out staleTime.
+  queryClient.invalidateQueries({ queryKey: queryKeys.chatsRecent });
 
   if (newChat.parent_chat_id) {
     // Sub-thread create bumps parent updated_at (workspace ordering).
@@ -174,7 +194,7 @@ export async function applyCreatedChat(queryClient: QueryClient, newChat: Chat):
   queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
 }
 
-// Patch single-chat query + every infinite chats list together.
+// Patch single-chat query + every infinite chats list + recent-chats mention list together.
 export function patchChatInCache(
   queryClient: QueryClient,
   chatId: string,
@@ -194,6 +214,14 @@ export function patchChatInCache(
       };
     },
   );
+  // Keep composer `@` chat-mention titles in sync (e.g. mid-stream title backfill).
+  queryClient.setQueryData<PaginatedChats>(queryKeys.chatsRecent, (oldData) => {
+    if (!oldData) return oldData;
+    return {
+      ...oldData,
+      items: oldData.items.map((chat) => (chat.id === chatId ? patch(chat) : chat)),
+    };
+  });
 }
 
 // Optimistic unread clear + server stamp; fire-and-forget (failed stamp resurfaces on refetch).
@@ -244,6 +272,22 @@ export const useUpdateChatMutation = createMutation<
         };
       },
     );
+
+    // Keep composer `@` chat-mention titles in sync with renames. The map handles
+    // cached entries instantly; the invalidation re-fetches membership/order, since
+    // renaming bumps updated_at and can pull an uncached chat into the recent page.
+    queryClient.setQueryData<PaginatedChats>(queryKeys.chatsRecent, (oldData) => {
+      if (!oldData) return oldData;
+      return {
+        ...oldData,
+        items: oldData.items.map((chat) =>
+          chat.id === updatedChat.id
+            ? { ...updatedChat, sub_thread_count: chat.sub_thread_count }
+            : chat,
+        ),
+      };
+    });
+    queryClient.invalidateQueries({ queryKey: queryKeys.chatsRecent });
 
     queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
     queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
@@ -314,6 +358,8 @@ export const useDeleteChatMutation = createMutation<void, Error, string>(
     queryClient.removeQueries({ queryKey: queryKeys.contextUsage(chatId) });
     queryClient.removeQueries({ queryKey: queryKeys.subThreads(chatId) });
     queryClient.invalidateQueries({ queryKey: [queryKeys.chats, 'infinite'] });
+    // Evict from `@` chat mentions — a mention token pointing at a deleted chat is dead.
+    queryClient.invalidateQueries({ queryKey: queryKeys.chatsRecent });
     queryClient.invalidateQueries({ queryKey: queryKeys.workspaces });
     queryClient.invalidateQueries({ queryKey: queryKeys.chatsSearchAll });
     invalidateCloudChats(queryClient, chatId);

--- a/frontend/src/hooks/useInputSuggestions.test.tsx
+++ b/frontend/src/hooks/useInputSuggestions.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { KeyboardEvent } from 'react';
+import { useInputSuggestions } from './useInputSuggestions';
+import type { AgentKind, Chat } from '@/types/chat.types';
+import type { FileStructure } from '@/types/file-system.types';
+import type { SlashCommand } from '@/types/ui.types';
+
+const CURRENT_CHAT_ID = 'chat-current';
+
+function makeChat(id: string, title: string): Chat {
+  return {
+    id,
+    user_id: 'u1',
+    title,
+    workspace_id: 'w1',
+    sandbox_id: 's1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    pinned_at: null,
+    worktree_cwd: null,
+    parent_chat_id: null,
+    sub_thread_count: 0,
+    session_agent_kind: null,
+    unread: false,
+    last_model_id: null,
+    last_thinking_mode: null,
+    last_persona_name: null,
+  };
+}
+
+const CHATS: Chat[] = [
+  makeChat('chat-1', 'Bugfix for the parser'),
+  makeChat('chat-2', 'Deploy runbook'),
+  makeChat(CURRENT_CHAT_ID, 'Bugfix current thread'),
+];
+
+const FILES: FileStructure[] = [
+  { path: 'src/bugreport.ts', content: '', type: 'file' },
+  { path: 'src/unrelated.ts', content: '', type: 'file' },
+];
+
+function renderSuggestions(message: string) {
+  const setMessage = vi.fn();
+  const messageRef = { current: message };
+  const { result } = renderHook(() =>
+    useInputSuggestions({
+      message,
+      cursorPosition: message.length,
+      setMessage,
+      setCursorPosition: vi.fn(),
+      messageRef,
+      textareaRef: { current: null },
+      fileStructure: FILES,
+      mentionChats: CHATS,
+      chatId: CURRENT_CHAT_ID,
+      customSkills: [],
+      builtinSlashCommands: { claude: [] } as unknown as Record<AgentKind, SlashCommand[]>,
+      agentKind: 'claude' as AgentKind,
+    }),
+  );
+  return { result, setMessage };
+}
+
+function pressKey(handler: (e: KeyboardEvent<Element>) => boolean, key: string) {
+  act(() => {
+    handler({ key, preventDefault: vi.fn() } as unknown as KeyboardEvent<Element>);
+  });
+}
+
+describe('chat mentions', () => {
+  it('suggests chats matching the query, excluding the current chat', () => {
+    const { result } = renderSuggestions('@bug');
+
+    expect(result.current.filteredChats.map((item) => item.path)).toEqual(['chat:chat-1']);
+    expect(result.current.filteredChats[0]).toMatchObject({
+      type: 'chat',
+      name: 'Bugfix for the parser',
+    });
+  });
+
+  it('lists the most recent chats for a bare @ query', () => {
+    const { result } = renderSuggestions('@');
+
+    expect(result.current.filteredChats.map((item) => item.path)).toEqual([
+      'chat:chat-1',
+      'chat:chat-2',
+    ]);
+  });
+
+  it('inserts the plain-text @chat:<id> token when a chat is selected', () => {
+    const { result, setMessage } = renderSuggestions('look at @bug');
+
+    act(() => {
+      result.current.selectMention(result.current.filteredChats[0]);
+    });
+
+    expect(setMessage).toHaveBeenCalledWith('look at @chat:chat-1 ');
+  });
+
+  it('keeps one keyboard index across the Files and Chats sections', () => {
+    const { result, setMessage } = renderSuggestions('@bug');
+
+    // Files come first in both the suggestion list and the panel sections.
+    expect(result.current.filteredFiles.map((item) => item.path)).toEqual(['src/bugreport.ts']);
+    expect(result.current.highlightedMentionIndex).toBe(0);
+
+    // Index 1 is the first chat — the section boundary must not reset it.
+    pressKey(result.current.handleMentionKeyDown, 'ArrowDown');
+    expect(result.current.highlightedMentionIndex).toBe(1);
+
+    pressKey(result.current.handleMentionKeyDown, 'Enter');
+    expect(setMessage).toHaveBeenCalledWith('@chat:chat-1 ');
+
+    // Wraps back to the first file rather than to the top of the Chats section.
+    pressKey(result.current.handleMentionKeyDown, 'ArrowDown');
+    expect(result.current.highlightedMentionIndex).toBe(0);
+  });
+});

--- a/frontend/src/hooks/useInputSuggestions.ts
+++ b/frontend/src/hooks/useInputSuggestions.ts
@@ -4,7 +4,7 @@ import { useMentionSuggestions } from '@/hooks/useMentionSuggestions';
 import { insertToken } from '@/utils/mentionParser';
 import type { MentionItem, SlashCommand } from '@/types/ui.types';
 import type { CustomSkill } from '@/types/user.types';
-import type { AgentKind } from '@/types/chat.types';
+import type { AgentKind, Chat } from '@/types/chat.types';
 import type { FileStructure } from '@/types/file-system.types';
 
 interface UseInputSuggestionsOptions {
@@ -15,6 +15,8 @@ interface UseInputSuggestionsOptions {
   messageRef: RefObject<string>;
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   fileStructure: FileStructure[];
+  mentionChats: Chat[];
+  chatId?: string;
   customSkills: CustomSkill[];
   builtinSlashCommands: Record<AgentKind, SlashCommand[]>;
   agentKind: AgentKind;
@@ -28,6 +30,8 @@ export function useInputSuggestions({
   messageRef,
   textareaRef,
   fileStructure,
+  mentionChats,
+  chatId,
   customSkills,
   builtinSlashCommands,
   agentKind,
@@ -80,6 +84,7 @@ export function useInputSuggestions({
 
   const {
     filteredFiles,
+    filteredChats,
     highlightedIndex: highlightedMentionIndex,
     selectItem: selectMention,
     handleKeyDown: handleMentionKeyDown,
@@ -88,6 +93,8 @@ export function useInputSuggestions({
     message,
     cursorPosition: cursorPosition,
     fileStructure,
+    chats: mentionChats,
+    currentChatId: chatId,
     onSelect: handleMentionSelect,
   });
 
@@ -97,6 +104,7 @@ export function useInputSuggestions({
     selectSlashCommand,
     handleSlashCommandKeyDown,
     filteredFiles,
+    filteredChats,
     highlightedMentionIndex,
     selectMention,
     handleMentionKeyDown,

--- a/frontend/src/hooks/useMentionSuggestions.ts
+++ b/frontend/src/hooks/useMentionSuggestions.ts
@@ -1,15 +1,20 @@
 import { useCallback, useDeferredValue, useMemo, useRef } from 'react';
 import type { FileStructure } from '@/types/file-system.types';
+import type { Chat } from '@/types/chat.types';
 import type { MentionItem } from '@/types/ui.types';
 import { useSuggestionBase } from './useSuggestionBase';
 import { traverseFileStructure, getFileName } from '@/utils/file';
 import { parseTokenQuery } from '@/utils/mentionParser';
 import { fuzzySearch } from '@/utils/fuzzySearch';
 
+const CHAT_SUGGESTION_LIMIT = 10;
+
 interface UseMentionOptions {
   message: string;
   cursorPosition: number;
   fileStructure: FileStructure[];
+  chats: Chat[];
+  currentChatId?: string;
   onSelect: (item: MentionItem, mentionStartPos: number, mentionEndPos: number) => void;
 }
 
@@ -26,13 +31,30 @@ const convertFilesToMentions = (files: FileStructure[]): MentionItem[] => {
   });
 };
 
+// `path` doubles as the inserted token body — `@chat:<id>` is resolved by the
+// agent via the agentrove MCP, so no chat content is inlined here.
+const convertChatsToMentions = (chats: Chat[], currentChatId?: string): MentionItem[] =>
+  chats
+    .filter((chat) => chat.id !== currentChatId)
+    .map((chat) => ({
+      type: 'chat' as const,
+      name: chat.title,
+      path: `chat:${chat.id}`,
+    }));
+
 export const useMentionSuggestions = ({
   message,
   cursorPosition,
   fileStructure,
+  chats,
+  currentChatId,
   onSelect,
 }: UseMentionOptions) => {
   const allFiles = useMemo(() => convertFilesToMentions(fileStructure), [fileStructure]);
+  const allChats = useMemo(
+    () => convertChatsToMentions(chats, currentChatId),
+    [chats, currentChatId],
+  );
 
   const {
     isActive,
@@ -50,7 +72,20 @@ export const useMentionSuggestions = ({
     return fuzzySearch(deferredQuery, allFiles, { keys: ['name', 'path'], limit: 30 });
   }, [isActive, deferredQuery, allFiles]);
 
-  const hasSuggestions = filteredFiles.length > 0;
+  const filteredChats = useMemo(() => {
+    if (!isActive) {
+      return [];
+    }
+    return fuzzySearch(deferredQuery, allChats, { keys: ['name'], limit: CHAT_SUGGESTION_LIMIT });
+  }, [isActive, deferredQuery, allChats]);
+
+  // Order must match the panel's sections — the keyboard index is global across both.
+  const suggestions = useMemo(
+    () => [...filteredFiles, ...filteredChats],
+    [filteredFiles, filteredChats],
+  );
+
+  const hasSuggestions = suggestions.length > 0;
 
   const mentionStartPosRef = useRef(mentionStartPos);
   mentionStartPosRef.current = mentionStartPos;
@@ -66,13 +101,14 @@ export const useMentionSuggestions = ({
   );
 
   const { highlightedIndex, selectItem, handleKeyDown } = useSuggestionBase({
-    suggestions: filteredFiles,
+    suggestions,
     hasSuggestions,
     onSelect: handleSelect,
   });
 
   return {
     filteredFiles,
+    filteredChats,
     highlightedIndex,
     hasSuggestions,
     selectItem,

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -143,6 +143,7 @@ async function listChats(params?: {
   per_page?: number;
   workspace_id?: string;
   pinned?: boolean;
+  include_sub_threads?: boolean;
 }): Promise<PaginatedChats> {
   return serviceCall(async () => {
     const queryString = buildQueryString(params);

--- a/frontend/src/types/ui.types.ts
+++ b/frontend/src/types/ui.types.ts
@@ -40,7 +40,7 @@ export type ResolvedTheme = 'light' | 'dark';
 // Palette = Theme without `system`; for Monaco/xterm which can't read CSS vars.
 export type Palette = Exclude<Theme, 'system'>;
 
-type MentionType = 'file';
+type MentionType = 'file' | 'chat';
 
 export interface MentionItem {
   type: MentionType;

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -267,10 +267,13 @@ async def get_messages(
     limit: int = 20,
     cursor: str | None = None,
 ) -> dict[str, Any]:
-    """List messages in an AgentRove chat, oldest first.
+    """Read messages from an AgentRove chat; cursor pagination reaches the full history.
 
-    Returns up to `limit` messages (1-100) with role, content_text and stream_status.
-    Use the returned next_cursor with a follow-up call to page through older messages.
+    Each call returns up to `limit` messages (1-100) with role, content_text and
+    stream_status, ordered oldest-to-newest within the page. The first call (no cursor)
+    returns the MOST RECENT messages; pass the returned next_cursor to fetch the
+    preceding, older page. Repeat while has_more is true to read the entire chat —
+    no part of the history is unreachable.
     """
     page = await client.get_messages(chat_id, limit=limit, cursor=cursor)
     # Backend is newest-first; reverse for chronological readability.


### PR DESCRIPTION
## What

The composer's `@` mention picker now suggests **chats** alongside files. Selecting one inserts a plain-text `@chat:<chat_id>` token that pills like a file mention (composer backdrop + sent-message bubbles — the existing generic token pipeline, zero parser changes).

**No chat content is inlined into the prompt.** Agents resolve the token themselves: a new `CHAT_MENTIONS_INSTRUCTIONS` block in the chat system prompt tells them to call the agentrove MCP `get_messages(chat_id)` and page with `next_cursor`/`has_more` for full history.

## How

- **Suggestions**: `useRecentChatsQuery` fetches the ~100 most recent chats once per 5-min staleTime (auth-gated so the public landing composer doesn't 401); fuzzy filtering is client-side over titles, mirroring files. Current chat excluded; sub-threads included.
- **Keyboard nav**: one concatenated suggestion list `[files, chats]` feeds `useSuggestionBase`, matching the panel's Files→Chats section order, so a single global index navigates, wraps, and selects across sections.
- **Backend**: `GET /chat/chats` gains an opt-in `include_sub_threads` param (default `false` — sidebar and MCP behavior unchanged) since the list query previously hard-filtered `parent_chat_id IS NULL`.
- **Cache freshness**: `['chats','recent']` is patched/invalidated on create, delete, and rename (rename bumps `updated_at`, which can pull an uncached chat into the recent page — so rename both patches cached titles and invalidates for membership).
- **MCP fix**: `get_messages` docstring said “oldest first”; actually the first page is the *newest* messages with cursors walking older. Verified the backend keyset pagination (`(created_at, id)`, limit 1–100, `has_more` via limit+1) reaches the entire history; the docstring now says exactly that so agents reading a mentioned chat don't stop at page one.

## Testing

- New `useInputSuggestions.test.tsx` (4 tests, real hook path, no over-mocking): chat suggestions with current-chat exclusion, bare-`@` recents, `@chat:<id>` insertion, cross-section keyboard index integrity.
- Full frontend suite **764/764 green**, typecheck **0 errors**, lint **0 errors** (22 pre-existing warnings).
- Note: `npm test` is broken on main independently of this PR — `vitest@4` requires vite ≥6 but the repo pins vite 5 (`ERR_PACKAGE_PATH_NOT_EXPORTED` at startup). Verified via a temporary local `vitest@3.2.4` run; `package.json`/lockfile untouched. Worth a separate dependency fix.

## Review trail

Implemented by claude-opus-5; adversarial logic review by gpt-5.5/Bugbot surfaced three confirmed defects (sub-threads unreachable, stale titles after rename, uncached-rename membership), all fixed and re-verified.