### PR TITLE
Mint per-user MCP tokens instead of shared email/password credentials

### DIFF
--- a/.env.desktop.example
+++ b/.env.desktop.example
@@ -6,8 +6,6 @@
 
 # --- Agentrove chat MCP server (opt-in) ---
 # Lets spawned agents (Claude Code, Codex, …) create/list/message chats via the
-# stdio MCP server in mcp-server/. The server logs into this backend, so it needs
-# a user's credentials.
+# stdio MCP server in mcp-server/. The server calls this backend with a per-user
+# token minted at session start — no credentials to configure.
 AGENTROVE_MCP_ENABLED=true
-AGENTROVE_MCP_EMAIL=you@example.com
-AGENTROVE_MCP_PASSWORD=your-password

--- a/.env.desktop.example
+++ b/.env.desktop.example
@@ -3,9 +3,46 @@
 # Copy to `.env.desktop` in the app data dir and fill in — on macOS that's:
 #   ~/Library/Application Support/com.agentrove.app/.env.desktop
 # Loaded at sidecar startup (desktop/entry.py), so a normal launch picks it up.
+#
+# Any backend setting (backend/app/core/config.py) can be set here, except the
+# ones the app pins at spawn: SECRET_KEY, BASE_URL, DATABASE_URL, STORAGE_PATH,
+# PATH. Below are the ones that make sense on desktop; defaults shown.
 
 # --- Agentrove chat MCP server (opt-in) ---
 # Lets spawned agents (Claude Code, Codex, …) create/list/message chats via the
 # stdio MCP server in mcp-server/. The server calls this backend with a per-user
 # token minted at session start — no credentials to configure.
 AGENTROVE_MCP_ENABLED=true
+# AGENTROVE_MCP_TOKEN_LIFETIME_SECONDS=604800
+
+# --- Logging ---
+# LOG_LEVEL=INFO
+
+# --- Git identity on agent commits (defaults: your global git config / keyring) ---
+# GIT_AUTHOR_NAME=
+# GIT_AUTHOR_EMAIL=
+# GIT_CONFIG_GLOBAL=
+# GNUPGHOME=
+
+# --- Docker sandbox provider ---
+# DOCKER_IMAGE=ghcr.io/mng-dev-ai/agentrove-sandbox:latest
+# DOCKER_NETWORK=agentrove-sandbox-net
+# DOCKER_HOST=
+# DOCKER_MEM_LIMIT=4g
+# DOCKER_CPU_PERIOD=100000
+# DOCKER_CPU_QUOTA=200000
+# DOCKER_PIDS_LIMIT=512
+
+# --- Host sandbox provider ---
+# Default: <storage>/host-sandboxes
+# HOST_SANDBOX_BASE_DIR=
+# HOST_PREVIEW_BASE_URL=http://localhost
+
+# --- Uploads / tuning ---
+# Idle agent sessions are reaped after this long (~500MB per warm session).
+# CHAT_PROCESS_IDLE_TTL_SECONDS=600
+# BACKGROUND_CHAT_SHUTDOWN_TIMEOUT_SECONDS=30
+# MAX_UPLOAD_SIZE=5242880
+# USER_SETTINGS_CACHE_TTL_SECONDS=300
+# MODELS_CACHE_TTL_SECONDS=3600
+# CONTEXT_USAGE_CACHE_TTL_SECONDS=600

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ FRONTEND_PORT=3000
 VITE_API_BASE_URL=/api/v1
 VITE_WS_URL=/api/v1/ws
 
+# Optional: let spawned agents manage AgentRove chats via the stdio MCP server
+# in mcp-server/. Each session gets a token minted for the chat's owner — no
+# credentials to configure.
+# AGENTROVE_MCP_ENABLED=true
+
 # Production / Coolify (docker-compose-production.yml)
 # APP_URL=https://yourdomain.com
 # ALLOWED_ORIGINS=https://yourdomain.com

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ VITE_WS_URL=/api/v1/ws
 # in mcp-server/. Each session gets a token minted for the chat's owner — no
 # credentials to configure.
 # AGENTROVE_MCP_ENABLED=true
+# AGENTROVE_MCP_TOKEN_LIFETIME_SECONDS=604800
 
 # Production / Coolify (docker-compose-production.yml)
 # APP_URL=https://yourdomain.com
