### PR TITLE
Count pending elicitations in the blocked/Needs-you chat indicators

### DIFF
--- a/frontend/src/components/layout/ChatTabs/ChatTabs.tsx
+++ b/frontend/src/components/layout/ChatTabs/ChatTabs.tsx
@@ -8,7 +8,7 @@ import { FloatingTooltip } from '@/components/ui/FloatingTooltip/FloatingTooltip
 import { ProviderIcon } from '@/components/ui/icons/ProviderIcon';
 import { useUIStore } from '@/store/uiStore';
 import { useStreamStore } from '@/store/streamStore';
-import { usePermissionStore } from '@/store/permissionStore';
+import { useBlockedChatIds } from '@/hooks/useBlockedChatIds';
 import { useChatQuery } from '@/hooks/queries/useChatQueries';
 import { useChatAgentKind } from '@/hooks/useChatAgentKind';
 import { useIsMobile } from '@/hooks/useIsMobile';
@@ -109,7 +109,8 @@ export function ChatTabs() {
   const activeStreamMetadata = useStreamStore((s) => s.activeStreamMetadata);
   // Marked on stream success; sidebar clears when the chat is viewed.
   const completedChatIds = useStreamStore((s) => s.completedChatIds);
-  const pendingRequests = usePermissionStore((s) => s.pendingRequests);
+  // Pending plan/permission requests or agent question forms — blocked on the user.
+  const blockedChatIdSet = useBlockedChatIds();
 
   // From layout (not splitChatIds): a split chat under a full-screen primary is off-screen.
   const visibleChatIds = useMemo(
@@ -121,7 +122,6 @@ export function ChatTabs() {
     () => new Set(activeStreamMetadata.map((meta) => meta.chatId)),
     [activeStreamMetadata],
   );
-  const blockedChatIdSet = useMemo(() => new Set(pendingRequests.keys()), [pendingRequests]);
 
   const handleSelect = useCallback(
     (chatId: string) => {

--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ import type { Workspace } from '@/types/workspace.types';
 import { useSidebarChatLists } from '@/hooks/queries/useSidebarChatLists';
 import { useUIStore } from '@/store/uiStore';
 import { useStreamStore } from '@/store/streamStore';
-import { usePermissionStore } from '@/store/permissionStore';
+import { useBlockedChatIds } from '@/hooks/useBlockedChatIds';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useCurrentUserQuery } from '@/hooks/queries/useAuthQueries';
 import { useAuthStore } from '@/store/authStore';
@@ -56,11 +56,9 @@ export function Sidebar({
     () => new Set(activeStreamMetadata.map((meta) => meta.chatId)),
     [activeStreamMetadata],
   );
-  // Chats with a pending plan/question/permission request — the agent is
-  // blocked on the user. Empty queues are deleted from the store, so every
-  // remaining key has an outstanding request.
-  const pendingRequests = usePermissionStore((state) => state.pendingRequests);
-  const blockedChatIdSet = useMemo(() => new Set(pendingRequests.keys()), [pendingRequests]);
+  // Chats with a pending plan/permission request or agent question form — the
+  // agent is blocked on the user.
+  const blockedChatIdSet = useBlockedChatIds();
   // Chats merge from two backends, so filters apply client-side over loaded
   // pages. Lives in the persisted uiStore so reloads keep the narrowed view.
   const filters = useUIStore((state) => state.sidebarFilters);

--- a/frontend/src/hooks/useBlockedChatIds.test.tsx
+++ b/frontend/src/hooks/useBlockedChatIds.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useBlockedChatIds } from './useBlockedChatIds';
+import { usePermissionStore } from '@/store/permissionStore';
+import { useElicitationStore } from '@/store/elicitationStore';
+import type { ElicitationRequest, PermissionRequest } from '@/types/chat.types';
+
+const permission = (id: string): PermissionRequest => ({
+  request_id: id,
+  tool_name: 'Bash',
+  tool_input: {},
+  options: [],
+  seq: 0,
+});
+
+const elicitation = (id: string): ElicitationRequest => ({
+  request_id: id,
+  message: 'Pick one',
+  tool_call_id: null,
+  requested_schema: { type: 'object', properties: {} },
+});
+
+beforeEach(() => {
+  usePermissionStore.setState({ pendingRequests: new Map() });
+  useElicitationStore.setState({ pendingRequests: new Map() });
+});
+
+describe('useBlockedChatIds', () => {
+  it('unions chats blocked on permissions with chats blocked on elicitations', () => {
+    const { result } = renderHook(() => useBlockedChatIds());
+    expect(result.current.size).toBe(0);
+
+    act(() => {
+      usePermissionStore.getState().enqueuePermissionRequest('c1', permission('r1'));
+      // AskUserQuestion arrives as an elicitation — it must flag the chat too.
+      useElicitationStore.getState().enqueueElicitationRequest('c2', elicitation('e1'));
+    });
+    expect([...result.current].sort()).toEqual(['c1', 'c2']);
+  });
+
+  it('unflags a chat only when its last pending request resolves', () => {
+    const { result } = renderHook(() => useBlockedChatIds());
+
+    act(() => {
+      usePermissionStore.getState().enqueuePermissionRequest('c1', permission('r1'));
+      useElicitationStore.getState().enqueueElicitationRequest('c1', elicitation('e1'));
+    });
+    expect(result.current.has('c1')).toBe(true);
+
+    act(() => usePermissionStore.getState().resolvePermissionRequest('c1', 'r1'));
+    expect(result.current.has('c1')).toBe(true);
+
+    act(() => useElicitationStore.getState().resolveElicitationRequest('c1', 'e1'));
+    expect(result.current.has('c1')).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useBlockedChatIds.ts
+++ b/frontend/src/hooks/useBlockedChatIds.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import { usePermissionStore } from '@/store/permissionStore';
+import { useElicitationStore } from '@/store/elicitationStore';
+
+// Chats blocked on the user — the union of both request channels:
+// - permissionStore: tool permissions, plan approvals, Grok's ask_user_question
+//   (mapped to permission_request by the backend).
+// - elicitationStore: agent question forms (Claude/Codex AskUserQuestion arrives
+//   as an ACP form elicitation) and MCP-server elicitations.
+// Both stores drop empty queues, so every remaining key has an outstanding request.
+export function useBlockedChatIds(): Set<string> {
+  const pendingPermissions = usePermissionStore((state) => state.pendingRequests);
+  const pendingElicitations = useElicitationStore((state) => state.pendingRequests);
+  return useMemo(
+    () => new Set([...pendingPermissions.keys(), ...pendingElicitations.keys()]),
+    [pendingPermissions, pendingElicitations],
+  );
+}

--- a/frontend/src/pages/LandingPage/RecentChats.tsx
+++ b/frontend/src/pages/LandingPage/RecentChats.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import type { Chat } from '@/types/chat.types';
 import { useStreamStore } from '@/store/streamStore';
-import { usePermissionStore } from '@/store/permissionStore';
+import { useBlockedChatIds } from '@/hooks/useBlockedChatIds';
 import { useModelMap } from '@/hooks/queries/useModelQueries';
 import { formatRelativeTime } from '@/utils/date';
 import { stripMarkdownTitle } from '@/utils/format';
@@ -29,8 +29,8 @@ export function RecentChats({ chats, workspaceBadgeById, onChatSelect }: RecentC
   const activeStreamMetadata = useStreamStore((state) => state.activeStreamMetadata);
   const lastToolTitleByChatId = useStreamStore((state) => state.lastToolTitleByChatId);
   const completedChatIds = useStreamStore((state) => state.completedChatIds);
-  // Empty queues are dropped; remaining keys = blocked on plan/question/permission.
-  const pendingRequests = usePermissionStore((state) => state.pendingRequests);
+  // Blocked on plan/permission approval or an agent question form.
+  const blockedChatIds = useBlockedChatIds();
   // Recents only mount when authenticated.
   const modelMap = useModelMap();
 
@@ -49,7 +49,7 @@ export function RecentChats({ chats, workspaceBadgeById, onChatSelect }: RecentC
         {chats.slice(0, MAX_RECENT_CHATS).map((chat) => {
           // Same tone order as sidebar/tabs; no open chat, so unread is never suppressed.
           const status = chatStatusTone({
-            blocked: pendingRequests.has(chat.id),
+            blocked: blockedChatIds.has(chat.id),
             streaming: streamingChatIds.has(chat.id),
             completed: completedChatIds.has(chat.id),
             unread: chat.unread,


### PR DESCRIPTION
## Problem

The "Needs you" / blocked indicators (Sidebar badge + `needs-you` filter, ChatTabs status dot, RecentChats on the landing page) read only `permissionStore.pendingRequests`. That covers tool permissions, plan approvals, and Grok's `ask_user_question` (mapped to `permission_request` by the backend) — but **not** agent question forms.

Claude's `AskUserQuestion` is bridged by `claude-agent-acp` as an ACP **form elicitation**, so it lands in `elicitationStore` — the same channel as opencode's question tool and MCP-server elicitations. A chat blocked on a question showed no indicator anywhere.

## Fix

- New shared `useBlockedChatIds()` hook: unions the pending keys of `permissionStore` and `elicitationStore`. Both stores delete empty queues, so every remaining key is a genuinely outstanding request.
- `Sidebar`, `ChatTabs`, and `RecentChats` now consume the hook instead of subscribing to `permissionStore` directly.

Dismiss/reconnect stay correct: `elicitation_dismissed` and the status-probe `reconcileElicitationRequests` already clear the elicitation store, so badges can't stick.

## Tests

- `useBlockedChatIds.test.tsx`: elicitation-blocked chats are flagged alongside permission-blocked ones; a chat unflags only when its last pending request of either kind resolves.
- Typecheck, eslint, and the existing store/layout suites pass.

## Out of scope

Elicitations still don't fire background notifications (permissions do via `notifyPermissionRequest`) — separate parity gap, can follow up.