### PR TITLE
Fix currency amounts rendering as inline math in chat markdown

### DIFF
--- a/frontend/src/components/ui/markdown/MarkDown.tsx
+++ b/frontend/src/components/ui/markdown/MarkDown.tsx
@@ -73,8 +73,9 @@ export const MarkDown = memo(function MarkDown({
   // stray `$` characters in ordinary text aren't parsed as TeX.
   const needsMath = useMemo(() => MATH_PATTERN.test(content), [content]);
 
-  const remarkPlugins = useMemo(
-    () => (needsMath ? [remarkGfm, remarkMath] : [remarkGfm]),
+  const remarkPlugins = useMemo<NonNullable<Options['remarkPlugins']>>(
+    () =>
+      needsMath ? [remarkGfm, [remarkMath, { singleDollarTextMath: false }]] : [remarkGfm],
     [needsMath],
   );
   const rehypePlugins = useMemo(

--- a/frontend/src/components/ui/markdown/markdownParsing.ts
+++ b/frontend/src/components/ui/markdown/markdownParsing.ts
@@ -4,7 +4,7 @@ import type { MessageAttachment } from '@/types/chat.types';
 import { buildHighlightSegments } from '@/utils/mentionParser';
 import { MENTION_PILL_CLASSNAME } from '../shared/HighlightedText/HighlightedText';
 
-export const MATH_PATTERN = /(^|[^\\])(\$[^$\n]+\$|\$\$[\s\S]*?\$\$|\\\(|\\\[)/;
+export const MATH_PATTERN = /(^|[^\\])(\$\$[\s\S]*?\$\$|\\\(|\\\[)/;
 
 // Unclosed ```visualizer at stream end — partial body for live preview.
 const UNCLOSED_VISUALIZER_RE = /```visualizer\n([\s\S]*)$/;


### PR DESCRIPTION
## Problem
Chat messages containing two dollar amounts (e.g. `$30 ... the $30 discount`) rendered everything between the amounts as KaTeX inline math — italic text with all spaces collapsed.

## Root cause
- `MATH_PATTERN` in `frontend/src/components/ui/markdown/markdownParsing.ts` counted any same-line `$...$` pair as math, enabling the math plugins for ordinary currency text.
- `remarkMath` in `MarkDown.tsx` ran with its default `singleDollarTextMath: true`, so it parsed the span between two amounts as inline math.

## Fix
- Pass `{ singleDollarTextMath: false }` to `remarkMath`.
- Remove the single-dollar alternative from `MATH_PATTERN` so the gate matches what the plugin accepts.

Inline math now requires `$$...$$` delimiters; bare `$x$` renders literally — the right default for a chat UI where dollar amounts are common.

## Validation
- `npm run typecheck` — clean
- `npm run test` — 767 tests passed
- `npm run lint` — 0 errors (22 pre-existing warnings)