### PR TITLE
Add Grok 4.6 and DeepSeek V4 Pro 0813, sync missing OpenCode models

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -211,6 +211,7 @@ MODELS: dict[str, ModelInfo] = {
         "Grok 4.20 Thinking", AgentKind.CURSOR, 200_000
     ),
     "cursor:kimi-k2.5": ModelInfo("Kimi K2.5", AgentKind.CURSOR, 262_000),
+    "grok:grok-4.6": ModelInfo("Grok 4.6", AgentKind.GROK, 500_000),
     "grok:grok-4.5": ModelInfo("Grok 4.5", AgentKind.GROK, 500_000),
     "grok:grok-composer-2.5-fast": ModelInfo(
         "Composer 2.5 (Grok)", AgentKind.GROK, 200_000
@@ -350,8 +351,14 @@ MODELS: dict[str, ModelInfo] = {
     "opencode:opencode/grok-4.5": ModelInfo(
         "Grok 4.5 (OpenCode)", AgentKind.OPENCODE, 500_000
     ),
+    "opencode:opencode/grok-4.6": ModelInfo(
+        "Grok 4.6 (OpenCode)", AgentKind.OPENCODE, 500_000
+    ),
     "opencode:opencode/grok-build-0.1": ModelInfo(
         "Grok Build 0.1 (OpenCode)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:opencode/hy3-free": ModelInfo(
+        "Hy3 Free (OpenCode)", AgentKind.OPENCODE, 190_000
     ),
     "opencode:opencode/kimi-k2.5": ModelInfo(
         "Kimi K2.5 (OpenCode)", AgentKind.OPENCODE, 262_144
@@ -371,6 +378,9 @@ MODELS: dict[str, ModelInfo] = {
     "opencode:opencode/ling-3.0-flash-free": ModelInfo(
         "Ling-3.0-flash Free (OpenCode)", AgentKind.OPENCODE, 262_144
     ),
+    "opencode:opencode/ling-3.0-tiny-free": ModelInfo(
+        "Ling-3.0-tiny Free (OpenCode)", AgentKind.OPENCODE, 262_144
+    ),
     "opencode:opencode/mimo-v2.5-free": ModelInfo(
         "MiMo V2.5 Free (OpenCode)", AgentKind.OPENCODE, 200_000
     ),
@@ -385,6 +395,9 @@ MODELS: dict[str, ModelInfo] = {
     ),
     "opencode:opencode/nemotron-3-ultra-free": ModelInfo(
         "Nemotron 3 Ultra Free (OpenCode)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:opencode/nemotron-3.5-lightning-free": ModelInfo(
+        "Nemotron 3.5 Lightning Free (OpenCode)", AgentKind.OPENCODE, 262_144
     ),
     "opencode:opencode/north-mini-code-free": ModelInfo(
         "North Mini Code Free (OpenCode)", AgentKind.OPENCODE, 256_000
@@ -445,6 +458,9 @@ MODELS: dict[str, ModelInfo] = {
     ),
     "opencode:opencode-go/qwen3.7-plus": ModelInfo(
         "Qwen3.7 Plus (Opencode Go)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:opencode-go/qwen3.8-max": ModelInfo(
+        "Qwen3.8 Max (Opencode Go)", AgentKind.OPENCODE, 1_000_000
     ),
     "opencode:amazon-bedrock/amazon.nova-2-lite-v1:0": ModelInfo(
         "Nova 2 Lite (Amazon Bedrock)", AgentKind.OPENCODE, 128_000
@@ -862,6 +878,9 @@ MODELS: dict[str, ModelInfo] = {
     "opencode:github-copilot/gemini-3.5-flash": ModelInfo(
         "Gemini 3.5 Flash (Github Copilot)", AgentKind.OPENCODE, 200_000
     ),
+    "opencode:github-copilot/gemini-3.6-flash": ModelInfo(
+        "Gemini 3.6 Flash (Github Copilot)", AgentKind.OPENCODE, 1_000_000
+    ),
     "opencode:github-copilot/gpt-4.1": ModelInfo(
         "GPT-4.1 (Github Copilot)", AgentKind.OPENCODE, 128_000
     ),
@@ -898,11 +917,20 @@ MODELS: dict[str, ModelInfo] = {
     "opencode:github-copilot/gpt-5.6-terra": ModelInfo(
         "GPT-5.6 Terra (Github Copilot)", AgentKind.OPENCODE, 1_050_000
     ),
+    "opencode:github-copilot/grok-4.5": ModelInfo(
+        "Grok 4.5 (Github Copilot)", AgentKind.OPENCODE, 500_000
+    ),
     "opencode:github-copilot/kimi-k2.7-code": ModelInfo(
         "Kimi K2.7 Code (Github Copilot)", AgentKind.OPENCODE, 256_000
     ),
+    "opencode:github-copilot/kimi-k3": ModelInfo(
+        "Kimi K3 (Github Copilot)", AgentKind.OPENCODE, 1_048_576
+    ),
     "opencode:github-copilot/mai-code-1-flash-picker": ModelInfo(
         "MAI-Code-1-Flash (Github Copilot)", AgentKind.OPENCODE, 256_000
+    ),
+    "opencode:github-copilot/mai-code-1.1-flash": ModelInfo(
+        "MAI-Code-1.1-Flash (Github Copilot)", AgentKind.OPENCODE, 256_000
     ),
     "opencode:google/deep-research-max-preview-04-2026": ModelInfo(
         "Deep Research Max Preview (Apr-21-2026) (Google)", AgentKind.OPENCODE, 131_072
@@ -1318,6 +1346,9 @@ MODELS: dict[str, ModelInfo] = {
     ),
     "opencode:openrouter/deepseek/deepseek-v4-pro": ModelInfo(
         "DeepSeek V4 Pro (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/deepseek/deepseek-v4-pro-0813": ModelInfo(
+        "DeepSeek V4 Pro 0813 (Openrouter)", AgentKind.OPENCODE, 1_048_576
     ),
     "opencode:openrouter/google/gemini-2.5-flash": ModelInfo(
         "Gemini 2.5 Flash (Openrouter)", AgentKind.OPENCODE, 1_048_576
@@ -2083,6 +2114,9 @@ MODELS: dict[str, ModelInfo] = {
     "opencode:openrouter/x-ai/grok-4.5": ModelInfo(
         "Grok 4.5 (Openrouter)", AgentKind.OPENCODE, 500_000
     ),
+    "opencode:openrouter/x-ai/grok-4.6": ModelInfo(
+        "Grok 4.6 (Openrouter)", AgentKind.OPENCODE, 500_000
+    ),
     "opencode:openrouter/x-ai/grok-build-0.1": ModelInfo(
         "Grok Build 0.1 (Openrouter)", AgentKind.OPENCODE, 256_000
     ),
@@ -2246,6 +2280,9 @@ MODELS: dict[str, ModelInfo] = {
     ),
     "opencode:zai-coding-plan/glm-5.2": ModelInfo(
         "GLM-5.2 (Zai Coding Plan)", AgentKind.OPENCODE, 1_000_000
+    ),
+    "opencode:zai-coding-plan/glm-5.2-highspeed": ModelInfo(
+        "GLM-5.2 Highspeed (Zai Coding Plan)", AgentKind.OPENCODE, 1_000_000
     ),
     "opencode:zai-coding-plan/glm-5v-turbo": ModelInfo(
         "GLM-5V-Turbo (Zai Coding Plan)", AgentKind.OPENCODE, 200_000

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -213,9 +213,6 @@ MODELS: dict[str, ModelInfo] = {
     "cursor:kimi-k2.5": ModelInfo("Kimi K2.5", AgentKind.CURSOR, 262_000),
     "grok:grok-4.6": ModelInfo("Grok 4.6", AgentKind.GROK, 500_000),
     "grok:grok-4.5": ModelInfo("Grok 4.5", AgentKind.GROK, 500_000),
-    "grok:grok-composer-2.5-fast": ModelInfo(
-        "Composer 2.5 (Grok)", AgentKind.GROK, 200_000
-    ),
     "opencode:opencode/big-pickle": ModelInfo(
         "Big Pickle (OpenCode)", AgentKind.OPENCODE, 200_000
     ),

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -72,10 +72,12 @@ CURSOR_SESSION_MODES = frozenset({"agent", "plan", "ask"})
 # default classifier behavior (routine calls pass, risky ones prompt); `plan`
 # stays for the set_mode plan-hop and revives if ACP modes return.
 GROK_SESSION_MODES = frozenset({"auto", "always-approve", "plan"})
-# Only Grok 4.5 exposes the low/medium/high reasoning-effort dial; Composer
-# ignores it, so the effort launch flag is skipped for other models.
+# Grok 4.5 exposes low/medium/high reasoning effort, Grok 4.6 adds xhigh, and
+# Composer ignores the dial, so its effort launch flag is skipped.
 GROK_VALID_THINKING_MODES = frozenset({"low", "medium", "high"})
-GROK_REASONING_MODEL_IDS = frozenset({"grok:grok-4.5"})
+GROK_REASONING_MODEL_IDS = frozenset({"grok:grok-4.5", "grok:grok-4.6"})
+GROK_XHIGH_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
+GROK_XHIGH_MODEL_IDS = frozenset({"grok:grok-4.6"})
 
 # OpenCode's built-in primary agents double as ACP session modes; `plan`
 # restricts edits to `.opencode/plans/*.md`, `build` has full tool access.
@@ -119,6 +121,8 @@ def valid_thinking_modes(agent_kind: AgentKind, model_id: str) -> frozenset[str]
     if agent_kind is AgentKind.COPILOT:
         return COPILOT_VALID_THINKING_MODES
     if agent_kind is AgentKind.GROK:
+        if model_id in GROK_XHIGH_MODEL_IDS:
+            return GROK_XHIGH_VALID_THINKING_MODES
         return (
             GROK_VALID_THINKING_MODES
             if model_id in GROK_REASONING_MODEL_IDS

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -72,8 +72,8 @@ CURSOR_SESSION_MODES = frozenset({"agent", "plan", "ask"})
 # default classifier behavior (routine calls pass, risky ones prompt); `plan`
 # stays for the set_mode plan-hop and revives if ACP modes return.
 GROK_SESSION_MODES = frozenset({"auto", "always-approve", "plan"})
-# Grok 4.5 exposes low/medium/high reasoning effort, Grok 4.6 adds xhigh, and
-# Composer ignores the dial, so its effort launch flag is skipped.
+# Grok 4.5 exposes low/medium/high reasoning effort and Grok 4.6 adds xhigh;
+# the effort launch flag is skipped for models outside these allowlists.
 GROK_VALID_THINKING_MODES = frozenset({"low", "medium", "high"})
 GROK_REASONING_MODEL_IDS = frozenset({"grok:grok-4.5", "grok:grok-4.6"})
 GROK_XHIGH_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -56,6 +56,12 @@ async def test_list_models_returns_registered_models(
         "max",
     ]
     assert by_id["grok:grok-4.5"]["thinking_modes"] == ["low", "medium", "high"]
+    assert by_id["grok:grok-4.6"]["thinking_modes"] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    ]
     assert by_id["cursor:auto"]["thinking_modes"] == []
 
 

--- a/frontend/src/components/chat/message-input/InputControls.tsx
+++ b/frontend/src/components/chat/message-input/InputControls.tsx
@@ -36,7 +36,7 @@ export function InputControls() {
     !!branchesData?.is_git_repo &&
     branchesData.branches.length > 0;
   // Model-aware: some agents only expose a reasoning dial on specific models
-  // (e.g. Grok 4.5 but not Composer), so the base per-agent list isn't enough.
+  // (e.g. Claude's Haiku has none), so the base per-agent list isn't enough.
   const showThinking = agentKind
     ? getThinkingModesForAgent(agentKind, state.selectedModelId).length > 0
     : true;

--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -51,8 +51,8 @@ const CODEX_ULTRA_MODEL_IDS = new Set(['gpt-5.6-sol', 'gpt-5.6-terra']);
 // so an empty list hides the selector.
 const EMPTY_THINKING_MODES: ThinkingModeOption[] = [];
 
-// Grok 4.5 has low–high reasoning effort, Grok 4.6 adds xhigh, and Composer
-// ignores the dial, so the selector is model-gated like Claude's xhigh tier.
+// Grok 4.5 has low–high reasoning effort and Grok 4.6 adds xhigh, so the
+// selector is model-gated like Claude's xhigh tier.
 const GROK_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'low', label: 'Low' },
   { value: 'medium', label: 'Medium' },

--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -51,14 +51,19 @@ const CODEX_ULTRA_MODEL_IDS = new Set(['gpt-5.6-sol', 'gpt-5.6-terra']);
 // so an empty list hides the selector.
 const EMPTY_THINKING_MODES: ThinkingModeOption[] = [];
 
-// Grok's reasoning-effort dial only exists on Grok 4.5 (Composer ignores it),
-// so the selector is model-gated like Claude's xhigh tier.
+// Grok 4.5 has low–high reasoning effort, Grok 4.6 adds xhigh, and Composer
+// ignores the dial, so the selector is model-gated like Claude's xhigh tier.
 const GROK_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'low', label: 'Low' },
   { value: 'medium', label: 'Medium' },
   { value: 'high', label: 'High' },
 ];
-const GROK_REASONING_MODEL_IDS = new Set(['grok:grok-4.5']);
+const GROK_REASONING_MODEL_IDS = new Set(['grok:grok-4.5', 'grok:grok-4.6']);
+const GROK_XHIGH_THINKING_MODES: ThinkingModeOption[] = [
+  ...GROK_THINKING_MODES,
+  { value: 'xhigh', label: 'XHigh' },
+];
+const GROK_XHIGH_MODEL_IDS = new Set(['grok:grok-4.6']);
 
 export const THINKING_MODES_BY_AGENT: Record<AgentKind, ThinkingModeOption[]> = {
   claude: CLAUDE_THINKING_MODES,
@@ -95,6 +100,9 @@ export function getThinkingModesForAgent(
   }
   if (agentKind === 'codex' && modelId && CODEX_MAX_MODEL_IDS.has(modelId)) {
     return CODEX_MAX_THINKING_MODES;
+  }
+  if (agentKind === 'grok' && modelId && GROK_XHIGH_MODEL_IDS.has(modelId)) {
+    return GROK_XHIGH_THINKING_MODES;
   }
   if (agentKind === 'grok' && modelId && GROK_REASONING_MODEL_IDS.has(modelId)) {
     return GROK_THINKING_MODES;


### PR DESCRIPTION
## What

**Grok Build (`grok` agent)**
- Register `grok:grok-4.6` — "Grok 4.6", 500k context, listed first (it is now the grok CLI's default model)
- Expose its reasoning tiers `low/medium/high/xhigh` via a per-model gate (`GROK_XHIGH_MODEL_IDS`) following the existing `CLAUDE_XHIGH_*` / `CODEX_ULTRA_*` pattern in both `adapters.py` and the frontend thinking-mode selector; `grok:grok-4.5` keeps `low/medium/high`
- xhigh is new and exclusive to 4.6: [xAI docs](https://docs.x.ai/developers/grok-4-6) list low/medium/high (default)/xhigh; 4.5 coerces xhigh→high. The CLI forwards `xhigh` as a canonical `--reasoning-effort` level
- **Retire `grok:grok-composer-2.5-fast`**: the grok CLI no longer lists Composer 2.5 (only 4.6 and 4.5 remain). Drops the catalog entry and the comments citing Composer as the dial-less example. ⚠️ Chats/automations still pinned to the retired ID will fail model validation on next send and need remapping to a current grok model

**OpenCode catalog** (names/context windows verified against models.dev + live `opencode models`, CLI 1.14.19)
- `opencode/grok-4.6`, `openrouter/x-ai/grok-4.6` (500k)
- `openrouter/deepseek/deepseek-v4-pro-0813` — DeepSeek's new pro snapshot released 2026-08-12 (1,048,576 ctx). The first-party `deepseek/deepseek-v4-pro` ID now serves this snapshot upstream, so no new entry needed there
- Resync of 9 models newly listed by the CLI: `github-copilot/{gemini-3.6-flash, grok-4.5, kimi-k3, mai-code-1.1-flash}`, `opencode-go/qwen3.8-max`, `opencode/{hy3-free, ling-3.0-tiny-free, nemotron-3.5-lightning-free}`, `zai-coding-plan/glm-5.2-highspeed`
- No removals on the OpenCode side: entries absent from the local CLI listing reflect unconfigured providers, not stale IDs

## Verification
- `backend/tests/test_models.py` extended: `grok:grok-4.6` advertises `["low","medium","high","xhigh"]`; backend model tests pass
- Registry loads 742 models; `grok-composer-2.5-fast` has zero remaining references outside the build-artifact sidecar
- Frontend typecheck passes; ruff format/lint clean; pre-commit hooks green on both commits