### PR TITLE
Pin cursor-agent and opencode installs in Docker images

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,16 +29,23 @@ RUN apt-get update && \
 
 RUN npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.64.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.36
 
-# Cursor CLI (installs `cursor-agent` to /root/.local/bin) — used for the Cursor
-# ACP server (`cursor-agent acp`). The install script downloads the binary for
-# the current platform.
-RUN curl -fsS https://cursor.com/install | bash && \
-    cp /root/.local/bin/cursor-agent /usr/local/bin/cursor-agent && \
+# Cursor CLI — used for the Cursor ACP server (`cursor-agent acp`). Pinned
+# download replicating cursor.com/install, which always fetches its own latest.
+RUN set -eux; \
+    v=2026.08.04-aaa8809; \
+    case "$(uname -m)" in x86_64) arch=x64;; aarch64) arch=arm64;; *) exit 1;; esac; \
+    dir=/root/.local/share/cursor-agent/versions/$v; \
+    mkdir -p "$dir" /root/.local/bin; \
+    curl -fsSL "https://downloads.cursor.com/lab/$v/linux/$arch/agent-cli-package.tar.gz" \
+      | tar --strip-components=1 -xz -C "$dir"; \
+    ln -sf "$dir/cursor-agent" /root/.local/bin/cursor-agent; \
+    cp "$dir/cursor-agent" /usr/local/bin/cursor-agent; \
     chmod +x /usr/local/bin/cursor-agent
 
-# OpenCode CLI — used for the OpenCode ACP server (`opencode acp`). The install
-# script downloads the binary to /root/.opencode/bin.
-RUN curl -fsSL https://opencode.ai/install | bash && \
+# OpenCode CLI — used for the OpenCode ACP server (`opencode acp`); installs to
+# /root/.opencode/bin. Pinned: the unpinned path resolves "latest" via the
+# rate-limited GitHub API.
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --version 1.18.15 && \
     cp /root/.opencode/bin/opencode /usr/local/bin/opencode && \
     chmod +x /usr/local/bin/opencode
 

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -75,12 +75,22 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
 RUN . "$NVM_DIR/nvm.sh" && \
     npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.64.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.36
 
-# Cursor CLI (installs `cursor-agent` to ~/.local/bin, which is already on PATH).
-RUN curl -fsS https://cursor.com/install | bash
+# Cursor CLI — pinned download replicating cursor.com/install (which always
+# fetches its own latest); cursor-agent lands in ~/.local/bin, already on PATH.
+RUN set -eux; \
+    v=2026.08.04-aaa8809; \
+    case "$(uname -m)" in x86_64) arch=x64;; aarch64) arch=arm64;; *) exit 1;; esac; \
+    dir=/home/user/.local/share/cursor-agent/versions/$v; \
+    mkdir -p "$dir" /home/user/.local/bin; \
+    curl -fsSL "https://downloads.cursor.com/lab/$v/linux/$arch/agent-cli-package.tar.gz" \
+      | tar --strip-components=1 -xz -C "$dir"; \
+    ln -sf "$dir/cursor-agent" /home/user/.local/bin/cursor-agent; \
+    ln -sf "$dir/cursor-agent" /home/user/.local/bin/agent
 
 # OpenCode CLI (installs `opencode` to ~/.opencode/bin; symlink into ~/.local/bin
-# so the ACP binary resolves without modifying PATH).
-RUN curl -fsSL https://opencode.ai/install | bash && \
+# so the ACP binary resolves without modifying PATH). Pinned: the unpinned path
+# resolves "latest" via the rate-limited GitHub API.
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --version 1.18.15 && \
     mkdir -p /home/user/.local/bin && \
     ln -sf /home/user/.opencode/bin/opencode /home/user/.local/bin/opencode
 


### PR DESCRIPTION
## Problem

Today's deploy of `main` failed at `backend/Dockerfile`'s opencode step. Root cause (reproduced): the unpinned installer resolves "latest" via the **unauthenticated GitHub API (60 req/hour/IP)** — when the deploy server's quota is exhausted, the script gets no `tag_name` and exits 1. Coolify builds with `--no-cache`, so both this and the cursor installer re-run on **every** deploy, making any upstream blip a deploy failure with zero repo changes — and images non-reproducible besides. Same pattern exists in `sandbox/docker/Dockerfile`.

## Change

- **opencode → `1.18.15`** via the installer's own `--version` flag. The pinned path skips `api.github.com` entirely and downloads the exact release artifact.
- **cursor-agent → `2026.08.04-aaa8809`**: `cursor.com/install` has no version argument (the script itself hardcodes whatever build is current), so the pinned step replicates its behavior directly — versioned download URL, `--strip-components=1` into `~/.local/share/cursor-agent/versions/<v>`, same symlinks — with `uname -m` → `x64`/`arm64` mapping (the sandbox image builds `linux/amd64,linux/arm64`).
- Applied to both `backend/Dockerfile` and `sandbox/docker/Dockerfile`; end-state file layout matches what the installers produced.

## Verification

- Pinned cursor sequence executed locally: extracts, `cursor-agent` runs and reports `2026.08.04-aaa8809`.
- `curl … | bash -s -- --version 1.18.15` executed in a clean env: exit 0, binary reports `1.18.15`.
- All pinned artifact URLs return 200: cursor linux/x64 + linux/arm64; opencode linux-x64, linux-arm64, linux-x64-baseline.