### PR TITLE
chore: bump ACP providers to latest

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,12 +27,12 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.64.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.79
+RUN npm install -g @anthropic-ai/claude-code@2.1.237 @agentclientprotocol/claude-agent-acp@0.70.0 @agentclientprotocol/codex-acp@1.6.0 @openai/codex@0.148.0 @github/copilot@1.0.80
 
 # Cursor CLI — used for the Cursor ACP server (`cursor-agent acp`). Pinned
 # download replicating cursor.com/install, which always fetches its own latest.
 RUN set -eux; \
-    v=2026.08.04-aaa8809; \
+    v=2026.08.11-e8db854; \
     case "$(uname -m)" in x86_64) arch=x64;; aarch64) arch=arm64;; *) exit 1;; esac; \
     dir=/root/.local/share/cursor-agent/versions/$v; \
     mkdir -p "$dir" /root/.local/bin; \
@@ -45,7 +45,7 @@ RUN set -eux; \
 # OpenCode CLI — used for the OpenCode ACP server (`opencode acp`); installs to
 # /root/.opencode/bin. Pinned: the unpinned path resolves "latest" via the
 # rate-limited GitHub API.
-RUN curl -fsSL https://opencode.ai/install | bash -s -- --version 1.18.15 && \
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --version 1.18.18 && \
     cp /root/.opencode/bin/opencode /usr/local/bin/opencode && \
     chmod +x /usr/local/bin/opencode
 

--- a/desktop/run_build.mjs
+++ b/desktop/run_build.mjs
@@ -22,8 +22,8 @@ const PYTHON_VERSION = '3.12.12';
 const NODE_VERSION = '22.12.0';
 const RELEASE_TAG = '20260211';
 const RIPGREP_VERSION = '14.1.1';
-const CLAUDE_AGENT_ACP_VERSION = '0.64.0';
-const CODEX_ACP_VERSION = '1.1.7';
+const CLAUDE_AGENT_ACP_VERSION = '0.70.0';
+const CODEX_ACP_VERSION = '1.6.0';
 const GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py';
 
 const platform = process.platform;

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -73,12 +73,12 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     nvm alias default $NODE_VERSION
 
 RUN . "$NVM_DIR/nvm.sh" && \
-    npm install -g @anthropic-ai/claude-code@2.1.206 @agentclientprotocol/claude-agent-acp@0.64.0 @agentclientprotocol/codex-acp@1.1.7 @openai/codex@0.144.1 @github/copilot@1.0.79
+    npm install -g @anthropic-ai/claude-code@2.1.237 @agentclientprotocol/claude-agent-acp@0.70.0 @agentclientprotocol/codex-acp@1.6.0 @openai/codex@0.148.0 @github/copilot@1.0.80
 
 # Cursor CLI — pinned download replicating cursor.com/install (which always
 # fetches its own latest); cursor-agent lands in ~/.local/bin, already on PATH.
 RUN set -eux; \
-    v=2026.08.04-aaa8809; \
+    v=2026.08.11-e8db854; \
     case "$(uname -m)" in x86_64) arch=x64;; aarch64) arch=arm64;; *) exit 1;; esac; \
     dir=/home/user/.local/share/cursor-agent/versions/$v; \
     mkdir -p "$dir" /home/user/.local/bin; \
@@ -90,7 +90,7 @@ RUN set -eux; \
 # OpenCode CLI (installs `opencode` to ~/.opencode/bin; symlink into ~/.local/bin
 # so the ACP binary resolves without modifying PATH). Pinned: the unpinned path
 # resolves "latest" via the rate-limited GitHub API.
-RUN curl -fsSL https://opencode.ai/install | bash -s -- --version 1.18.15 && \
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --version 1.18.18 && \
     mkdir -p /home/user/.local/bin && \
     ln -sf /home/user/.opencode/bin/opencode /home/user/.local/bin/opencode
 


### PR DESCRIPTION
Bump the ACP agent binaries we ship in the backend image, sandbox image, and desktop sidecar to the current npm / installer releases.

| Provider | From | To |
|---|---|---|
| `@agentclientprotocol/claude-agent-acp` | 0.64.0 | 0.70.0 |
| `@agentclientprotocol/codex-acp` | 1.1.7 | 1.6.0 |
| `@github/copilot` | 1.0.79 | 1.0.80 |
| `@anthropic-ai/claude-code` | 2.1.206 | 2.1.237 |
| `@openai/codex` | 0.144.1 | 0.148.0 |
| `cursor-agent` | 2026.08.04-aaa8809 | 2026.08.11-e8db854 |
| OpenCode | 1.18.15 | 1.18.18 |

`codex-acp` 1.6.0 depends on `@openai/codex` ^0.148.0; Claude Code is bumped alongside `claude-agent-acp`. Grok stays unpinned (`https://x.ai/cli/stable`). Copilot 1.0.80 is a patch (ACP allow-all / reasoning-effort fixes plus model-config updates); catalog code is unchanged from the 1.0.79 sync.

Pins live in `backend/Dockerfile`, `sandbox/docker/Dockerfile`, and `desktop/run_build.mjs`.