### PR TITLE
Add pass-through migration for phantom Alembic revision c9d0e1f2a3b4

### DIFF
--- a/backend/migrations/versions/c9d0e1f2a3b4_reconcile_unknown_deployed_revision.py
+++ b/backend/migrations/versions/c9d0e1f2a3b4_reconcile_unknown_deployed_revision.py
@@ -1,0 +1,26 @@
+# Revision ID: c9d0e1f2a3b4
+# Revises: b8c9d0e1f2a3
+# Create Date: 2026-08-13 00:00:00.000000
+
+"""Reconcile a deployed revision whose migration never landed on main.
+
+A deployed build once stamped databases with revision c9d0e1f2a3b4. This
+pass-through revision re-anchors them into the chain so ``alembic upgrade head``
+can resolve. It intentionally has no operations and must not be deleted while any
+environment's alembic_version may still contain c9d0e1f2a3b4.
+"""
+
+from typing import Sequence
+
+revision: str = "c9d0e1f2a3b4"
+down_revision: str | None = "b8c9d0e1f2a3"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Problem

Production deploys crash-loop at startup:

```
alembic.util.exc.CommandError: Can't locate revision identified by 'c9d0e1f2a3b4'
```

The production SQLite database (`/data/agentrove/storage/agentrove.db`) has `alembic_version = c9d0e1f2a3b4`, but no migration file with that ID exists on `main` — or on any branch, PR, reflog entry, or unreachable git object (GitHub-wide code/commit search included). The last real migration is `b8c9d0e1f2a3` (#874). `entrypoint.sh` → `migrate.py` → `alembic upgrade head` can't resolve the stamp, re-raises in production mode, and the container never reaches uvicorn.

A build containing a phantom successor migration (it follows the repo's hand-rolled revision-ID pattern exactly) evidently ran against the prod DB and stamped it, and the file never landed on `main`. Most likely vector: a Coolify PR preview sharing production storage — the compose default binds previews to `/data/agentrove/storage` unless `AGENTROVE_STORAGE_SOURCE=agentrove_storage` is set in the preview env (see `docker-compose-production.yml:46-51`).

## Fix

Add a committed **no-op pass-through migration** with the phantom's exact ID, chained after the current head:

- `revision = c9d0e1f2a3b4`, `down_revision = b8c9d0e1f2a3`, empty `upgrade()`/`downgrade()`
- Databases already stamped at `c9d0e1f2a3b4` resolve and `upgrade head` is a no-op — prod boots with zero manual DB surgery
- Fresh databases run it as an empty step; future migrations chain after it normally

## Verification

- `alembic heads` → single head `c9d0e1f2a3b4`, parent `b8c9d0e1f2a3`
- **Prod repro:** throwaway DB containing only `alembic_version = c9d0e1f2a3b4` (the exact failing prod state) → `alembic upgrade head` exits 0 as a no-op; before this fix it fails with the error above
- **Fresh DB:** `alembic upgrade head` applies all 10 revisions cleanly, ending at `c9d0e1f2a3b4`
- Current SQLAlchemy models match the `b8c9d0e1f2a3` head exactly, so no schema change is being skipped

## Operational follow-ups (not in this PR)

1. Back up prod DB before redeploying: `cp -a /data/agentrove/storage/agentrove.db{,.bak}`
2. After boot, compare prod's actual tables/columns against the models to detect any leftover DDL the phantom revision may have applied
3. Set `AGENTROVE_STORAGE_SOURCE=agentrove_storage` in the Coolify preview environment so previews can't touch production storage again