### PR TITLE
Correct codex context windows to the CLI's real 272k catalog cap

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -138,17 +138,20 @@ MODELS: dict[str, ModelInfo] = {
     "haiku": ModelInfo("Haiku", AgentKind.CLAUDE, 200_000),
     "claude-fable-5": ModelInfo("Fable 5", AgentKind.CLAUDE, 1_000_000),
     "claude-opus-5": ModelInfo("Opus 5", AgentKind.CLAUDE, 1_000_000),
-    # 1M via model_context_window in ~/.codex/config.toml (registry default 372k).
+    # Codex CLI clamps model_context_window to its bundled catalog max — 272k for
+    # these slugs — then sessions report ~95% of the resolved window (e.g. 258,400).
+    # gpt-5.4's catalog max is 1M via config opt-in; raise it here once a live
+    # session verifies the opt-in survives our app-server launch path.
     # Live-reported window still wins over these fallbacks.
-    "gpt-5.6-sol": ModelInfo("GPT 5.6 Sol", AgentKind.CODEX, 1_050_000),
-    "gpt-5.6-terra": ModelInfo("GPT 5.6 Terra", AgentKind.CODEX, 1_050_000),
-    "gpt-5.6-luna": ModelInfo("GPT 5.6 Luna", AgentKind.CODEX, 1_050_000),
-    "gpt-5.5": ModelInfo("GPT 5.5", AgentKind.CODEX, 1_000_000),
-    "gpt-5.4": ModelInfo("GPT 5.4", AgentKind.CODEX, 1_000_000),
-    "gpt-5.4-mini": ModelInfo("GPT 5.4 Mini", AgentKind.CODEX, 400_000),
+    "gpt-5.6-sol": ModelInfo("GPT 5.6 Sol", AgentKind.CODEX, 272_000),
+    "gpt-5.6-terra": ModelInfo("GPT 5.6 Terra", AgentKind.CODEX, 272_000),
+    "gpt-5.6-luna": ModelInfo("GPT 5.6 Luna", AgentKind.CODEX, 272_000),
+    "gpt-5.5": ModelInfo("GPT 5.5", AgentKind.CODEX, 272_000),
+    "gpt-5.4": ModelInfo("GPT 5.4", AgentKind.CODEX, 272_000),
+    "gpt-5.4-mini": ModelInfo("GPT 5.4 Mini", AgentKind.CODEX, 272_000),
     "gpt-5.3-codex": ModelInfo("GPT 5.3 Codex", AgentKind.CODEX, 400_000),
     "gpt-5.2-codex": ModelInfo("GPT 5.2 Codex", AgentKind.CODEX, 400_000),
-    "gpt-5.2": ModelInfo("GPT 5.2", AgentKind.CODEX, 400_000),
+    "gpt-5.2": ModelInfo("GPT 5.2", AgentKind.CODEX, 272_000),
     "gpt-5.1-codex-max": ModelInfo("GPT 5.1 Codex Max", AgentKind.CODEX, 400_000),
     "gpt-5.1-codex-mini": ModelInfo("GPT 5.1 Codex Mini", AgentKind.CODEX, 400_000),
     "copilot:claude-sonnet-4.6": ModelInfo("Sonnet 4.6", AgentKind.COPILOT, 160_000),


### PR DESCRIPTION
## Why

The registry carried 1.05M/1M context windows for the codex GPT-5.6 family, GPT-5.5 and GPT-5.4, on the assumption that the `model_context_window = 1000000` opt-in in `~/.codex/config.toml` was in effect (comment even cited a 372k registry default). Neither holds today:

- The Codex CLI **clamps** `model_context_window` to its bundled catalog's `max_context_window` — **272,000** for these slugs (`codex-rs/models-manager/src/model_info.rs`; catalog `models.json` on `main`, retrieved 2026-08-15). The 1M config is silently ignored for 5.6/5.5.
- Sessions then report ~95% of the resolved window as effective. A live `gpt-5.6-luna` session in this deployment reported exactly **258,400 = 272,000 × 0.95**, confirming the 272k resolution (372k would report 353,400; 1M would report 950,000).

## Impact

`/models/` feeds the frontend's context-usage denominator (`useContextUsageState.ts`), so the stale values made the composer meter understate context fill ~4× — the observed session showed **6.8%** in the UI while the agent was actually **27.7%** full (and auto-compacts near 90% of 258k). It also skewed the `context-usage` endpoint's DB-fallback percentage after the Redis cache TTL.

## Changes

| slug | before | after |
|---|---:|---:|
| `gpt-5.6-sol` / `terra` / `luna` | 1,050,000 | 272,000 |
| `gpt-5.5` | 1,000,000 | 272,000 |
| `gpt-5.4` | 1,000,000 | 272,000 (catalog max is 1M via config opt-in — raise once a live session proves the opt-in survives our app-server launch path; upstream openai/codex#14133 is still open) |
| `gpt-5.4-mini` | 400,000 | 272,000 (per today's bundled catalog) |
| `gpt-5.2` | 400,000 | 272,000 (per today's bundled catalog) |

Unchanged on purpose: `gpt-5.3-codex` / `gpt-5.2-codex` / `gpt-5.1-codex-*` (400k is correct for codex-family slugs) and all claude/copilot/cursor/grok/opencode lanes (opencode's 1.05M entries ride a different client and weren't measured — flagged as unaudited).

Live-reported windows still take precedence over these fallbacks at runtime (`streaming/runtime.py`), so this only corrects the fallback/catalog surface.

## Validation

- `backend`: `python -m pytest tests/ -q` → **387 passed** (no fixtures were pinned to the old values)
- `MODELS['gpt-5.6-luna'].context_window` → `272000`

## Follow-ups (not in this PR)

- Frontend: use the backend's live `context_window` as the meter denominator instead of the `/models/` catalog value (closes the remaining ~5% gap from the 95% effective-window discount).
- MCP: return `context_usage: null`/flagged for ACP-lane chats that never emit usage instead of a misleading 0%.