### PR TITLE
Keep toolbar dropdown labels on mobile; return context usage from MCP get_messages

### DIFF
--- a/frontend/src/components/chat/worktree-selector/BranchWorktreeSelector.tsx
+++ b/frontend/src/components/chat/worktree-selector/BranchWorktreeSelector.tsx
@@ -142,7 +142,6 @@ export const BranchWorktreeSelector = memo(function BranchWorktreeSelector({
       triggerVariant="toolbar"
       width="17rem"
       disabled={disabled || isPending}
-      compactOnMobile
       searchable={visibleBranches.length >= 6}
       searchPlaceholder="Search branches..."
       searchVariant="underline"

--- a/frontend/src/components/ui/shared/ToggleDropdown/ToggleDropdown.module.scss
+++ b/frontend/src/components/ui/shared/ToggleDropdown/ToggleDropdown.module.scss
@@ -37,15 +37,11 @@
   color: var(--theme-text-quaternary);
 }
 
-// Same compact-on-mobile behavior as the Dropdown primitive's triggers: below
-// the sm breakpoint the icon stands in for the label.
+// The label stays visible at every breakpoint (the icon alone doesn't convey
+// state like Local/Cloud or Worktree); it truncates when the row gets tight.
 .trigger-label {
-  display: none;
+  @include type.type-overflow;
   min-width: 0;
-
-  @include responsive.media('sm-up') {
-    display: block;
-  }
 }
 
 .chevron {

--- a/frontend/src/pages/LandingPage/LandingPage.module.scss
+++ b/frontend/src/pages/LandingPage/LandingPage.module.scss
@@ -98,6 +98,12 @@
   padding-left: var(--space-4);
   padding-right: var(--space-4);
 
+  // All triggers keep their labels on phones; let each shrink so long
+  // workspace/branch names truncate with ellipsis instead of overflowing.
+  > * {
+    min-width: 0;
+  }
+
   @include responsive.media('sm-up') {
     padding-left: var(--space-6);
     padding-right: var(--space-6);

--- a/mcp-server/client.py
+++ b/mcp-server/client.py
@@ -218,6 +218,15 @@ class AgentroveClient:
         resp = await self.request("GET", f"/chat/chats/{chat_id}/messages", params=params)
         return resp.json()
 
+    async def get_context_usage(self, chat_id: str) -> dict[str, Any] | None:
+        try:
+            resp = await self.request("GET", f"/chat/chats/{chat_id}/context-usage")
+        except AgentroveError:
+            # No usage yet (fresh chat) or transient failure — not worth failing
+            # the read that asked for messages.
+            return None
+        return resp.json()
+
     async def list_automations(self) -> list[dict[str, Any]]:
         resp = await self.request("GET", "/automations")
         return resp.json()

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -274,8 +274,14 @@ async def get_messages(
     returns the MOST RECENT messages; pass the returned next_cursor to fetch the
     preceding, older page. Repeat while has_more is true to read the entire chat —
     no part of the history is unreachable.
+
+    Also returns context_usage — {tokens_used, context_window, percentage} for the
+    chat's agent session (null until the first turn completes). A high percentage
+    means follow-ups in this chat run with little headroom; prefer a fresh chat or
+    sub-thread with a distilled handoff instead of continuing a nearly-full one.
     """
     page = await client.get_messages(chat_id, limit=limit, cursor=cursor)
+    context_usage = await client.get_context_usage(chat_id)
     # Backend is newest-first; reverse for chronological readability.
     messages = [
         {
@@ -291,6 +297,7 @@ async def get_messages(
         "messages": messages,
         "next_cursor": page["next_cursor"],
         "has_more": page["has_more"],
+        "context_usage": context_usage,
     }
 
 


### PR DESCRIPTION
## Summary
- Keep `ToggleDropdown` trigger labels visible at all breakpoints (with truncation) so mobile toolbar controls still show state like Local/Cloud and worktree/branch names instead of icon-only.
- Allow landing-page toolbar children to shrink (`min-width: 0`) so long names truncate with ellipsis instead of overflowing.
- MCP `get_messages` now also returns `context_usage` (`tokens_used`, `context_window`, `percentage`) so agents can judge remaining context headroom before continuing a chat.

## Test plan
- [ ] On a phone-width viewport, open the landing toolbar: workspace, branch/worktree, and Local/Cloud labels remain visible and truncate cleanly when long.
- [ ] Confirm branch worktree selector still works without `compactOnMobile`.
- [ ] Call MCP `get_messages` on a chat that has completed at least one turn; response includes `context_usage` with percentage.
- [ ] Call MCP `get_messages` on a fresh chat; `context_usage` is `null` and the call still succeeds.