@@ -29,3 +30,69 @@ VITE_WS_URL=/api/v1/ws
 # Optional: pin sandbox network (default: auto-detect compose sandbox network)
 # DOCKER_NETWORK=agentrove-sandbox-net
 # Coolify PR previews: leave APP_URL/ALLOWED_ORIGINS unset (or $SERVICE_URL_WEB)
+
+# The sections below list every other backend setting (defaults shown — see
+# backend/app/core/config.py). Uncomment to override.
+
+# --- Environment ---
+# ENVIRONMENT=development
+# FRONTEND_URL=http://localhost:3000
+
+# --- Auth & registration ---
+# ACCESS_TOKEN_EXPIRE_MINUTES=15
+# REFRESH_TOKEN_EXPIRE_DAYS=30
+# Default: derived from SECRET_KEY
+# SESSION_SECRET_KEY=
+# REQUIRE_EMAIL_VERIFICATION=false
+# REGISTRATION_DISABLED=false
+# BLOCK_DISPOSABLE_EMAILS=true
+
+# --- Email (verification / password reset) ---
+# MAIL_USERNAME=apikey
+# MAIL_PASSWORD=
+# MAIL_FROM=noreply@agentrove.pro
+# MAIL_FROM_NAME=Agentrove
+# MAIL_PORT=587
+# MAIL_SERVER=smtp.sendgrid.net
+# MAIL_STARTTLS=true
+# MAIL_SSL_TLS=false
+
+# --- Proxy & security headers ---
+# DISABLE_PROXY_HEADERS=false
+# ENABLE_SECURITY_HEADERS=true
+# HSTS_MAX_AGE=31536000
+# HSTS_INCLUDE_SUBDOMAINS=true
+# HSTS_PRELOAD=false
+# FRAME_OPTIONS=DENY
+# CONTENT_TYPE_OPTIONS=nosniff
+# XSS_PROTECTION=1; mode=block
+# REFERRER_POLICY=strict-origin-when-cross-origin
+# PERMISSIONS_POLICY=geolocation=(), microphone=(), camera=()
+
+# --- Git identity on agent commits (defaults: host git config / keyring) ---
+# GIT_AUTHOR_NAME=
+# GIT_AUTHOR_EMAIL=
+# GIT_CONFIG_GLOBAL=
+# GNUPGHOME=
+
+# --- Docker sandbox limits ---
+# DOCKER_HOST=
+# DOCKER_MEM_LIMIT=4g
+# DOCKER_CPU_PERIOD=100000
+# DOCKER_CPU_QUOTA=200000
+# DOCKER_PIDS_LIMIT=512
+
+# --- Host sandbox provider ---
+# Default: <storage>/host-sandboxes
+# HOST_SANDBOX_BASE_DIR=
+# HOST_PREVIEW_BASE_URL=http://localhost
+
+# --- Uploads / tuning ---
+# MAX_UPLOAD_SIZE=5242880
+# Idle agent sessions are reaped after this long (~500MB per warm session).
+# CHAT_PROCESS_IDLE_TTL_SECONDS=600
+# BACKGROUND_CHAT_SHUTDOWN_TIMEOUT_SECONDS=30
+# USER_SETTINGS_CACHE_TTL_SECONDS=300
+# MODELS_CACHE_TTL_SECONDS=3600
+# CONTEXT_USAGE_CACHE_TTL_SECONDS=600
+# DISPOSABLE_DOMAINS_CACHE_TTL_SECONDS=3600

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -150,11 +150,10 @@ class Settings(BaseSettings):
     GIT_CONFIG_GLOBAL: str = str(Path.home() / ".gitconfig")
     GNUPGHOME: str = str(Path.home() / ".gnupg")
 
-    # Opt-in stdio MCP server (mcp-server/server.py); needs credentials to log
-    # into this backend at BASE_URL.
+    # Opt-in stdio MCP server (mcp-server/server.py); calls this backend at
+    # BASE_URL with a per-user access token minted at session spawn.
     AGENTROVE_MCP_ENABLED: bool = False
-    AGENTROVE_MCP_EMAIL: str | None = None
-    AGENTROVE_MCP_PASSWORD: str | None = None
+    AGENTROVE_MCP_TOKEN_LIFETIME_SECONDS: int = 604800
 
     DOCKER_IMAGE: str = "ghcr.io/mng-dev-ai/agentrove-sandbox:latest"
     DOCKER_NETWORK: str = "agentrove-sandbox-net"

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 from cryptography.fernet import Fernet
 from fastapi import Depends, HTTPException, Query, WebSocket, status
