### PR TITLE
Fix root:root ownership of bind-mounted git workspaces in docker sandbox

### DIFF
--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -17,6 +17,7 @@ from app.constants import (
     SANDBOX_DEFAULT_COMMAND_TIMEOUT,
     TERMINAL_TYPE,
 )
+from app.core.config import get_settings
 from app.services.exceptions import SandboxException
 from app.services.sandbox_providers.base import GIT_LS_FILES_CMD, SandboxProvider
 from app.services.sandbox_providers.types import (
@@ -142,8 +143,26 @@ class LocalDockerProvider(SandboxProvider):
         container = await self._create_container(
             sandbox_id, workspace_path=workspace_path
         )
+        if workspace_path:
+            await self._fix_workspace_ownership(container, workspace_path)
         self._containers[sandbox_id] = container
         return sandbox_id
+
+    async def _fix_workspace_ownership(
+        self, container: Any, workspace_path: str
+    ) -> None:
+        workspace_dir = Path(workspace_path).expanduser().resolve()
+        storage_root = Path(get_settings().STORAGE_PATH).resolve()
+        if not workspace_dir.is_relative_to(storage_root):
+            return
+
+        exec_obj = await container.exec(
+            cmd=["chown", "-R", "1000:1000", self.workspace_root],
+            user="root",
+        )
+        exit_code, output = await self._collect_exec_output(exec_obj)
+        if exit_code != 0:
+            logger.warning("Failed to set workspace ownership: %s", output)
 
     async def _get_container_by_id(self, sandbox_id: str) -> Any | None:
         # Daemon lookup when missing from the in-memory cache (e.g. after API restart).

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -4,6 +4,7 @@ import shlex
 import subprocess
 import zipfile
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import AsyncClient
@@ -31,6 +32,10 @@ from app.services.git import (
 )
 from app.services.sandbox import SandboxService
 from app.services.sandbox_providers.base import SandboxProvider
+from app.services.sandbox_providers.docker_provider import (
+    DockerConfig,
+    LocalDockerProvider,
+)
 from app.services.sandbox_providers.types import (
     CommandResult,
     FileContent,
@@ -47,6 +52,41 @@ from tests.helpers import (
 
 
 pytestmark = pytest.mark.anyio
+
+
+async def test_docker_sandbox_chowns_only_managed_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    storage_root = tmp_path / "storage"
+    managed_workspace = storage_root / "workspaces" / "user" / "repo"
+    external_workspace = tmp_path / "local-repo"
+    monkeypatch.setattr(get_settings(), "STORAGE_PATH", str(storage_root))
+
+    provider = LocalDockerProvider(DockerConfig())
+    exec_obj = MagicMock()
+    container = MagicMock()
+    container.exec = AsyncMock(return_value=exec_obj)
+    create_container = AsyncMock(return_value=container)
+    collect_exec_output = AsyncMock(return_value=(0, ""))
+    monkeypatch.setattr(provider, "_create_container", create_container)
+    monkeypatch.setattr(provider, "_collect_exec_output", collect_exec_output)
+
+    await provider.create_sandbox(str(managed_workspace))
+
+    container.exec.assert_awaited_once_with(
+        cmd=["chown", "-R", "1000:1000", provider.workspace_root],
+        user="root",
+    )
+    collect_exec_output.assert_awaited_once_with(exec_obj)
+
+    container.exec.reset_mock()
+    collect_exec_output.reset_mock()
+
+    await provider.create_sandbox(str(external_workspace))
+    await provider.create_sandbox(None)
+
+    container.exec.assert_not_awaited()
+    collect_exec_output.assert_not_awaited()
 
 
 @pytest.mark.parametrize("base_ref", ["main", "feat/api-keys", "release-1.2"])


### PR DESCRIPTION
## Summary
- After the sandbox container starts, run `chown -R 1000:1000 /home/user/workspace` as a root exec when (and only when) the bind-mounted workspace path is under the backend-managed `STORAGE_PATH`.
- Add a unit test covering the three cases: chown issued for managed paths, skipped for external paths, skipped when no workspace is mounted.

## Root cause
The backend clones git repos on the host (`workspace.py::_clone_git_workspace`) into `STORAGE_PATH/workspaces/...`; in web deployments the backend runs as root, so the clone is root-owned. `docker_provider.py` bind-mounts that directory at `/home/user/workspace` while the container runs as uid 1000 — the workspace shows up `root:root` and is unwritable. Scratch (non-git) workspaces hit the same path.

The `STORAGE_PATH` guard is deliberate: `source_type: local` workspaces bind-mount a directory the user owns on the host, and we must never rewrite ownership of a user's own tree.

Notes: ownership is host-filesystem state, so one chown at creation persists across container/backend restarts. Workspaces created before this fix remain root-owned and need recreation (or a manual chown).

Closes #921

## Test plan
- [x] `pytest tests/test_sandbox.py tests/test_workspace.py` — 72 passed
- [x] `ruff check` / `ruff format --check` — clean
- [ ] Manual: create a docker workspace from a git repo, confirm `/home/user/workspace` contents are `user:user`