### PR TITLE
Restore passwordless sudo in docker sandbox image

### DIFF
--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     zip \
     build-essential \
     software-properties-common \
+    sudo \
     openssh-client \
     jq \
     tmux \
@@ -56,6 +57,8 @@ RUN curl -fsSL https://get.docker.com | sh && \
     echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
 
 RUN useradd -m -s /bin/bash -u 1000 user && \
+    echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/user && \
+    chmod 0440 /etc/sudoers.d/user && \
     usermod -aG docker user && \
     chown -R user:user /home/user
 


### PR DESCRIPTION
## Summary
- Reinstall the `sudo` package in the sandbox image and grant the sandbox user `NOPASSWD:ALL` via a `/etc/sudoers.d/user` drop-in (`0440`), instead of the pre-#347 append to `/etc/sudoers`.

## Rationale
#347 removed sudo entirely, which left the dev sandbox unable to `apt install` packages or perform other root-requiring operations — the container is the security boundary, and that's exactly the kind of work the sandbox exists for. The removal also bought little in practice: the sandbox user keeps `docker` group membership, which is already root-equivalent.

This is deliberately **not** a full revert of #347: the user-owned `write_file` (tar uid/gid 1000) and removal of `sudo chown` shell-outs in the backend are kept — they're correct regardless of sudo availability.

Closes #922

## Test plan
- [ ] Build the sandbox image
- [ ] `sudo apt-get update` succeeds as `user` inside a running sandbox without a password prompt