+from fastapi_users.jwt import generate_jwt
 from fastapi_users.password import PasswordHelper
 from jose import jwt
 from sqlalchemy import select
@@ -107,6 +108,20 @@ async def get_current_user(
         raise credentials_exception
 
     return user
+
+
+def create_mcp_access_token(user_id: str) -> str:
+    # Minted for the MCP server spawned into a chat session — audience must match
+    # the JWTStrategy in user_manager.py (fastapi-users default) so the normal
+    # bearer path accepts it. `mcp` marks its origin in logs.
+    return str(
+        generate_jwt(
+            {"sub": str(user_id), "aud": ["fastapi-users:auth"], "mcp": True},
+            settings.SECRET_KEY,
+            lifetime_seconds=settings.AGENTROVE_MCP_TOKEN_LIFETIME_SECONDS,
+            algorithm=settings.ALGORITHM,
+        )
+    )
 
 
 def generate_refresh_token() -> str:

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -12,6 +12,7 @@ from sqlalchemy import update
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.core.config import get_settings
+from app.core.security import create_mcp_access_token
 from app.db.session import SessionLocal
 from app.models.db_models.chat import Chat
 from app.models.db_models.user import User, UserSettings
@@ -461,13 +462,10 @@ class AgentService:
 
     @staticmethod
     def _build_mcp_server_configs(
-        chat_id: str | None, sandbox_provider: SandboxProviderType
+        chat_id: str | None, user_id: str, sandbox_provider: SandboxProviderType
     ) -> list[dict[str, Any]]:
         # Opt-in: hand the agent Agentrove's own chat tools over a stdio MCP server.
-        # Skipped unless enabled with credentials — the server logs into this backend.
         if not settings.AGENTROVE_MCP_ENABLED:
-            return []
-        if not (settings.AGENTROVE_MCP_EMAIL and settings.AGENTROVE_MCP_PASSWORD):
             return []
         if sandbox_provider is SandboxProviderType.HOST:
             # Host-provider agents share this process's network namespace, but the
@@ -481,8 +479,7 @@ class AgentService:
             api_base = settings.BASE_URL
         env = {
             "AGENTROVE_API_URL": f"{api_base}{settings.API_V1_STR}",
-            "AGENTROVE_EMAIL": settings.AGENTROVE_MCP_EMAIL,
-            "AGENTROVE_PASSWORD": settings.AGENTROVE_MCP_PASSWORD,
+            "AGENTROVE_ACCESS_TOKEN": create_mcp_access_token(user_id),
         }
         # The chat this session runs in — lets the agent create sub-threads under it
         if chat_id:
@@ -554,7 +551,9 @@ class AgentService:
             user_id=user_id,
             agent_kind=agent_kind,
             env=env,
-            mcp_servers=self._build_mcp_server_configs(chat_id, sandbox_provider),
+            mcp_servers=self._build_mcp_server_configs(
+                chat_id, user_id, sandbox_provider
+            ),
             model=model_id,
             permission_mode=session_config.permission.session_mode,
             resume_session_id=session_id,

--- a/backend/app/services/session_registry.py
+++ b/backend/app/services/session_registry.py
@@ -175,6 +175,21 @@ class SessionRegistry:
             logger.info("Closed %d idle chat session(s)", len(expired))
 
     @staticmethod
+    def _redact_mcp_tokens(mcp_servers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        # The MCP token is minted per spawn, so hashing it would respawn every
+        # turn. A chat's owner can't change — same chat means same identity, and
+        # a reused session keeps the still-valid token it was spawned with.
+        redacted: list[dict[str, Any]] = []
+        for server in mcp_servers:
+            env = {
+                k: v
+                for k, v in server.get("env", {}).items()
+                if k != "AGENTROVE_ACCESS_TOKEN"
+            }
+            redacted.append({**server, "env": env})
+        return redacted
+
+    @staticmethod
     def _compute_fingerprint(config: AcpSessionConfig) -> str:
         # cwd is stable per chat (workspace root or the chat's worktree, never
         # agent-reported paths), so including it respawns the agent process in
@@ -185,7 +200,7 @@ class SessionRegistry:
             "agent_kind": config.agent_kind.value,
             "cwd": config.cwd,
             "env": config.env,
-            "mcp_servers": config.mcp_servers,
+            "mcp_servers": SessionRegistry._redact_mcp_tokens(config.mcp_servers),
             "system_prompt": config.system_prompt,
             "reasoning_effort": config.reasoning_effort,
             # Grok bakes approval into launch, so mode changes must respawn;

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -212,21 +212,15 @@ def pin_ambient_settings() -> Iterator[None]:
     settings = get_settings()
     original = (
         settings.AGENTROVE_MCP_ENABLED,
-        settings.AGENTROVE_MCP_EMAIL,
-        settings.AGENTROVE_MCP_PASSWORD,
         settings.DESKTOP_MODE,
     )
     settings.AGENTROVE_MCP_ENABLED = False
-    settings.AGENTROVE_MCP_EMAIL = None
-    settings.AGENTROVE_MCP_PASSWORD = None
     settings.DESKTOP_MODE = False
     try:
         yield
     finally:
         (
             settings.AGENTROVE_MCP_ENABLED,
-            settings.AGENTROVE_MCP_EMAIL,
-            settings.AGENTROVE_MCP_PASSWORD,
             settings.DESKTOP_MODE,
         ) = original
 
@@ -1491,14 +1485,8 @@ async def test_chat_attachments_and_mcp_servers_reach_the_agent(
     acp_cache: EndpointCache,
 ) -> None:
     settings = get_settings()
-    original = (
-        settings.AGENTROVE_MCP_ENABLED,
-        settings.AGENTROVE_MCP_EMAIL,
-        settings.AGENTROVE_MCP_PASSWORD,
-    )
+    original = settings.AGENTROVE_MCP_ENABLED
     settings.AGENTROVE_MCP_ENABLED = True
-    settings.AGENTROVE_MCP_EMAIL = "mcp@example.com"
-    settings.AGENTROVE_MCP_PASSWORD = "mcp-password"
     try:
         headers, workspace = auth_workspace
         # Codex only treats "image" as natively embeddable — the pdf forces
@@ -1524,11 +1512,7 @@ async def test_chat_attachments_and_mcp_servers_reach_the_agent(
         )
         assert message["stream_status"] == "completed"
     finally:
-        (
-            settings.AGENTROVE_MCP_ENABLED,
-            settings.AGENTROVE_MCP_EMAIL,
-            settings.AGENTROVE_MCP_PASSWORD,
-        ) = original
+        settings.AGENTROVE_MCP_ENABLED = original
 
     new_sessions = fake_agent.events_of("new_session")
     assert new_sessions
@@ -1536,12 +1520,65 @@ async def test_chat_attachments_and_mcp_servers_reach_the_agent(
     assert len(mcp_servers) == 1
     assert mcp_servers[0]["name"] == "agentrove"
     assert mcp_servers[0]["command"] == sys.executable
+    mcp_env = {v["name"]: v["value"] for v in mcp_servers[0]["env"]}
+    assert mcp_env["AGENTROVE_ACCESS_TOKEN"]
+    assert "AGENTROVE_EMAIL" not in mcp_env
+    assert "AGENTROVE_PASSWORD" not in mcp_env
 
     prompts = fake_agent.main_turn_prompts()
     assert prompts
     last_prompt = prompts[-1]
     assert "image" in last_prompt["block_types"]
     assert "doc.pdf is available at" in last_prompt["text"]
+
+
+async def test_mcp_session_is_reused_across_turns(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A fresh token per turn (real mints differ once a second has passed) must
+    # not change the session fingerprint, or every turn respawns the agent.
+    settings = get_settings()
+    original = settings.AGENTROVE_MCP_ENABLED
+    settings.AGENTROVE_MCP_ENABLED = True
+    mints = iter(("token-one", "token-two", "token-three", "token-four"))
+    monkeypatch.setattr(
+        "app.services.agent.create_mcp_access_token", lambda user_id: next(mints)
+    )
+    try:
+        headers, workspace = auth_workspace
+        chat = await create_chat(client, headers, workspace, model_id="sonnet")
+
+        spawns = []
+        for prompt in ("first turn", "second turn"):
+            response = await send_message(
+                client,
+                headers,
+                chat_id=chat["id"],
+                model_id="sonnet",
+                prompt=prompt,
+            )
+            assert response.status_code == 200, response.text
+            message = await wait_for_message(
+                client,
+                headers,
+                chat_id=chat["id"],
+                message_id=response.json()["message_id"],
+            )
+            assert message["stream_status"] == "completed"
+            spawns.append(
+                len(fake_agent.events_of("new_session"))
+                + len(fake_agent.events_of("load_session"))
+            )
+    finally:
+        settings.AGENTROVE_MCP_ENABLED = original
+
+    # A respawn resumes the old session id, so count load_session too. The first
+    # turn's count also covers the one-off title-gen session.
+    assert spawns[1] == spawns[0]
 
 
 def test_untracked_tool_updates_use_meta_name_or_are_dropped() -> None:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -6,10 +6,12 @@ import aiosmtplib
 import httpx
 import pytest
 from httpx import AsyncClient
+from jose import jwt
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.security import hash_refresh_token
+from app.core.config import get_settings
+from app.core.security import create_mcp_access_token, hash_refresh_token
 from app.models.db_models.refresh_token import RefreshToken
 from app.models.db_models.user import User
 from app.services.email import EmailService, email_service
@@ -872,3 +874,26 @@ async def test_forgot_password_returns_false_without_smtp_configured(
     )
 
     assert response.status_code == 202
+
+
+async def test_mcp_access_token_authenticates_bearer_requests(
+    client: AsyncClient,
+    create_user: UserFactory,
+) -> None:
+    user = await create_user(email="mcp-token@example.com", username="mcptoken")
+    token = create_mcp_access_token(str(user.id))
+
+    payload = jwt.decode(
+        token,
+        get_settings().SECRET_KEY,
+        algorithms=[get_settings().ALGORITHM],
+        audience="fastapi-users:auth",
+    )
+    assert payload["sub"] == str(user.id)
+    assert payload["mcp"] is True
+
+    # The real check: fastapi-users' bearer strategy must accept the token.
+    response = await client.get(
+        "/api/v1/workspaces", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 200, response.text

--- a/frontend/src-tauri/src/desktop.rs
+++ b/frontend/src-tauri/src/desktop.rs
@@ -152,7 +152,6 @@ fn spawn_backend(
     let db_path = data_dir.join("agentrove.db").to_string_lossy().to_string();
     let mut command = Command::new(&backend_bin);
     command
-        .env("DESKTOP_MODE", "true")
         .env("SECRET_KEY", secret_key)
         .env("BASE_URL", format!("http://127.0.0.1:{port}"))
         .env("DATABASE_URL", format!("sqlite+aiosqlite:///{db_path}"))

--- a/mcp-server/client.py
+++ b/mcp-server/client.py
@@ -10,42 +10,14 @@ class AgentroveError(Exception):
 
 
 class AgentroveClient:
-    def __init__(self, base_url: str, email: str, password: str) -> None:
+    def __init__(self, base_url: str, access_token: str) -> None:
         self._base_url = base_url.rstrip("/")
-        self._email = email
-        self._password = password
         self._http = httpx.AsyncClient(base_url=self._base_url, timeout=60.0)
-        self._access_token: str | None = None
-        self._refresh_token: str | None = None
+        self._access_token = access_token
         self._models_cache: list[dict[str, Any]] | None = None
 
     async def aclose(self) -> None:
         await self._http.aclose()
-
-    async def _login(self) -> None:
-        # fastapi-users JWT login: OAuth2 form (username = email).
-        resp = await self._http.post(
-            "/auth/jwt/login",
-            data={"username": self._email, "password": self._password},
-        )
-        if resp.status_code != 200:
-            raise AgentroveError(f"Login failed ({resp.status_code}): {resp.text}")
-        body = resp.json()
-        self._access_token = body["access_token"]
-        self._refresh_token = body.get("refresh_token")
-
-    async def _refresh(self) -> bool:
-        if not self._refresh_token:
-            return False
-        resp = await self._http.post(
-            "/auth/jwt/refresh", json={"refresh_token": self._refresh_token}
-        )
-        if resp.status_code != 200:
-            return False
-        body = resp.json()
-        self._access_token = body["access_token"]
-        self._refresh_token = body.get("refresh_token", self._refresh_token)
-        return True
 
     async def _send(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
         headers = {"Authorization": f"Bearer {self._access_token}"}
@@ -56,14 +28,12 @@ class AgentroveClient:
         self, method: str, path: str, *, expected: tuple[int, ...] = (200,), **kwargs: Any
     ) -> httpx.Response:
         try:
-            if self._access_token is None:
-                await self._login()
             resp = await self._send(method, path, **kwargs)
-            # Short-lived access token: on 401, refresh/re-login and retry once.
             if resp.status_code == 401:
-                if not await self._refresh():
-                    await self._login()
-                resp = await self._send(method, path, **kwargs)
+                raise AgentroveError(
+                    "AgentRove access token was rejected (expired or revoked) "
+                    "— start a new session to get a fresh token."
+                )
         except httpx.HTTPError as e:
             # Transport errors (e.g. ConnectTimeout) often str() to "" — name the
             # exception class and target URL so tool errors stay diagnosable.

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -38,12 +38,12 @@ def _automation_summary(a: dict[str, Any]) -> dict[str, Any]:
 
 
 def _build_client() -> AgentroveClient:
-    email = os.environ.get("AGENTROVE_EMAIL")
-    password = os.environ.get("AGENTROVE_PASSWORD")
-    if not email or not password:
-        raise AgentroveError("AGENTROVE_EMAIL and AGENTROVE_PASSWORD must be set")
+    # The backend mints a per-user token for the chat's owner at session spawn.
+    access_token = os.environ.get("AGENTROVE_ACCESS_TOKEN")
+    if not access_token:
+        raise AgentroveError("AGENTROVE_ACCESS_TOKEN must be set")
     base_url = os.environ.get("AGENTROVE_API_URL", DEFAULT_API_URL)
-    return AgentroveClient(base_url, email, password)
+    return AgentroveClient(base_url, access_token)
 
 
 client = _build_client()


### PR DESCRIPTION
## Problem

The stdio MCP server (`mcp-server/`) that gets spawned into agent chat sessions authenticated with a single instance-wide `AGENTROVE_MCP_EMAIL`/`AGENTROVE_MCP_PASSWORD` pair. With more than one user, every user's agent acted as that one account — full cross-tenant read/write on chats, workspaces, personas, and automations — and the raw password sat in every sandbox process env.

## Approach

The backend spawning the server already knows the chat owner's `user_id` and owns the JWT secret, so it mints a per-user access token at session spawn and injects `AGENTROVE_ACCESS_TOKEN`. Each agent now acts as its chat's owner; isolation falls out of existing per-user API authorization. **Users configure nothing** — deployments keep only the opt-in `AGENTROVE_MCP_ENABLED` flag, now documented for web in `.env.example` and for desktop in `.env.desktop.example`.

- `create_mcp_access_token` (security.py): 7-day JWT via `fastapi_users.jwt.generate_jwt`, audience `fastapi-users:auth` so the normal bearer path accepts it, plus an `mcp` marker claim for auditability. No refresh machinery: session env can't be rotated post-spawn, and idle sessions close after 10 minutes, so every fresh session re-mints.
- **Session fingerprint redacts the token** (`SessionRegistry._redact_mcp_tokens`): the token differs on every mint, and hashing it made every follow-up turn look like a config change — tearing down and respawning the agent session each turn. Regression test proves reuse across turns (a respawn resumes the old session id, so it surfaces as `load_session`, not `new_session`).
- MCP client is token-only; the email/password login + refresh protocol surface is removed. A rejected token raises a clear start-a-new-session error.

## Breaking changes

- `AGENTROVE_MCP_EMAIL` / `AGENTROVE_MCP_PASSWORD` settings are gone (`.env.desktop.example` now documents only the enable flag).
- Running `server.py` standalone now requires a minted `AGENTROVE_ACCESS_TOKEN`; per-user API keys would be the future answer for standalone use.

## Tests

- New: minted token decodes with expected claims and passes real fastapi-users bearer validation against `GET /api/v1/workspaces` (audience mismatch was the likely failure mode).
- New: MCP-enabled session is reused across turns (fails without the fingerprint redaction).
- Strengthened: spawned MCP env carries `AGENTROVE_ACCESS_TOKEN` and no email/password.
- `test_acp.py` + `test_auth.py`: **114 passed**.

## Also in this PR

- Both env example files now document the full overridable settings surface for their mode (`.env.desktop.example` also states the five spawn-pinned vars it can't override). Every documented key is cross-checked against `Settings`.
- Dropped the redundant `DESKTOP_MODE` pin from `desktop.rs` — `entry.py` already `setdefault`s it.
