### PR TITLE
fix(frontend): auto-reload once on stale lazy-chunk import failure

### DIFF
--- a/frontend/src/components/ui/ErrorBoundary/ErrorBoundary.module.scss
+++ b/frontend/src/components/ui/ErrorBoundary/ErrorBoundary.module.scss
@@ -20,3 +20,7 @@
 .message {
   @include type.type-body;
 }
+
+.reload {
+  margin-top: var(--space-3);
+}

--- a/frontend/src/components/ui/ErrorBoundary/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, ReactNode } from 'react';
+import { Button } from '@/components/ui/primitives/Button/Button';
 import { logger } from '@/utils/logger';
 import styles from './ErrorBoundary.module.scss';
 
@@ -38,10 +39,17 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           <p className={styles.message}>
             {this.state.error?.message || 'An unexpected error occurred'}
           </p>
+          <Button className={styles.reload} size="sm" onClick={reloadPage}>
+            Reload page
+          </Button>
         </div>
       );
     }
 
     return this.props.children;
   }
+}
+
+function reloadPage(): void {
+  window.location.reload();
 }

--- a/frontend/src/components/ui/markdown/MarkDown.tsx
+++ b/frontend/src/components/ui/markdown/MarkDown.tsx
@@ -74,8 +74,7 @@ export const MarkDown = memo(function MarkDown({
   const needsMath = useMemo(() => MATH_PATTERN.test(content), [content]);
 
   const remarkPlugins = useMemo<NonNullable<Options['remarkPlugins']>>(
-    () =>
-      needsMath ? [remarkGfm, [remarkMath, { singleDollarTextMath: false }]] : [remarkGfm],
+    () => (needsMath ? [remarkGfm, [remarkMath, { singleDollarTextMath: false }]] : [remarkGfm]),
     [needsMath],
   );
   const rehypePlugins = useMemo(

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,7 +7,14 @@ import App from './App.tsx';
 // Build-time palette CSS overrides (vite.config.ts).
 import 'virtual:palette-overrides.css';
 import { queryClient, persistOptions } from './lib/queryClient';
+import { reloadStaleChunk } from './utils/lazyNamed';
 import { isMobileApp } from './utils/platform';
+
+window.addEventListener('vite:preloadError', (event) => {
+  if (reloadStaleChunk()) {
+    event.preventDefault();
+  }
+});
 
 // iOS WebKit zooms inputs with font-size < 16px; lock scale in the native shell only.
 if (isMobileApp()) {

--- a/frontend/src/utils/lazyNamed.ts
+++ b/frontend/src/utils/lazyNamed.ts
@@ -1,5 +1,27 @@
 import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
 
+const CHUNK_RELOAD_KEY = 'chunk-reload-at';
+const CHUNK_RELOAD_INTERVAL = 30_000;
+
+export function reloadStaleChunk(): boolean {
+  const now = Date.now();
+
+  try {
+    const reloadAt = Number(window.sessionStorage.getItem(CHUNK_RELOAD_KEY));
+
+    if (reloadAt && now - reloadAt < CHUNK_RELOAD_INTERVAL) {
+      return false;
+    }
+
+    window.sessionStorage.setItem(CHUNK_RELOAD_KEY, String(now));
+  } catch {
+    return false;
+  }
+
+  window.location.reload();
+  return true;
+}
+
 // React.lazy for named exports. ComponentType<any> keeps T as the concrete
 // component type (stricter props bounds break contravariant inference).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -7,5 +29,16 @@ export function lazyNamed<T extends ComponentType<any>>(
   factory: () => Promise<Record<string, T>>,
   name: string,
 ): LazyExoticComponent<T> {
-  return lazy(() => factory().then((m) => ({ default: m[name] })));
+  return lazy(() =>
+    factory().then(
+      (m) => ({ default: m[name] }),
+      (error: unknown) => {
+        if (reloadStaleChunk()) {
+          return new Promise<never>(() => {});
+        }
+
+        throw error;
+      },
+    ),
+  );
 }


### PR DESCRIPTION
## Problem
Every deploy replaces the hashed `/assets/` chunks wholesale (fresh nginx image, no old hashes kept). A tab opened before a deploy still holds the old bundle graph; navigating to a lazy route (e.g. `/settings`) then `import()`s a chunk that no longer exists → 404 → `TypeError: Importing a module script failed.` (Safari) → the app-level ErrorBoundary renders a dead "Something went wrong" panel with no recovery.

## Fix
- **`lazyNamed`**: on dynamic-import rejection, perform a one-shot automatic `window.location.reload()` guarded by a sessionStorage timestamp (`chunk-reload-at`, 30s window), returning a never-resolving promise so the Suspense fallback stays visible during reload. A second failure inside the window rethrows to the ErrorBoundary, so permanent failures (offline, outage) can't cause reload loops. sessionStorage access is wrapped for Safari private mode (guard unavailable → no auto-reload, error surfaces normally).
- **`main.tsx`**: `vite:preloadError` listener reuses the same guard for CSS/dependency preload failures; `preventDefault()` only when a reload actually starts, so blocked reloads don't swallow the error.
- **`ErrorBoundary`**: default error panel gains a "Reload page" button as manual backstop.

Since `index.html` is served with `Cache-Control: no-cache`, the reload fetches the new chunk hashes and recovers.

## Validation
- `npm run typecheck` ✅
- `npm run lint` ✅ (0 errors, 22 pre-existing warnings)
- `npm run build` ✅

Reviewed via Bugbot pass; two findings (guard re-arming on successful imports enabling reload loops; unconditional `preventDefault` swallowing blocked errors) were fixed.