### PR TITLE
Sync Copilot provider with CLI 1.0.79

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.64.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.36
+RUN npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.64.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.79
 
 # Cursor CLI — used for the Cursor ACP server (`cursor-agent acp`). Pinned
 # download replicating cursor.com/install, which always fetches its own latest.

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -151,20 +151,43 @@ MODELS: dict[str, ModelInfo] = {
     "gpt-5.2": ModelInfo("GPT 5.2", AgentKind.CODEX, 400_000),
     "gpt-5.1-codex-max": ModelInfo("GPT 5.1 Codex Max", AgentKind.CODEX, 400_000),
     "gpt-5.1-codex-mini": ModelInfo("GPT 5.1 Codex Mini", AgentKind.CODEX, 400_000),
+    "copilot:auto": ModelInfo("Auto", AgentKind.COPILOT, None),
+    "copilot:claude-sonnet-5": ModelInfo("Sonnet 5", AgentKind.COPILOT, 160_000),
+    "copilot:claude-fable-5": ModelInfo("Fable 5", AgentKind.COPILOT, 160_000),
+    "copilot:claude-opus-5": ModelInfo("Opus 5", AgentKind.COPILOT, 160_000),
+    "copilot:claude-opus-4.8": ModelInfo("Opus 4.8", AgentKind.COPILOT, 160_000),
+    "copilot:claude-opus-4.8-fast": ModelInfo(
+        "Opus 4.8 Fast", AgentKind.COPILOT, 160_000
+    ),
+    "copilot:claude-opus-4.7": ModelInfo("Opus 4.7", AgentKind.COPILOT, 160_000),
     "copilot:claude-sonnet-4.6": ModelInfo("Sonnet 4.6", AgentKind.COPILOT, 160_000),
-    "copilot:claude-sonnet-4.5": ModelInfo("Sonnet 4.5", AgentKind.COPILOT, 160_000),
     "copilot:claude-opus-4.6": ModelInfo("Opus 4.6", AgentKind.COPILOT, 160_000),
+    "copilot:claude-sonnet-4.5": ModelInfo("Sonnet 4.5", AgentKind.COPILOT, 160_000),
     "copilot:claude-opus-4.5": ModelInfo("Opus 4.5", AgentKind.COPILOT, 160_000),
     "copilot:claude-haiku-4.5": ModelInfo("Haiku 4.5", AgentKind.COPILOT, 160_000),
-    "copilot:claude-sonnet-4": ModelInfo("Sonnet 4", AgentKind.COPILOT, 144_000),
+    "copilot:gpt-5.6-sol": ModelInfo("GPT 5.6 Sol", AgentKind.COPILOT, 304_000),
+    "copilot:gpt-5.6-terra": ModelInfo("GPT 5.6 Terra", AgentKind.COPILOT, 304_000),
+    "copilot:gpt-5.6-luna": ModelInfo("GPT 5.6 Luna", AgentKind.COPILOT, 304_000),
+    "copilot:gpt-5.5": ModelInfo("GPT 5.5", AgentKind.COPILOT, 304_000),
     "copilot:gpt-5.4": ModelInfo("GPT 5.4", AgentKind.COPILOT, 304_000),
     "copilot:gpt-5.4-mini": ModelInfo("GPT 5.4 Mini", AgentKind.COPILOT, 304_000),
     "copilot:gpt-5.3-codex": ModelInfo("GPT 5.3 Codex", AgentKind.COPILOT, 304_000),
-    "copilot:gpt-5.2-codex": ModelInfo("GPT 5.2 Codex", AgentKind.COPILOT, 304_000),
-    "copilot:gpt-5.2": ModelInfo("GPT 5.2", AgentKind.COPILOT, 160_000),
-    "copilot:gpt-5.1": ModelInfo("GPT 5.1", AgentKind.COPILOT, 160_000),
     "copilot:gpt-5-mini": ModelInfo("GPT 5 Mini", AgentKind.COPILOT, 160_000),
-    "copilot:gpt-4.1": ModelInfo("GPT 4.1", AgentKind.COPILOT, 80_000),
+    "copilot:mai-code-1-flash-picker": ModelInfo(
+        "MAI Code 1 Flash", AgentKind.COPILOT, 128_000
+    ),
+    "copilot:gemini-3.6-flash": ModelInfo(
+        "Gemini 3.6 Flash", AgentKind.COPILOT, 1_000_000
+    ),
+    "copilot:gemini-3.5-flash": ModelInfo(
+        "Gemini 3.5 Flash", AgentKind.COPILOT, 1_000_000
+    ),
+    "copilot:gemini-3.1-pro-preview": ModelInfo(
+        "Gemini 3.1 Pro Preview", AgentKind.COPILOT, 200_000
+    ),
+    "copilot:grok-4.5": ModelInfo("Grok 4.5", AgentKind.COPILOT, 256_000),
+    "copilot:kimi-k3": ModelInfo("Kimi K3", AgentKind.COPILOT, 256_000),
+    "copilot:kimi-k2.7-code": ModelInfo("Kimi K2.7 Code", AgentKind.COPILOT, 256_000),
     "cursor:auto": ModelInfo("Auto", AgentKind.CURSOR, None),
     "cursor:composer-2.5-fast": ModelInfo(
         "Composer 2.5 Fast", AgentKind.CURSOR, 200_000

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -62,7 +62,45 @@ CODEX_MAX_MODEL_IDS = frozenset({"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"}
 # delegation) is supported by Sol/Terra but not Luna.
 CODEX_ULTRA_VALID_THINKING_MODES = CODEX_MAX_VALID_THINKING_MODES | {"ultra"}
 CODEX_ULTRA_MODEL_IDS = frozenset({"gpt-5.6-sol", "gpt-5.6-terra"})
-COPILOT_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
+COPILOT_MAX_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh", "max"})
+COPILOT_MAX_MODEL_IDS = frozenset(
+    {
+        "copilot:claude-sonnet-5",
+        "copilot:claude-fable-5",
+        "copilot:claude-opus-5",
+        "copilot:claude-opus-4.8",
+        "copilot:claude-opus-4.8-fast",
+        "copilot:claude-opus-4.7",
+        "copilot:gpt-5.6-sol",
+        "copilot:gpt-5.6-terra",
+        "copilot:gpt-5.6-luna",
+    }
+)
+COPILOT_NO_XHIGH_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "max"})
+COPILOT_NO_XHIGH_MODEL_IDS = frozenset(
+    {"copilot:claude-sonnet-4.6", "copilot:claude-opus-4.6"}
+)
+COPILOT_XHIGH_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
+COPILOT_XHIGH_MODEL_IDS = frozenset(
+    {
+        "copilot:gpt-5.5",
+        "copilot:gpt-5.4",
+        "copilot:gpt-5.4-mini",
+        "copilot:gpt-5.3-codex",
+    }
+)
+COPILOT_VALID_THINKING_MODES = frozenset({"low", "medium", "high"})
+COPILOT_REASONING_MODEL_IDS = frozenset(
+    {
+        "copilot:gpt-5-mini",
+        "copilot:mai-code-1-flash-picker",
+        "copilot:gemini-3.6-flash",
+        "copilot:gemini-3.5-flash",
+        "copilot:gemini-3.1-pro-preview",
+        "copilot:grok-4.5",
+    }
+)
+COPILOT_KIMI_K3_VALID_THINKING_MODES = frozenset({"low", "high", "max"})
 
 # Cursor CLI exposes three ACP session modes (see https://cursor.com/docs/cli/acp).
 CURSOR_SESSION_MODES = frozenset({"agent", "plan", "ask"})
@@ -117,7 +155,17 @@ def valid_thinking_modes(agent_kind: AgentKind, model_id: str) -> frozenset[str]
             return CODEX_MAX_VALID_THINKING_MODES
         return CODEX_VALID_THINKING_MODES
     if agent_kind is AgentKind.COPILOT:
-        return COPILOT_VALID_THINKING_MODES
+        if model_id in COPILOT_MAX_MODEL_IDS:
+            return COPILOT_MAX_VALID_THINKING_MODES
+        if model_id in COPILOT_NO_XHIGH_MODEL_IDS:
+            return COPILOT_NO_XHIGH_VALID_THINKING_MODES
+        if model_id in COPILOT_XHIGH_MODEL_IDS:
+            return COPILOT_XHIGH_VALID_THINKING_MODES
+        if model_id in COPILOT_REASONING_MODEL_IDS:
+            return COPILOT_VALID_THINKING_MODES
+        if model_id == "copilot:kimi-k3":
+            return COPILOT_KIMI_K3_VALID_THINKING_MODES
+        return frozenset()
     if agent_kind is AgentKind.GROK:
         return (
             GROK_VALID_THINKING_MODES
@@ -127,9 +175,18 @@ def valid_thinking_modes(agent_kind: AgentKind, model_id: str) -> frozenset[str]
     return frozenset()
 
 
-def coerce_thinking_mode(mode: str | None, valid_modes: frozenset[str]) -> str:
-    # Clamp UI thinking tier to one the agent accepts (default medium).
-    return mode if mode in valid_modes else "medium"
+def coerce_thinking_mode(
+    mode: str | None, valid_modes: frozenset[str], default: str = "medium"
+) -> str:
+    requested = mode or default
+    if requested in valid_modes:
+        return requested
+    if requested in THINKING_MODE_ORDER:
+        requested_index = THINKING_MODE_ORDER.index(requested)
+        for candidate in reversed(THINKING_MODE_ORDER[:requested_index]):
+            if candidate in valid_modes:
+                return candidate
+    return next((mode for mode in THINKING_MODE_ORDER if mode in valid_modes), default)
 
 
 def build_system_prompt_meta(
@@ -344,8 +401,11 @@ class CopilotCliAdapter(AgentAdapter):
     ) -> SessionConfig:
         meta = build_system_prompt_meta(system_prompt, system_prompt_is_full_replace)
 
-        reasoning_effort = coerce_thinking_mode(
-            thinking_mode, valid_thinking_modes(AgentKind.COPILOT, model_id)
+        copilot_modes = valid_thinking_modes(AgentKind.COPILOT, model_id)
+        reasoning_effort = (
+            coerce_thinking_mode(thinking_mode, copilot_modes, default="high")
+            if copilot_modes
+            else None
         )
 
         return SessionConfig(

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -69,6 +69,7 @@ EMPTY_FROZENSET: frozenset[str] = frozenset()
 # option; value IDs are the supported Claude UI tiers.
 CLAUDE_EFFORT_CONFIG_ID = "effort"
 CLAUDE_MODEL_CONFIG_ID = "model"
+COPILOT_EFFORT_CONFIG_ID = "reasoning_effort"
 
 # codex-acp advertises Fast mode as a session config option (select on/off, or
 # boolean when the client supports it). Values match FastModeConfig.ts.
@@ -264,6 +265,20 @@ class AcpSession:
             )
         except Exception:
             logger.warning("Failed to set ACP model: %s", model_id, exc_info=True)
+        else:
+            if self._agent_kind == AgentKind.COPILOT and reasoning_effort:
+                try:
+                    await self._conn.set_config_option(
+                        config_id=COPILOT_EFFORT_CONFIG_ID,
+                        session_id=self.acp_session_id,
+                        value=reasoning_effort,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to set Copilot effort: %s",
+                        reasoning_effort,
+                        exc_info=True,
+                    )
 
     async def set_mode(self, mode_id: str) -> None:
         try:
@@ -416,6 +431,7 @@ class AcpSession:
                 )
                 acp_session_id = response.session_id
 
+            model_set = False
             if config.model:
                 try:
                     await cls._set_model_on_conn(
@@ -425,6 +441,7 @@ class AcpSession:
                         config.model,
                         config.reasoning_effort,
                     )
+                    model_set = True
                 except Exception:
                     logger.warning(
                         "Failed to set initial model: %s", config.model, exc_info=True
@@ -459,6 +476,24 @@ class AcpSession:
                 except Exception:
                     logger.warning(
                         "Failed to set initial effort: %s",
+                        config.reasoning_effort,
+                        exc_info=True,
+                    )
+
+            if (
+                config.agent_kind == AgentKind.COPILOT
+                and config.reasoning_effort
+                and model_set
+            ):
+                try:
+                    await conn.set_config_option(
+                        config_id=COPILOT_EFFORT_CONFIG_ID,
+                        session_id=acp_session_id,
+                        value=config.reasoning_effort,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to set initial Copilot effort: %s",
                         config.reasoning_effort,
                         exc_info=True,
                     )

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -108,7 +108,7 @@ def test_grok_launch_args_apply_always_approve_flag(
         ("haiku", "high", None),
         ("sonnet", None, "medium"),
         ("sonnet", "high", "high"),
-        ("sonnet", "xhigh", "medium"),  # xhigh is fable/opus-only; clamps
+        ("sonnet", "xhigh", "high"),
         ("claude-opus-5", "xhigh", "xhigh"),
     ],
 )
@@ -293,6 +293,7 @@ async def send_message(
     model_id: str,
     prompt: str,
     permission_mode: str = "default",
+    thinking_mode: str | None = None,
     attached_files: list[tuple[str, tuple[str, bytes, str]]] | None = None,
 ) -> httpx.Response:
     data = {
@@ -301,6 +302,8 @@ async def send_message(
         "model_id": model_id,
         "permission_mode": permission_mode,
     }
+    if thinking_mode is not None:
+        data["thinking_mode"] = thinking_mode
     return await client.post(
         "/api/v1/chat/chat",
         data=data,
@@ -415,6 +418,55 @@ async def test_enhance_prompt_round_trips_through_real_acp_session(
     new_sessions = fake_agent.events_of("new_session")
     assert new_sessions
     assert new_sessions[-1]["mcp_servers"] == []
+
+
+@pytest.mark.parametrize(
+    "model_id,thinking_mode,expected_effort",
+    [
+        ("copilot:gpt-5.4", "max", "xhigh"),
+        ("copilot:claude-haiku-4.5", "high", None),
+        ("copilot:kimi-k3", "medium", "low"),
+    ],
+)
+async def test_copilot_session_setup_gates_and_clamps_reasoning_effort(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+    model_id: str,
+    thinking_mode: str,
+    expected_effort: str | None,
+) -> None:
+    headers, workspace = auth_workspace
+    chat = await create_chat(client, headers, workspace, model_id=model_id)
+
+    response = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id=model_id,
+        prompt="reason carefully",
+        permission_mode="agent",
+        thinking_mode=thinking_mode,
+    )
+    assert response.status_code == 200, response.text
+    message = await wait_for_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        message_id=response.json()["message_id"],
+    )
+    assert message["stream_status"] == "completed"
+
+    effort_calls = [
+        event
+        for event in fake_agent.events_of("set_config_option")
+        if event["config_id"] == "reasoning_effort"
+    ]
+    if expected_effort is None:
+        assert effort_calls == []
+    else:
+        assert effort_calls[-1]["value"] == expected_effort
 
 
 @pytest.mark.parametrize(
@@ -1476,6 +1528,114 @@ async def test_chat_mid_session_model_and_mode_switch_survives_config_errors(
     set_modes = fake_agent.events_of("set_session_mode")
     assert set_modes
     assert set_modes[-1]["mode_id"] == "read-only"
+
+
+async def test_copilot_mid_session_model_switch_reapplies_supported_effort(
+    client: httpx.AsyncClient,
+    auth_workspace: tuple[dict[str, str], Workspace],
+    fake_agent: FakeAgentHandle,
+    acp_cache: EndpointCache,
+) -> None:
+    headers, workspace = auth_workspace
+    chat = await create_chat(
+        client, headers, workspace, model_id="copilot:grok-4.5"
+    )
+
+    first = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="copilot:grok-4.5",
+        prompt="first turn",
+        permission_mode="agent",
+        thinking_mode="high",
+    )
+    first_message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=first.json()["message_id"]
+    )
+    assert first_message["stream_status"] == "completed"
+
+    event_count = len(fake_agent.events())
+    second = await send_message(
+        client,
+        headers,
+        chat_id=chat["id"],
+        model_id="copilot:claude-opus-4.6",
+        prompt="second turn",
+        permission_mode="agent",
+        thinking_mode="high",
+    )
+    second_message = await wait_for_message(
+        client, headers, chat_id=chat["id"], message_id=second.json()["message_id"]
+    )
+    assert second_message["stream_status"] == "completed"
+
+    switch_events = fake_agent.events()[event_count:]
+    assert not any(
+        event["event"] in {"new_session", "load_session"}
+        for event in switch_events
+    )
+    switch_calls = [
+        event
+        for event in switch_events
+        if event["event"] == "set_config_option"
+    ]
+    assert [(event["config_id"], event["value"]) for event in switch_calls] == [
+        ("model", "claude-opus-4.6"),
+        ("reasoning_effort", "high"),
+    ]
+
+    no_dial_chat = await create_chat(
+        client, headers, workspace, model_id="copilot:auto"
+    )
+    no_dial_first = await send_message(
+        client,
+        headers,
+        chat_id=no_dial_chat["id"],
+        model_id="copilot:auto",
+        prompt="first no-dial turn",
+        permission_mode="agent",
+        thinking_mode="high",
+    )
+    no_dial_first_message = await wait_for_message(
+        client,
+        headers,
+        chat_id=no_dial_chat["id"],
+        message_id=no_dial_first.json()["message_id"],
+    )
+    assert no_dial_first_message["stream_status"] == "completed"
+
+    event_count = len(fake_agent.events())
+    no_dial_second = await send_message(
+        client,
+        headers,
+        chat_id=no_dial_chat["id"],
+        model_id="copilot:kimi-k2.7-code",
+        prompt="second no-dial turn",
+        permission_mode="agent",
+        thinking_mode="high",
+    )
+    no_dial_second_message = await wait_for_message(
+        client,
+        headers,
+        chat_id=no_dial_chat["id"],
+        message_id=no_dial_second.json()["message_id"],
+    )
+    assert no_dial_second_message["stream_status"] == "completed"
+
+    no_dial_switch_events = fake_agent.events()[event_count:]
+    assert not any(
+        event["event"] in {"new_session", "load_session"}
+        for event in no_dial_switch_events
+    )
+    no_dial_switch_calls = [
+        event
+        for event in no_dial_switch_events
+        if event["event"] == "set_config_option"
+    ]
+    assert [(event["config_id"], event["value"]) for event in no_dial_switch_calls] == [
+        ("model", "kimi-k2.7-code")
+    ]
 
 
 async def test_chat_attachments_and_mcp_servers_reach_the_agent(

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -1537,9 +1537,7 @@ async def test_copilot_mid_session_model_switch_reapplies_supported_effort(
     acp_cache: EndpointCache,
 ) -> None:
     headers, workspace = auth_workspace
-    chat = await create_chat(
-        client, headers, workspace, model_id="copilot:grok-4.5"
-    )
+    chat = await create_chat(client, headers, workspace, model_id="copilot:grok-4.5")
 
     first = await send_message(
         client,
@@ -1572,13 +1570,10 @@ async def test_copilot_mid_session_model_switch_reapplies_supported_effort(
 
     switch_events = fake_agent.events()[event_count:]
     assert not any(
-        event["event"] in {"new_session", "load_session"}
-        for event in switch_events
+        event["event"] in {"new_session", "load_session"} for event in switch_events
     )
     switch_calls = [
-        event
-        for event in switch_events
-        if event["event"] == "set_config_option"
+        event for event in switch_events if event["event"] == "set_config_option"
     ]
     assert [(event["config_id"], event["value"]) for event in switch_calls] == [
         ("model", "claude-opus-4.6"),

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -55,6 +55,14 @@ async def test_list_models_returns_registered_models(
         "xhigh",
         "max",
     ]
+    assert by_id["copilot:gpt-5.4"]["thinking_modes"] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    ]
+    assert by_id["copilot:kimi-k3"]["thinking_modes"] == ["low", "high", "max"]
+    assert by_id["copilot:claude-haiku-4.5"]["thinking_modes"] == []
     assert by_id["grok:grok-4.5"]["thinking_modes"] == ["low", "medium", "high"]
     assert by_id["cursor:auto"]["thinking_modes"] == []
 

--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -5,6 +5,8 @@ export interface ThinkingModeOption {
   label: string;
 }
 
+const THINKING_MODE_ORDER = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
+
 const CLAUDE_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'low', label: 'Low' },
   { value: 'medium', label: 'Medium' },
@@ -46,6 +48,49 @@ const CODEX_ULTRA_THINKING_MODES: ThinkingModeOption[] = [
 ];
 const CODEX_ULTRA_MODEL_IDS = new Set(['gpt-5.6-sol', 'gpt-5.6-terra']);
 
+const COPILOT_MAX_THINKING_MODES = CODEX_MAX_THINKING_MODES;
+const COPILOT_MAX_MODEL_IDS = new Set([
+  'copilot:claude-sonnet-5',
+  'copilot:claude-fable-5',
+  'copilot:claude-opus-5',
+  'copilot:claude-opus-4.8',
+  'copilot:claude-opus-4.8-fast',
+  'copilot:claude-opus-4.7',
+  'copilot:gpt-5.6-sol',
+  'copilot:gpt-5.6-terra',
+  'copilot:gpt-5.6-luna',
+]);
+const COPILOT_NO_XHIGH_THINKING_MODES = CLAUDE_THINKING_MODES;
+const COPILOT_NO_XHIGH_MODEL_IDS = new Set([
+  'copilot:claude-sonnet-4.6',
+  'copilot:claude-opus-4.6',
+]);
+const COPILOT_XHIGH_THINKING_MODES = CODEX_THINKING_MODES;
+const COPILOT_XHIGH_MODEL_IDS = new Set([
+  'copilot:gpt-5.5',
+  'copilot:gpt-5.4',
+  'copilot:gpt-5.4-mini',
+  'copilot:gpt-5.3-codex',
+]);
+const COPILOT_THINKING_MODES: ThinkingModeOption[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+const COPILOT_REASONING_MODEL_IDS = new Set([
+  'copilot:gpt-5-mini',
+  'copilot:mai-code-1-flash-picker',
+  'copilot:gemini-3.6-flash',
+  'copilot:gemini-3.5-flash',
+  'copilot:gemini-3.1-pro-preview',
+  'copilot:grok-4.5',
+]);
+const COPILOT_KIMI_K3_THINKING_MODES: ThinkingModeOption[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'high', label: 'High' },
+  { value: 'max', label: 'Max' },
+];
+
 // Cursor bakes reasoning effort into the model ID; OpenCode delegates to the
 // per-model provider. Neither exposes a uniform thinking-mode dial via ACP,
 // so an empty list hides the selector.
@@ -63,7 +108,7 @@ const GROK_REASONING_MODEL_IDS = new Set(['grok:grok-4.5']);
 export const THINKING_MODES_BY_AGENT: Record<AgentKind, ThinkingModeOption[]> = {
   claude: CLAUDE_THINKING_MODES,
   codex: CODEX_THINKING_MODES,
-  copilot: CODEX_THINKING_MODES,
+  copilot: EMPTY_THINKING_MODES,
   cursor: EMPTY_THINKING_MODES,
   grok: EMPTY_THINKING_MODES,
   opencode: EMPTY_THINKING_MODES,
@@ -96,6 +141,21 @@ export function getThinkingModesForAgent(
   if (agentKind === 'codex' && modelId && CODEX_MAX_MODEL_IDS.has(modelId)) {
     return CODEX_MAX_THINKING_MODES;
   }
+  if (agentKind === 'copilot' && modelId && COPILOT_MAX_MODEL_IDS.has(modelId)) {
+    return COPILOT_MAX_THINKING_MODES;
+  }
+  if (agentKind === 'copilot' && modelId && COPILOT_NO_XHIGH_MODEL_IDS.has(modelId)) {
+    return COPILOT_NO_XHIGH_THINKING_MODES;
+  }
+  if (agentKind === 'copilot' && modelId && COPILOT_XHIGH_MODEL_IDS.has(modelId)) {
+    return COPILOT_XHIGH_THINKING_MODES;
+  }
+  if (agentKind === 'copilot' && modelId && COPILOT_REASONING_MODEL_IDS.has(modelId)) {
+    return COPILOT_THINKING_MODES;
+  }
+  if (agentKind === 'copilot' && modelId === 'copilot:kimi-k3') {
+    return COPILOT_KIMI_K3_THINKING_MODES;
+  }
   if (agentKind === 'grok' && modelId && GROK_REASONING_MODEL_IDS.has(modelId)) {
     return GROK_THINKING_MODES;
   }
@@ -109,8 +169,19 @@ export function coerceThinkingModeForAgent(
   modelId?: string,
 ): string {
   const modes = getThinkingModesForAgent(agentKind, modelId);
-  const defaultMode = DEFAULT_BY_AGENT[agentKind];
-  return modes.find((mode) => mode.value === thinkingMode)?.value ?? defaultMode;
+  const requestedMode = THINKING_MODE_ORDER.includes(thinkingMode)
+    ? thinkingMode
+    : DEFAULT_BY_AGENT[agentKind];
+  const exactMode = modes.find((mode) => mode.value === requestedMode);
+  if (exactMode) return exactMode.value;
+
+  const requestedIndex = THINKING_MODE_ORDER.indexOf(requestedMode);
+  for (let index = requestedIndex - 1; index >= 0; index -= 1) {
+    const lowerMode = modes.find((mode) => mode.value === THINKING_MODE_ORDER[index]);
+    if (lowerMode) return lowerMode.value;
+  }
+
+  return modes[0]?.value ?? DEFAULT_BY_AGENT[agentKind];
 }
 
 export function getThinkingModeOption(

--- a/frontend/src/utils/chatRequest.test.ts
+++ b/frontend/src/utils/chatRequest.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { coerceThinkingModeForAgent } from '@/components/chat/thinking-mode-selector/thinkingModes';
 import { buildAgentChatFields } from './chatRequest';
 import type { Model } from '@/types/chat.types';
 import type { Persona } from '@/types/user.types';
@@ -19,6 +20,13 @@ const raw = (over: Partial<Parameters<typeof buildAgentChatFields>[2]> = {}) => 
   fastMode: false,
   persona: 'Default',
   ...over,
+});
+
+describe('coerceThinkingModeForAgent', () => {
+  it('uses the agent default for empty or unknown modes', () => {
+    expect(coerceThinkingModeForAgent('', 'claude')).toBe('high');
+    expect(coerceThinkingModeForAgent('unknown', 'copilot', 'copilot:gpt-5.4')).toBe('high');
+  });
 });
 
 describe('buildAgentChatFields', () => {
@@ -56,10 +64,10 @@ describe('buildAgentChatFields', () => {
     expect(fields.thinking_mode).toBe('max');
   });
 
-  it('coerces a thinking mode the model does not support to the agent default', () => {
-    // gpt-5.5 (codex, non-max) has no 'max' tier -> falls back to 'high'.
+  it('clamps an unsupported thinking mode to the nearest lower tier', () => {
+    // gpt-5.5 (codex, non-max) has no 'max' tier, so it clamps to 'xhigh'.
     const fields = buildAgentChatFields('gpt-5.5', new Map(), raw({ thinkingMode: 'max' }), []);
-    expect(fields.thinking_mode).toBe('high');
+    expect(fields.thinking_mode).toBe('xhigh');
   });
 
   it('maps worktree to true only when enabled, else undefined', () => {

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.64.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.36
+    npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.64.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.79
 
 # Cursor CLI — pinned download replicating cursor.com/install (which always
 # fetches its own latest); cursor-agent lands in ~/.local/bin, already on PATH.


### PR DESCRIPTION
## Summary

Brings the Copilot provider up to date with `@github/copilot@1.0.79` (we were pinned at 1.0.36, 43 stable releases behind). All CLI-side facts were verified against the actual 1.0.79 binary — bundle inspection plus a live `--acp --stdio` handshake — not reconstructed from changelogs.

### 1. Pin bump
- `backend/Dockerfile` and `sandbox/docker/Dockerfile`: `@github/copilot@1.0.36` → `1.0.79`.
- Live-probed compatibility: our `initialize` (protocol v1) works unchanged; session-mode URIs (`#agent`/`#plan`/`#autopilot`) and the `"model"` config option id are the same.

### 2. Model registry refresh (14 → 27 entries)
- **Removed** (retired upstream, absent from the 1.0.79 picker): `claude-sonnet-4`, `gpt-4.1`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.1`.
- **Added** (ids verified from the CLI picker): `auto`, Claude Sonnet 5 / Fable 5 / Opus 5 / Opus 4.8 / Opus 4.8 Fast / Opus 4.7, GPT 5.6 Sol/Terra/Luna, GPT 5.5, MAI Code 1 Flash, Gemini 3.6 Flash / 3.5 Flash / 3.1 Pro Preview, Grok 4.5, Kimi K3 / K2.7 Code.
- Kept the models that still work today but retire 2026-09-01 (Opus 4.5/4.6, Sonnet 4.5/4.6, Gemini 3.1 Pro Preview) — follow-up prune planned.
- Context windows for new non-Claude/GPT families are conservative fallbacks; the CLI reports real usage at runtime.

### 3. Reasoning effort wired over ACP (was previously a dead selector)
- Per-model thinking-mode sets extending the existing `valid_thinking_modes` gating (incl. no-dial models — `auto`, Sonnet 4.5, Opus 4.5, Haiku 4.5, Kimi K2.7 Code — and Kimi K3's sparse `low/high/max`).
- Transmitted via `set_config_option(config_id="reasoning_effort")` after session create/load and re-sent after mid-chat model switches (the CLI resets config options on model change). Values are clamped nearest-lower to the model's supported set, so a value the CLI would reject with `-32602` can never be sent; failures degrade to logged warnings.
- `coerce_thinking_mode` is now total (empty set → default) and the frontend clamp mirrors backend semantics for unknown/empty stored values instead of silently downgrading to the lowest tier.

## Testing
- Backend: `pytest tests/test_acp.py tests/test_models.py` — **81 passed**, including new coverage: effort sent + clamped on session setup, no effort call for no-dial models, Kimi K3 `medium` → `low`, and a fingerprint-stable mid-chat switch asserting session reuse and `model` → `reasoning_effort` call ordering.
- Frontend: `vitest run` — **767 passed**; `tsc --noEmit` clean.
- Live probe of the 1.0.79 binary confirmed the ACP handshake, config option ids, per-model effort sets, and the unauthenticated `session/new` error shape.

## Review
Two independent blind review rounds (logic-focused); all accepted findings fixed and re-verified — final round returned approve.