### PR TITLE
Disable no-new-privileges on sandbox containers

### DIFF
--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -101,6 +101,7 @@ class LocalDockerProvider(SandboxProvider):
 
         host_config: dict[str, Any] = {
             "NetworkMode": self.config.network,
+            "SecurityOpt": ["no-new-privileges=false"],
         }
 
         if self.config.mem_limit:


### PR DESCRIPTION
## Summary
- Set `SecurityOpt: ["no-new-privileges=false"]` on sandbox container creation.

## Rationale
Follow-up to #927. On hosts where the Docker daemon is configured with `no-new-privileges` as a global default (visible in `docker info` → Security Options), the kernel ignores setuid bits inside every container, so `sudo` fails with:

```
sudo: The "no new privileges" flag is set, which prevents sudo from running as root.
```

even with the sudo-enabled image from #927. Sandbox containers are designed to permit internal privilege transitions, so the provider now overrides the daemon default explicitly.

Verified on an affected host: default run reproduces the error; `--security-opt no-new-privileges=false` makes `sudo -n true` succeed.

## Test plan
- [x] `pytest tests/test_sandbox.py` — 55 passed
- [x] `ruff check` — clean
- [ ] After deploy: recreate a sandbox on a host with daemon-level `no-new-privileges` and confirm `sudo` works